### PR TITLE
HADOOP-19236. Incorporate VolcanoEngine Cloud TOS File System Implementation. Part 2: add unit tests. 

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-tos/src/main/java/org/apache/hadoop/fs/tosfs/object/FileStore.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/main/java/org/apache/hadoop/fs/tosfs/object/FileStore.java
@@ -117,7 +117,7 @@ public class FileStore implements ObjectStorage {
         "Checksum type %s is not supported by FileStore.", checksumType.name());
     checksumInfo = new ChecksumInfo(algorithm, checksumType);
 
-    Preconditions.checkState(new File(root).mkdirs(), "Failed to create root directory %s.", root);
+    new File(root).mkdirs();
   }
 
   @Override

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestEnv.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestEnv.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs;
+
+import org.apache.hadoop.fs.tosfs.util.ParseUtils;
+
+public class TestEnv {
+  public static final String ENV_TOS_UNIT_TEST_ENABLED = "TOS_UNIT_TEST_ENABLED";
+  private static final boolean TOS_TEST_ENABLED;
+
+  static {
+    TOS_TEST_ENABLED = ParseUtils.envAsBoolean(ENV_TOS_UNIT_TEST_ENABLED, false);
+  }
+
+  public static boolean checkTestEnabled() {
+    return TOS_TEST_ENABLED;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestRawFSUtils.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestRawFSUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRawFSUtils {
+
+  @Test
+  public void testIsAncestor() {
+    Assert.assertTrue(RawFSUtils.inSubtree("/", "/"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/", "/a"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/a", "/a"));
+    Assert.assertFalse(RawFSUtils.inSubtree("/a", "/"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/", "/a/b/c"));
+    Assert.assertFalse(RawFSUtils.inSubtree("/a/b/c", "/"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/", "/a/b/c.txt"));
+    Assert.assertFalse(RawFSUtils.inSubtree("/a/b/c.txt", "/"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/a/b/", "/a/b"));
+    Assert.assertTrue(RawFSUtils.inSubtree("/a/b/", "/a/b/c"));
+    Assert.assertFalse(RawFSUtils.inSubtree("/a/b/c", "/a/b"));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestRawFileSystem.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestRawFileSystem.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertThrows;
+
+public class TestRawFileSystem {
+  @Test
+  public void testInitializeFileSystem() throws URISyntaxException, IOException {
+    Configuration conf = new Configuration();
+    try (RawFileSystem fs = new RawFileSystem()) {
+      fs.initialize(new URI("filestore://bucket_a/a/b/c"), conf);
+      Assert.assertEquals("bucket_a", fs.bucket());
+
+      fs.initialize(new URI("filestore://bucket-/a/b/c"), conf);
+      Assert.assertEquals("bucket-", fs.bucket());
+
+      fs.initialize(new URI("filestore://-bucket/a/b/c"), conf);
+      Assert.assertEquals("-bucket", fs.bucket());
+    }
+  }
+
+  @Test
+  public void testBucketNotExist() {
+    Configuration conf = new Configuration();
+    RawFileSystem fs = new RawFileSystem();
+    assertThrows("Bucket doesn't exist.", FileNotFoundException.class,
+        () -> fs.initialize(new URI("tos://not-exist-bucket/"), conf));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestTosChecksum.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestTosChecksum.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.conf.FileStoreKeys;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.ChecksumType;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.util.TempFiles;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class TestTosChecksum {
+  private static final String FILE_STORE_ROOT = TempFiles.newTempDir("TestTosChecksum");
+  private static final String ALGORITHM_NAME = "mock-algorithm";
+  private static final String PREFIX = UUIDUtils.random();
+
+  @Parameterized.Parameters(name = "checksumType = {0}, conf = {1}, uri = {2}, objectStorage = {3}")
+  public static Iterable<Object[]> createStorage() throws URISyntaxException {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+    return createTestObjectStorage(FILE_STORE_ROOT);
+  }
+
+  public static Iterable<Object[]> createTestObjectStorage(String fileStoreRoot)
+      throws URISyntaxException {
+    List<Object[]> list = new ArrayList<>();
+
+    // The 1st argument.
+    Configuration fileStoreConf = new Configuration();
+    fileStoreConf.set(FileStoreKeys.FS_FILESTORE_CHECKSUM_ALGORITHM, ALGORITHM_NAME);
+    fileStoreConf.set(FileStoreKeys.FS_FILESTORE_CHECKSUM_TYPE, ChecksumType.MD5.name());
+    fileStoreConf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key("filestore"), fileStoreRoot);
+
+    URI uri0 = new URI("filestore://" + TestUtility.bucket() + "/");
+    Object[] objs = new Object[] { ChecksumType.MD5, fileStoreConf, uri0,
+        ObjectStorageFactory.create(uri0.getScheme(), uri0.getAuthority(), fileStoreConf) };
+    list.add(objs);
+
+    // The 2nd argument.
+    Configuration tosConf = new Configuration();
+    tosConf.set(TosKeys.FS_TOS_CHECKSUM_ALGORITHM, ALGORITHM_NAME);
+    tosConf.set(TosKeys.FS_TOS_CHECKSUM_TYPE, ChecksumType.CRC32C.name());
+
+    URI uri1 = new URI(TOS_SCHEME + "://" + TestUtility.bucket() + "/");
+    objs = new Object[] { ChecksumType.CRC32C, tosConf, uri1,
+        ObjectStorageFactory.create(uri1.getScheme(), uri1.getAuthority(), tosConf) };
+    list.add(objs);
+
+    return list;
+  }
+
+  @After
+  public void tearDown() {
+    objectStorage.deleteAll(PREFIX);
+  }
+
+  private ChecksumType type;
+  private Configuration conf;
+  private URI uri;
+  private ObjectStorage objectStorage;
+
+  public TestTosChecksum(ChecksumType type, Configuration conf, URI uri,
+      ObjectStorage objectStorage) {
+    this.type = type;
+    this.conf = conf;
+    this.uri = uri;
+    this.objectStorage = objectStorage;
+  }
+
+  @Test
+  public void testChecksumInfo() {
+    assertEquals(ALGORITHM_NAME, objectStorage.checksumInfo().algorithm());
+    assertEquals(type, objectStorage.checksumInfo().checksumType());
+  }
+
+  @Test
+  public void testFileChecksum() throws Exception {
+    try (RawFileSystem fs = new RawFileSystem()) {
+      fs.initialize(uri, conf);
+      Path file = new Path("/" + PREFIX, "testFileChecksum");
+      fs.create(file).close();
+      FileChecksum checksum = fs.getFileChecksum(file, Long.MAX_VALUE);
+      assertEquals(ALGORITHM_NAME, checksum.getAlgorithmName());
+
+      String key = file.toString().substring(1);
+      byte[] checksumData = objectStorage.head(key).checksum();
+      assertArrayEquals(checksumData, checksum.getBytes());
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestTosFileSystem.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/TestTosFileSystem.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertThrows;
+
+public class TestTosFileSystem {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Test
+  public void testUriVerification() throws URISyntaxException, IOException {
+    Configuration conf = new Configuration(false);
+    conf.set(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY, "hdfs://cluster-0/");
+
+    TosFileSystem tfs = new TosFileSystem();
+    assertThrows("Expect invalid uri error.", IllegalArgumentException.class,
+        () -> tfs.initialize(new URI("hdfs://cluster/"), conf));
+    assertThrows("Expect invalid uri error.", IllegalArgumentException.class,
+        () -> tfs.initialize(new URI("/path"), conf));
+    tfs.initialize(new URI(String.format("tos://%s/", TestUtility.bucket())), conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/BaseJobSuite.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/BaseJobSuite.java
@@ -1,0 +1,227 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.object.MultipartUpload;
+import org.apache.hadoop.fs.tosfs.object.ObjectInfo;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.util.ParseUtils;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public abstract class BaseJobSuite {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseJobSuite.class);
+  public static final int DEFAULT_APP_ATTEMPT_ID = 1;
+  protected static final Text KEY_1 = new Text("key1");
+  protected static final Text KEY_2 = new Text("key2");
+  protected static final Text VAL_1 = new Text("val1");
+  protected static final Text VAL_2 = new Text("val2");
+
+  protected Job job;
+  protected String jobId;
+  protected FileSystem fs;
+  protected Path outputPath;
+  protected ObjectStorage storage;
+
+  private final boolean dumpObjectStorage = ParseUtils.envAsBoolean("DUMP_OBJECT_STORAGE", false);
+
+  protected abstract Path magicPartPath();
+
+  protected abstract Path magicPendingSetPath();
+
+  protected abstract void assertSuccessMarker() throws IOException;
+
+  protected abstract void assertSummaryReport(Path reportDir) throws IOException;
+
+  protected abstract void assertNoTaskAttemptPath() throws IOException;
+
+  protected void assertMagicPathExist(Path outputPath) throws IOException {
+    Path magicPath = CommitUtils.magicPath(outputPath);
+    Assert.assertTrue(String.format("Magic path: %s should exist", magicPath), fs.exists(magicPath));
+  }
+
+  protected void assertMagicPathNotExist(Path outputPath) throws IOException {
+    Path magicPath = CommitUtils.magicPath(outputPath);
+    Assert.assertFalse(String.format("Magic path: %s should not exist", magicPath), fs.exists(magicPath));
+  }
+
+  protected abstract boolean skipTests();
+
+  public Path magicPendingPath() {
+    Path magicPart = magicPartPath();
+    return new Path(magicPart.getParent(), magicPart.getName() + ".pending");
+  }
+
+  public Path magicJobPath() {
+    return CommitUtils.magicPath(outputPath);
+  }
+
+  public String magicPartKey() {
+    return ObjectUtils.pathToKey(magicPartPath());
+  }
+
+  public String destPartKey() {
+    return MagicOutputStream.toDestKey(magicPartPath());
+  }
+
+  public FileSystem fs() {
+    return fs;
+  }
+
+  public ObjectStorage storage() {
+    return storage;
+  }
+
+  public Job job() {
+    return job;
+  }
+
+  public void assertHasMagicKeys() {
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(magicJobPath(), true), "");
+    Assert.assertTrue("Should have some __magic object keys", Iterables.any(objects, o -> o.key().contains(
+        CommitUtils.MAGIC) && o.key().contains(jobId)));
+  }
+
+  public void assertHasBaseKeys() {
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(magicJobPath(), true), "");
+    Assert.assertTrue("Should have some __base object keys", Iterables.any(objects, o -> o.key().contains(
+        CommitUtils.BASE) && o.key().contains(jobId)));
+  }
+
+  public void assertNoMagicPendingFile() {
+    String magicPendingKey = String.format("%s.pending", magicPartKey());
+    Assert.assertNull("Magic pending key should exist", storage.head(magicPendingKey));
+  }
+
+  public void assertHasMagicPendingFile() {
+    String magicPendingKey = String.format("%s.pending", magicPartKey());
+    Assert.assertNotNull("Magic pending key should exist", storage.head(magicPendingKey));
+  }
+
+  public void assertNoMagicMultipartUpload() {
+    Iterable<MultipartUpload> uploads = storage.listUploads(ObjectUtils.pathToKey(magicJobPath(), true));
+    boolean anyMagicUploads = Iterables.any(uploads, u -> u.key().contains(CommitUtils.MAGIC));
+    Assert.assertFalse("Should have no magic multipart uploads", anyMagicUploads);
+  }
+
+  public void assertNoMagicObjectKeys() {
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(magicJobPath(), true), "");
+    boolean anyMagicUploads =
+        Iterables.any(objects, o -> o.key().contains(CommitUtils.MAGIC) && o.key().contains(jobId));
+    Assert.assertFalse("Should not have any magic keys", anyMagicUploads);
+  }
+
+  public void assertHasPendingSet() {
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(magicJobPath(), true), "");
+    boolean anyPendingSet =
+        Iterables.any(objects, o -> o.key().contains(CommitUtils.PENDINGSET_SUFFIX) && o.key().contains(jobId));
+    Assert.assertTrue("Should have the expected .pendingset file", anyPendingSet);
+  }
+
+  public void assertPendingSetAtRightLocation() {
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(magicJobPath(), true), "");
+    Path magicJobAttemptPath =
+        CommitUtils.magicJobAttemptPath(job().getJobID().toString(), DEFAULT_APP_ATTEMPT_ID, outputPath);
+    String inQualifiedPath = magicJobAttemptPath.toUri().getPath().substring(1);
+    Iterable<ObjectInfo> filtered =
+        Iterables.filter(objects, o -> o.key().contains(CommitUtils.PENDINGSET_SUFFIX) && o.key().contains(jobId));
+    boolean pendingSetAtRightLocation =
+        Iterables.any(filtered, o -> o.key().startsWith(inQualifiedPath) && o.key().contains(jobId));
+    Assert.assertTrue("The .pendingset file should locate at the job's magic output path.", pendingSetAtRightLocation);
+  }
+
+  public void assertMultipartUpload(int expectedUploads) {
+    // Note: should be care in concurrent case: they need to check the same output path.
+    Iterable<MultipartUpload> uploads = storage.listUploads(ObjectUtils.pathToKey(outputPath, true));
+    long actualUploads = StreamSupport.stream(uploads.spliterator(), false).count();
+    Assert.assertEquals(expectedUploads, actualUploads);
+  }
+
+  public void assertPartFiles(int num) throws IOException {
+    FileStatus[] files = fs.listStatus(outputPath,
+        f -> !MagicOutputStream.isMagic(new Path(f.toUri())) && f.toUri().toString().contains("part-"));
+    Assert.assertEquals(num, files.length);
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(outputPath, true), "");
+    List<ObjectInfo> infos = Arrays.stream(Iterables.toArray(objects, ObjectInfo.class))
+        .filter(o -> o.key().contains("part-")).collect(Collectors.toList());
+    Assert.assertEquals(
+        String.format("Part files number should be %d, but got %d", num, infos.size()), num, infos.size());
+  }
+
+  public void assertNoPartFiles() throws IOException {
+    FileStatus[] files = fs.listStatus(outputPath,
+        f -> !MagicOutputStream.isMagic(new Path(f.toUri())) && f.toUri().toString().contains("part-"));
+    Assert.assertEquals(0, files.length);
+    Iterable<ObjectInfo> objects = storage.listAll(ObjectUtils.pathToKey(outputPath, true), "");
+    boolean anyPartFile = Iterables.any(objects, o -> o.key().contains("part-"));
+    Assert.assertFalse("Should have no part files", anyPartFile);
+  }
+
+  public void dumpObjectStorage() {
+    if (dumpObjectStorage) {
+      LOG.info("===> Dump object storage - Start <===");
+      dumpObjectKeys();
+      dumpMultipartUploads();
+      LOG.info("===> Dump object storage -  End  <===");
+    }
+  }
+
+  public void dumpObjectKeys() {
+    String prefix = ObjectUtils.pathToKey(magicJobPath());
+    LOG.info("Dump object keys with prefix {}", prefix);
+    storage.listAll("", "").forEach(o -> LOG.info("Dump object keys - {}", o));
+  }
+
+  public void dumpMultipartUploads() {
+    String prefix = ObjectUtils.pathToKey(magicJobPath());
+    LOG.info("Dump multi part uploads with prefix {}", prefix);
+    storage.listUploads("")
+        .forEach(u -> LOG.info("Dump multipart uploads - {}", u));
+  }
+
+  public void verifyPartContent() throws IOException {
+    String partKey = destPartKey();
+    LOG.info("Part key to verify is: {}", partKey);
+    try (InputStream in = storage.get(partKey).stream()) {
+      byte[] data = IOUtils.toByteArray(in);
+      String expected = String.format("%s\t%s\n%s\t%s\n", KEY_1, VAL_1, KEY_2, VAL_2);
+      Assert.assertEquals(expected, new String(data, StandardCharsets.UTF_8));
+    }
+  }
+
+  public void assertSuccessMarkerNotExist() throws IOException {
+    Path succPath = CommitUtils.successMarker(outputPath);
+    Assert.assertFalse(String.format("%s should not exists", succPath), fs.exists(succPath));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/CommitterTestBase.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/CommitterTestBase.java
@@ -1,0 +1,429 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+public abstract class CommitterTestBase {
+  private Configuration conf;
+  private FileSystem fs;
+  private Path outputPath;
+  private TaskAttemptID job1Task0Attempt0;
+  private TaskAttemptID job2Task1Attempt0;
+  private Path reportDir;
+
+  @Before
+  public void setup() throws IOException {
+    conf = newConf();
+    fs = FileSystem.get(conf);
+    String uuid = UUIDUtils.random();
+    outputPath = fs.makeQualified(new Path("/test/" + uuid));
+    job1Task0Attempt0 = JobSuite.createTaskAttemptId(randomTrimmedJobId(), 0, 0);
+    job2Task1Attempt0 = JobSuite.createTaskAttemptId(randomTrimmedJobId(), 1, 0);
+
+    reportDir = fs.makeQualified(new Path("/report/" + uuid));
+    fs.mkdirs(reportDir);
+    conf.set(Committer.COMMITTER_SUMMARY_REPORT_DIR, reportDir.toUri().toString());
+  }
+
+  protected abstract Configuration newConf();
+
+  @After
+  public void teardown() {
+    CommonUtils.runQuietly(() -> fs.delete(outputPath, true));
+    IOUtils.closeStream(fs);
+  }
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    List<String> committerThreads = Thread.getAllStackTraces().keySet()
+        .stream()
+        .map(Thread::getName)
+        .filter(n -> n.startsWith(Committer.THREADS_PREFIX))
+        .collect(Collectors.toList());
+    Assert.assertTrue("Outstanding committer threads", committerThreads.isEmpty());
+  }
+
+  private static String randomTrimmedJobId() {
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+    return String.format("%s%04d_%04d", formatter.format(new Date()),
+        (long) (Math.random() * 1000),
+        (long) (Math.random() * 1000));
+  }
+
+  private static String randomFormedJobId() {
+    return String.format("job_%s", randomTrimmedJobId());
+  }
+
+  @Test
+  public void testSetupJob() throws IOException {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    // Setup job.
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+  }
+
+  @Test
+  public void testSetupJobWithOrphanPaths() throws IOException, InterruptedException {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    // Orphan success marker.
+    Path successPath = CommitUtils.successMarker(outputPath);
+    CommitUtils.save(fs, successPath, new byte[]{});
+    Assert.assertTrue(fs.exists(successPath));
+
+    // Orphan job path.
+    Path jobPath = CommitUtils.magicJobPath(suite.committer().jobId(), outputPath);
+    fs.mkdirs(jobPath);
+    Assert.assertTrue("The job path should be existing", fs.exists(jobPath));
+    Path subPath = new Path(jobPath, "tmp.pending");
+    CommitUtils.save(fs, subPath, new byte[]{});
+    Assert.assertTrue("The sub path under job path should be existing.", fs.exists(subPath));
+    FileStatus jobPathStatus = fs.getFileStatus(jobPath);
+
+    Thread.sleep(1000L);
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+
+    assertFalse("Should have deleted the success path", fs.exists(successPath));
+    Assert.assertTrue("Should have re-created the job path", fs.exists(jobPath));
+    assertFalse("Should have deleted the sub path under the job path", fs.exists(subPath));
+  }
+
+  @Test
+  public void testSetupTask() throws IOException {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    // Remaining attempt task path.
+    Path taskAttemptBasePath = CommitUtils.magicTaskAttemptBasePath(suite.taskAttemptContext(), outputPath);
+    Path subTaskAttemptPath = new Path(taskAttemptBasePath, "tmp.pending");
+    CommitUtils.save(fs, subTaskAttemptPath, new byte[]{});
+    Assert.assertTrue(fs.exists(taskAttemptBasePath));
+    Assert.assertTrue(fs.exists(subTaskAttemptPath));
+
+    // Setup job.
+    suite.setupJob();
+    suite.assertHasMagicKeys();
+    // It will clear all the job path once we've set up the job.
+    assertFalse(fs.exists(taskAttemptBasePath));
+    assertFalse(fs.exists(subTaskAttemptPath));
+
+    // Left some the task paths.
+    CommitUtils.save(fs, subTaskAttemptPath, new byte[]{});
+    Assert.assertTrue(fs.exists(taskAttemptBasePath));
+    Assert.assertTrue(fs.exists(subTaskAttemptPath));
+
+    // Setup task.
+    suite.setupTask();
+    assertFalse(fs.exists(subTaskAttemptPath));
+  }
+
+  @Test
+  public void testCommitTask() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // Setup job
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+
+    // Setup task
+    suite.setupTask();
+
+    // Write records.
+    suite.assertNoMagicPendingFile();
+    suite.assertMultipartUpload(0);
+    suite.writeOutput();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(1);
+    // Assert the pending file content.
+    Path pendingPath = suite.magicPendingPath();
+    byte[] pendingData = CommitUtils.load(suite.fs(), pendingPath);
+    Pending pending = Pending.deserialize(pendingData);
+    assertEquals(suite.destPartKey(), pending.destKey());
+    assertEquals(20, pending.length());
+    assertEquals(1, pending.parts().size());
+
+    // Commit the task.
+    suite.commitTask();
+
+    // Verify the pending set file.
+    suite.assertHasPendingSet();
+    // Assert the pending set file content.
+    Path pendingSetPath = suite.magicPendingSetPath();
+    byte[] pendingSetData = CommitUtils.load(suite.fs(), pendingSetPath);
+    PendingSet pendingSet = PendingSet.deserialize(pendingSetData);
+    assertEquals(suite.job().getJobID().toString(), pendingSet.jobId());
+    assertEquals(1, pendingSet.commits().size());
+    assertEquals(pending, pendingSet.commits().get(0));
+    assertEquals(pendingSet.extraData(),
+        ImmutableMap.of(CommitUtils.TASK_ATTEMPT_ID, suite.taskAttemptContext().getTaskAttemptID().toString()));
+
+    // Complete the multipart upload and verify the results.
+    ObjectStorage storage = suite.storage();
+    storage.completeUpload(pending.destKey(), pending.uploadId(), pending.parts());
+    suite.verifyPartContent();
+  }
+
+  @Test
+  public void testAbortTask() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+
+    // Pre-check before the output write.
+    suite.assertNoMagicPendingFile();
+    suite.assertMultipartUpload(0);
+
+    // Execute the output write.
+    suite.writeOutput();
+
+    // Post-check after the output write.
+    suite.assertHasMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(1);
+    // Assert the pending file content.
+    Path pendingPath = suite.magicPendingPath();
+    byte[] pendingData = CommitUtils.load(suite.fs(), pendingPath);
+    Pending pending = Pending.deserialize(pendingData);
+    assertEquals(suite.destPartKey(), pending.destKey());
+    assertEquals(20, pending.length());
+    assertEquals(1, pending.parts().size());
+
+    // Abort the task.
+    suite.abortTask();
+
+    // Verify the state after aborting task.
+    suite.assertNoMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(0);
+    suite.assertNoTaskAttemptPath();
+  }
+
+  @Test
+  public void testCommitJob() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job.
+    suite.assertNoPartFiles();
+    suite.commitJob();
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.assertSummaryReport(reportDir);
+    suite.verifyPartContent();
+  }
+
+
+  @Test
+  public void testCommitJobFailed() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job.
+    suite.assertNoPartFiles();
+    suite.commitJob();
+  }
+
+  @Test
+  public void testCommitJobSuccessMarkerFailed() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    CommitUtils.injectError("marker");
+    // Commit the job.
+    suite.assertNoPartFiles();
+    assertThrows("Expect commit job error.", IOException.class, suite::commitJob);
+    CommitUtils.removeError("marker");
+
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarkerNotExist();
+    assertEquals(0, suite.fs().listStatus(suite.outputPath).length);
+  }
+
+  @Test
+  public void testTaskCommitAfterJobCommit() throws Exception {
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job
+    suite.assertNoPartFiles();
+    suite.commitJob();
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.verifyPartContent();
+
+    // Commit the task again.
+    assertThrows(FileNotFoundException.class, suite::commitTask);
+  }
+
+  @Test
+  public void testTaskCommitWithConsistentJobId() throws Exception {
+    Configuration conf = newConf();
+    String consistentJobId = randomFormedJobId();
+    conf.set(CommitUtils.SPARK_WRITE_UUID, consistentJobId);
+    JobSuite suite = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // By now, we have two "jobId"s, one is spark uuid, and the other is the jobId in taskAttempt.
+    // The job committer will adopt the former.
+    suite.setupJob();
+
+    // Next, we clear spark uuid, and set the jobId of taskAttempt to another value. In this case,
+    // the committer will take the jobId of taskAttempt as the final jobId, which is not consistent
+    // with the one that committer holds.
+    conf.unset(CommitUtils.SPARK_WRITE_UUID);
+    String anotherJobId = randomTrimmedJobId();
+    TaskAttemptID taskAttemptId1 = JobSuite.createTaskAttemptId(anotherJobId, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+    final TaskAttemptContext attemptContext1 =
+        JobSuite.createTaskAttemptContext(conf, taskAttemptId1, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+
+    assertThrows("JobId set in the context", IllegalArgumentException.class,
+        () -> suite.setupTask(attemptContext1));
+
+    // Even though we use another taskAttempt, as long as we ensure the spark uuid is consistent,
+    // the jobId in committer is consistent.
+    conf.set(CommitUtils.SPARK_WRITE_UUID, consistentJobId);
+    conf.set(FileOutputFormat.OUTDIR, outputPath.toString());
+    anotherJobId = randomTrimmedJobId();
+    TaskAttemptID taskAttemptId2 = JobSuite.createTaskAttemptId(anotherJobId, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+    TaskAttemptContext attemptContext2 =
+        JobSuite.createTaskAttemptContext(conf, taskAttemptId2, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+
+    suite.setupTask(attemptContext2);
+    // Write output must use the same task context with setup task.
+    suite.writeOutput(attemptContext2);
+    // Commit task must use the same task context with setup task.
+    suite.commitTask(attemptContext2);
+    suite.assertPendingSetAtRightLocation();
+
+    // Commit the job
+    suite.assertNoPartFiles();
+    suite.commitJob();
+
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.verifyPartContent();
+  }
+
+  @Test
+  public void testConcurrentJobs() throws Exception {
+    JobSuite suite1 = JobSuite.create(conf, job1Task0Attempt0, outputPath);
+    JobSuite suite2 = JobSuite.create(conf, job2Task1Attempt0, outputPath);
+    Assume.assumeFalse(suite1.skipTests());
+    Assume.assumeFalse(suite2.skipTests());
+    suite1.setupJob();
+    suite2.setupJob();
+    suite1.setupTask();
+    suite2.setupTask();
+    suite1.writeOutput();
+    suite2.writeOutput();
+    suite1.commitTask();
+    suite2.commitTask();
+
+    // Job2 commit the job.
+    suite2.assertNoPartFiles();
+    suite2.commitJob();
+    suite2.assertPartFiles(1);
+
+    suite2.assertNoMagicMultipartUpload();
+    suite2.assertNoMagicObjectKeys();
+    suite2.assertSuccessMarker();
+    suite2.assertSummaryReport(reportDir);
+    suite2.verifyPartContent();
+    suite2.assertMagicPathExist(outputPath);
+
+    // Job1 commit the job.
+    suite1.commitJob();
+    suite2.assertPartFiles(2);
+
+    // Verify the output.
+    suite1.assertNoMagicMultipartUpload();
+    suite1.assertNoMagicObjectKeys();
+    suite1.assertSuccessMarker();
+    suite1.assertSummaryReport(reportDir);
+    suite1.verifyPartContent();
+    suite1.assertMagicPathNotExist(outputPath);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/JobSuite.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/JobSuite.java
@@ -1,0 +1,219 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitterFactory;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.hadoop.net.NetUtils;
+import org.junit.Assert;
+
+import java.io.IOException;
+
+public class JobSuite extends BaseJobSuite {
+  private static final CommitterFactory FACTORY = new CommitterFactory();
+  private final JobContext jobContext;
+  private final TaskAttemptContext taskAttemptContext;
+  private final Committer committer;
+
+  private JobSuite(FileSystem fs, Configuration conf, TaskAttemptID taskAttemptId, int appAttemptId, Path outputPath)
+      throws IOException {
+    this.fs = fs;
+    // Initialize the job instance.
+    this.job = Job.getInstance(conf);
+    job.setJobID(JobID.forName(CommitUtils.buildJobId(conf, taskAttemptId.getJobID())));
+    this.jobContext = createJobContext(job.getConfiguration(), taskAttemptId);
+    this.jobId = CommitUtils.buildJobId(jobContext);
+    this.taskAttemptContext = createTaskAttemptContext(job.getConfiguration(), taskAttemptId, appAttemptId);
+
+    // Set job output directory.
+    FileOutputFormat.setOutputPath(job, outputPath);
+    this.outputPath = outputPath;
+    this.storage = ObjectStorageFactory.create(outputPath.toUri().getScheme(), outputPath.toUri().getAuthority(), conf);
+
+    // Initialize committer.
+    this.committer = (Committer) FACTORY.createOutputCommitter(outputPath, taskAttemptContext);
+  }
+
+  public static JobSuite create(Configuration conf, TaskAttemptID taskAttemptId, Path outDir) throws IOException {
+    FileSystem fs = outDir.getFileSystem(conf);
+    return new JobSuite(fs, conf, taskAttemptId, DEFAULT_APP_ATTEMPT_ID, outDir);
+  }
+
+  public static TaskAttemptID createTaskAttemptId(String trimmedJobId, int attemptId) {
+    String attempt = String.format("attempt_%s_m_000000_%d", trimmedJobId, attemptId);
+    return TaskAttemptID.forName(attempt);
+  }
+
+  public static TaskAttemptID createTaskAttemptId(String trimmedJobId, int taskId, int attemptId) {
+    String[] parts = trimmedJobId.split("_");
+    return new TaskAttemptID(parts[0], Integer.parseInt(parts[1]), TaskType.MAP, taskId, attemptId);
+  }
+
+  public static JobContext createJobContext(Configuration jobConf, TaskAttemptID taskAttemptId) {
+    return new JobContextImpl(jobConf, taskAttemptId.getJobID());
+  }
+
+  public static TaskAttemptContext createTaskAttemptContext(
+      Configuration jobConf, TaskAttemptID taskAttemptId, int appAttemptId) throws IOException {
+    // Set the key values for job configuration.
+    jobConf.set(MRJobConfig.TASK_ATTEMPT_ID, taskAttemptId.toString());
+    jobConf.setInt(MRJobConfig.APPLICATION_ATTEMPT_ID, appAttemptId);
+    jobConf.set(PathOutputCommitterFactory.COMMITTER_FACTORY_CLASS, CommitterFactory.class.getName());
+    return new TaskAttemptContextImpl(jobConf, taskAttemptId);
+  }
+
+  public void setupJob() throws IOException {
+    committer.setupJob(jobContext);
+  }
+
+  public void setupTask() throws IOException {
+    committer.setupTask(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    committer.setupTask(taskAttemptContext);
+  }
+
+  public void writeOutput() throws Exception {
+    writeOutput(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void writeOutput(TaskAttemptContext taskAttemptContext) throws Exception {
+    RecordWriter<Object, Object> writer = new TextOutputFormat<>().getRecordWriter(taskAttemptContext);
+    NullWritable nullKey = NullWritable.get();
+    NullWritable nullVal = NullWritable.get();
+    Object[] keys = new Object[]{KEY_1, nullKey, null, nullKey, null, KEY_2};
+    Object[] vals = new Object[]{VAL_1, nullVal, null, null, nullVal, VAL_2};
+    try {
+      Assert.assertEquals(keys.length, vals.length);
+      for (int i = 0; i < keys.length; i++) {
+        writer.write(keys[i], vals[i]);
+      }
+    } finally {
+      writer.close(taskAttemptContext);
+    }
+  }
+
+  public boolean needsTaskCommit() {
+    return committer.needsTaskCommit(taskAttemptContext);
+  }
+
+  public void commitTask() throws IOException {
+    committer.commitTask(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    committer.commitTask(taskAttemptContext);
+  }
+
+  public void abortTask() throws IOException {
+    committer.abortTask(taskAttemptContext);
+  }
+
+  public void commitJob() throws IOException {
+    committer.commitJob(jobContext);
+  }
+
+  @Override
+  public Path magicPartPath() {
+    return new Path(committer.getWorkPath(), FileOutputFormat.getUniqueFile(taskAttemptContext, "part", ""));
+  }
+
+  @Override
+  public Path magicPendingSetPath() {
+    return CommitUtils.magicTaskPendingSetPath(taskAttemptContext, outputPath);
+  }
+
+  public TaskAttemptContext taskAttemptContext() {
+    return taskAttemptContext;
+  }
+
+  public Committer committer() {
+    return committer;
+  }
+
+  @Override
+  public void assertNoTaskAttemptPath() throws IOException {
+    Path path = CommitUtils.magicTaskAttemptBasePath(taskAttemptContext, outputPath);
+    Assert.assertFalse("Task attempt path should be not existing", fs.exists(path));
+    String pathToKey = ObjectUtils.pathToKey(path);
+    Assert.assertNull("Should have no task attempt path key", storage.head(pathToKey));
+  }
+
+  @Override
+  protected boolean skipTests() {
+    return storage.bucket().isDirectory();
+  }
+
+  @Override
+  public void assertSuccessMarker() throws IOException {
+    Path succPath = CommitUtils.successMarker(outputPath);
+    Assert.assertTrue(String.format("%s should be exists", succPath), fs.exists(succPath));
+    SuccessData successData = SuccessData.deserialize(CommitUtils.load(fs, succPath));
+    Assert.assertEquals(SuccessData.class.getName(), successData.name());
+    Assert.assertTrue(successData.success());
+    Assert.assertEquals(NetUtils.getHostname(), successData.hostname());
+    Assert.assertEquals(CommitUtils.COMMITTER_NAME, successData.committer());
+    Assert.assertEquals(
+        String.format("Task committer %s", taskAttemptContext.getTaskAttemptID()),
+        successData.description());
+    Assert.assertEquals(job.getJobID().toString(), successData.jobId());
+    Assert.assertEquals(1, successData.filenames().size());
+    Assert.assertEquals(destPartKey(), successData.filenames().get(0));
+  }
+
+  @Override
+  public void assertSummaryReport(Path reportDir) throws IOException {
+    Path reportPath = CommitUtils.summaryReport(reportDir, job().getJobID().toString());
+    Assert.assertTrue(String.format("%s should be exists", reportPath), fs.exists(reportPath));
+    SuccessData reportData = SuccessData.deserialize(CommitUtils.load(fs, reportPath));
+    Assert.assertEquals(SuccessData.class.getName(), reportData.name());
+    Assert.assertTrue(reportData.success());
+    Assert.assertEquals(NetUtils.getHostname(), reportData.hostname());
+    Assert.assertEquals(CommitUtils.COMMITTER_NAME, reportData.committer());
+    Assert.assertEquals(
+        String.format("Task committer %s", taskAttemptContext.getTaskAttemptID()),
+        reportData.description());
+    Assert.assertEquals(job.getJobID().toString(), reportData.jobId());
+    Assert.assertEquals(1, reportData.filenames().size());
+    Assert.assertEquals(destPartKey(), reportData.filenames().get(0));
+    Assert.assertEquals("clean", reportData.diagnostics().get("stage"));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/MRJobTestBase.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/MRJobTestBase.java
@@ -1,0 +1,234 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.examples.terasort.TeraGen;
+import org.apache.hadoop.examples.terasort.TeraSort;
+import org.apache.hadoop.examples.terasort.TeraSortConfigKeys;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.object.ObjectInfo;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.WordCount;
+import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
+import org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig;
+import org.apache.hadoop.util.ToolRunner;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class MRJobTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(MRJobTestBase.class);
+
+  private static Configuration conf = new Configuration();
+  private static MiniMRYarnCluster yarnCluster;
+
+  private static FileSystem fs;
+
+  private static Path testDataPath;
+
+  public static void setConf(Configuration newConf) {
+    conf = newConf;
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+
+    conf.setBoolean(JHAdminConfig.MR_HISTORY_CLEANER_ENABLE, false);
+    conf.setBoolean(YarnConfiguration.NM_DISK_HEALTH_CHECK_ENABLE, false);
+    conf.setInt(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, 100);
+
+    conf.set("mapreduce.outputcommitter.factory.scheme.tos",
+        CommitterFactory.class.getName()); // 3x newApiCommitter=true.
+    conf.set("mapred.output.committer.class",
+        Committer.class.getName()); // 2x and 3x newApiCommitter=false.
+    conf.set("mapreduce.outputcommitter.class",
+        org.apache.hadoop.fs.tosfs.commit.Committer.class.getName()); // 2x newApiCommitter=true.
+
+    // Start the yarn cluster.
+    yarnCluster = new MiniMRYarnCluster("yarn-" + System.currentTimeMillis(), 2);
+    LOG.info("Default filesystem: {}", conf.get("fs.defaultFS"));
+    LOG.info("Default filesystem implementation: {}", conf.get("fs.AbstractFileSystem.tos.impl"));
+
+    yarnCluster.init(conf);
+    yarnCluster.start();
+
+    fs = FileSystem.get(conf);
+    testDataPath = new Path("/mr-test-" + UUIDUtils.random())
+        .makeQualified(fs.getUri(), fs.getWorkingDirectory());
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    if (!TestEnv.checkTestEnabled()) {
+      return;
+    }
+
+    fs.delete(testDataPath, true);
+    if (yarnCluster != null) {
+      yarnCluster.stop();
+    }
+  }
+
+  @After
+  public void after() throws IOException {
+  }
+
+  @Test
+  public void testTeraGen() throws Exception {
+    Path teraGenPath = new Path(testDataPath, "teraGen").makeQualified(fs.getUri(), fs.getWorkingDirectory());
+    Path output = new Path(teraGenPath, "output");
+    JobConf jobConf = new JobConf(yarnCluster.getConfig());
+    jobConf.addResource(conf);
+    jobConf.setInt(TeraSortConfigKeys.SAMPLE_SIZE.key(), 1000);
+    jobConf.setInt(TeraSortConfigKeys.NUM_PARTITIONS.key(), 10);
+    jobConf.setBoolean(TeraSortConfigKeys.USE_SIMPLE_PARTITIONER.key(), false);
+
+    String[] args = new String[]{Integer.toString(1000), output.toString()};
+    int result = ToolRunner.run(jobConf, new TeraGen(), args);
+    Assert.assertEquals(String.format("teragen %s", StringUtils.join(" ", args)), 0, result);
+
+    // Verify the success data.
+    ObjectStorage storage = ObjectStorageFactory.create(
+        output.toUri().getScheme(), output.toUri().getAuthority(), conf);
+    int byteSizes = 0;
+
+    Path success = new Path(output, CommitUtils.SUCCESS);
+    byte[] serializedData = CommitUtils.load(fs, success);
+    SuccessData successData = SuccessData.deserialize(serializedData);
+    Assert.assertTrue("Should execute successfully", successData.success());
+    // Assert the destination paths.
+    Assert.assertEquals(2, successData.filenames().size());
+    successData.filenames().sort(String::compareTo);
+    Assert.assertEquals(ObjectUtils.pathToKey(new Path(output, "part-m-00000")),
+        successData.filenames().get(0));
+    Assert.assertEquals(ObjectUtils.pathToKey(new Path(output, "part-m-00001")),
+        successData.filenames().get(1));
+
+    for (String partFileKey : successData.filenames()) {
+      ObjectInfo objectInfo = storage.head(partFileKey);
+      Assert.assertNotNull("Output file should be existing", objectInfo);
+      byteSizes += objectInfo.size();
+    }
+
+    Assert.assertEquals(byteSizes, 100 /* Each row 100 bytes */ * 1000 /* total 1000 rows */);
+  }
+
+  @Test
+  public void testTeraSort() throws Exception {
+    Path teraGenPath = new Path(testDataPath, "teraGen").makeQualified(fs.getUri(), fs.getWorkingDirectory());
+    Path inputPath = new Path(teraGenPath, "output");
+    Path outputPath = new Path(teraGenPath, "sortOutput");
+    JobConf jobConf = new JobConf(yarnCluster.getConfig());
+    jobConf.addResource(conf);
+    jobConf.setInt(TeraSortConfigKeys.SAMPLE_SIZE.key(), 1000);
+    jobConf.setInt(TeraSortConfigKeys.NUM_PARTITIONS.key(), 10);
+    jobConf.setBoolean(TeraSortConfigKeys.USE_SIMPLE_PARTITIONER.key(), false);
+    String[] args = new String[]{inputPath.toString(), outputPath.toString()};
+    int result = ToolRunner.run(jobConf, new TeraSort(), args);
+    Assert.assertEquals(String.format("terasort %s", StringUtils.join(" ", args)), 0, result);
+
+    // Verify the success data.
+    ObjectStorage storage = ObjectStorageFactory
+        .create(outputPath.toUri().getScheme(), outputPath.toUri().getAuthority(), conf);
+    int byteSizes = 0;
+
+    Path success = new Path(outputPath, CommitUtils.SUCCESS);
+    byte[] serializedData = CommitUtils.load(fs, success);
+    SuccessData successData = SuccessData.deserialize(serializedData);
+    Assert.assertTrue("Should execute successfully", successData.success());
+    // Assert the destination paths.
+    Assert.assertEquals(1, successData.filenames().size());
+    successData.filenames().sort(String::compareTo);
+    Assert.assertEquals(ObjectUtils.pathToKey(new Path(outputPath, "part-r-00000")), successData.filenames().get(0));
+
+    for (String partFileKey : successData.filenames()) {
+      ObjectInfo objectInfo = storage.head(partFileKey);
+      Assert.assertNotNull("Output file should be existing", objectInfo);
+      byteSizes += objectInfo.size();
+    }
+
+    Assert.assertEquals(byteSizes, 100 /* Each row 100 bytes */ * 1000 /* total 1000 rows */);
+  }
+
+  @Ignore
+  @Test
+  public void testWordCount() throws Exception {
+    Path wordCountPath = new Path(testDataPath, "wc").makeQualified(fs.getUri(), fs.getWorkingDirectory());
+    Path output = new Path(wordCountPath, "output");
+    Path input = new Path(wordCountPath, "input");
+    JobConf jobConf = new JobConf(yarnCluster.getConfig());
+    jobConf.addResource(conf);
+
+    if (!fs.mkdirs(input)) {
+      throw new IOException("Mkdirs failed to create " + input.toString());
+    }
+
+    DataOutputStream file = fs.create(new Path(input, "part-0"));
+    file.writeBytes("a a b c");
+    file.close();
+
+    String[] args = new String[]{input.toString(), output.toString()};
+    int result = ToolRunner.run(jobConf, new WordCount(), args);
+    Assert.assertEquals(String.format("WordCount %s", StringUtils.join(" ", args)), 0, result);
+
+    // Verify the success path.
+    Assert.assertTrue(fs.exists(new Path(output, CommitUtils.SUCCESS)));
+    Assert.assertTrue(fs.exists(new Path(output, "part-00000")));
+
+    Path success = new Path(output, CommitUtils.SUCCESS);
+    Assert.assertTrue("Success file must be not empty", CommitUtils.load(fs, success).length != 0);
+
+    byte[] serializedData = CommitUtils.load(fs, new Path(output, "part-00000"));
+    String outputAsStr = new String(serializedData);
+    Map<String, Integer> resAsMap = getResultAsMap(outputAsStr);
+    Assert.assertEquals(2, (int) resAsMap.get("a"));
+    Assert.assertEquals(1, (int) resAsMap.get("b"));
+    Assert.assertEquals(1, (int) resAsMap.get("c"));
+  }
+
+  private Map<String, Integer> getResultAsMap(String outputAsStr) {
+    Map<String, Integer> result = new HashMap<>();
+    for (String line : outputAsStr.split("\n")) {
+      String[] tokens = line.split("\t");
+      Assert.assertTrue(String.format("Not enough tokens in in string %s from output %s", line, outputAsStr),
+          tokens.length > 1);
+      result.put(tokens[0], Integer.parseInt(tokens[1]));
+    }
+    return result;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestCommitter.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestCommitter.java
@@ -1,0 +1,30 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.util.ParseUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+
+public class TestCommitter extends CommitterTestBase {
+  @Override
+  protected Configuration newConf() {
+    Configuration conf = new Configuration();
+    conf.set("fs.defaultFS", String.format("tos://%s", TestUtility.bucket()));
+    return conf;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestMRJob.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestMRJob.java
@@ -1,0 +1,49 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.tos.TOS;
+import org.apache.hadoop.fs.tosfs.util.ParseUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+public class TestMRJob extends MRJobTestBase {
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    // Create the new configuration and set it to the IT Case.
+    Configuration newConf = new Configuration();
+    newConf.set("fs.defaultFS", String.format("tos://%s", TestUtility.bucket()));
+    // Application in yarn cluster cannot read the environment variables from user bash, so here we
+    // set it into the config manually.
+    newConf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key("tos"),
+        ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT, false));
+    newConf.set(TosKeys.FS_TOS_ACCESS_KEY_ID,
+        ParseUtils.envAsString(TOS.ENV_TOS_ACCESS_KEY_ID, false));
+    newConf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY,
+        ParseUtils.envAsString(TOS.ENV_TOS_SECRET_ACCESS_KEY, false));
+
+    MRJobTestBase.setConf(newConf);
+    // Continue to prepare the IT Case environments.
+    MRJobTestBase.beforeClass();
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestMagicOutputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/TestMagicOutputStream.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.object.MultipartUpload;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageTestBase;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.object.Part;
+import org.apache.hadoop.fs.tosfs.object.staging.StagingPart;
+import org.apache.hadoop.fs.tosfs.object.staging.State;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class TestMagicOutputStream extends ObjectStorageTestBase {
+
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = ThreadPools.newWorkerPool("TestMagicOutputStream-pool");
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (!threadPool.isShutdown()) {
+      threadPool.shutdown();
+    }
+  }
+
+  private static Path path(String p) {
+    return new Path(p);
+  }
+
+  private static Path path(Path parent, String child) {
+    return new Path(parent, child);
+  }
+
+  @Test
+  public void testCreateDestKey() {
+    Object[][] testCases = new Object[][]{
+        new Object[]{path("tos://bucket/__magic/a.txt"), "a.txt"},
+        new Object[]{path("tos://bucket/output/__magic/job-1/tasks/tasks-attempt-0/a.txt"), "output/a.txt"},
+        new Object[]{path("tos://bucket/__magic/job0/task0/__base/a.txt"), "a.txt"},
+        new Object[]{path("tos://bucket/output/__magic/job0/task0/__base/part/part-m-1000"), "output/part/part-m-1000"},
+        new Object[]{path("tos://bucket/a/b/c/__magic/__base/d/e/f"), "a/b/c/d/e/f"},
+        new Object[]{path("tos://bucket/a/b/c/__magic/d/e/f"), "a/b/c/f"},
+    };
+
+    for (Object[] input : testCases) {
+      String actualDestKey = MagicOutputStream.toDestKey((Path) input[0]);
+      Assert.assertEquals("Unexpected destination key.", actualDestKey, input[1]);
+    }
+  }
+
+  @Test
+  public void testNonMagicPath() {
+    try (MagicOutputStream ignored = new TestingMagicOutputStream(path(testDir, "non-magic"))) {
+      Assert.fail("Cannot create magic output stream for non-magic path");
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  public void testWriteZeroByte() throws IOException {
+    Path magic = path(path(testDir, CommitUtils.MAGIC), "zero-byte.txt");
+    MagicOutputStream out = new TestingMagicOutputStream(magic);
+    // write zero-byte and close.
+    out.close();
+    assertStagingFiles(0, out.stagingParts());
+
+    // Read and validate the .pending contents
+    try (InputStream in = storage.get(out.pendingKey()).stream()) {
+      byte[] data = IOUtils.toByteArray(in);
+      Pending commit = Pending.deserialize(data);
+      Assert.assertEquals(storage.bucket().name(), commit.bucket());
+      Assert.assertEquals(out.destKey(), commit.destKey());
+      Assert.assertTrue(StringUtils.isNoneEmpty(commit.uploadId()));
+      Assert.assertTrue(commit.createdTimestamp() > 0);
+      Assert.assertEquals(1, commit.parts().size());
+      Assert.assertEquals(0, commit.length());
+      Assert.assertEquals(out.upload().uploadId(), commit.uploadId());
+    }
+  }
+
+  public void testWrite(int len) throws IOException {
+    Path magic = path(path(testDir, CommitUtils.MAGIC), len + ".txt");
+    int uploadPartSize = 8 << 20;
+    int partNum = (len - 1) / (8 << 20) + 1;
+
+    MagicOutputStream out = new TestingMagicOutputStream(magic);
+    byte[] data = TestUtility.rand(len);
+    out.write(data);
+    out.close();
+
+    assertStagingFiles(partNum, out.stagingParts());
+    Assert.assertEquals(ObjectUtils.pathToKey(magic) + CommitUtils.PENDING_SUFFIX, out.pendingKey());
+
+    Pending commit;
+    try (InputStream in = storage.get(out.pendingKey()).stream()) {
+      byte[] serializedData = IOUtils.toByteArray(in);
+      commit = Pending.deserialize(serializedData);
+      Assert.assertEquals(storage.bucket().name(), commit.bucket());
+      Assert.assertEquals(out.destKey(), commit.destKey());
+      Assert.assertTrue(commit.createdTimestamp() > 0);
+      Assert.assertEquals(len, commit.length());
+      Assert.assertEquals(out.upload().uploadId(), commit.uploadId());
+      // Verify the upload part list.
+      Assert.assertEquals(partNum, commit.parts().size());
+      if (!commit.parts().isEmpty()) {
+        for (int i = 0; i < partNum - 1; i += 1) {
+          Assert.assertEquals(uploadPartSize, commit.parts().get(i).size());
+        }
+        Part lastPart = commit.parts().get(partNum - 1);
+        Assert.assertTrue(lastPart.size() > 0 && lastPart.size() <= uploadPartSize);
+      }
+    }
+
+    // List multipart uploads
+    int uploadsNum = 0;
+    for (MultipartUpload upload : storage.listUploads(out.destKey())) {
+      uploadsNum += 1;
+      Assert.assertEquals(out.upload(), upload);
+    }
+    Assert.assertEquals(1L, uploadsNum);
+
+    // The target object is still not visible for object storage.
+    Assert.assertNull(storage.head(out.destKey()));
+
+    // Complete the upload and validate the content.
+    storage.completeUpload(out.destKey(), out.upload().uploadId(), commit.parts());
+    try (InputStream in = storage.get(out.destKey()).stream()) {
+      Assert.assertArrayEquals(data, IOUtils.toByteArray(in));
+    }
+  }
+
+  @Test
+  public void testWrite1MB() throws IOException {
+    testWrite(1 << 20);
+  }
+
+  @Test
+  public void testWrite24MB() throws IOException {
+    testWrite(24 << 20);
+  }
+
+  @Test
+  public void testWrite100MB() throws IOException {
+    testWrite(100 << 20);
+  }
+
+  private static void assertStagingFiles(int expectedNum, List<StagingPart> stagings) {
+    Assert.assertEquals(expectedNum, stagings.size());
+    for (StagingPart staging : stagings) {
+      Assert.assertEquals(State.CLEANED, staging.state());
+    }
+  }
+
+  private class TestingMagicOutputStream extends MagicOutputStream {
+
+    TestingMagicOutputStream(Path magic) {
+      super(fs, storage, threadPool, tosConf, magic);
+    }
+
+    protected void persist(Path p, byte[] data) {
+      storage().put(ObjectUtils.pathToKey(p), data);
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/CommitterTestBase.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/CommitterTestBase.java
@@ -1,0 +1,375 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit.mapred;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.commit.CommitUtils;
+import org.apache.hadoop.fs.tosfs.commit.Pending;
+import org.apache.hadoop.fs.tosfs.commit.PendingSet;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class CommitterTestBase {
+  private Configuration conf;
+  private FileSystem fs;
+  private Path outputPath;
+  private TaskAttemptID taskAttempt0;
+  private Path reportDir;
+
+  @Before
+  public void setup() throws IOException {
+    conf = newConf();
+    fs = FileSystem.get(conf);
+    String uuid = UUIDUtils.random();
+    outputPath = fs.makeQualified(new Path("/test/" + uuid));
+    taskAttempt0 = JobSuite.createTaskAttemptId(randomTrimmedJobId(), 0);
+
+    reportDir = fs.makeQualified(new Path("/report/" + uuid));
+    fs.mkdirs(reportDir);
+    conf.set(org.apache.hadoop.fs.tosfs.commit.Committer.COMMITTER_SUMMARY_REPORT_DIR,
+        reportDir.toUri().toString());
+  }
+
+  protected abstract Configuration newConf();
+
+  @After
+  public void teardown() {
+    CommonUtils.runQuietly(() -> fs.delete(outputPath, true));
+    IOUtils.closeStream(fs);
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (!TestEnv.checkTestEnabled()) {
+      return;
+    }
+
+    List<String> committerThreads = Thread.getAllStackTraces().keySet()
+        .stream()
+        .map(Thread::getName)
+        .filter(n -> n.startsWith(org.apache.hadoop.fs.tosfs.commit.Committer.THREADS_PREFIX))
+        .collect(Collectors.toList());
+    Assert.assertTrue("Outstanding committer threads", committerThreads.isEmpty());
+  }
+
+  private static String randomTrimmedJobId() {
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+    return String.format("%s%04d_%04d", formatter.format(new Date()),
+        (long) (Math.random() * 1000),
+        (long) (Math.random() * 1000));
+  }
+
+  private static String randomFormedJobId() {
+    return String.format("job_%s", randomTrimmedJobId());
+  }
+
+  @Test
+  public void testSetupJob() throws IOException {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // Setup job.
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+  }
+
+  @Test
+  public void testSetupJobWithOrphanPaths() throws IOException, InterruptedException {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // Orphan success marker.
+    Path successPath = CommitUtils.successMarker(outputPath);
+    CommitUtils.save(fs, successPath, new byte[]{});
+    Assert.assertTrue(fs.exists(successPath));
+
+    // Orphan job path.
+    Path jobPath = CommitUtils.magicJobPath(suite.committer().jobId(), outputPath);
+    fs.mkdirs(jobPath);
+    Assert.assertTrue("The job path should be existing", fs.exists(jobPath));
+    Path subPath = new Path(jobPath, "tmp.pending");
+    CommitUtils.save(fs, subPath, new byte[]{});
+    Assert.assertTrue("The sub path under job path should be existing.", fs.exists(subPath));
+    FileStatus jobPathStatus = fs.getFileStatus(jobPath);
+
+    Thread.sleep(1000L);
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+
+    Assert.assertFalse("Should have deleted the success path", fs.exists(successPath));
+    Assert.assertTrue("Should have re-created the job path", fs.exists(jobPath));
+    Assert.assertFalse("Should have deleted the sub path under the job path", fs.exists(subPath));
+  }
+
+  @Test
+  public void testSetupTask() throws IOException {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // Remaining attempt task path.
+    Path taskAttemptBasePath = CommitUtils.magicTaskAttemptBasePath(suite.taskAttemptContext(), outputPath);
+    Path subTaskAttemptPath = new Path(taskAttemptBasePath, "tmp.pending");
+    CommitUtils.save(fs, subTaskAttemptPath, new byte[]{});
+    Assert.assertTrue(fs.exists(taskAttemptBasePath));
+    Assert.assertTrue(fs.exists(subTaskAttemptPath));
+
+    // Setup job.
+    suite.setupJob();
+    suite.assertHasMagicKeys();
+    // It will clear all the job path once we've set up the job.
+    Assert.assertFalse(fs.exists(taskAttemptBasePath));
+    Assert.assertFalse(fs.exists(subTaskAttemptPath));
+
+    // Left some the task paths.
+    CommitUtils.save(fs, subTaskAttemptPath, new byte[]{});
+    Assert.assertTrue(fs.exists(taskAttemptBasePath));
+    Assert.assertTrue(fs.exists(subTaskAttemptPath));
+
+    // Setup task.
+    suite.setupTask();
+    Assert.assertFalse(fs.exists(subTaskAttemptPath));
+  }
+
+  @Test
+  public void testCommitTask() throws Exception {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    // Setup job
+    suite.setupJob();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicKeys();
+
+    // Setup task
+    suite.setupTask();
+
+    // Write records.
+    suite.assertNoMagicPendingFile();
+    suite.assertMultipartUpload(0);
+    suite.writeOutput();
+    suite.dumpObjectStorage();
+    suite.assertHasMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(1);
+    // Assert the pending file content.
+    Path pendingPath = suite.magicPendingPath();
+    byte[] pendingData = CommitUtils.load(suite.fs(), pendingPath);
+    Pending pending = Pending.deserialize(pendingData);
+    Assert.assertEquals(suite.destPartKey(), pending.destKey());
+    Assert.assertEquals(20, pending.length());
+    Assert.assertEquals(1, pending.parts().size());
+
+    // Commit the task.
+    suite.commitTask();
+
+    // Verify the pending set file.
+    suite.assertHasPendingSet();
+    // Assert the pending set file content.
+    Path pendingSetPath = suite.magicPendingSetPath();
+    byte[] pendingSetData = CommitUtils.load(suite.fs(), pendingSetPath);
+    PendingSet pendingSet = PendingSet.deserialize(pendingSetData);
+    Assert.assertEquals(suite.job().getJobID().toString(), pendingSet.jobId());
+    Assert.assertEquals(1, pendingSet.commits().size());
+    Assert.assertEquals(pending, pendingSet.commits().get(0));
+    Assert.assertEquals(pendingSet.extraData(),
+        ImmutableMap.of(CommitUtils.TASK_ATTEMPT_ID, suite.taskAttemptContext().getTaskAttemptID().toString()));
+
+    // Complete the multipart upload and verify the results.
+    ObjectStorage storage = suite.storage();
+    storage.completeUpload(pending.destKey(), pending.uploadId(), pending.parts());
+    suite.verifyPartContent();
+  }
+
+  @Test
+  public void testAbortTask() throws Exception {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+
+    // Pre-check before the output write.
+    suite.assertNoMagicPendingFile();
+    suite.assertMultipartUpload(0);
+
+    // Execute the output write.
+    suite.writeOutput();
+
+    // Post-check after the output write.
+    suite.assertHasMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(1);
+    // Assert the pending file content.
+    Path pendingPath = suite.magicPendingPath();
+    byte[] pendingData = CommitUtils.load(suite.fs(), pendingPath);
+    Pending pending = Pending.deserialize(pendingData);
+    Assert.assertEquals(suite.destPartKey(), pending.destKey());
+    Assert.assertEquals(20, pending.length());
+    Assert.assertEquals(1, pending.parts().size());
+
+    // Abort the task.
+    suite.abortTask();
+
+    // Verify the state after aborting task.
+    suite.assertNoMagicPendingFile();
+    suite.assertNoMagicMultipartUpload();
+    suite.assertMultipartUpload(0);
+    suite.assertNoTaskAttemptPath();
+  }
+
+  @Test
+  public void testCommitJob() throws Exception {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job.
+    suite.assertNoPartFiles();
+    suite.commitJob();
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.assertSummaryReport(reportDir);
+    suite.verifyPartContent();
+  }
+
+
+  @Test
+  public void testCommitJobFailed() throws Exception {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job.
+    suite.assertNoPartFiles();
+    suite.commitJob();
+  }
+
+  @Test
+  public void testTaskCommitAfterJobCommit() throws Exception {
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+    suite.setupJob();
+    suite.setupTask();
+    suite.writeOutput();
+    suite.commitTask();
+
+    // Commit the job
+    suite.assertNoPartFiles();
+    suite.commitJob();
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.verifyPartContent();
+
+    // Commit the task again.
+    Assert.assertThrows(FileNotFoundException.class, suite::commitTask);
+  }
+
+  @Test
+  public void testTaskCommitWithConsistentJobId() throws Exception {
+    Configuration conf = newConf();
+    String consistentJobId = randomFormedJobId();
+    conf.set(CommitUtils.SPARK_WRITE_UUID, consistentJobId);
+    JobSuite suite = JobSuite.create(conf, taskAttempt0, outputPath);
+    Assume.assumeFalse(suite.skipTests());
+
+    // By now, we have two "jobId"s, one is spark uuid, and the other is the jobId in taskAttempt.
+    // The job committer will adopt the former.
+    suite.setupJob();
+
+    // Next, we clear spark uuid, and set the jobId of taskAttempt to another value. In this case,
+    // the committer will take the jobId of taskAttempt as the final jobId, which is not consistent
+    // with the one that committer holds.
+    conf.unset(CommitUtils.SPARK_WRITE_UUID);
+    JobConf jobConf = new JobConf(conf);
+    String anotherJobId = randomTrimmedJobId();
+    TaskAttemptID taskAttemptId1 =
+        JobSuite.createTaskAttemptId(anotherJobId, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+    final TaskAttemptContext attemptContext1 =
+        JobSuite.createTaskAttemptContext(jobConf, taskAttemptId1, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+
+    Assert.assertThrows("JobId set in the context", IllegalArgumentException.class,
+        () -> suite.setupTask(attemptContext1));
+
+    // Even though we use another taskAttempt, as long as we ensure the spark uuid is consistent,
+    // the jobId in committer is consistent.
+    conf.set(CommitUtils.SPARK_WRITE_UUID, consistentJobId);
+    conf.set(FileOutputFormat.OUTDIR, outputPath.toString());
+    jobConf = new JobConf(conf);
+    anotherJobId = randomTrimmedJobId();
+    TaskAttemptID taskAttemptId2 =
+        JobSuite.createTaskAttemptId(anotherJobId, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+    TaskAttemptContext attemptContext2 =
+        JobSuite.createTaskAttemptContext(jobConf, taskAttemptId2, JobSuite.DEFAULT_APP_ATTEMPT_ID);
+
+    suite.setupTask(attemptContext2);
+    // Write output must use the same task context with setup task.
+    suite.writeOutput(attemptContext2);
+    // Commit task must use the same task context with setup task.
+    suite.commitTask(attemptContext2);
+    suite.assertPendingSetAtRightLocation();
+
+    // Commit the job
+    suite.assertNoPartFiles();
+    suite.commitJob();
+
+    // Verify the output.
+    suite.assertNoMagicMultipartUpload();
+    suite.assertNoMagicObjectKeys();
+    suite.assertSuccessMarker();
+    suite.verifyPartContent();
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/JobSuite.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/JobSuite.java
@@ -1,0 +1,228 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit.mapred;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.commit.BaseJobSuite;
+import org.apache.hadoop.fs.tosfs.commit.CommitUtils;
+import org.apache.hadoop.fs.tosfs.commit.SuccessData;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileOutputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.JobContextImpl;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapred.TaskAttemptContextImpl;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapred.TextOutputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.net.NetUtils;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class JobSuite extends BaseJobSuite {
+  private static final Logger LOG = LoggerFactory.getLogger(JobSuite.class);
+  private final JobContext jobContext;
+  private final TaskAttemptContext taskAttemptContext;
+  private final Committer committer;
+
+  private JobSuite(FileSystem fs, JobConf conf,
+                   TaskAttemptID taskAttemptId, int appAttemptId, Path outputPath)
+      throws IOException {
+    this.fs = fs;
+    // Initialize the job instance.
+    this.job = Job.getInstance(conf);
+    job.setJobID(JobID.forName(CommitUtils.buildJobId(conf, taskAttemptId.getJobID())));
+    this.jobContext = createJobContext(conf, taskAttemptId);
+    this.taskAttemptContext = createTaskAttemptContext(conf, taskAttemptId, appAttemptId);
+    this.jobId = CommitUtils.buildJobId(jobContext);
+
+    // Set job output directory.
+    FileOutputFormat.setOutputPath(conf, outputPath);
+    this.outputPath = outputPath;
+    this.storage = ObjectStorageFactory.create(outputPath.toUri().getScheme(),
+        outputPath.toUri().getAuthority(), conf);
+
+    // Initialize committer.
+    this.committer = new Committer();
+    this.committer.setupTask(taskAttemptContext);
+  }
+
+  public static JobSuite create(Configuration conf, TaskAttemptID taskAttemptId, Path outDir)
+      throws IOException {
+    FileSystem fs = outDir.getFileSystem(conf);
+    return new JobSuite(fs, new JobConf(conf), taskAttemptId, DEFAULT_APP_ATTEMPT_ID, outDir);
+  }
+
+  public static TaskAttemptID createTaskAttemptId(String trimmedJobId, int attemptId) {
+    String attempt = String.format("attempt_%s_m_000000_%d", trimmedJobId, attemptId);
+    return TaskAttemptID.forName(attempt);
+  }
+
+  public static JobContext createJobContext(JobConf jobConf, TaskAttemptID taskAttemptId) {
+    return new JobContextImpl(jobConf, taskAttemptId.getJobID());
+  }
+
+  public static TaskAttemptContext createTaskAttemptContext(
+      JobConf jobConf, TaskAttemptID taskAttemptId, int appAttemptId) throws IOException {
+    // Set the key values for job configuration.
+    jobConf.set(MRJobConfig.TASK_ATTEMPT_ID, taskAttemptId.toString());
+    jobConf.setInt(MRJobConfig.APPLICATION_ATTEMPT_ID, appAttemptId);
+    jobConf.set("mapred.output.committer.class",
+        Committer.class.getName()); // 2x and 3x newApiCommitter=false.
+    return new TaskAttemptContextImpl(jobConf, taskAttemptId);
+  }
+
+  public void setupJob() throws IOException {
+    committer.setupJob(jobContext);
+  }
+
+  public void setupTask() throws IOException {
+    committer.setupTask(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    committer.setupTask(taskAttemptContext);
+  }
+
+  public void writeOutput() throws Exception {
+    writeOutput(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void writeOutput(TaskAttemptContext taskAttemptContext) throws Exception {
+    RecordWriter<Object, Object> writer = new TextOutputFormat<>().getRecordWriter(fs,
+        taskAttemptContext.getJobConf(),
+        CommitUtils.buildJobId(taskAttemptContext),
+        taskAttemptContext.getProgressible());
+    NullWritable nullKey = NullWritable.get();
+    NullWritable nullVal = NullWritable.get();
+    Object[] keys = new Object[]{KEY_1, nullKey, null, nullKey, null, KEY_2};
+    Object[] vals = new Object[]{VAL_1, nullVal, null, null, nullVal, VAL_2};
+    try {
+      Assert.assertEquals(keys.length, vals.length);
+      for (int i = 0; i < keys.length; i++) {
+        writer.write(keys[i], vals[i]);
+      }
+    } finally {
+      writer.close(Reporter.NULL);
+    }
+  }
+
+  public boolean needsTaskCommit() throws IOException {
+    return committer.needsTaskCommit(taskAttemptContext);
+  }
+
+  public void commitTask() throws IOException {
+    committer.commitTask(taskAttemptContext);
+  }
+
+  // This method simulates the scenario that the job may set up task with a different
+  // taskAttemptContext, e.g., for a spark job.
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    committer.commitTask(taskAttemptContext);
+  }
+
+  public void abortTask() throws IOException {
+    committer.abortTask(taskAttemptContext);
+  }
+
+  public void commitJob() throws IOException {
+    committer.commitJob(jobContext);
+  }
+
+  @Override
+  public Path magicPartPath() {
+    return new Path(committer.getWorkPath(), committer.jobId());
+  }
+
+  @Override
+  public Path magicPendingSetPath() {
+    return CommitUtils.magicTaskPendingSetPath(taskAttemptContext, outputPath);
+  }
+
+  public TaskAttemptContext taskAttemptContext() {
+    return taskAttemptContext;
+  }
+
+  public Committer committer() {
+    return committer;
+  }
+
+  @Override
+  public void assertNoTaskAttemptPath() throws IOException {
+    Path path = CommitUtils.magicTaskAttemptBasePath(taskAttemptContext, outputPath);
+    Assert.assertFalse("Task attempt path should be not existing", fs.exists(path));
+    String pathToKey = ObjectUtils.pathToKey(path);
+    Assert.assertNull("Should have no task attempt path key", storage.head(pathToKey));
+  }
+
+  @Override
+  protected boolean skipTests() {
+    return storage.bucket().isDirectory();
+  }
+
+  @Override
+  public void assertSuccessMarker() throws IOException {
+    Path succPath = CommitUtils.successMarker(outputPath);
+    Assert.assertTrue(String.format("%s should be exists", succPath), fs.exists(succPath));
+    SuccessData successData = SuccessData.deserialize(CommitUtils.load(fs, succPath));
+    Assert.assertEquals(SuccessData.class.getName(), successData.name());
+    Assert.assertTrue(successData.success());
+    Assert.assertEquals(NetUtils.getHostname(), successData.hostname());
+    Assert.assertEquals(CommitUtils.COMMITTER_NAME, successData.committer());
+    Assert.assertEquals(
+        String.format("Task committer %s", taskAttemptContext.getTaskAttemptID()),
+        successData.description());
+    Assert.assertEquals(job.getJobID().toString(), successData.jobId());
+    Assert.assertEquals(1, successData.filenames().size());
+    Assert.assertEquals(destPartKey(), successData.filenames().get(0));
+  }
+
+  @Override
+  public void assertSummaryReport(Path reportDir) throws IOException {
+    Path reportPath = CommitUtils.summaryReport(reportDir, job().getJobID().toString());
+    Assert.assertTrue(String.format("%s should be exists", reportPath), fs.exists(reportPath));
+    SuccessData reportData = SuccessData.deserialize(CommitUtils.load(fs, reportPath));
+    Assert.assertEquals(SuccessData.class.getName(), reportData.name());
+    Assert.assertTrue(reportData.success());
+    Assert.assertEquals(NetUtils.getHostname(), reportData.hostname());
+    Assert.assertEquals(CommitUtils.COMMITTER_NAME, reportData.committer());
+    Assert.assertEquals(
+        String.format("Task committer %s", taskAttemptContext.getTaskAttemptID()),
+        reportData.description());
+    Assert.assertEquals(job.getJobID().toString(), reportData.jobId());
+    Assert.assertEquals(1, reportData.filenames().size());
+    Assert.assertEquals(destPartKey(), reportData.filenames().get(0));
+    Assert.assertEquals("clean", reportData.diagnostics().get("stage"));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/TestCommitter.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/commit/mapred/TestCommitter.java
@@ -1,0 +1,29 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.commit.mapred;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+
+public class TestCommitter extends CommitterTestBase {
+  @Override
+  protected Configuration newConf() {
+    Configuration conf = new Configuration();
+    conf.set("fs.defaultFS", String.format("tos://%s", TestUtility.bucket()));
+    return conf;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestChecksum.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestChecksum.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.AbstractFSContractTestBase;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.tosfs.RawFileSystem;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+
+public class TestChecksum extends AbstractFSContractTestBase {
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+
+  private Path testCreateNewFile(String fileName, byte[] data, boolean useBuilder) throws IOException {
+    describe("Foundational 'create a file' test, using builder API=" + useBuilder);
+    Path path = path(fileName, useBuilder);
+
+    writeDataset(getFileSystem(), path, data, data.length, 1024 * 1024, false, useBuilder);
+    ContractTestUtils.verifyFileContents(getFileSystem(), path, data);
+
+    return path;
+  }
+
+  private Path path(String filepath, boolean useBuilder) throws IOException {
+    return super.path(filepath + (useBuilder ? "" : "-builder"));
+  }
+
+  @Test
+  public void testCheckSumWithSimplePut() throws IOException {
+    byte[] data = dataset(256, 'a', 'z');
+    Path path1 = testCreateNewFile("file1", data, true);
+    Path path2 = testCreateNewFile("file2", data, true);
+    Path path3 = testCreateNewFile("file3", dataset(512, 'a', 'z'), true);
+
+    FileChecksum expected = getFileSystem().getFileChecksum(path1);
+    assertEquals("Checksum value should be same among objects with same content",
+        expected, getFileSystem().getFileChecksum(path2));
+    assertEquals("Checksum value should be same among multiple call for same object",
+        expected, getFileSystem().getFileChecksum(path1));
+    assertNotEquals("Checksum value should be different for different objects with different content",
+        expected, getFileSystem().getFileChecksum(path3));
+
+    Path renamed = path("renamed");
+    getFileSystem().rename(path1, renamed);
+    assertEquals("Checksum value should not change after rename",
+        expected, getFileSystem().getFileChecksum(renamed));
+  }
+
+  @Test
+  public void testCheckSumShouldSameViaPutAndMPU() throws IOException {
+    byte[] data = TestUtility.rand(11 << 20);
+
+    // simple put
+    Path singleFile = path("singleFile");
+    RawFileSystem fs = (RawFileSystem) getFileSystem();
+    fs.storage().put(ObjectUtils.pathToKey(singleFile), data);
+
+    // MPU upload data, the default threshold is 10MB
+    Path mpuFile = testCreateNewFile("mpuFile", data, true);
+
+    assertEquals(fs.getFileChecksum(singleFile), fs.getFileChecksum(mpuFile));
+  }
+
+  @Test
+  public void testDisableCheckSum() throws IOException {
+    Path path1 = testCreateNewFile("file1", dataset(256, 'a', 'z'), true);
+    Path path2 = testCreateNewFile("file2", dataset(512, 'a', 'z'), true);
+    assertNotEquals(getFileSystem().getFileChecksum(path1), getFileSystem().getFileChecksum(path2));
+
+    // disable checksum
+    Configuration newConf = new Configuration(getFileSystem().getConf());
+    newConf.setBoolean(ConfKeys.FS_CHECKSUM_ENABLED.key("tos"), false);
+    FileSystem newFS = FileSystem.get(newConf);
+
+    assertEquals(newFS.getFileChecksum(path1), newFS.getFileChecksum(path2));
+  }
+
+  @Test
+  public void testGetDirChecksum() throws IOException {
+    FileSystem fs = getFileSystem();
+
+    Path dir1 = path("dir1", true);
+    Path dir2 = path("dir2", true);
+    assertPathDoesNotExist("directory already exists", dir1);
+    assertPathDoesNotExist("directory already exists", dir2);
+    fs.mkdirs(dir1);
+
+    assertThrows("Path is not a file", FileNotFoundException.class,
+        () -> getFileSystem().getFileChecksum(dir1));
+    assertThrows("No such file or directory", FileNotFoundException.class,
+        () -> getFileSystem().getFileChecksum(dir2));
+
+    assertDeleted(dir1, false);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestCreate.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestCreate.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class TestCreate extends AbstractContractCreateTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestDelete.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestDelete.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractDeleteTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.fs.tosfs.object.ObjectTestUtils.assertDirExist;
+import static org.apache.hadoop.fs.tosfs.object.ObjectTestUtils.assertObjectNotExist;
+
+public class TestDelete extends AbstractContractDeleteTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+
+  @Test
+  public void testParentDirCreatedAfterDeleteSubChildren() throws IOException {
+    Path path = path("testParentDirCreatedAfterDeleteSubChildren/");
+    Path file1 = new Path(path, "f1");
+    Path file2 = new Path(path, "f2");
+    ContractTestUtils.writeTextFile(getFileSystem(), file1,
+        "the first file", true);
+    ContractTestUtils.writeTextFile(getFileSystem(), file2,
+        "the second file", true);
+    assertPathExists("file1 not created", file1);
+    assertPathExists("file1 not created", file2);
+
+    assertObjectNotExist(path, false);
+    assertObjectNotExist(path, true);
+
+    assertDeleted(file1, false);
+    assertPathExists("parent path should exist", path);
+
+    assertObjectNotExist(path, false);
+    assertDirExist(path);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestDistCp.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestDistCp.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.tools.contract.AbstractContractDistCpTest;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestDistCp extends AbstractContractDistCpTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+
+  // ignore this test case as there is intermittent IllegalStateException issue
+  @Test
+  public void testDistCpWithIterator() {
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestGetFileStatus.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestGetFileStatus.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractGetFileStatusTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.RawFileStatus;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.Constants;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+
+@RunWith(Parameterized.class)
+public class TestGetFileStatus extends AbstractContractGetFileStatusTest {
+
+  private final boolean getFileStatusEnabled;
+
+  @Parameterized.Parameters(name = "getFileStatusEnabled={0}")
+  public static List<Boolean> createParameters() {
+    return Arrays.asList(false, true);
+  }
+
+  public TestGetFileStatus(boolean getFileStatusEnabled) {
+    this.getFileStatusEnabled = getFileStatusEnabled;
+  }
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    conf.setBoolean(TosKeys.FS_TOS_GET_FILE_STATUS_ENABLED, getFileStatusEnabled);
+    conf.setBoolean(ConfKeys.FS_ASYNC_CREATE_MISSED_PARENT.key("tos"), false);
+    return new TosContract(conf);
+  }
+
+  @Test
+  public void testDirModificationTimeShouldNotBeZero() throws IOException {
+    FileSystem fs = getFileSystem();
+    Path path = getContract().getTestPath();
+    fs.delete(path, true);
+
+    Path subfolder = path.suffix('/' + this.methodName.getMethodName() + "-" + UUIDUtils.random());
+    mkdirs(subfolder);
+
+    FileStatus fileStatus = fs.getFileStatus(path);
+    assertTrue(fileStatus.getModificationTime() > 0);
+  }
+
+  @Test
+  public void testThrowExceptionWhenListStatusForNonExistPath() {
+    FileSystem fs = getFileSystem();
+    Path path = getContract().getTestPath();
+
+    assertThrows("Path doesn't exist", FileNotFoundException.class,
+        () -> fs.listStatusIterator(new Path(path, "testListStatusForNonExistPath")));
+  }
+
+  @Test
+  public void testPathStatNonexistentFile() {
+    FileSystem fs = getFileSystem();
+    // working dir does not exist.
+    Path file = new Path(getContract().getTestPath(), this.methodName.getMethodName());
+    assertThrows("Path doesn't exist", FileNotFoundException.class, () -> fs.getFileStatus(file));
+  }
+
+  @Test
+  public void testPathStatExistentFile() throws IOException {
+    FileSystem fs = getFileSystem();
+    Path file = new Path(getContract().getTestPath(), this.methodName.getMethodName());
+
+    int size = 1 << 20;
+    byte[] data = dataset(size, 'a', 'z');
+    createFile(fs, file, true, data);
+    FileStatus status = fs.getFileStatus(file);
+    Assert.assertTrue(status.isFile());
+    Assert.assertTrue(status.getModificationTime() > 0);
+    Assert.assertEquals(size, status.getLen());
+  }
+
+  @Test
+  public void testPathStatEmptyDirectory() throws IOException {
+    FileSystem fs = getFileSystem();
+    Path workingPath = new Path(getContract().getTestPath(), this.methodName.getMethodName());
+    mkdirs(workingPath);
+
+    FileStatus dirStatus = fs.getFileStatus(workingPath);
+    Assert.assertTrue(dirStatus.isDirectory());
+    Assert.assertTrue(dirStatus.getModificationTime() > 0);
+    if (dirStatus instanceof RawFileStatus) {
+      Assert.assertArrayEquals(Constants.MAGIC_CHECKSUM, ((RawFileStatus) dirStatus).checksum());
+    }
+  }
+
+  @Test
+  public void testPathStatWhenCreateSubDir() throws IOException {
+    FileSystem fs = getFileSystem();
+    Path workintPath = new Path(getContract().getTestPath(), this.methodName.getMethodName());
+    // create sub directory directly.
+    Path subDir = new Path(workintPath, UUIDUtils.random());
+    mkdirs(subDir);
+    Assert.assertTrue(fs.getFileStatus(subDir).isDirectory());
+
+    // can get FileStatus of working dir.
+    Assert.assertTrue(fs.getFileStatus(workintPath).isDirectory());
+    // delete sub directory.
+    fs.delete(subDir, true);
+    // still cat get FileStatus of working dir.
+    Assert.assertTrue(fs.getFileStatus(workintPath).isDirectory());
+  }
+
+  @Test
+  public void testPathStatDirNotExistButSubFileExist() throws IOException {
+    FileSystem fs = getFileSystem();
+    // working dir does not exist.
+    Path workintPath = new Path(getContract().getTestPath(), this.methodName.getMethodName());
+    assertThrows("Path doesn't exist", FileNotFoundException.class, () -> fs.getFileStatus(workintPath));
+
+    // create sub file in working dir directly.
+    Path file = workintPath.suffix('/' + UUIDUtils.random());
+    touch(fs, file);
+
+    // can get FileStatus of working dir.
+    Assert.assertTrue(fs.getFileStatus(workintPath).isDirectory());
+
+    // delete sub file, will create parent directory.
+    fs.delete(file, false);
+    Assert.assertTrue(fs.getFileStatus(workintPath).isDirectory());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestMkdir.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestMkdir.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class TestMkdir extends AbstractContractMkdirTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestOpen.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestOpen.java
@@ -1,0 +1,74 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.RawFileStatus;
+import org.apache.hadoop.fs.tosfs.RawFileSystem;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.object.exceptions.ChecksumMismatchException;
+import org.apache.hadoop.fs.tosfs.util.Range;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+
+public class TestOpen extends AbstractContractOpenTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+
+  @Test
+  public void testOpenAExpiredFile() throws IOException {
+    Path file = path("testOpenAOutageFile");
+    FileSystem fs = getFileSystem();
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(fs, file, data, data.length, 1024 * 1024, true);
+
+    FileStatus fileStatus = fs.getFileStatus(file);
+    if (fs instanceof RawFileSystem) {
+      byte[] expectChecksum = ((RawFileStatus) fileStatus).checksum();
+      FSDataInputStream fsDataInputStream =
+          ((RawFileSystem) fs).open(file, expectChecksum, Range.of(0, Long.MAX_VALUE));
+      fsDataInputStream.close();
+
+      // update the file
+      data = dataset(512, 'a', 'z');
+      writeDataset(fs, file, data, data.length, 1024 * 1024, true);
+
+      FSDataInputStream newStream = ((RawFileSystem) fs).open(file, expectChecksum, Range.of(0, Long.MAX_VALUE));
+      assertThrows("the file is expired", ChecksumMismatchException.class, () -> newStream.read());
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestRename.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestRename.java
@@ -1,0 +1,278 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+
+public class TestRename extends AbstractContractRenameTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    // Add follow two keys into hadoop configuration.
+    String defaultScheme = FileSystem.getDefaultUri(conf).getScheme();
+    Configuration newConf = new Configuration(conf);
+    newConf.setLong(ConfKeys.FS_MULTIPART_SIZE.key(defaultScheme), ConfKeys.FS_MULTIPART_SIZE_DEFAULT);
+    newConf.setLong(ConfKeys.FS_MULTIPART_THRESHOLD.key(defaultScheme),
+        ConfKeys.FS_MULTIPART_THRESHOLD_DEFAULT);
+
+    return new TosContract(newConf);
+  }
+
+  @Test
+  public void testSucceedRenameFile() throws IOException {
+    describe("check if source file and dest file exists when succeed to rename");
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+    FileSystem fs = getFileSystem();
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(fs, renameSrc, data, data.length, 1024 * 1024, true);
+    boolean renamed = rename(renameSrc, renameDest);
+    assertTrue(renamed);
+    assertPathExists("dest file should exist when succeed to rename", renameDest);
+    assertPathDoesNotExist("source file should not exist when succeed to rename", renameSrc);
+  }
+
+  @Test
+  public void testSucceedRenameDir() throws IOException {
+    describe("check if source dir and dest dir exists when succeed to rename");
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+    int fileNums = 10;
+    int byteSize = 10 << 20; // trigger multipart upload
+    FileSystem fs = getFileSystem();
+    for (int i = 0; i < fileNums; i++) {
+      byte[] data = dataset(byteSize >> i, 'a', 'z');
+      writeDataset(fs, new Path(renameSrc, String.format("src%02d", i)), data, data.length, 1024 * 1024, true);
+    }
+    boolean renamed = rename(renameSrc, renameDest);
+    assertTrue(renamed);
+    for (int i = 0; i < fileNums; i++) {
+      Path srcFilePath = new Path(renameSrc, String.format("src%02d", i));
+      Path dstFilePath = new Path(renameDest, String.format("src%02d", i));
+      byte[] data = dataset(byteSize >> i, 'a', 'z');
+      assertPathExists("dest file should exist when succeed to rename", dstFilePath);
+      assertPathDoesNotExist("source file should not exist when succeed to rename", srcFilePath);
+      try (InputStream is = fs.open(dstFilePath)) {
+        assertArrayEquals(data, IOUtils.toByteArray(is));
+      }
+    }
+  }
+
+  @Test
+  public void testFailedRename() throws IOException {
+    describe("check if source file and dest file exists when failed to rename");
+    Path renameSrc = path("src/renameSrc");
+    Path renameDest = path("src/renameSrc/renameDst");
+    FileSystem fs = getFileSystem();
+    byte[] data = dataset(256, 'a', 'z');
+    writeDataset(fs, renameSrc, data, data.length, 1024 * 1024, true);
+    boolean renamed;
+    try {
+      renamed = rename(renameSrc, renameDest);
+    } catch (IOException e) {
+      renamed = false;
+    }
+    assertFalse(renamed);
+    assertPathExists("source file should exist when failed to rename", renameSrc);
+    assertPathDoesNotExist("dest file should not exist when failed to rename", renameDest);
+  }
+
+  @Test
+  public void testRenameSmallFile() throws IOException {
+    testRenameFileByPut(1 << 20);
+    testRenameFileByPut(3 << 20);
+  }
+
+  @Test
+  public void testRenameLargeFile() throws IOException {
+    testRenameFileByUploadParts(16 << 20);
+    testRenameFileByUploadParts(10 << 20);
+  }
+
+  @Test
+  public void testRenameDirWithSubFileAndSubDir() throws IOException {
+    FileSystem fs = getFileSystem();
+
+    Path renameSrc = path("dir/renameSrc");
+    Path renameDest = path("dir/renameDst");
+    int size = 1024;
+    byte[] data = dataset(size, 'a', 'z');
+    String fileName = "file.txt";
+    writeDataset(fs, new Path(renameSrc, fileName), data, data.length, 1024, true);
+
+    String dirName = "dir";
+    Path dirPath = new Path(renameSrc, dirName);
+    mkdirs(dirPath);
+    assertPathExists("source dir should exist", dirPath);
+
+    boolean renamed = fs.rename(renameSrc, renameDest);
+
+    assertTrue(renamed);
+    Path srcFilePath = new Path(renameSrc, fileName);
+    Path dstFilePath = new Path(renameDest, fileName);
+    assertPathExists("dest file should exist when succeed to rename", dstFilePath);
+    assertPathDoesNotExist("source file should not exist when succeed to rename", srcFilePath);
+
+    assertPathExists("dest dir should exist when succeed to rename", new Path(renameDest, dirName));
+    assertPathDoesNotExist("source dir should not exist when succeed to rename", new Path(renameSrc, dirName));
+
+    ContractTestUtils.cleanup("TEARDOWN", fs, getContract().getTestPath());
+  }
+
+  public void testRenameFileByPut(int size) throws IOException {
+    describe("check if use put method when rename file");
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+    FileSystem fs = getFileSystem();
+
+    byte[] data = dataset(size, 'a', 'z');
+    String fileName = String.format("%sMB.txt", size >> 20);
+    writeDataset(fs, new Path(renameSrc, fileName), data, data.length, 1024 * 1024, true);
+    boolean renamed = fs.rename(renameSrc, renameDest);
+
+    assertTrue(renamed);
+    Path srcFilePath = new Path(renameSrc, fileName);
+    Path dstFilePath = new Path(renameDest, fileName);
+    assertPathExists("dest file should exist when succeed to rename", dstFilePath);
+    assertPathDoesNotExist("source file should not exist when succeed to rename", srcFilePath);
+
+    assertPathExists("dest src should exist when succeed to rename", renameDest);
+    assertPathDoesNotExist("source src should not exist when succeed to rename", renameSrc);
+
+    try (InputStream is = fs.open(dstFilePath)) {
+      assertArrayEquals(data, IOUtils.toByteArray(is));
+    }
+    ContractTestUtils.cleanup("TEARDOWN", fs, getContract().getTestPath());
+  }
+
+  @Test
+  public void testCreateParentDirAfterRenameSubFile() throws IOException {
+    FileSystem fs = getFileSystem();
+
+    Path srcDir = path("srcDir");
+    Path destDir = path("destDir");
+
+    assertPathDoesNotExist("Src dir should not exist", srcDir);
+    assertPathDoesNotExist("Dest dir should not exist", destDir);
+    int size = 1 << 20;
+    byte[] data = dataset(size, 'a', 'z');
+    String fileName = String.format("%sMB.txt", size >> 20);
+    Path srcFile = new Path(srcDir, fileName);
+    Path destFile = new Path(destDir, fileName);
+    writeDataset(fs, srcFile, data, data.length, 1024 * 1024, true);
+
+    assertPathExists("Src file should exist", srcFile);
+    assertPathExists("Src dir should exist", srcDir);
+
+    mkdirs(destDir);
+    assertPathExists("Dest dir should exist", destDir);
+
+    boolean renamed = fs.rename(srcFile, destFile);
+    assertTrue(renamed);
+
+    assertPathExists("Dest file should exist", destFile);
+    assertPathExists("Dest dir should exist", destDir);
+    assertPathDoesNotExist("Src file should not exist", srcFile);
+    assertPathExists("Src dir should exist", srcDir);
+  }
+
+  @Test
+  public void testCreateParentDirAfterRenameSubDir() throws IOException {
+    FileSystem fs = getFileSystem();
+
+    Path srcDir = path("srcDir");
+    Path destDir = path("destDir");
+
+    assertPathDoesNotExist("Src dir should not exist", srcDir);
+    assertPathDoesNotExist("Dest dir should not exist", destDir);
+
+    String subDirName = String.format("subDir");
+    Path srcSubDir = new Path(srcDir, subDirName);
+    Path destDestDir = new Path(destDir, subDirName);
+    mkdirs(srcSubDir);
+
+    assertPathExists("Src sub dir should exist", srcSubDir);
+    assertPathExists("Src dir should exist", srcDir);
+
+    mkdirs(destDir);
+    assertPathExists("Dest dir should exist", destDir);
+
+    boolean renamed = fs.rename(srcSubDir, destDestDir);
+    assertTrue(renamed);
+
+    assertPathExists("Dest sub dir should exist", destDestDir);
+    assertPathExists("Dest dir should exist", destDir);
+    assertPathDoesNotExist("Src sub dir should not exist", srcSubDir);
+    assertPathExists("Src sub dir should exist", srcDir);
+  }
+
+  public void testRenameFileByUploadParts(int size) throws IOException {
+    describe("check if use upload parts method when rename file");
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+    FileSystem fs = getFileSystem();
+
+    byte[] data = dataset(size, 'a', 'z');
+    String fileName = String.format("%sMB.txt", size >> 20);
+    writeDataset(fs, new Path(renameSrc, fileName), data, data.length, 1024 * 1024, true);
+    boolean renamed = fs.rename(renameSrc, renameDest);
+
+    assertTrue(renamed);
+    Path srcFilePath = new Path(renameSrc, fileName);
+    Path dstFilePath = new Path(renameDest, fileName);
+    assertPathExists("dest file should exist when succeed to rename", dstFilePath);
+    assertPathDoesNotExist("source file should not exist when succeed to rename", srcFilePath);
+
+    try (InputStream is = fs.open(dstFilePath)) {
+      assertArrayEquals(data, IOUtils.toByteArray(is));
+    }
+    ContractTestUtils.cleanup("TEARDOWN", fs, getContract().getTestPath());
+  }
+
+  @Ignore
+  @Test
+  public void testRenameFileUnderFileSubdir() {
+  }
+
+  @Ignore
+  @Test
+  public void testRenameFileUnderFile() {
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestRootDir.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestRootDir.java
@@ -1,0 +1,37 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class TestRootDir extends AbstractContractRootDirectoryTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestSeek.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestSeek.java
@@ -1,0 +1,37 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractSeekTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class TestSeek extends AbstractContractSeekTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestUnbuffer.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestUnbuffer.java
@@ -1,0 +1,37 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.contract.AbstractContractUnbufferTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class TestUnbuffer extends AbstractContractUnbufferTest {
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestXAttr.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TestXAttr.java
@@ -1,0 +1,177 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.fs.contract.AbstractFSContractTestBase;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.common.Bytes;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+public class TestXAttr extends AbstractFSContractTestBase {
+  private static final String XATTR_NAME = "xAttrName";
+  private static final byte[] XATTR_VALUE = "xAttrValue".getBytes();
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  protected AbstractFSContract createContract(Configuration conf) {
+    return new TosContract(conf);
+  }
+
+  @Test
+  public void testGetNonExistedXAttr() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testSetAndGet/file");
+    fs.create(path).close();
+
+    fs.setXAttr(path, XATTR_NAME, XATTR_VALUE);
+    assertThrows("Not found.", IOException.class,
+        () -> fs.getXAttr(path, "non-exist"));
+    assertThrows("Not found.", IOException.class,
+        () -> fs.getXAttrs(path, Arrays.asList("non-exist")));
+    assertThrows("Not found.", IOException.class,
+        () -> fs.getXAttrs(path, Arrays.asList("non-exist", XATTR_NAME)));
+  }
+
+  @Test
+  public void testSetAndGetWhenPathNotExist() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testXAttrWhenPathNotExist/file");
+    fs.delete(path);
+
+    assertThrows("No such file", FileNotFoundException.class,
+        () -> fs.setXAttr(path, XATTR_NAME, XATTR_VALUE));
+    assertThrows("No such file", FileNotFoundException.class,
+        () -> fs.getXAttrs(path));
+    assertThrows("No such file", FileNotFoundException.class,
+        () -> fs.removeXAttr(path, "name"));
+  }
+
+  @Test
+  public void testSetAndGet() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testSetAndGet/file");
+    fs.create(path).close();
+
+    fs.setXAttr(path, XATTR_NAME, XATTR_VALUE);
+    assertArrayEquals(XATTR_VALUE, fs.getXAttr(path, XATTR_NAME));
+  }
+
+  @Test
+  public void testSetAndGetNonExistedObject() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testSetAndGetOnNonExistedObject/dir-0/dir-1/file");
+    fs.create(path).close();
+
+    Path nonExistedPath = path.getParent().getParent();
+    fs.setXAttr(nonExistedPath, XATTR_NAME, XATTR_VALUE);
+    assertThrows("Not found.", IOException.class,
+        () -> fs.getXAttr(nonExistedPath, XATTR_NAME));
+  }
+
+  @Test
+  public void testSetAndGetOnExistedObjectDir() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testSetAndGetOnDir/dir-0/dir-1");
+    fs.mkdirs(path);
+
+    fs.setXAttr(path, XATTR_NAME, XATTR_VALUE);
+    assertThrows("Not found.", IOException.class,
+        () -> fs.getXAttr(path, XATTR_NAME));
+  }
+
+  @Test
+  public void testGetAndListAll() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testGetAndListAll/file");
+    fs.create(path).close();
+
+    int size = 10;
+    for (int i = 0; i < size; i++) {
+      fs.setXAttr(path, XATTR_NAME + i, Bytes.toBytes("VALUE" + i));
+    }
+
+    Map<String, byte[]> result = fs.getXAttrs(path);
+    assertEquals(size, result.size());
+    for (int i = 0; i < size; i++) {
+      assertEquals("VALUE" + i, Bytes.toString(result.get(XATTR_NAME + i)));
+    }
+
+    List<String> names = fs.listXAttrs(path);
+    assertEquals(size, names.size());
+    for (int i = 0; i < size; i++) {
+      assertTrue(names.contains(XATTR_NAME + i));
+    }
+  }
+
+  @Test
+  public void testRemove() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testRemove/file");
+    fs.create(path).close();
+
+    int size = 10;
+    for (int i = 0; i < size; i++) {
+      fs.setXAttr(path, XATTR_NAME + i, Bytes.toBytes("VALUE" + i));
+    }
+
+    for (int i = 0; i < size; i++) {
+      fs.removeXAttr(path, XATTR_NAME + i);
+      String name = XATTR_NAME + i;
+      assertThrows("Not found.", IOException.class,
+          () -> fs.getXAttr(path, name));
+      assertEquals(size - 1 - i, fs.listXAttrs(path).size());
+    }
+  }
+
+  @Test
+  public void testXAttrFlag() throws Exception {
+    FileSystem fs = getFileSystem();
+    Path path = path("testXAttrFlag/file");
+    fs.create(path).close();
+
+    String key = XATTR_NAME;
+    byte[] value = XATTR_VALUE;
+    assertThrows("The CREATE flag must be specified", IOException.class,
+        () -> fs.setXAttr(path, key, value, EnumSet.of(XAttrSetFlag.REPLACE)));
+    fs.setXAttr(path, key, value, EnumSet.of(XAttrSetFlag.CREATE));
+    assertArrayEquals(value, fs.getXAttr(path, key));
+
+    byte[] newValue = Bytes.toBytes("new value");
+    assertThrows("The REPLACE flag must be specified", IOException.class,
+        () -> fs.setXAttr(path, key, newValue, EnumSet.of(XAttrSetFlag.CREATE)));
+    fs.setXAttr(path, key, newValue, EnumSet.of(XAttrSetFlag.REPLACE));
+    assertArrayEquals(newValue, fs.getXAttr(path, key));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TosContract.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/contract/TosContract.java
@@ -1,0 +1,62 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.contract;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.AbstractBondedFSContract;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TosContract extends AbstractBondedFSContract {
+  private static final Logger LOG = LoggerFactory.getLogger(TosContract.class);
+  private final String testDir;
+
+  public TosContract(Configuration conf) {
+    super(conf);
+    addConfResource("contract/tos.xml");
+    // Set the correct contract test path if there is a provided bucket name from environment.
+    if (StringUtils.isNoneEmpty(TestUtility.bucket())) {
+      conf.set("fs.contract.test.fs.tos", String.format("tos://%s/", TestUtility.bucket()));
+    }
+
+    testDir = "/test-" + UUIDUtils.random();
+  }
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  public String getScheme() {
+    return "tos";
+  }
+
+  @Override
+  public Path getTestPath() {
+    LOG.info("the test dir is: {}", testDir);
+    return new Path(testDir);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/ObjectStorageTestBase.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/ObjectStorageTestBase.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class ObjectStorageTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(ObjectStorageTestBase.class);
+  protected Configuration conf;
+  protected Configuration tosConf;
+  protected Path testDir;
+  protected FileSystem fs;
+  protected String scheme;
+  protected ObjectStorage storage;
+
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("The test temporary folder is {}", tempDir.getRoot().getAbsolutePath());
+
+    String tempDirPath = tempDir.getRoot().getAbsolutePath();
+    conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key("filestore"), tempDirPath);
+    conf.set("fs.filestore.impl", LocalFileSystem.class.getName());
+    tosConf = new Configuration(conf);
+    // Set the environment variable for ObjectTestUtils#assertObject
+    TestUtility.setSystemEnv(FileStore.ENV_FILE_STORAGE_ROOT, tempDirPath);
+
+    testDir = new Path("filestore://" + FileStore.DEFAULT_BUCKET + "/", UUIDUtils.random());
+    fs = testDir.getFileSystem(conf);
+    scheme = testDir.toUri().getScheme();
+    storage = ObjectStorageFactory.create(scheme, testDir.toUri().getAuthority(), tosConf);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (storage != null) {
+      // List all keys with test dir prefix and delete them.
+      String prefix = ObjectUtils.pathToKey(testDir);
+      CommonUtils.runQuietly(() -> storage.deleteAll(prefix));
+      // List all multipart uploads and abort them.
+      CommonUtils.runQuietly(() -> {
+        for (MultipartUpload upload : storage.listUploads(prefix)) {
+          LOG.info("Abort the multipart upload {}", upload);
+          storage.abortMultipartUpload(upload.key(), upload.uploadId());
+        }
+      });
+
+      storage.close();
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/ObjectTestUtils.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/ObjectTestUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Objects;
+
+public class ObjectTestUtils {
+
+  public static final byte[] EMPTY_BYTES = new byte[]{};
+
+  private ObjectTestUtils() {
+  }
+
+  /**
+   * Assert that all the parent directories should be existing.
+   *
+   * @param path to validate, can be directory or file.
+   */
+  public static void assertParentDirExist(Path path) throws IOException {
+    for (Path p = path.getParent(); p != null && p.getParent() != null; p = p.getParent()) {
+      assertObject(p, EMPTY_BYTES, true);
+    }
+  }
+
+  /**
+   * Assert that all the parent directories and current directory should be existing.
+   *
+   * @param path to validate, must be a directory.
+   */
+  public static void assertDirExist(Path path) throws IOException {
+    // All parent directories exist.
+    assertParentDirExist(path);
+    // The current directory exist.
+    assertObject(path, EMPTY_BYTES, true);
+  }
+
+  public static void assertObjectNotExist(Path path) throws IOException {
+    assertObjectNotExist(path, false);
+  }
+
+  public static void assertObjectNotExist(Path path, boolean isDir) throws IOException {
+    ObjectStorage store = ObjectStorageFactory.create(
+        path.toUri().getScheme(), path.toUri().getHost(), new Configuration());
+    String objectKey = ObjectUtils.pathToKey(path, isDir);
+    ObjectInfo info = store.head(objectKey);
+    Assert.assertNull(String.format("Object key %s shouldn't exist in backend storage.", objectKey), info);
+
+    store.close();
+  }
+
+  public static void assertObject(Path path, byte[] data) throws IOException {
+    assertObject(path, data, false);
+  }
+
+  public static void assertObject(Path path, byte[] data, boolean isDir) throws IOException {
+    ObjectStorage store = ObjectStorageFactory.create(
+        path.toUri().getScheme(), path.toUri().getHost(), new Configuration());
+    String objectKey = ObjectUtils.pathToKey(path, isDir);
+    // Verify the existence of object.
+    ObjectInfo info = store.head(objectKey);
+    Assert.assertNotNull(String.format("there should be an key %s in object storage", objectKey), info);
+    Assert.assertEquals(info.key(), objectKey);
+    Assert.assertEquals(data.length, info.size());
+    // Verify the data content.
+    try (InputStream in = store.get(objectKey, 0, -1).stream()) {
+      byte[] actual = IOUtils.toByteArray(in);
+      Assert.assertArrayEquals("Unexpected binary", data, actual);
+    }
+
+    store.close();
+  }
+
+  public static void assertMultipartUploadExist(Path path, String uploadId) throws IOException {
+    ObjectStorage store = ObjectStorageFactory.create(
+        path.toUri().getScheme(), path.toUri().getHost(), new Configuration());
+    String objectKey = ObjectUtils.pathToKey(path, false);
+
+    Iterator<MultipartUpload> uploadIterator = store.listUploads(objectKey).iterator();
+    Assert.assertTrue(uploadIterator.hasNext());
+    assertMultipartUploadIdExist(uploadIterator, uploadId);
+
+    store.close();
+  }
+
+  private static void assertMultipartUploadIdExist(Iterator<MultipartUpload> uploadIterator, String uploadId) {
+    boolean exist = false;
+    while (uploadIterator.hasNext()) {
+      if (Objects.equals(uploadIterator.next().uploadId(), uploadId)) {
+        exist = true;
+      }
+    }
+    Assert.assertTrue(exist);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestDirectoryStorage.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestDirectoryStorage.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.tosfs.util.TestUtility.scheme;
+
+public class TestDirectoryStorage {
+  private final ObjectStorage storage;
+
+  public TestDirectoryStorage() {
+    Configuration conf = new Configuration();
+    storage =
+        ObjectStorageFactory.createWithPrefix(String.format("%s-%s/", scheme(), UUIDUtils.random()),
+            scheme(), TestUtility.bucket(), conf);
+  }
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @After
+  public void tearDown() {
+    CommonUtils.runQuietly(() -> storage.deleteAll(""));
+    for (MultipartUpload upload : storage.listUploads("")) {
+      storage.abortMultipartUpload(upload.key(), upload.uploadId());
+    }
+  }
+
+  @Test
+  public void testListEmptyDir() {
+    String key = "testListEmptyDir/";
+    mkdir(key);
+    Assert.assertNotNull(directoryStorage().head(key));
+
+    Assert.assertFalse(directoryStorage().listDir(key, false).iterator().hasNext());
+    Assert.assertFalse(directoryStorage().listDir(key, false).iterator().hasNext());
+    Assert.assertTrue(directoryStorage().isEmptyDir(key));
+  }
+
+  @Test
+  public void testListNonExistDir() {
+    String key = "testListNonExistDir/";
+    Assert.assertNull(directoryStorage().head(key));
+
+    Assert.assertFalse(directoryStorage().listDir(key, false).iterator().hasNext());
+    Assert.assertFalse(directoryStorage().listDir(key, false).iterator().hasNext());
+    Assert.assertTrue(directoryStorage().isEmptyDir(key));
+  }
+
+  @Test
+  public void testRecursiveList() {
+    String root = "root/";
+    String file1 = "root/file1";
+    String file2 = "root/afile2";
+    String dir1 = "root/dir1/";
+    String file3 = "root/dir1/file3";
+
+    mkdir(root);
+    mkdir(dir1);
+    touchFile(file1, TestUtility.rand(8));
+    touchFile(file2, TestUtility.rand(8));
+    touchFile(file3, TestUtility.rand(8));
+
+    Assertions.assertThat(directoryStorage().listDir(root, false))
+        .hasSize(3)
+        .extracting(ObjectInfo::key)
+        .contains(dir1, file1, file2);
+
+    Assertions.assertThat(directoryStorage().listDir(root, true))
+        .hasSize(4)
+        .extracting(ObjectInfo::key)
+        .contains(dir1, file1, file2, file3);
+  }
+
+  @Test
+  public void testRecursiveListWithSmallBatch() {
+    Configuration conf = new Configuration(directoryStorage().conf());
+    conf.setInt(TosKeys.FS_TOS_LIST_OBJECTS_COUNT, 5);
+    directoryStorage().initialize(conf, directoryStorage().bucket().name());
+
+    String root = "root/";
+    mkdir(root);
+
+    // Create 2 files start with 'a', 2 sub dirs start with 'b', 2 files start with 'c'
+    for (int i = 1; i <= 2; i++) {
+      touchFile("root/a-file-" + i, TestUtility.rand(8));
+      mkdir("root/b-dir-" + i + "/");
+      touchFile("root/c-file-" + i, TestUtility.rand(8));
+    }
+
+    // Create two files under each sub dirs.
+    for (int j = 1; j <= 2; j++) {
+      touchFile(String.format("root/b-dir-%d/file1", j), TestUtility.rand(8));
+      touchFile(String.format("root/b-dir-%d/file2", j), TestUtility.rand(8));
+    }
+
+    Assertions.assertThat(directoryStorage().listDir(root, false))
+        .hasSize(6)
+        .extracting(ObjectInfo::key)
+        .contains(
+            "root/a-file-1", "root/a-file-2",
+            "root/b-dir-1/", "root/b-dir-2/",
+            "root/c-file-1", "root/c-file-2");
+
+    Assertions.assertThat(directoryStorage().listDir(root, true))
+        .hasSize(10)
+        .extracting(ObjectInfo::key)
+        .contains(
+            "root/a-file-1", "root/a-file-2",
+            "root/b-dir-1/", "root/b-dir-1/file1", "root/b-dir-1/file2",
+            "root/b-dir-2/", "root/b-dir-2/file1", "root/b-dir-2/file2",
+            "root/c-file-1", "root/c-file-2");
+  }
+
+  @Test
+  public void testRecursiveListRoot() {
+    String root = "root/";
+    String dir1 = "root/dir1/";
+    mkdir(root);
+    mkdir(dir1);
+
+    Assertions.assertThat(directoryStorage().listDir("", true))
+        .hasSize(2)
+        .extracting(ObjectInfo::key)
+        .contains("root/", "root/dir1/");
+  }
+
+  @Test
+  public void testDeleteEmptyDir() {
+    String dir = "a/b/";
+    mkdir(dir);
+
+    directoryStorage().deleteDir(dir, false);
+    Assert.assertNull(directoryStorage().head(dir));
+  }
+
+  @Test
+  public void testDeleteNonEmptyDir() {
+    String dir = "a/b/";
+    String subDir = "a/b/c/";
+    String file = "a/b/file.txt";
+    mkdir(dir);
+    mkdir(subDir);
+    touchFile(file, new byte[10]);
+
+    Assert.assertThrows(RuntimeException.class, () -> directoryStorage().deleteDir(dir, false));
+    Assert.assertNotNull(directoryStorage().head(dir));
+    Assert.assertNotNull(directoryStorage().head(subDir));
+    Assert.assertNotNull(directoryStorage().head(file));
+
+    directoryStorage().deleteDir(dir, true);
+    Assert.assertNull(directoryStorage().head(dir));
+    Assert.assertNull(directoryStorage().head(subDir));
+    Assert.assertNull(directoryStorage().head(file));
+  }
+
+  @Test
+  public void testRecursiveDeleteDirViaTosSDK() {
+    Configuration conf = new Configuration(directoryStorage().conf());
+    conf.setBoolean(TosKeys.FS_TOS_RMR_CLIENT_ENABLE, true);
+    directoryStorage().initialize(conf, directoryStorage().bucket().name());
+
+    testDeleteNonEmptyDir();
+  }
+
+  // TOS doesn't enable recursive delete in server side currently.
+  @Ignore
+  @Test
+  public void testAtomicDeleteDir() {
+    Configuration conf = new Configuration(directoryStorage().conf());
+    conf.setBoolean(TosKeys.FS_TOS_RMR_SERVER_ENABLED, true);
+    directoryStorage().initialize(conf, directoryStorage().bucket().name());
+
+    testDeleteNonEmptyDir();
+  }
+
+  private void touchFile(String key, byte[] data) {
+    directoryStorage().put(key, data);
+  }
+
+  private void mkdir(String key) {
+    directoryStorage().put(key, new byte[0]);
+  }
+
+  private DirectoryStorage directoryStorage() {
+    Assume.assumeTrue(storage.bucket().isDirectory());
+    return (DirectoryStorage) storage;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectMultiRangeInputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectMultiRangeInputStream.java
@@ -1,0 +1,447 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.common.Bytes;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.object.exceptions.ChecksumMismatchException;
+import org.apache.hadoop.fs.tosfs.util.Range;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestObjectMultiRangeInputStream extends ObjectStorageTestBase {
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = ThreadPools.newWorkerPool("TestObjectInputStream-pool");
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (!threadPool.isShutdown()) {
+      threadPool.shutdown();
+    }
+  }
+
+  @Test
+  public void testSequentialAndRandomRead() throws IOException {
+    Path outPath = new Path(testDir, "testSequentialAndRandomRead.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(5 << 20);
+    storage.put(key, rawData);
+
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(threadPool, storage,
+        ObjectUtils.pathToKey(outPath), rawData.length, Long.MAX_VALUE, content.checksum())) {
+      // sequential read
+      assertEquals(0, in.getPos());
+      assertEquals(0, in.nextExpectPos());
+
+      byte[] b = new byte[1024];
+      int readCnt = in.read(b);
+      assertEquals(readCnt, b.length);
+      assertArrayEquals(Arrays.copyOfRange(rawData, 0, 1024), b);
+      assertEquals(1024, in.getPos());
+      assertEquals(1024, in.nextExpectPos());
+
+      readCnt = in.read(b);
+      assertEquals(readCnt, b.length);
+      assertArrayEquals(Arrays.copyOfRange(rawData, 1024, 2048), b);
+      assertEquals(2048, in.getPos());
+      assertEquals(2048, in.nextExpectPos());
+
+      // random read forward
+      in.seek(4 << 20);
+      assertEquals(4 << 20, in.getPos());
+      assertEquals(2048, in.nextExpectPos());
+
+      readCnt = in.read(b);
+      assertEquals(readCnt, b.length);
+      assertArrayEquals(Arrays.copyOfRange(rawData, 4 << 20, 1024 + (4 << 20)), b);
+      assertEquals((4 << 20) + 1024, in.getPos());
+      assertEquals((4 << 20) + 1024, in.nextExpectPos());
+
+      // random read back
+      in.seek(2 << 20);
+      assertEquals(2 << 20, in.getPos());
+      assertEquals((4 << 20) + 1024, in.nextExpectPos());
+
+      readCnt = in.read(b);
+      assertEquals(readCnt, b.length);
+      assertArrayEquals(Arrays.copyOfRange(rawData, 2 << 20, 1024 + (2 << 20)), b);
+      assertEquals((2 << 20) + 1024, in.getPos());
+      assertEquals((2 << 20) + 1024, in.nextExpectPos());
+    }
+  }
+
+  private InputStream getStream(String key) {
+    return storage.get(key).stream();
+  }
+
+  @Test
+  public void testReadSingleByte() throws IOException {
+    int len = 10;
+    Path outPath = new Path(testDir, "testReadSingleByte.txt");
+    byte[] data = TestUtility.rand(len);
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] checksum = storage.put(key, data);
+
+    try (InputStream in = new ObjectMultiRangeInputStream(threadPool, storage, key,
+        data.length, Long.MAX_VALUE, checksum)) {
+      for (int i = 0; i < data.length; i++) {
+        assertTrue(in.read() >= 0);
+      }
+      assertEquals(-1, in.read());
+    }
+  }
+
+  @Test
+  public void testReadStreamButTheFileChangedDuringReading() throws IOException {
+    int len = 2048;
+    Path outPath = new Path(testDir, "testReadStreamButTheFileChangedDuringReading.txt");
+    byte[] data = TestUtility.rand(len);
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] checksum = storage.put(key, data);
+
+    try (InputStream in = new ObjectMultiRangeInputStream(threadPool, storage, key, data.length, 1024, checksum)) {
+      byte[] read = new byte[1024];
+      int n = in.read(read);
+      Assert.assertEquals(1024, n);
+
+      storage.put(key, TestUtility.rand(1024));
+      assertThrows("The file is staled", ChecksumMismatchException.class, () -> in.read(read));
+    }
+  }
+
+  @Test
+  public void testRead100M() throws IOException {
+    testSequentialReadData(100 << 20, 6 << 20);
+    testSequentialReadData(100 << 20, 5 << 20);
+  }
+
+  @Test
+  public void testRead10M() throws IOException {
+    testSequentialReadData(10 << 20, 4 << 20);
+    testSequentialReadData(10 << 20, 5 << 20);
+  }
+
+  @Test
+  public void testParallelRead10M() throws IOException, ExecutionException, InterruptedException {
+    testParallelRandomRead(10 << 20, 4 << 20);
+    testParallelRandomRead(10 << 20, 5 << 20);
+  }
+
+  @Test
+  public void testRead100b() throws IOException {
+    testSequentialReadData(100, 40);
+    testSequentialReadData(100, 50);
+    testSequentialReadData(100, 100);
+    testSequentialReadData(100, 101);
+  }
+
+  private void testSequentialReadData(int dataSize, int partSize) throws IOException {
+    Path outPath = new Path(testDir, String.format("%d-%d.txt", dataSize, partSize));
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(dataSize);
+    storage.put(key, rawData);
+
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    int batchSize = (dataSize - 1) / partSize + 1;
+    try (InputStream in = new ObjectMultiRangeInputStream(threadPool, storage, ObjectUtils.pathToKey(outPath),
+        rawData.length, Long.MAX_VALUE, content.checksum())) {
+      for (int i = 0; i < batchSize; i++) {
+        int start = i * partSize;
+        int end = Math.min(dataSize, start + partSize);
+        byte[] expectArr = Arrays.copyOfRange(rawData, start, end);
+
+        byte[] b = new byte[end - start];
+        int ret = in.read(b, 0, b.length);
+
+        assertEquals(b.length, ret);
+        assertArrayEquals(String.format("the read bytes mismatched at batch: %d", i), expectArr, b);
+      }
+      assertEquals(-1, in.read());
+    }
+  }
+
+  private void testParallelRandomRead(int dataSize, int partSize)
+      throws IOException, ExecutionException, InterruptedException {
+
+    Path outPath = new Path(testDir, String.format("%d-%d.txt", dataSize, partSize));
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(dataSize);
+    storage.put(key, rawData);
+
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    Random random = new Random();
+    List<Future<Boolean>> tasks = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      int position = random.nextInt(rawData.length);
+      tasks.add(threadPool.submit(() ->
+          testReadDataFromSpecificPosition(rawData, outPath, position, partSize, content.checksum())));
+    }
+
+    for (Future<Boolean> task : tasks) {
+      assertTrue(task.get());
+    }
+  }
+
+  private boolean testReadDataFromSpecificPosition(
+      final byte[] rawData,
+      final Path objPath,
+      final int startPosition,
+      final int partSize,
+      byte[] checksum) {
+    int rawDataSize = rawData.length;
+    int batchSize = (rawDataSize - startPosition - 1) / partSize + 1;
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(threadPool, storage,
+        ObjectUtils.pathToKey(objPath), rawDataSize, Long.MAX_VALUE, checksum)) {
+      in.seek(startPosition);
+
+      for (int i = 0; i < batchSize; i++) {
+        int start = startPosition + i * partSize;
+        int end = Math.min(rawDataSize, start + partSize);
+        byte[] expectArr = Arrays.copyOfRange(rawData, start, end);
+
+        byte[] b = new byte[end - start];
+        int ret = in.read(b, 0, b.length);
+
+        assertEquals(b.length, ret);
+        assertArrayEquals(String.format("the read bytes mismatched at batch: %d", i), expectArr, b);
+      }
+      assertEquals(-1, in.read());
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  @Test
+  public void testParallelReadFromOneInputStream() throws IOException, ExecutionException, InterruptedException {
+    testParallelReadFromOneInputStreamImpl(10 << 20, 512, 10);
+    testParallelReadFromOneInputStreamImpl(10 << 20, 64, 100);
+    testParallelReadFromOneInputStreamImpl(1 << 20, 2 << 20, 5);
+  }
+
+  public void testParallelReadFromOneInputStreamImpl(int dataSize, int batchSize, int parallel)
+      throws IOException, ExecutionException, InterruptedException {
+
+    Path outPath = new Path(testDir,
+        String.format("%d-%d-testParallelReadFromOneInputStreamImpl.txt", dataSize, batchSize));
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(dataSize);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    AtomicInteger sum = new AtomicInteger(0);
+    CopyOnWriteArrayList<byte[]> readBytes = new CopyOnWriteArrayList();
+    List<Future<?>> futures = new ArrayList<>();
+    try (ObjectMultiRangeInputStream inputStream = new ObjectMultiRangeInputStream(threadPool,
+        storage, ObjectUtils.pathToKey(outPath), rawData.length, Long.MAX_VALUE, content.checksum())) {
+      for (int i = 0; i < parallel; i++) {
+        futures.add(threadPool.submit(() -> {
+          byte[] data = new byte[batchSize];
+          try {
+            int count;
+            while ((count = inputStream.read(data)) != -1) {
+              sum.getAndAdd(count);
+              readBytes.add(Arrays.copyOfRange(data, 0, count));
+              data = new byte[batchSize];
+            }
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }));
+      }
+
+      for (Future<?> future : futures) {
+        future.get();
+
+      }
+      assertEquals(rawData.length, sum.get());
+    }
+
+    byte[] actualBytes = new byte[rawData.length];
+    int offset = 0;
+    for (byte[] bytes : readBytes) {
+      System.arraycopy(bytes, 0, actualBytes, offset, bytes.length);
+      offset += bytes.length;
+    }
+
+    Arrays.sort(actualBytes);
+    Arrays.sort(rawData);
+    assertArrayEquals(rawData, actualBytes);
+  }
+
+  @Test
+  public void testPositionalRead() throws IOException {
+    Path outPath = new Path(testDir, "testPositionalRead.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    int fileSize = 5 << 20;
+    byte[] rawData = TestUtility.rand(fileSize);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    Random rand = ThreadLocalRandom.current();
+
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(threadPool, storage,
+        ObjectUtils.pathToKey(outPath), fileSize, Long.MAX_VALUE, content.checksum())) {
+      for (int i = 0; i < 100; i++) {
+        int pos = rand.nextInt(fileSize);
+        int len = rand.nextInt(fileSize);
+
+        int expectSize = Math.min(fileSize - pos, len);
+        byte[] actual = new byte[expectSize];
+        int actualLen = in.read(pos, actual, 0, expectSize);
+
+        assertEquals(expectSize, actualLen);
+        assertArrayEquals(Bytes.toBytes(rawData, pos, expectSize), actual);
+      }
+    }
+  }
+
+  @Test
+  public void testReadAcrossRange() throws IOException {
+    Path outPath = new Path(testDir, "testReadAcrossRange.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    int fileSize = 1 << 10;
+    byte[] rawData = TestUtility.rand(fileSize);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(ThreadPools.defaultWorkerPool(),
+        storage, key, fileSize, 10, content.checksum())) {
+      byte[] data = new byte[fileSize / 2];
+      for (int i = 0; i < 2; i++) {
+        assertEquals(data.length, in.read(data));
+        assertEquals((i + 1) * data.length, in.getPos());
+        assertArrayEquals(Bytes.toBytes(rawData, i * data.length, data.length), data);
+      }
+    }
+  }
+
+  @Test
+  public void testStorageRange() throws IOException {
+    Path outPath = new Path(testDir, "testStorageRange.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    int fileSize = 5 << 20;
+    byte[] rawData = TestUtility.rand(fileSize);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    int oneMB = 1 << 20;
+    long rangeOpenLen = oneMB;
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(ThreadPools.defaultWorkerPool(),
+        storage, key, fileSize, rangeOpenLen, content.checksum())) {
+      assertNull(in.stream());
+
+      // Init range.
+      in.read();
+      assertEquals(Range.of(0, rangeOpenLen), in.stream().range());
+      // Range doesn't change.
+      in.read(new byte[(int) (rangeOpenLen - 1)], 0, (int) (rangeOpenLen - 1));
+      assertEquals(Range.of(0, rangeOpenLen), in.stream().range());
+
+      // Move to next range.
+      in.read();
+      assertEquals(Range.of(rangeOpenLen, rangeOpenLen), in.stream().range());
+
+      // Seek and move.
+      in.seek(rangeOpenLen * 3 + 10);
+      in.read();
+      assertEquals(Range.of(rangeOpenLen * 3, rangeOpenLen), in.stream().range());
+
+      // Seek small and range doesn't change.
+      in.seek(in.getPos() + 1);
+      in.read();
+      assertEquals(Range.of(rangeOpenLen * 3, rangeOpenLen), in.stream().range());
+
+      // Seek big and range changes.
+      in.seek(rangeOpenLen * 2);
+      in.read(new byte[(int) (rangeOpenLen - 10)], 0, (int) (rangeOpenLen - 10));
+      assertEquals(Range.of(rangeOpenLen * 2, rangeOpenLen), in.stream().range());
+      // Old range has 10 bytes left. Seek 10 bytes then read 10 bytes. Old range can't read any bytes, so
+      // range changes.
+      assertEquals(rangeOpenLen * 3 - 10, in.getPos());
+      in.seek(rangeOpenLen * 3);
+      in.read(new byte[10], 0, 10);
+      assertEquals(Range.of(rangeOpenLen * 3, rangeOpenLen), in.stream().range());
+
+      // Read big buffer.
+      in.seek(10);
+      in.read(new byte[oneMB * 3], 0, oneMB * 3);
+      assertEquals(oneMB * 3 + 10, in.getPos());
+      assertEquals(Range.of(3 * rangeOpenLen, rangeOpenLen), in.stream().range());
+    }
+
+    try (ObjectMultiRangeInputStream in = new ObjectMultiRangeInputStream(threadPool, storage,
+        ObjectUtils.pathToKey(outPath), fileSize, Long.MAX_VALUE, content.checksum())) {
+      assertNull(in.stream());
+
+      // Init range.
+      in.read();
+      assertEquals(Range.of(0, fileSize), in.stream().range());
+
+      // Range doesn't change.
+      in.read(new byte[oneMB], 0, oneMB);
+      assertEquals(Range.of(0, fileSize), in.stream().range());
+
+      // Seek and move.
+      long pos = oneMB * 3 + 10;
+      in.seek(pos);
+      in.read();
+      assertEquals(Range.of(0, fileSize), in.stream().range());
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectOutputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectOutputStream.java
@@ -1,0 +1,407 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.object.staging.StagingPart;
+import org.apache.hadoop.fs.tosfs.object.staging.State;
+import org.apache.hadoop.fs.tosfs.util.FSUtils;
+import org.apache.hadoop.fs.tosfs.util.TempFiles;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.apache.hadoop.util.Lists;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TestObjectOutputStream extends ObjectStorageTestBase {
+
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = ThreadPools.newWorkerPool("TestObjectOutputStream-pool");
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (!threadPool.isShutdown()) {
+      threadPool.shutdown();
+    }
+  }
+
+  @Test
+  public void testMkStagingDir() throws ExecutionException, InterruptedException, IOException {
+    try (TempFiles tmp = TempFiles.of()) {
+      List<String> tmpDirs = Lists.newArrayList();
+      for (int i = 0; i < 3; i++) {
+        tmpDirs.add(tmp.newDir());
+      }
+      Configuration newConf = new Configuration(tosConf);
+      newConf.set(ConfKeys.FS_MULTIPART_STAGING_DIR.key("filestore"), Joiner.on(",").join(tmpDirs));
+
+      // Start multiple threads to open streams to create staging dir.
+      List<Future<ObjectOutputStream>> futures = Collections.synchronizedList(new ArrayList<>());
+      for (int i = 0; i < 10; i++) {
+        futures.add(threadPool.submit(() ->
+            new ObjectOutputStream(storage, threadPool, newConf, path("none.txt"), true)));
+      }
+      for (Future<ObjectOutputStream> f : futures) {
+        f.get().close();
+      }
+    }
+  }
+
+  @Test
+  public void testWriteZeroByte() throws IOException {
+    Path zeroByteTxt = path("zero-byte.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, zeroByteTxt, true);
+    // write zero-byte and close.
+    out.write(new byte[0], 0, 0);
+    out.close();
+    assertStagingPart(0, out.stagingParts());
+
+    // Read and validate the dest object contents
+    ObjectTestUtils.assertObject(zeroByteTxt, ObjectTestUtils.EMPTY_BYTES);
+  }
+
+  @Test
+  public void testWriteZeroByteWithoutAllowPut() throws IOException {
+    Path zeroByteTxt = path("zero-byte-without-allow-put.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, zeroByteTxt, false);
+    // write zero-byte and close.
+    out.close();
+    assertStagingPart(0, out.stagingParts());
+
+    // Read and validate the dest object content.
+    ObjectTestUtils.assertObject(zeroByteTxt, ObjectTestUtils.EMPTY_BYTES);
+  }
+
+  @Test
+  public void testDeleteStagingFileWhenUploadPartsOK() throws IOException {
+    Path path = path("data.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, path, true);
+    byte[] data = TestUtility.rand((int) (ConfKeys.FS_MULTIPART_SIZE_DEFAULT * 2));
+    out.write(data);
+    out.waitForPartsUpload();
+    for (StagingPart part : out.stagingParts()) {
+      Assert.assertEquals(State.CLEANED, part.state());
+    }
+    out.close();
+    for (StagingPart part : out.stagingParts()) {
+      Assert.assertEquals(State.CLEANED, part.state());
+    }
+  }
+
+  @Test
+  public void testDeleteStagingFileWithClose() throws IOException {
+    Path path = path("data.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, path, true);
+    byte[] data = TestUtility.rand((int) (ConfKeys.FS_MULTIPART_SIZE_DEFAULT * 2));
+    out.write(data);
+    out.close();
+    for (StagingPart part : out.stagingParts()) {
+      Assert.assertEquals(State.CLEANED, part.state());
+    }
+  }
+
+  @Test
+  public void testDeleteSimplePutStagingFile() throws IOException {
+    Path smallTxt = path("small.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, smallTxt, true);
+    byte[] data = TestUtility.rand(4 << 20);
+    out.write(data);
+    for (StagingPart part : out.stagingParts()) {
+      Assert.assertTrue(part.size() > 0);
+    }
+    out.close();
+    for (StagingPart part : out.stagingParts()) {
+      Assert.assertEquals(State.CLEANED, part.state());
+    }
+  }
+
+  @Test
+  public void testSimplePut() throws IOException {
+    Path smallTxt = path("small.txt");
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, smallTxt, true);
+    byte[] data = TestUtility.rand(4 << 20);
+    out.write(data);
+    out.close();
+    assertStagingPart(1, out.stagingParts());
+    assertNull("Should use the simple PUT to upload object for small file.", out.upload());
+
+    // Read and validate the dest object content.
+    ObjectTestUtils.assertObject(smallTxt, data);
+  }
+
+  public void testWrite(int uploadPartSize, int len) throws IOException {
+    Configuration newConf = new Configuration(tosConf);
+    newConf.setLong(ConfKeys.FS_MULTIPART_SIZE.key(FSUtils.scheme(conf, testDir.toUri())),
+        uploadPartSize);
+
+    Path outPath = path(len + ".txt");
+    int partNum = (len - 1) / uploadPartSize + 1;
+
+    byte[] data = TestUtility.rand(len);
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, newConf, outPath, true);
+    try {
+      out.write(data);
+    } finally {
+      out.close();
+    }
+
+    assertStagingPart(partNum, out.stagingParts());
+    ObjectTestUtils.assertObject(outPath, data);
+
+    // List multipart uploads
+    int uploadsNum = 0;
+    for (MultipartUpload ignored : storage.listUploads(out.destKey())) {
+      uploadsNum += 1;
+    }
+    Assert.assertEquals(0L, uploadsNum);
+  }
+
+  @Test
+  public void testParallelWriteOneOutPutStream() throws IOException, ExecutionException, InterruptedException {
+    testParallelWriteOneOutPutStreamImpl(5 << 20, 10, 128);
+    testParallelWriteOneOutPutStreamImpl(5 << 20, 10, 1 << 20);
+    testParallelWriteOneOutPutStreamImpl(5 << 20, 10, 2 << 20);
+    testParallelWriteOneOutPutStreamImpl(5 << 20, 10, 6 << 20);
+  }
+
+  public void testParallelWriteOneOutPutStreamImpl(int partSize, int epochs, int batchSize)
+      throws IOException, ExecutionException, InterruptedException {
+    Configuration newConf = new Configuration(tosConf);
+    newConf.setLong(ConfKeys.FS_MULTIPART_SIZE.key(FSUtils.scheme(conf, testDir.toUri())),
+        partSize);
+
+    String file = String.format("%d-%d-%d-testParallelWriteOneOutPutStream.txt", partSize, epochs, batchSize);
+    Path outPath = path(file);
+    try (ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, newConf, outPath, true)) {
+      List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < epochs; i++) {
+        final int index = i;
+        futures.add(threadPool.submit(() -> {
+          try {
+            out.write(dataset(batchSize, index));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }));
+      }
+
+      // wait for all tasks finished
+      for (Future<?> future : futures) {
+        future.get();
+      }
+    }
+
+    try (InputStream inputStream = storage.get(ObjectUtils.pathToKey(outPath)).stream()) {
+      List<byte[]> ret = new ArrayList<>();
+      byte[] data = new byte[batchSize];
+      while (inputStream.read(data) != -1) {
+        ret.add(data);
+        data = new byte[batchSize];
+      }
+
+      assertEquals(epochs, ret.size());
+      List<byte[]> sortedRet = ret.stream()
+          .sorted(Comparator.comparingInt(o -> o[0]))
+          .collect(Collectors.toList());
+
+      int j = 0;
+      for (byte[] e : sortedRet) {
+        assertArrayEquals(dataset(batchSize, j), e);
+        j++;
+      }
+    }
+  }
+
+  public static byte[] dataset(int len, int base) {
+    byte[] dataset = new byte[len];
+    for (int i = 0; i < len; i++) {
+      dataset[i] = (byte) (base);
+    }
+    return dataset;
+  }
+
+  @Test
+  public void testWrite1MB() throws IOException {
+    testWrite(5 << 20, 1 << 20);
+    testWrite(8 << 20, 1 << 20);
+    testWrite(16 << 20, 1 << 20);
+  }
+
+  @Test
+  public void testWrite24MB() throws IOException {
+    testWrite(5 << 20, 24 << 20);
+    testWrite(8 << 20, 24 << 20);
+    testWrite(16 << 20, 24 << 20);
+  }
+
+  @Test
+  public void testWrite100MB() throws IOException {
+    testWrite(5 << 20, 100 << 20);
+    testWrite(8 << 20, 100 << 20);
+    testWrite(16 << 20, 100 << 20);
+  }
+
+  private void testMultipartThreshold(int partSize, int multipartThreshold, int dataSize) throws IOException {
+    Configuration newConf = new Configuration(tosConf);
+    newConf.setLong(ConfKeys.FS_MULTIPART_SIZE.key(scheme), partSize);
+    newConf.setLong(ConfKeys.FS_MULTIPART_THRESHOLD.key(scheme), multipartThreshold);
+    Path outPath = path(String.format("threshold-%d-%d-%d.txt", partSize, multipartThreshold, dataSize));
+
+    byte[] data = TestUtility.rand(dataSize);
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, newConf, outPath, true);
+    try {
+      // Verify for every 1MB data writing, unless reaching the threshold.
+      int upperLimit = Math.min(multipartThreshold, dataSize);
+      int curOff = 0;
+      for (; curOff < upperLimit; curOff += (1 << 20)) {
+        int end = Math.min(curOff + (1 << 20), upperLimit);
+        out.write(Arrays.copyOfRange(data, curOff, end));
+
+        List<MultipartUpload> uploads = Lists.newArrayList(storage.listUploads(out.destKey()));
+        if (end < multipartThreshold) {
+          Assert.assertEquals("Shouldn't has any uploads because it just use simple PUT", 0, uploads.size());
+        } else {
+          Assert.assertEquals("Switch to use MPU.", 1, uploads.size());
+        }
+        assertEquals((end - 1) / partSize + 1, out.stagingParts().size());
+      }
+
+      // Verify for every 1MB data writing, unless reaching the data size.
+      for (; curOff < dataSize; curOff += (1 << 20)) {
+        int end = Math.min(curOff + (1 << 20), dataSize);
+        out.write(Arrays.copyOfRange(data, curOff, end));
+
+        List<MultipartUpload> uploads = Lists.newArrayList(storage.listUploads(out.destKey()));
+        Assert.assertEquals(1, uploads.size());
+        assertEquals(out.destKey(), uploads.get(0).key());
+        assertEquals((end - 1) / partSize + 1, out.stagingParts().size());
+      }
+    } finally {
+      out.close();
+    }
+
+    assertStagingPart((dataSize - 1) / partSize + 1, out.stagingParts());
+    ObjectTestUtils.assertObject(outPath, data);
+
+    List<MultipartUpload> uploads = Lists.newArrayList(storage.listUploads(out.destKey()));
+    Assert.assertEquals(0, uploads.size());
+  }
+
+  @Test
+  public void testMultipartThreshold2MB() throws IOException {
+    testMultipartThreshold(5 << 20, 2 << 20, 1 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, (2 << 20) - 1);
+    testMultipartThreshold(5 << 20, 2 << 20, 2 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, 4 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, 5 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, (5 << 20) + 1);
+    testMultipartThreshold(5 << 20, 2 << 20, 6 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, 10 << 20);
+    testMultipartThreshold(5 << 20, 2 << 20, 20 << 20);
+  }
+
+  @Test
+  public void testMultipartThreshold5MB() throws IOException {
+    testMultipartThreshold(5 << 20, 5 << 20, 1 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 4 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 5 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 5 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 6 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 10 << 20);
+    testMultipartThreshold(5 << 20, 5 << 20, 20 << 20);
+  }
+
+  @Test
+  public void testMultipartThreshold10MB() throws IOException {
+    testMultipartThreshold(5 << 20, 10 << 20, 1 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 10 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 11 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 15 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 20 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 40 << 20);
+    testMultipartThreshold(5 << 20, 10 << 20, 30 << 20);
+  }
+
+  @Test
+  public void testCloseStreamTwice() throws IOException {
+    int len = 100;
+    Path outPath = path(len + ".txt");
+    int partNum = 1;
+
+    byte[] data = TestUtility.rand(len);
+    ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, outPath, true);
+    try {
+      out.write(data);
+      out.close();
+    } finally {
+      out.close();
+    }
+
+    assertStagingPart(partNum, out.stagingParts());
+    ObjectTestUtils.assertObject(outPath, data);
+  }
+
+  @Test
+  public void testWriteClosedStream() throws IOException {
+    byte[] data = TestUtility.rand(10);
+    Path outPath = path("testWriteClosedStream.txt");
+    try (ObjectOutputStream out = new ObjectOutputStream(storage, threadPool, tosConf, outPath, true)) {
+      out.close();
+      out.write(data);
+    } catch (IllegalStateException e) {
+      assertEquals("OutputStream is closed.", e.getMessage());
+    }
+  }
+
+  private static void assertStagingPart(int expectedNum, List<StagingPart> parts) {
+    Assert.assertEquals(expectedNum, parts.size());
+    for (StagingPart part : parts) {
+      Assert.assertTrue(part.size() > 0);
+    }
+  }
+
+  private Path path(String name) {
+    return new Path(testDir, name);
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectRangeInputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectRangeInputStream.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.util.Range;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestObjectRangeInputStream extends ObjectStorageTestBase {
+
+  @Test
+  public void testRead() throws IOException {
+    Path outPath = new Path(testDir, "testRead.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(1 << 10);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    int position = 100;
+    int len = 200;
+    try (ObjectRangeInputStream ri =
+             new ObjectRangeInputStream(storage, key, Range.of(position, len), content.checksum())) {
+      // Test read byte.
+      assertEquals(rawData[position] & 0xff, ri.read());
+
+      // Test read buffer.
+      byte[] buffer = new byte[len];
+      assertEquals(buffer.length - 1, ri.read(buffer, 0, buffer.length));
+      assertArrayEquals(
+          Arrays.copyOfRange(rawData, position + 1, position + len),
+          Arrays.copyOfRange(buffer, 0, buffer.length - 1));
+      assertEquals(0, ri.available());
+
+      assertEquals(-1, ri.read());
+      assertEquals(-1, ri.read(buffer, 0, buffer.length));
+    }
+  }
+
+  @Test
+  public void testRangeExceedInnerStream() throws IOException {
+    Path outPath = new Path(testDir, "testRangeExceedInnerStream.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(10);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    int position = 10;
+    int badLen = 10;
+    try (ObjectRangeInputStream ri =
+             new ObjectRangeInputStream(storage, key, Range.of(position, badLen), content.checksum())) {
+      byte[] buffer = new byte[1];
+      assertEquals(-1, ri.read());
+      assertEquals(-1, ri.read(buffer, 0, buffer.length));
+    }
+  }
+
+  @Test
+  public void testRangeInclude() throws IOException {
+    Path outPath = new Path(testDir, "testRangeInclude.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(10);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    long pos = 100;
+    long len = 300;
+
+    try (ObjectRangeInputStream in = new ObjectRangeInputStream(storage, key, Range.of(pos, len), content.checksum())) {
+      assertEquals(Range.of(pos, len), in.range());
+
+      assertTrue(in.include(pos));
+      assertTrue(in.include((pos + len) / 2));
+      assertTrue(in.include(pos + len - 1));
+
+      assertFalse(in.include(pos - 1));
+      assertFalse(in.include(pos + len));
+    }
+  }
+
+  @Test
+  public void testSeek() throws IOException {
+    Path outPath = new Path(testDir, "testSeek.txt");
+    String key = ObjectUtils.pathToKey(outPath);
+    byte[] rawData = TestUtility.rand(1 << 10);
+    storage.put(key, rawData);
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(rawData, IOUtils.toByteArray(content.stream()));
+
+    long pos = 100;
+    long len = 300;
+
+    try (ObjectRangeInputStream in = new ObjectRangeInputStream(storage, key, Range.of(pos, len), content.checksum())) {
+      assertEquals(pos, in.getPos());
+
+      Exception error = assertThrows("Overflow", IllegalArgumentException.class, () -> in.seek(-1));
+      assertTrue(error.getMessage().contains("must be in range Range{offset=100, length=300}"));
+      error = assertThrows("Overflow", IllegalArgumentException.class, () -> in.seek(99));
+      assertTrue(error.getMessage().contains("must be in range Range{offset=100, length=300}"));
+      error = assertThrows("Overflow", IllegalArgumentException.class, () -> in.seek(401));
+      assertTrue(error.getMessage().contains("must be in range Range{offset=100, length=300}"));
+      error = assertThrows("Overflow", IllegalArgumentException.class, () -> in.seek(1 << 20));
+      assertTrue(error.getMessage().contains("must be in range Range{offset=100, length=300}"));
+
+      in.seek(399);
+      assertTrue(0 <= in.read());
+      assertEquals(-1, in.read());
+
+      in.seek(100);
+      assertTrue(in.read() >= 0);
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectStorage.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/TestObjectStorage.java
@@ -1,0 +1,1409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object;
+
+import com.volcengine.tos.TosServerException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.exceptions.InvalidObjectKeyException;
+import org.apache.hadoop.fs.tosfs.object.exceptions.NotAppendableException;
+import org.apache.hadoop.fs.tosfs.object.request.ListObjectsRequest;
+import org.apache.hadoop.fs.tosfs.object.response.ListObjectsResponse;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TempFiles;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
+import org.apache.hadoop.util.Lists;
+import org.apache.hadoop.util.Preconditions;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TestObjectStorage {
+  private static final String FILE_STORE_ROOT = TempFiles.newTempDir("TestObjectStorage");
+  private final ObjectStorage storage;
+
+  public TestObjectStorage(ObjectStorage storage) {
+    this.storage = storage;
+  }
+
+  @Parameterized.Parameters(name = "ObjectStorage = {0}")
+  public static List<ObjectStorage> createStorage() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+    return TestUtility.createTestObjectStorage(FILE_STORE_ROOT);
+  }
+
+  @After
+  public void tearDown() {
+    CommonUtils.runQuietly(() -> storage.deleteAll(""));
+    for (MultipartUpload upload : storage.listUploads("")) {
+      storage.abortMultipartUpload(upload.key(), upload.uploadId());
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    CommonUtils.runQuietly(() -> TempFiles.deleteDir(FILE_STORE_ROOT));
+  }
+
+  @Test
+  public void testHeadNonExistObject() {
+    assertNull(storage.head("a/b/c.txt"));
+
+    byte[] data = TestUtility.rand(256);
+    storage.put("a/b/c.txt", data);
+    assertNotNull(storage.head("a/b/c.txt"));
+
+    assertNull(storage.head("a/b/c/non-exits"));
+    if (storage.bucket().isDirectory()) {
+      assertThrows(InvalidObjectKeyException.class, () -> storage.head("a/b/c.txt/non-exits"));
+    } else {
+      assertNull(storage.head("a/b/c.txt/non-exits"));
+    }
+  }
+
+  @Test
+  public void testHeadExistObject() {
+    byte[] data = TestUtility.rand(256);
+    String key = "testHeadExistObject.txt";
+    storage.put(key, data);
+
+    ObjectInfo obj = storage.head(key);
+    Assert.assertEquals(key, obj.key());
+    Assert.assertFalse(obj.isDir());
+    if (storage.bucket().isDirectory()) {
+      assertThrows(InvalidObjectKeyException.class, () -> storage.head(key + "/"));
+    } else {
+      Assert.assertNull(storage.head(key + "/"));
+    }
+
+    String dirKey = "testHeadExistObject/";
+    storage.put(dirKey, new byte[0]);
+    obj = storage.head(dirKey);
+    Assert.assertEquals(dirKey, obj.key());
+    Assert.assertTrue(obj.isDir());
+
+    if (storage.bucket().isDirectory()) {
+      obj = storage.head("testHeadExistObject");
+      Assert.assertEquals("testHeadExistObject", obj.key());
+      Assert.assertTrue(obj.isDir());
+    } else {
+      Assert.assertNull(storage.head("testHeadExistObject"));
+    }
+  }
+
+  @Test
+  public void testGetAndDeleteNonExistFile() {
+    // ensure file is not exist
+    assertNull(storage.head("a/b/c.txt"));
+
+    assertThrows(RuntimeException.class, () -> storage.get("a/b/c.txt", 0, 0));
+    assertThrows(RuntimeException.class, () -> storage.get("a/b/c.txt", 0, 1));
+
+    // Allow to delete a non-exist object.
+    storage.delete("a/b/c.txt");
+  }
+
+  @Test
+  public void testPutAndDeleteFileWithEmptyKey() {
+    assertThrows(RuntimeException.class, () -> storage.put("", new byte[0]));
+    assertThrows(RuntimeException.class, () -> storage.put(null, new byte[0]));
+    assertThrows(RuntimeException.class, () -> storage.delete(null));
+    assertThrows(RuntimeException.class, () -> storage.head(""));
+    assertThrows(RuntimeException.class, () -> storage.head(null));
+    assertThrows(RuntimeException.class, () -> getStream(""));
+    assertThrows(RuntimeException.class, () -> getStream(null));
+  }
+
+  @Test
+  public void testPutObjectButContentLengthDisMatch() throws IOException {
+    byte[] data = TestUtility.rand(256);
+    String key = "a/truncated.txt";
+
+    // The final object data will be truncated if content length is smaller.
+    byte[] checksum = storage.put(key, () -> new ByteArrayInputStream(data), 200);
+    assertArrayEquals(Arrays.copyOfRange(data, 0, 200), IOUtils.toByteArray(getStream(key)));
+    ObjectInfo info = storage.head(key);
+    assertEquals(key, info.key());
+    assertEquals(200, info.size());
+    assertArrayEquals(checksum, info.checksum());
+
+    // Will create object failed is the content length is bigger.
+    assertThrows(RuntimeException.class, () -> storage.put(key, () -> new ByteArrayInputStream(data), 300));
+  }
+
+  private InputStream getStream(String key) {
+    return storage.get(key).stream();
+  }
+
+  @Test
+  public void testPutAndGetFile() throws IOException {
+    byte[] data = TestUtility.rand(256);
+    String key = "a/test.txt";
+    byte[] checksum = storage.put(key, data);
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+
+    if (storage.bucket().isDirectory()) {
+      // Directory bucket will create missed parent dir.
+      assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream("a")));
+      assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream("a/")));
+    } else {
+      assertNull(storage.head("a"));
+      assertNull(storage.head("a/"));
+    }
+
+    ObjectInfo info = storage.head(key);
+    assertEquals(key, info.key());
+    assertEquals(data.length, info.size());
+    assertArrayEquals(checksum, info.checksum());
+
+    ObjectContent content = storage.get(key);
+    assertArrayEquals(info.checksum(), content.checksum());
+    assertArrayEquals(data, IOUtils.toByteArray(content.stream()));
+
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key, 0, -1)));
+    assertThrows("offset is negative", RuntimeException.class, () -> storage.get(key, -1, -1));
+    assertThrows("path not found or resource type is invalid",
+        RuntimeException.class, () -> storage.get(key + "/", 0, -1));
+
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key, 0, 256)));
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key, 0, 512)));
+
+    byte[] secondHalfData = Arrays.copyOfRange(data, 128, 256);
+    assertArrayEquals(secondHalfData, IOUtils.toByteArray(getStream(key, 128, -1)));
+    assertArrayEquals(secondHalfData, IOUtils.toByteArray(getStream(key, 128, 256)));
+    assertArrayEquals(secondHalfData, IOUtils.toByteArray(getStream(key, 128, 257)));
+    assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream(key, 128, 0)));
+
+    ObjectContent partContent = storage.get(key, 8, 32);
+    assertArrayEquals(info.checksum(), partContent.checksum());
+    assertArrayEquals(Arrays.copyOfRange(data, 8, 40),
+        IOUtils.toByteArray(partContent.stream()));
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+
+    assertThrows("offset is bigger than object length", RuntimeException.class, () -> storage.get(key, 257, 8));
+    assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream(key, 256, 8)));
+
+    assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream(key, 0, 0)));
+    assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream(key, 1, 0)));
+
+
+    // assert the original data is not changed during random get request
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+
+    storage.delete(key);
+    assertNull(storage.head(key));
+  }
+
+  @Test
+  public void testAppendAndGetFile() throws Exception {
+    String key = "a/testAppendAndGetFile.txt";
+
+    // Append zero bytes.
+    assertThrows("Append non-existed object with zero byte is not supported.",
+        NotAppendableException.class, () -> storage.append(key, new byte[0]));
+
+    // Append 256 bytes.
+    byte[] data = TestUtility.rand(256);
+    byte[] checksum = storage.append(key, data);
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+
+    // Append zero bytes.
+    byte[] newChecksum = storage.append(key, new byte[0]);
+    assertArrayEquals(checksum, newChecksum);
+    checksum = newChecksum;
+
+    // Append one byte.
+    newChecksum = storage.append(key, new byte[1]);
+    assertFalse(Arrays.equals(checksum, newChecksum));
+    assertArrayEquals(newChecksum, storage.head(key).checksum());
+    checksum = newChecksum;
+
+    // Append 1024 byte.
+    data = TestUtility.rand(1024);
+    newChecksum = storage.append(key, data);
+    assertFalse(Arrays.equals(checksum, newChecksum));
+    assertArrayEquals(newChecksum, storage.head(key).checksum());
+
+    storage.delete(key);
+  }
+
+  @Test
+  public void testAppendLengthNotMatch() {
+    byte[] data = TestUtility.rand(256);
+    String key = "a/testAppendLengthNotMatch.txt";
+    storage.append(key, () -> new ByteArrayInputStream(data), 128);
+    assertEquals(128, storage.head(key).size());
+
+    assertThrows("Expect unexpected end of stream error.", RuntimeException.class,
+        () -> storage.append(key, () -> new ByteArrayInputStream(data), 1024));
+  }
+
+  @Test
+  public void testHeadAndListAndObjectStatusShouldGetSameObjectInfo() {
+    String key = "testHeadAndListObjectCheckSum.txt";
+    byte[] data = TestUtility.rand(256);
+    byte[] checksum = storage.put(key, data);
+
+    ObjectInfo obj = storage.head(key);
+    assertEquals(obj, storage.objectStatus(key));
+    if (!storage.bucket().isDirectory()) {
+      List<ObjectInfo> objects = toList(storage.list(key, null, 1));
+      assertEquals(1, objects.size());
+      assertEquals(obj, objects.get(0));
+      assertArrayEquals(checksum, objects.get(0).checksum());
+    }
+
+
+    key = "testHeadAndListObjectCheckSum/";
+    checksum = storage.put(key, new byte[0]);
+    obj = storage.head(key);
+    assertEquals(obj, storage.objectStatus(key));
+    if (!storage.bucket().isDirectory()) {
+      List<ObjectInfo> objects = toList(storage.list(key, null, 1));
+      assertEquals(1, objects.size());
+      assertEquals(obj, objects.get(0));
+      assertArrayEquals(checksum, objects.get(0).checksum());
+    }
+  }
+
+  @Test
+  public void testObjectStatus() {
+    // test get file status
+    String key = "a/b/testObjectStatus.txt";
+    byte[] data = TestUtility.rand(256);
+    byte[] checksum = storage.put(key, data);
+
+    ObjectInfo obj = storage.head(key);
+    assertArrayEquals(checksum, obj.checksum());
+    Assert.assertEquals(obj, storage.objectStatus(key));
+
+    if (storage.bucket().isDirectory()) {
+      assertThrows(InvalidObjectKeyException.class, () -> storage.head(key + "/"));
+      assertThrows(InvalidObjectKeyException.class, () -> storage.objectStatus(key + "/"));
+    } else {
+      Assert.assertNull(storage.head(key + "/"));
+      Assert.assertNull(storage.objectStatus(key + "/"));
+    }
+
+    // test get dir status
+    String dirKey = "a/b/dir/";
+    checksum = storage.put(dirKey, new byte[0]);
+    obj = storage.head(dirKey);
+    Assert.assertEquals(Constants.MAGIC_CHECKSUM, checksum);
+    assertArrayEquals(Constants.MAGIC_CHECKSUM, checksum);
+    assertArrayEquals(checksum, obj.checksum());
+    Assert.assertTrue(obj.isDir());
+    Assert.assertEquals(dirKey, obj.key());
+    Assert.assertEquals(obj, storage.objectStatus(dirKey));
+
+    if (storage.bucket().isDirectory()) {
+      Assert.assertNotNull(storage.head("a/b/dir"));
+      Assert.assertEquals("a/b/dir", storage.objectStatus("a/b/dir").key());
+    } else {
+      Assert.assertNull(storage.head("a/b/dir"));
+      Assert.assertEquals(dirKey, storage.objectStatus("a/b/dir").key());
+    }
+
+    // test get dir status of prefix
+    String prefix = "a/b/";
+    obj = storage.objectStatus(prefix);
+    Assert.assertEquals(prefix, obj.key());
+    Assert.assertEquals(Constants.MAGIC_CHECKSUM, obj.checksum());
+    Assert.assertTrue(obj.isDir());
+
+    if (storage.bucket().isDirectory()) {
+      Assert.assertEquals(obj, storage.head(prefix));
+      Assert.assertEquals("a/b", storage.objectStatus("a/b").key());
+    } else {
+      Assert.assertNull(storage.head(prefix));
+      Assert.assertEquals(prefix, storage.objectStatus("a/b").key());
+    }
+  }
+
+  @Test
+  public void testPutAndGetDirectory() throws IOException {
+    String key = "a/b/";
+    byte[] data = new byte[0];
+    storage.put(key, data);
+
+    ObjectInfo info = storage.head(key);
+    assertEquals(key, info.key());
+    assertEquals(data.length, info.size());
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(key, 0, 256)));
+
+    // test create the same dir again
+    storage.put(key, data);
+
+    storage.delete(key);
+    assertNull(storage.head(key));
+  }
+
+  @Test
+  public void testOverwriteFile() throws IOException {
+    String key = "a/test.txt";
+    byte[] data1 = TestUtility.rand(256);
+    byte[] data2 = TestUtility.rand(128);
+
+    storage.put(key, data1);
+    assertArrayEquals(data1, IOUtils.toByteArray(getStream(key, 0, -1)));
+
+    storage.put(key, data2);
+    assertArrayEquals(data2, IOUtils.toByteArray(getStream(key, 0, -1)));
+
+    storage.delete(key);
+    assertNull(storage.head(key));
+  }
+
+  @Test
+  public void testListObjectsWithEmptyDelimiters() {
+    // Directory bucket only supports list with delimiter = '/' currently.
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    String key1 = "a/b/c/d";
+    String key2 = "a/b";
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%s/file-%d.txt", key1, i), data);
+      storage.put(String.format("%s/file-%d.txt", key2, i), data);
+    }
+
+    // list 100 objects under 'a/', there are total 20 objects.
+    ListObjectsResponse response = list("a/", "", 100, "");
+    assertEquals(20, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(19).key());
+
+    // list 20 objects and there only have 20 objects under 'a/'
+    response = list("a/", "", 20, "");
+    assertEquals(20, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(19).key());
+
+    // list the top 10 objects among 20 objects
+    response = list("a/", "", 10, "");
+    assertEquals(10, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/c/d/file-9.txt", response.objects().get(9).key());
+
+    // list the next 5 objects behind a/b/c/d/file-9.txt among 20 objects
+    response = list("a/", "a/b/c/d/file-9.txt", 5, "");
+    assertEquals(5, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-4.txt", response.objects().get(4).key());
+
+    // list the next 10 objects behind a/b/c/d/file-9.txt among 20 objects
+    response = list("a/", "a/b/c/d/file-9.txt", 10, "");
+    assertEquals(10, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(9).key());
+  }
+
+  @Test
+  public void testListEmptyDirWithSlashDelimiter() {
+    String key = "a/b/";
+    storage.put(key, new byte[0]);
+
+    ListObjectsResponse response = list(key, null, 10, "/");
+    assertEquals(1, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/", response.objects().get(0).key());
+
+    response = list(key, key, 10, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+  }
+
+  @Test
+  public void testDeleteMultipleKeys() {
+    String prefix = "a/b";
+    byte[] data = TestUtility.rand(256);
+
+    List<String> keys = Lists.newArrayList();
+    for (int i = 0; i < 50; i++) {
+      String existingKey = String.format("%s/existing-file-%d.txt", prefix, i);
+      storage.put(existingKey, data);
+      keys.add(existingKey);
+
+      String unExistingKey = String.format("%s/unExisting-file-%d.txt", prefix, i);
+      keys.add(unExistingKey);
+    }
+
+    List<String> failedKeys = storage.batchDelete(keys);
+
+    for (String key : failedKeys) {
+      Assert.assertNotNull(storage.head(key));
+    }
+
+    for (String key : keys) {
+      if (!failedKeys.contains(key)) {
+        Assert.assertNull(storage.head(key));
+      }
+    }
+
+    assertThrows("The deleted keys size should be <= 1000", IllegalArgumentException.class,
+        () -> storage.batchDelete(
+            IntStream.range(0, 1001).mapToObj(String::valueOf).collect(Collectors.toList())));
+  }
+
+  @Test
+  public void testListObjectsWithEmptyMarkers() {
+    String key1 = "a/b/c/d";
+    String key2 = "a/b";
+    String key3 = "a1/b1";
+
+    // create the folder to compatible with directory bucket.
+    storage.put("a/", new byte[0]);
+    storage.put("a/b/", new byte[0]);
+    storage.put("a/b/c/", new byte[0]);
+    storage.put("a/b/c/d/", new byte[0]);
+    storage.put("a1/", new byte[0]);
+    storage.put("a1/b1/", new byte[0]);
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%s/file-%d.txt", key1, i), data);
+      storage.put(String.format("%s/file-%d.txt", key2, i), data);
+      storage.put(String.format("%s/file-%d.txt", key3, i), data);
+    }
+
+    // group objects by '/' under 'a/'
+    ListObjectsResponse response = list("a/", null, 100, "/");
+    assertEquals(1, response.objects().size());
+    assertEquals("a/", response.objects().get(0).key());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+
+    response = list("a", null, 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(2, response.commonPrefixes().size());
+    assertEquals("a/", response.commonPrefixes().get(0));
+    assertEquals("a1/", response.commonPrefixes().get(1));
+
+    // group objects by '/' under 'a/b/' and group objects by 'b/' under 'a', they are same
+    response = list("a/b/", null, 100, "/");
+    assertEquals(11, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/", response.objects().get(0).key());
+    assertEquals("a/b/file-0.txt", response.objects().get(1).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(10).key());
+
+    response = list("a/b", null, 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+
+    if (!storage.bucket().isDirectory()) {
+      // Directory bucket only supports list with delimiter = '/' currently.
+      response = list("a", null, 100, "b/");
+      assertEquals(13, response.objects().size());
+      assertEquals(1, response.commonPrefixes().size());
+      assertEquals("a/b/", response.commonPrefixes().get(0));
+      assertEquals("a/", response.objects().get(0).key());
+      assertEquals("a1/", response.objects().get(1).key());
+      assertEquals("a1/b1/", response.objects().get(2).key());
+      assertEquals("a1/b1/file-0.txt", response.objects().get(3).key());
+      assertEquals("a1/b1/file-9.txt", response.objects().get(12).key());
+
+      response = list("a/", null, 100, "b/");
+      assertEquals(1, response.objects().size());
+      assertEquals(1, response.commonPrefixes().size());
+      assertEquals("a/b/", response.commonPrefixes().get(0));
+      assertEquals("a/", response.objects().get(0).key());
+    }
+
+    // group objects by different delimiter under 'a/b/c/d/' or 'a/b/c/d'
+    response = list("a/b/c/d/", null, 100, "/");
+    assertEquals(11, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/", response.objects().get(0).key());
+
+    response = list("a/b/c/d/", null, 5, "/");
+    assertEquals(5, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/", response.objects().get(0).key());
+
+    response = list("a/b/c/d", null, 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/", response.commonPrefixes().get(0));
+  }
+
+  @Test
+  public void testListObjectWithLimitObjectAndCommonPrefixes() {
+    String key1 = "a/b/c/d";
+    String key2 = "a/b";
+    String key3 = "a1/b1";
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%s/file-%d.txt", key1, i), data);
+      storage.put(String.format("%s/file-%d.txt", key2, i), data);
+      storage.put(String.format("%s/file-%d.txt", key3, i), data);
+    }
+
+    List<String> dirKeys = Lists.newArrayList("a/b/d/", "a/b/e/", "a/b/f/", "a/b/g/");
+    for (String key : dirKeys) {
+      storage.put(key, new byte[0]);
+    }
+
+    // group objects by '/' under 'a/b/', and limit top 5 objects among 10 objects and 1 common prefix
+    ListObjectsResponse response = list("a/b/", "a/b/", 5, "/");
+    assertEquals(1, response.objects().size());
+    assertEquals(4, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+    assertEquals("a/b/e/", response.commonPrefixes().get(2));
+    assertEquals("a/b/f/", response.commonPrefixes().get(3));
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+
+    response = list("a/b/", "a/b/", 14, "/");
+    assertEquals(10, response.objects().size());
+    assertEquals(4, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+    assertEquals("a/b/e/", response.commonPrefixes().get(2));
+    assertEquals("a/b/f/", response.commonPrefixes().get(3));
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(9).key());
+
+    response = list("a/b/", "a/b/", 15, "/");
+    assertEquals(10, response.objects().size());
+    assertEquals(5, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+    assertEquals("a/b/e/", response.commonPrefixes().get(2));
+    assertEquals("a/b/f/", response.commonPrefixes().get(3));
+    assertEquals("a/b/g/", response.commonPrefixes().get(4));
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(9).key());
+
+    // a/b/h-file-0.txt is behind from a/b/g/
+    storage.put("a/b/h-file-0.txt", data);
+    response = list("a/b/", "a/b/", 15, "/");
+    assertEquals(10, response.objects().size());
+    assertEquals(5, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+    assertEquals("a/b/e/", response.commonPrefixes().get(2));
+    assertEquals("a/b/f/", response.commonPrefixes().get(3));
+    assertEquals("a/b/g/", response.commonPrefixes().get(4));
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/file-9.txt", response.objects().get(9).key());
+
+    response = list("a/b/", "a/b/", 20, "/");
+    assertEquals(11, response.objects().size());
+    assertEquals(5, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+    assertEquals("a/b/e/", response.commonPrefixes().get(2));
+    assertEquals("a/b/f/", response.commonPrefixes().get(3));
+    assertEquals("a/b/g/", response.commonPrefixes().get(4));
+    assertEquals("a/b/file-0.txt", response.objects().get(0).key());
+    assertEquals("a/b/h-file-0.txt", response.objects().get(10).key());
+
+    response = list("a/b/", "a/b/", 1, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+
+    response = list("a/b/", "a/b/", 2, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(2, response.commonPrefixes().size());
+    assertEquals("a/b/c/", response.commonPrefixes().get(0));
+    assertEquals("a/b/d/", response.commonPrefixes().get(1));
+  }
+
+  @Test
+  public void testListedIteratorIsIdempotent() {
+    String key1 = "a/b/c/d";
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%s/file-%d.txt", key1, i), data);
+    }
+
+    Iterable<ObjectInfo> res;
+    if (storage.bucket().isDirectory()) {
+      res = ((DirectoryStorage) storage).listDir("a/b/c/d/", true);
+    } else {
+      res = storage.list("a/b/c/d/", "a/b/c/d/", 10);
+    }
+    Iterator<ObjectInfo> batch1 = res.iterator();
+    Iterator<ObjectInfo> batch2 = res.iterator();
+
+    for (int i = 0; i < 10; i++) {
+      assertTrue(batch1.hasNext());
+      ObjectInfo obj = batch1.next();
+      assertEquals(String.format("a/b/c/d/file-%d.txt", i), obj.key());
+    }
+    assertFalse(batch1.hasNext());
+
+    for (int i = 0; i < 10; i++) {
+      assertTrue(batch2.hasNext());
+      ObjectInfo obj = batch2.next();
+      assertEquals(String.format("a/b/c/d/file-%d.txt", i), obj.key());
+    }
+    assertFalse(batch2.hasNext());
+  }
+
+  @Test
+  public void testListObjectsWithSmallBatch() {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    String key1 = "a/b/c/d/";
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%sfile-%d.txt", key1, i), data);
+    }
+
+    // change list object count
+    Configuration newConf = new Configuration(storage.conf());
+    newConf.setInt(TosKeys.FS_TOS_LIST_OBJECTS_COUNT, 5);
+    storage.initialize(newConf, storage.bucket().name());
+
+    List<Integer> maxKeys = Arrays.asList(5, 10, 9, 20, -1);
+    for (int maxKey : maxKeys) {
+      Iterator<ObjectInfo> objs = storage.list(key1, key1, maxKey).iterator();
+      int end = Math.min(maxKey == -1 ? 10 : maxKey, 10);
+      for (int i = 0; i < end; i++) {
+        assertTrue(objs.hasNext());
+        ObjectInfo obj = objs.next();
+        assertEquals(String.format("a/b/c/d/file-%d.txt", i), obj.key());
+      }
+      assertFalse(objs.hasNext());
+    }
+
+    // reset list object count
+    newConf = new Configuration(storage.conf());
+    newConf.setInt(TosKeys.FS_TOS_LIST_OBJECTS_COUNT, 1000);
+    storage.initialize(newConf, storage.bucket().name());
+  }
+
+  @Test
+  public void testListObjectsWithSpecificDelimiters() {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    String key1 = "a/b/c/d";
+    String key2 = "a/b";
+    String key3 = "a1/b1";
+
+    byte[] data = TestUtility.rand(256);
+    for (int i = 0; i < 10; i++) {
+      storage.put(String.format("%s/file-%d.txt", key1, i), data);
+      storage.put(String.format("%s/file-%d.txt", key2, i), data);
+      storage.put(String.format("%s/file-%d.txt", key3, i), data);
+    }
+
+    ListObjectsResponse response = list("a", "", 11, "b/");
+    assertEquals(10, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+    assertEquals("a1/b1/file-0.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-9.txt", response.objects().get(9).key());
+
+    response = list("a", "", 5, "b/");
+    assertEquals(4, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+    assertEquals("a1/b1/file-0.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-3.txt", response.objects().get(3).key());
+
+    response = list("a", "a1/b1/file-3.txt", 5, "b/");
+    assertEquals(5, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a1/b1/file-4.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-8.txt", response.objects().get(4).key());
+
+    response = list("a", "a1/b1/file-3.txt", 6, "b/");
+    assertEquals(6, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+    assertEquals("a1/b1/file-4.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-9.txt", response.objects().get(5).key());
+
+    response = list("a", "a/b/file-3.txt", 5, "b/");
+    assertEquals(4, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+    assertEquals("a1/b1/file-0.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-3.txt", response.objects().get(3).key());
+
+    response = list("a", "a/b/file-3.txt", 10, "b/");
+    assertEquals(9, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+    assertEquals("a1/b1/file-0.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-8.txt", response.objects().get(8).key());
+
+    response = list("a", "a/b/file-3.txt", 11, "b/");
+    assertEquals(10, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/", response.commonPrefixes().get(0));
+    assertEquals("a1/b1/file-0.txt", response.objects().get(0).key());
+    assertEquals("a1/b1/file-9.txt", response.objects().get(9).key());
+
+    response = list("a", "a/b/", 1, "b/");
+    assertEquals(1, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+
+    response = list("a/b/c/d", "", 100, "/file");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/file", response.commonPrefixes().get(0));
+
+    response = list("a/b/c/d/", "", 100, "file");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a/b/c/d/file", response.commonPrefixes().get(0));
+
+
+    // group objects by different delimiter under 'a1' or 'a1/'
+    response = list("a1", "", 100, "");
+    assertEquals(10, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+
+    response = list("a1", "", 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a1/", response.commonPrefixes().get(0));
+
+    response = list("a1/", "", 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a1/b1/", response.commonPrefixes().get(0));
+
+    response = list("a1/", "", 1, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(1, response.commonPrefixes().size());
+    assertEquals("a1/b1/", response.commonPrefixes().get(0));
+
+    // group objects by non-exist delimiter under 'a1' or 'a1/'
+    response = list("a1", "", 100, "non-exist");
+    assertEquals(10, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+
+    response = list("a1/", "", 100, "non-exist");
+    assertEquals(10, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+
+    // test the sequent of common prefixes
+    response = list("a", "", 100, "b");
+    assertEquals(0, response.objects().size());
+    assertEquals(2, response.commonPrefixes().size());
+    assertEquals("a/b", response.commonPrefixes().get(0));
+    assertEquals("a1/b", response.commonPrefixes().get(1));
+  }
+
+  @Test
+  public void testOverwriteDirectoryWithAFile() throws IOException {
+    String dirKey = "a/b/";
+    String key = "a/b";
+    storage.delete("a/");
+
+    byte[] data1 = new byte[0];
+    byte[] data2 = TestUtility.rand(128);
+
+    storage.put(dirKey, data1);
+    assertArrayEquals(data1, IOUtils.toByteArray(getStream(dirKey, 0, 256)));
+
+    if (!storage.bucket().isDirectory()) {
+      // Directory bucket doesn't allow overwrote if the resource type is changed.
+      storage.put(key, data2);
+      assertArrayEquals(data2, IOUtils.toByteArray(getStream(key, 0, 256)));
+    }
+
+    storage.delete(key);
+    storage.delete(dirKey);
+    assertNull(storage.head(key));
+    assertNull(storage.head(dirKey));
+  }
+
+  private InputStream getStream(String key, long off, long limit) {
+    return storage.get(key, off, limit).stream();
+  }
+
+  @Test
+  public void testDeleteNonEmptyDir() throws IOException {
+    storage.put("a/", new byte[0]);
+    storage.put("a/b/", new byte[0]);
+    assertArrayEquals(new byte[0], IOUtils.toByteArray(getStream("a/b/", 0, 256)));
+
+    ListObjectsResponse response = list("a/b/", "a/b/", 100, "/");
+    assertEquals(0, response.objects().size());
+    assertEquals(0, response.commonPrefixes().size());
+
+    if (!storage.bucket().isDirectory()) {
+      // Directory bucket only supports list with delimiter = '/'.
+      response = list("a/b/", "a/b/", 100, null);
+      assertEquals(0, response.objects().size());
+      assertEquals(0, response.commonPrefixes().size());
+    }
+
+    storage.delete("a/b/");
+    assertNull(storage.head("a/b/"));
+    assertNull(storage.head("a/b"));
+    assertNotNull(storage.head("a/"));
+  }
+
+  @Test
+  public void testRecursiveDelete() {
+    storage.put("a/", new byte[0]);
+    storage.put("a/b/", new byte[0]);
+    storage.put("a/b/c1/", new byte[0]);
+    storage.put("a/b/c2/", new byte[0]);
+    storage.put("a/b/c3/", new byte[0]);
+    assertNotNull(storage.head("a/"));
+    assertNotNull(storage.head("a/b/"));
+    assertNotNull(storage.head("a/b/c1/"));
+    assertNotNull(storage.head("a/b/c2/"));
+    assertNotNull(storage.head("a/b/c3/"));
+
+    storage.delete("a/b/c3/");
+    assertNull(storage.head("a/b/c3/"));
+
+    storage.deleteAll("");
+    assertNull(storage.head("a/b/c1/"));
+    assertNull(storage.head("a/b/c2/"));
+    assertNull(storage.head("a/b/"));
+    assertNull(storage.head("a/"));
+  }
+
+  @Test
+  public void testListObjectKeys() {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    byte[] dirBytes = new byte[0];
+    byte[] fileBytes = TestUtility.rand(128);
+    storage.put("a/b1/", dirBytes);
+    storage.put("a/b2/c0/", dirBytes);
+    storage.put("a/b2/c1/d1.txt", fileBytes);
+    storage.put("a/b2/c1/e1.txt", fileBytes);
+    storage.put("a/b2/c2.txt", fileBytes);
+
+    // list single dir
+    List<ObjectInfo> ret = toList(storage.list("a/b1", "", 10));
+    assertEquals(1, ret.size());
+    assertEquals("a/b1/", ret.get(0).key());
+    assertEquals(0, ret.get(0).size());
+
+    ret = toList(storage.list("a/b1/", "", 10));
+    assertEquals(1, ret.size());
+    assertEquals("a/b1/", ret.get(0).key());
+    assertEquals(0, ret.get(0).size());
+
+    // list single file
+    ret = toList(storage.list("a/b2/c1/d1.txt", "", 10));
+    assertEquals(1, ret.size());
+    assertEquals("a/b2/c1/d1.txt", ret.get(0).key());
+    assertEquals(fileBytes.length, ret.get(0).size());
+
+    // list multiple files & dirs
+    ret = toList(storage.list("a/b2", "", 10));
+    assertEquals(4, ret.size());
+    assertEquals("a/b2/c0/", ret.get(0).key());
+    assertEquals("a/b2/c1/d1.txt", ret.get(1).key());
+    assertEquals("a/b2/c1/e1.txt", ret.get(2).key());
+    assertEquals("a/b2/c2.txt", ret.get(3).key());
+    assertEquals(dirBytes.length, ret.get(0).size());
+
+    // list single file with marker
+    ret = toList(storage.list("a/b2", "a/b2/c1/e1.txt", 10));
+    assertEquals(1, ret.size());
+    assertEquals("a/b2/c2.txt", ret.get(0).key());
+    assertEquals(fileBytes.length, ret.get(0).size());
+
+    // list multiple files with marker
+    ret = toList(storage.list("a/b2", "a/b2/c1/", 10));
+    assertEquals(3, ret.size());
+    assertEquals("a/b2/c1/d1.txt", ret.get(0).key());
+    assertEquals("a/b2/c1/e1.txt", ret.get(1).key());
+    assertEquals("a/b2/c2.txt", ret.get(2).key());
+    assertEquals(fileBytes.length, ret.get(0).size());
+
+    // list multiple files & dirs with part path as prefix
+    ret = toList(storage.list("a/b2/c", "", 10));
+    assertEquals(4, ret.size());
+    assertEquals("a/b2/c0/", ret.get(0).key());
+    assertEquals("a/b2/c1/d1.txt", ret.get(1).key());
+    assertEquals("a/b2/c1/e1.txt", ret.get(2).key());
+    assertEquals("a/b2/c2.txt", ret.get(3).key());
+    assertEquals(dirBytes.length, ret.get(0).size());
+
+    ret = toList(storage.list("a/b2/c", "", 2));
+    assertEquals(2, ret.size());
+    assertEquals("a/b2/c0/", ret.get(0).key());
+
+    ret = toList(storage.list("a/b2/c1/d1.", "", 10));
+    assertEquals(1, ret.size());
+    assertEquals("a/b2/c1/d1.txt", ret.get(0).key());
+    assertEquals(fileBytes.length, ret.get(0).size());
+  }
+
+  @Test
+  public void testListAllObjectKeys() {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    byte[] dirBytes = new byte[0];
+    byte[] fileBytes = TestUtility.rand(128);
+    storage.put("a/b1/", dirBytes);
+    storage.put("a/b2/c0/", dirBytes);
+    storage.put("a/b2/c1/d1.txt", fileBytes);
+    storage.put("a/b2/c1/e1.txt", fileBytes);
+    storage.put("a/b2/c2.txt", dirBytes);
+
+    // list single dir
+    List<ObjectInfo> ret = Lists.newArrayList(storage.listAll("a/b1", ""));
+    assertEquals(1, ret.size());
+    assertEquals("a/b1/", ret.get(0).key());
+    assertEquals(0, ret.get(0).size());
+
+    // list single file
+    ret = Lists.newArrayList(storage.listAll("a/b2/c1/d1.txt", ""));
+    assertEquals(1, ret.size());
+    assertEquals("a/b2/c1/d1.txt", ret.get(0).key());
+    assertEquals(fileBytes.length, ret.get(0).size());
+
+    // list multiple files & dirs
+    ret = Lists.newArrayList(storage.listAll("a/b2", ""));
+    assertEquals(4, ret.size());
+    assertEquals("a/b2/c0/", ret.get(0).key());
+    assertEquals("a/b2/c1/d1.txt", ret.get(1).key());
+    assertEquals("a/b2/c1/e1.txt", ret.get(2).key());
+    assertEquals("a/b2/c2.txt", ret.get(3).key());
+    assertEquals(dirBytes.length, ret.get(0).size());
+
+    // list multiple files & dirs with part path as prefix
+    ret = Lists.newArrayList(storage.listAll("a/b2/c", ""));
+    assertEquals(4, ret.size());
+    assertEquals("a/b2/c0/", ret.get(0).key());
+    assertEquals("a/b2/c1/d1.txt", ret.get(1).key());
+    assertEquals("a/b2/c1/e1.txt", ret.get(2).key());
+    assertEquals("a/b2/c2.txt", ret.get(3).key());
+    assertEquals(dirBytes.length, ret.get(0).size());
+  }
+
+  @Test
+  public void testListEmptyKeys() {
+    if (storage.bucket().isDirectory()) {
+      assertEquals(0, Lists.newArrayList(((DirectoryStorage) storage).listDir("not-exist", true)).size());
+    } else {
+      assertEquals(0, Lists.newArrayList(storage.list("not-exist", "", 2)).size());
+    }
+  }
+
+  @Test
+  public void testMultiUploadEmptyFile() {
+    String key = "a/b/empty.txt";
+    MultipartUpload upload = storage.createMultipartUpload(key);
+    assertThrows(Exception.class, () -> storage.completeUpload(key, upload.uploadId(), Lists.newArrayList()));
+  }
+
+  @Test
+  public void testMultiUploadZeroByte() throws IOException {
+    String key = "a/b/zero.txt";
+    MultipartUpload upload = storage.createMultipartUpload(key);
+    Part part = storage.uploadPart(key, upload.uploadId(), 1, () -> new ByteArrayInputStream(new byte[0]), 0);
+    storage.completeUpload(key, upload.uploadId(), Lists.newArrayList(part));
+    assertArrayEquals(ObjectTestUtils.EMPTY_BYTES, IOUtils.toByteArray(getStream(key)));
+  }
+
+  @Test
+  public void testMultiUploadFile() throws IOException {
+    String key1 = "a/b/c/e.txt";
+    String uploadId1 = storage.createMultipartUpload(key1).uploadId();
+    assertNotEquals(uploadId1, "");
+
+    byte[] dataset = multipleUpload(key1, uploadId1, 2, true);
+    assertArrayEquals(dataset, IOUtils.toByteArray(getStream(key1)));
+
+    String key2 = "a/b/e/e.txt";
+    String uploadId2 = storage.createMultipartUpload(key2).uploadId();
+    assertNotEquals(uploadId2, "");
+
+    dataset = multipleUpload(key2, uploadId2, 3, true);
+    assertArrayEquals(dataset, IOUtils.toByteArray(getStream(key2)));
+  }
+
+  @Test
+  public void testPutAndCompleteMPUWithSameContent() throws IOException {
+    String mpu = "a/b/mpu.txt";
+    String put = "a/b/put.txt";
+    byte[] dataset = TestUtility.rand(11 << 20);
+    byte[] checksum = multipleUpload(mpu, dataset);
+
+    storage.put(put, dataset);
+
+    ObjectInfo mputObj = storage.head(mpu);
+    ObjectInfo putObj = storage.head(put);
+    assertArrayEquals(checksum, mputObj.checksum());
+    assertArrayEquals(checksum, putObj.checksum());
+
+    if (!storage.bucket().isDirectory()) {
+      List<ObjectInfo> objectInfo = toList(storage.list(mpu, null, 10));
+      Assert.assertEquals(mputObj, objectInfo.get(0));
+    }
+  }
+
+  /*@Test
+  public void testMultiUpload11M() throws IOException {
+    byte[] dataset = TestUtility.rand(11 << 20);
+    multipleUpload("a11/b/c.txt", dataset);
+  }
+
+  @Test
+  public void testMultiUpload101M() throws IOException {
+    byte[] dataset = TestUtility.rand(101 << 20);
+    multipleUpload("a101/b/c.txt", dataset);
+  }*/
+
+  @Test
+  public void testListUploads() {
+    String key1 = "a/b/c/e.txt";
+    String uploadId1 = storage.createMultipartUpload(key1).uploadId();
+    assertNotEquals(uploadId1, "");
+    multipleUpload(key1, uploadId1, 2, false);
+
+    String key2 = "a/b/e/e.txt";
+    String uploadId2 = storage.createMultipartUpload(key2).uploadId();
+    assertNotEquals(uploadId2, "");
+    multipleUpload(key2, uploadId2, 3, false);
+
+    Iterable<MultipartUpload> iterable = storage.listUploads("");
+    List<MultipartUpload> uploads = Lists.newArrayList(iterable.iterator());
+    assertEquals(2, uploads.size());
+    assertEquals(key1, uploads.get(0).key());
+    assertEquals(uploadId1, uploads.get(0).uploadId());
+    assertEquals(key2, uploads.get(1).key());
+    assertEquals(uploadId2, uploads.get(1).uploadId());
+
+    // check iterator is idempotent
+    uploads = Lists.newArrayList(iterable.iterator());
+    assertEquals(2, uploads.size());
+    assertEquals(key1, uploads.get(0).key());
+    assertEquals(uploadId1, uploads.get(0).uploadId());
+    assertEquals(key2, uploads.get(1).key());
+    assertEquals(uploadId2, uploads.get(1).uploadId());
+
+    uploads = Lists.newArrayList(storage.listUploads("a/b/"));
+    assertEquals(2, uploads.size());
+    assertEquals(key1, uploads.get(0).key());
+    assertEquals(uploadId1, uploads.get(0).uploadId());
+    assertEquals(key2, uploads.get(1).key());
+    assertEquals(uploadId2, uploads.get(1).uploadId());
+
+    uploads = Lists.newArrayList(storage.listUploads("a/b/c/"));
+    assertEquals(1, uploads.size());
+    assertEquals(key1, uploads.get(0).key());
+    assertEquals(uploadId1, uploads.get(0).uploadId());
+
+    storage.abortMultipartUpload(key1, uploadId1);
+    storage.abortMultipartUpload(key2, uploadId2);
+    assertEquals(0, Lists.newArrayList((storage.listUploads("a/b/"))).size());
+  }
+
+  private byte[] multipleUpload(String key, String uploadId, int partCnt, boolean completeUpload) {
+    int partSize = 5 * 1024 * 1024;
+    byte[] dataset = new byte[partCnt * partSize];
+    byte[] partData = TestUtility.rand(partSize);
+    try {
+      int offset = 0;
+      List<Part> parts = new ArrayList<>();
+      for (int i = 1; i <= partCnt; i++) {
+        Part part = storage.uploadPart(key, uploadId, i, () -> new ByteArrayInputStream(partData), partData.length);
+        parts.add(part);
+        System.arraycopy(partData, 0, dataset, offset, partData.length);
+        offset += partData.length;
+      }
+      if (completeUpload) {
+        storage.completeUpload(key, uploadId, parts);
+      }
+    } catch (RuntimeException e) {
+      storage.abortMultipartUpload(key, uploadId);
+    }
+    return dataset;
+  }
+
+  private byte[] multipleUpload(String key, byte[] dataset) throws IOException {
+    int partSize = 5 * 1024 * 1024;
+    int partCnt = (int) Math.ceil((double) dataset.length / partSize);
+
+    String uploadId = storage.createMultipartUpload(key).uploadId();
+    assertNotEquals(uploadId, "");
+
+    try {
+      List<Part> parts = new ArrayList<>();
+      for (int i = 0; i < partCnt; i++) {
+        int start = i * partSize;
+        int end = Math.min(dataset.length, start + partSize);
+        byte[] partData = Arrays.copyOfRange(dataset, start, end);
+
+        Part part = storage.uploadPart(key, uploadId, i + 1, () -> new ByteArrayInputStream(partData), partData.length);
+
+        assertEquals(DigestUtils.md5Hex(partData), part.eTag().replace("\"", ""));
+        parts.add(part);
+      }
+
+      byte[] checksum = storage.completeUpload(key, uploadId, parts);
+      assertArrayEquals(dataset, IOUtils.toByteArray(getStream(key)));
+
+      return checksum;
+    } catch (IOException | RuntimeException e) {
+      storage.abortMultipartUpload(key, uploadId);
+      throw e;
+    }
+  }
+
+  @Test
+  public void testUploadPartCopy10MB() {
+    String srcKey = "src10MB.txt";
+    String dstKey = "dst10MB.txt";
+    testUploadPartCopy(srcKey, dstKey, 10 << 20); // 10MB
+  }
+
+  @Test
+  public void testUploadPartCopy100MB() {
+    String srcKey = "src100MB.txt";
+    String dstKey = "dst100MB.txt";
+    testUploadPartCopy(srcKey, dstKey, 100 << 20);// 100MB
+  }
+
+  @Test
+  public void testUploadPartCopy65MB() {
+    String srcKey = "src65MB.txt";
+    String dstKey = "dst65MB.txt";
+    testUploadPartCopy(srcKey, dstKey, 65 << 20);// 65MB
+  }
+
+  private void testUploadPartCopy(String srcKey, String key, int fileSize) {
+    MultipartUpload srcMultipartUpload = storage.createMultipartUpload(srcKey);
+    long partSize = 5 << 20;
+    int partCnt = (int) (fileSize / partSize + (fileSize % partSize == 0 ? 0 : 1));
+    byte[] data = multipleUpload(srcMultipartUpload.key(), srcMultipartUpload.uploadId(), partCnt, true);
+    MultipartUpload dstMultipartUpload = storage.createMultipartUpload(key);
+    long copyPartRangeStart = 0L;
+    List<Part> results = Lists.newArrayList();
+    try {
+      for (int i = 0; i < partCnt; i++) {
+        Part result = storage.uploadPartCopy(srcKey, key, dstMultipartUpload.uploadId(), i + 1,
+            copyPartRangeStart, Math.min(copyPartRangeStart + partSize, fileSize) - 1);
+        results.add(result);
+        copyPartRangeStart += partSize;
+      }
+      storage.completeUpload(key, dstMultipartUpload.uploadId(), results);
+      assertArrayEquals(data, IOUtils.toByteArray(getStream(key)));
+    } catch (Exception e) {
+      storage.abortMultipartUpload(key, dstMultipartUpload.uploadId());
+    }
+  }
+
+  @Test
+  public void testCopy0MB() throws IOException {
+    String srcKey = "src0MB.txt";
+    String dstKey = "dst0MB.txt";
+    testCopy(srcKey, dstKey, 0);
+  }
+
+  @Test
+  public void testCopy5MB() throws IOException {
+    String srcKey = "src5MB.txt";
+    String dstKey = "dst5MB.txt";
+    testCopy(srcKey, dstKey, 5 << 20);
+  }
+
+  @Test
+  public void testCopy10MB() throws IOException {
+    String srcKey = "src10MB.txt";
+    String dstKey = "dst10MB.txt";
+    testCopy(srcKey, dstKey, 10 << 20);
+  }
+
+  @Test
+  public void testRename() throws IOException {
+    String srcKey = "src.txt";
+    String dstKey = "dst.txt";
+
+    // Rename source to a un-exist object
+    renameObject(srcKey, dstKey, 256);
+    renameObject(srcKey, dstKey, 0);
+
+    // Overwrite an existing object
+    renameObjectWhenDestExist(srcKey, dstKey, 256, 0);
+    renameObjectWhenDestExist(srcKey, dstKey, 0, 256);
+
+    assertNull(storage.head(srcKey));
+    assertThrows("Source key not found", RuntimeException.class,
+        () -> storage.rename(srcKey, dstKey));
+
+    assertThrows("Cannot rename to the same object", RuntimeException.class,
+        () -> renameObject(srcKey, srcKey, 256));
+  }
+
+  private void renameObjectWhenDestExist(String srcKey, String dstKey, int srcSize, int destSize) throws IOException {
+    byte[] dstData = new byte[destSize];
+    storage.put(dstKey, dstData, 0, destSize);
+    assertArrayEquals(dstData, IOUtils.toByteArray(getStream(dstKey)));
+
+    renameObject(srcKey, dstKey, srcSize);
+  }
+
+  private void renameObject(String srcKey, String dstKey, int fileSize) throws IOException {
+    byte[] data = new byte[fileSize];
+    storage.put(srcKey, data, 0, fileSize);
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(srcKey)));
+
+    storage.rename(srcKey, dstKey);
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(dstKey)));
+    assertNull(storage.head(srcKey));
+
+    storage.delete(dstKey);
+    assertNull(storage.head(dstKey));
+  }
+
+  private void testCopy(String srcKey, String dstKey, int fileSize) throws IOException {
+    byte[] data = new byte[fileSize];
+    storage.put(srcKey, data, 0, fileSize);
+    storage.copy(srcKey, dstKey);
+    assertArrayEquals(data, IOUtils.toByteArray(getStream(dstKey)));
+  }
+
+  private ListObjectsResponse list(String prefix, String startAfter, int limit, String delimiter) {
+    Preconditions.checkArgument(limit <= 1000, "Cannot list more than 1000 objects.");
+    ListObjectsRequest request = ListObjectsRequest.builder()
+        .prefix(prefix)
+        .startAfter(startAfter)
+        .maxKeys(limit)
+        .delimiter(delimiter)
+        .build();
+    Iterator<ListObjectsResponse> iterator = storage.list(request).iterator();
+    if (iterator.hasNext()) {
+      return iterator.next();
+    } else {
+      return new ListObjectsResponse(new ArrayList<>(), new ArrayList<>());
+    }
+  }
+
+  private static <T> List<T> toList(final Iterable<T> iterable) {
+    return StreamSupport.stream(iterable.spliterator(), false)
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  public void testObjectTagging() {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    if (storage instanceof FileStore) {
+      return;
+    }
+
+    // create key.
+    String key = "ObjectTagging";
+    String tagPrefix = "tag" + UUIDUtils.random() + "_";
+    String valuePrefix = "value" + UUIDUtils.random() + "_";
+    storage.put(key, new byte[0], 0, 0);
+
+    Map<String, String> tagsMap = new HashMap<>();
+    for (int i = 0; i < 10; i++) {
+      tagsMap.put(tagPrefix + i, valuePrefix + i);
+    }
+
+    // 1. put and get when key exists.
+    storage.putTags(key, tagsMap);
+    Map<String, String> tags = storage.getTags(key);
+    assertEquals(10, tags.keySet().size());
+    assertTrue(Maps.difference(tagsMap, tags).areEqual());
+
+    // 2. put and get when key doesn't exist.
+    assertThrows("NoSuchKey", TosServerException.class, () -> storage.putTags("non-exist-key", tagsMap));
+    assertThrows("doesn't exist", TosServerException.class, () -> storage.getTags("non-exist-key"));
+
+    // 3. tag threshold.
+    Map<String, String> bigMap = new HashMap<>(tagsMap);
+    bigMap.put(tagPrefix + 11, valuePrefix + 11);
+    assertThrows("exceed limit of 10", RuntimeException.class, () -> storage.putTags(key, bigMap));
+
+    // 4. put tag with null tagName.
+    Map<String, String> nullKeyTag = new HashMap<>();
+    nullKeyTag.put(null, "some value");
+    assertThrows("TagKey you have provided is invalid", TosServerException.class,
+        () -> storage.putTags(key, nullKeyTag));
+
+    // 5. put tag with null value.
+    Map<String, String> nullValueTag = new HashMap<>();
+    nullValueTag.put("some-key", null);
+    storage.putTags(key, nullValueTag);
+    assertNull(storage.getTags(key).get("some-key"));
+
+    // 6. remove tags.
+    Map<String, String> emptyTag = new HashMap<>();
+    storage.putTags(key, emptyTag);
+    assertEquals(0, storage.getTags(key).size());
+  }
+
+  @Test
+  public void testObjectChecksum() throws IOException {
+    byte[] data = TestUtility.rand(256);
+    String key = "a/truncated.txt";
+
+    // Read object at the end offset.
+    byte[] checksum = storage.put(key, () -> new ByteArrayInputStream(data), 200);
+    ObjectContent objContent = storage.get(key, 200, -1);
+    objContent.stream().close();
+    assertArrayEquals(checksum, objContent.checksum());
+
+    // Read empty object.
+    checksum = storage.put(key, () -> new ByteArrayInputStream(new byte[0]), 0);
+    objContent = storage.get(key, 0, -1);
+    objContent.stream().close();
+    assertArrayEquals(checksum, objContent.checksum());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestChainTOSInputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestChainTOSInputStream.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos;
+
+import com.volcengine.tos.model.object.GetObjectBasicOutput;
+import com.volcengine.tos.model.object.GetObjectV2Output;
+import org.apache.hadoop.fs.tosfs.common.Bytes;
+import org.apache.hadoop.fs.tosfs.object.Constants;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestChainTOSInputStream {
+
+  private static final int DATA_SIZE = 1 << 20;
+  private static final byte[] DATA = TestUtility.rand(DATA_SIZE);
+
+  @Test
+  public void testRetryReadData() throws IOException {
+    int readLen = DATA_SIZE - 1;
+    int cutOff = readLen / 2;
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // The read length is more than the cut-off position, and equal to data length,
+      // so the first stream will throw IOException, and fallback to the second stream.
+      byte[] data = new byte[readLen];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, 0, readLen), data);
+    }
+
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // The read length is more than data length, so the first stream will throw IOException,
+      // and fallback to the second stream.
+      byte[] data = new byte[readLen + 2];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, 0, readLen), Bytes.toBytes(data, 0, n));
+    }
+
+    readLen = DATA_SIZE / 3;
+    cutOff = DATA_SIZE / 2;
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE, 1024,
+        cutOff)) {
+      for (int i = 0; i <= 3; i++) {
+        // The cut-off position is between (readLen, 2 * readLen), so the data of first read come from the first stream,
+        // and then the second read will meet IOException, and fallback to the second stream.
+        byte[] data = new byte[readLen];
+        int n = stream.read(data);
+
+        int off = i * readLen;
+        int len = Math.min(readLen, DATA_SIZE - off);
+
+        Assert.assertEquals(len, n);
+        Assert.assertArrayEquals(Bytes.toBytes(DATA, off, len), Bytes.toBytes(data, 0, len));
+      }
+    }
+
+    int smallDataSize = 1 << 10;
+    cutOff = smallDataSize / 2;
+    byte[] smallData = TestUtility.rand(1 << 10);
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(smallData, 0, smallDataSize,
+        1024, cutOff)) {
+      for (int i = 0; i < smallDataSize; i++) {
+        // The cut-off position is 512, the 512th read operation will meet IOException,
+        // and then fallback to the second stream.
+        int read = stream.read();
+        Assert.assertEquals(smallData[i] & 0xFF, read);
+      }
+    }
+  }
+
+  @Test
+  public void testSkipAndRead() throws IOException {
+    int cutOff = (DATA_SIZE - 1) / 2;
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // The skip pos is equal to cut-off pos, once skip finished, the first read operation will meet IOException,
+      // and the fallback to the second stream.
+      int readPos = (DATA_SIZE - 1) / 2;
+      stream.skip(readPos);
+
+      int readLen = 1024;
+      byte[] data = new byte[readLen];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, readPos, readLen), data);
+    }
+
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // The skip pos is more than cut-off pos, the skip operation will throw IOException,
+      // and the fallback to the second stream and skip(readPos) again
+      int readPos = cutOff + 1024;
+      stream.skip(readPos);
+
+      int readLen = 1024;
+      byte[] data = new byte[readLen];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, readPos, readLen), data);
+    }
+
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // The skip pos = cut-off pos - 1025, the skip operation will succeed on the first stream,
+      // the 1024 bytes read operation also succeed on the first stream,
+      // but the next 1024 bytes read operation will fail on the first stream, and fallback to the second stream
+      int readPos = cutOff - 1024 - 1;
+      stream.skip(readPos);
+
+      int readLen = 1024;
+      byte[] data = new byte[readLen];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, readPos, readLen), data);
+
+      n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, readPos + 1024, readLen), data);
+    }
+
+    try (ChainTOSInputStream stream = createTestChainTOSInputStream(DATA, 0, DATA_SIZE - 1, 1024,
+        cutOff)) {
+      // 1. Skip 1024 bytes and then read 1024 bytes from the first stream.
+      // 2. And then skip cut-off - 512 bytes, the target off = 1024 + 1024 + cut-off - 512,
+      // which is bigger than cut-off pos, so the second skip operation will fail,
+      // and then fallback to the second stream.
+      // 3. Read 1024 bytes
+      int readPos = 1024;
+      stream.skip(readPos);
+
+      int readLen = 1024;
+      byte[] data = new byte[readLen];
+      int n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, readPos, readLen), data);
+
+      int skipPos = cutOff - 512;
+      stream.skip(skipPos);
+
+      n = stream.read(data);
+      Assert.assertEquals(readLen, n);
+      int targetOff = readPos + 1024 + skipPos;
+      Assert.assertArrayEquals(Bytes.toBytes(DATA, targetOff, readLen), data);
+    }
+  }
+
+  /**
+   * The ChainTOSInputStream contains two stream created by TestObjectFactory.
+   * Once the read pos of first stream is more than cutPos, the stream will throw IOException with
+   * unexpect end of stream error msg, but the second stream will contain the remaining data.
+   */
+  private ChainTOSInputStream createTestChainTOSInputStream(byte[] data, long startOff, long endOff,
+      long maxDrainSize, long cutPos) {
+    String key = "dummy-key";
+    TOS.GetObjectFactory factory = new TestObjectFactory(data, Arrays.asList(cutPos, -1L));
+    return new ChainTOSInputStream(factory, key, startOff, endOff, maxDrainSize, 1);
+  }
+
+  private static class TestObjectFactory implements TOS.GetObjectFactory {
+    private final byte[] data;
+    private final List<Long> streamBreakPoses;
+    private int streamIndex = 0;
+
+    TestObjectFactory(byte[] data, List<Long> streamBreakPoses) {
+      this.data = data;
+      this.streamBreakPoses = streamBreakPoses;
+    }
+
+    @Override
+    public GetObjectOutput create(String key, long offset, long end) {
+      long len = Math.min(end, data.length) - offset;
+      ByteArrayInputStream data = new ByteArrayInputStream(this.data, (int) offset, (int) len);
+
+      if (streamIndex < streamBreakPoses.size()) {
+        return new GetObjectOutput(new GetObjectV2Output(new GetObjectBasicOutput(),
+            new UnExpectedEndOfStream(data, streamBreakPoses.get(streamIndex++))),
+            Constants.MAGIC_CHECKSUM);
+      } else {
+        throw new RuntimeException("No more output");
+      }
+    }
+  }
+
+  private static class UnExpectedEndOfStream extends InputStream {
+    private final ByteArrayInputStream delegate;
+    private final long breakPos;
+    private int readPos;
+
+    UnExpectedEndOfStream(ByteArrayInputStream stream, long breakPos) {
+      delegate = stream;
+      this.breakPos = breakPos;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (breakPos != -1 && readPos >= breakPos) {
+        throw new IOException("unexpected end of stream on dummy source.");
+      } else {
+        int n = delegate.read();
+        readPos += 1;
+        return n;
+      }
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      if (breakPos != -1 && readPos >= breakPos) {
+        throw new IOException("unexpected end of stream on dummy source.");
+      } else {
+        int n = delegate.read(b, off, len);
+        readPos += n;
+        return n;
+      }
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestDelegationClientBuilder.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestDelegationClientBuilder.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos;
+
+import com.volcengine.tos.TOSV2;
+import com.volcengine.tos.TOSV2ClientBuilder;
+import com.volcengine.tos.TosClientException;
+import com.volcengine.tos.TosException;
+import com.volcengine.tos.TosServerException;
+import com.volcengine.tos.auth.Credential;
+import com.volcengine.tos.auth.StaticCredentials;
+import com.volcengine.tos.comm.HttpStatus;
+import com.volcengine.tos.model.object.DeleteObjectInput;
+import com.volcengine.tos.model.object.HeadObjectV2Input;
+import com.volcengine.tos.model.object.HeadObjectV2Output;
+import com.volcengine.tos.model.object.ListObjectsV2Input;
+import com.volcengine.tos.model.object.ListObjectsV2Output;
+import com.volcengine.tos.model.object.PutObjectInput;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.common.Tasks;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.tos.auth.EnvironmentCredentialsProvider;
+import org.apache.hadoop.fs.tosfs.object.tos.auth.SimpleCredentialsProvider;
+import org.apache.hadoop.fs.tosfs.util.ParseUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import javax.net.ssl.SSLException;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.DelegationClient.isRetryableException;
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestDelegationClientBuilder {
+
+  private static final String TEST_KEY = UUIDUtils.random();
+  private static final String TEST_DATA = "1234567890";
+  private static final String ENV_ACCESS_KEY =
+      ParseUtils.envAsString(TOS.ENV_TOS_ACCESS_KEY_ID, false);
+  private static final String ENV_SECRET_KEY =
+      ParseUtils.envAsString(TOS.ENV_TOS_SECRET_ACCESS_KEY, false);
+  private static final String ENV_ENDPOINT = ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT, false);
+
+  @Rule
+  public TestName name = new TestName();
+
+  // Maximum retry times of the tos http client.
+  public static final String MAX_RETRY_COUNT_KEY = "fs.tos.http.maxRetryCount";
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Before
+  public void setUp() {
+    TOSV2 tosSdkClientV2 =
+        new TOSV2ClientBuilder().build(TestUtility.region(), TestUtility.endpoint(),
+            new StaticCredentials(ENV_ACCESS_KEY, ENV_SECRET_KEY));
+    try (ByteArrayInputStream stream = new ByteArrayInputStream(TEST_DATA.getBytes())) {
+      PutObjectInput putObjectInput =
+          new PutObjectInput().setBucket(TestUtility.bucket()).setKey(TEST_KEY).setContent(stream);
+      tosSdkClientV2.putObject(putObjectInput);
+    } catch (IOException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testHeadApiRetry() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), "https://test.tos-cn-beijing.ivolces.com");
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, false);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key("test"), "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key("test"), "SECRET_KEY");
+
+    DelegationClient tosV2 = new DelegationClientBuilder().bucket("test").conf(conf).build();
+    TOSV2 mockClient = mock(TOSV2.class);
+    tosV2.setClient(mockClient);
+    tosV2.setMaxRetryTimes(5);
+
+    HeadObjectV2Input input = HeadObjectV2Input.builder().bucket("test").build();
+    when(tosV2.headObject(input)).thenThrow(
+            new TosServerException(HttpStatus.INTERNAL_SERVER_ERROR),
+            new TosServerException(HttpStatus.TOO_MANY_REQUESTS),
+            new TosClientException("fake toe", new IOException("fake ioe")),
+            new TosException(new SocketException("fake msg")),
+            new TosException(new UnknownHostException("fake msg")),
+            new TosException(new SSLException("fake msg")),
+            new TosException(new InterruptedException("fake msg")),
+            new TosException(new InterruptedException("fake msg")))
+        .thenReturn(new HeadObjectV2Output());
+
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> tosV2.headObject(input));
+    assertTrue(exception instanceof TosException);
+    assertTrue(exception.getCause() instanceof UnknownHostException);
+    verify(tosV2.client(), times(5)).headObject(input);
+
+    HeadObjectV2Input inputOneTime = HeadObjectV2Input.builder().bucket("inputOneTime").build();
+    HeadObjectV2Output output = new HeadObjectV2Output();
+    when(tosV2.headObject(inputOneTime)).thenReturn(output);
+    HeadObjectV2Output headObject = tosV2.headObject(inputOneTime);
+    Assert.assertEquals(headObject, output);
+    verify(tosV2.client(), times(1)).headObject(inputOneTime);
+    tosV2.close();
+
+    DelegationClient newClient = new DelegationClientBuilder().bucket("test").conf(conf).build();
+    mockClient = mock(TOSV2.class);
+    newClient.setClient(mockClient);
+    newClient.setMaxRetryTimes(5);
+    when(newClient.headObject(input)).thenThrow(
+        new TosClientException("fake toe", new EOFException("fake eof")),
+        new TosServerException(HttpStatus.INTERNAL_SERVER_ERROR),
+        new TosServerException(HttpStatus.TOO_MANY_REQUESTS)).thenReturn(new HeadObjectV2Output());
+
+    exception = assertThrows(RuntimeException.class, () -> newClient.headObject(input));
+    assertTrue(exception instanceof TosClientException);
+    assertTrue(exception.getCause() instanceof EOFException);
+    verify(newClient.client(), times(1)).headObject(input);
+    newClient.close();
+  }
+
+  @Test
+  public void testEnableCrcCheck() throws IOException {
+    String bucket = name.getMethodName();
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), "https://test.tos-cn-beijing.ivolces.com");
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, true);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(bucket), "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(bucket), "SECRET_KEY");
+
+    DelegationClient tosV2 = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+    Assert.assertTrue(tosV2.config().isEnableCrc());
+
+    conf.setBoolean(TosKeys.FS_TOS_CRC_CHECK_ENABLED, false);
+    tosV2 = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+    Assert.assertFalse(tosV2.config().isEnableCrc());
+
+    tosV2.close();
+  }
+
+  @Test
+  public void testClientCache() throws IOException {
+    String bucket = name.getMethodName();
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), "https://test.tos-cn-beijing.ivolces.com");
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, false);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(bucket), "ACCESS_KEY_A");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(bucket), "SECRET_KEY_A");
+
+    DelegationClient tosV2 = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+    DelegationClient tosV2Cached = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+    Assert.assertEquals("client must be load in cache", tosV2Cached, tosV2);
+    Assert.assertEquals("ACCESS_KEY_A", tosV2.usedCredential().getAccessKeyId());
+    tosV2Cached.close();
+
+    String newBucket = "new-test-bucket";
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(newBucket), "ACCESS_KEY_B");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(newBucket), "SECRET_KEY_B");
+    DelegationClient changeBucketClient =
+        new DelegationClientBuilder().bucket(newBucket).conf(conf).build();
+    Assert.assertNotEquals("client should be created entirely new", changeBucketClient, tosV2);
+    Assert.assertEquals("ACCESS_KEY_B", changeBucketClient.usedCredential().getAccessKeyId());
+    changeBucketClient.close();
+
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, true); // disable cache: true
+    DelegationClient tosV2NotCached =
+        new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+    Assert.assertNotEquals("client should be created entirely new", tosV2NotCached, tosV2);
+    Assert.assertEquals("ACCESS_KEY_A", tosV2NotCached.usedCredential().getAccessKeyId());
+    tosV2NotCached.close();
+
+    tosV2.close();
+  }
+
+  @Test
+  public void testOverwriteHttpConfig() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), "https://tos-cn-beijing.ivolces.com");
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key("test"), "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key("test"), "SECRET_KEY");
+    conf.setInt(TosKeys.FS_TOS_HTTP_MAX_CONNECTIONS, 24);
+    conf.setInt(MAX_RETRY_COUNT_KEY, 24);
+    conf.setInt(TosKeys.FS_TOS_REQUEST_MAX_RETRY_TIMES, 24);
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, true);
+
+    DelegationClient tosV2 = new DelegationClientBuilder().bucket("test").conf(conf).build();
+    Assert.assertEquals("ACCESS_KEY", tosV2.usedCredential().getAccessKeyId());
+    Assert.assertEquals("http max connection overwrite to 24 from 1024, must be 24", 24,
+        tosV2.config().getTransportConfig().getMaxConnections());
+    Assert.assertEquals("tos maxRetryCount disabled, must be -1",
+        DelegationClientBuilder.DISABLE_TOS_RETRY_VALUE,
+        tosV2.config().getTransportConfig().getMaxRetryCount());
+    Assert.assertEquals("maxRetryTimes must be 24", 24, tosV2.maxRetryTimes());
+    Assert.assertEquals("endpoint must be equals to https://tos-cn-beijing.ivolces.com",
+        "https://tos-cn-beijing.ivolces.com", tosV2.config().getEndpoint());
+
+    tosV2.close();
+  }
+
+  @Test
+  public void testDynamicRefreshAkSk() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), ENV_ENDPOINT);
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(TestUtility.bucket()), ENV_ACCESS_KEY);
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(TestUtility.bucket()), ENV_SECRET_KEY);
+    conf.setInt(TosKeys.FS_TOS_HTTP_MAX_CONNECTIONS, 24);
+    conf.setInt(MAX_RETRY_COUNT_KEY, 24);
+
+    TOSV2 tosSdkClientV2 =
+        new TOSV2ClientBuilder().build(TestUtility.region(), TestUtility.endpoint(),
+            new StaticCredentials("a", "b"));
+    DelegationClient delegationClientV2 =
+        new DelegationClientBuilder().bucket(TestUtility.bucket()).conf(conf).build();
+
+    ListObjectsV2Input inputV2 =
+        ListObjectsV2Input.builder().bucket(TestUtility.bucket()).prefix(TEST_KEY).marker("")
+            .maxKeys(10).build();
+
+    Assert.assertThrows(TosServerException.class, () -> tosSdkClientV2.listObjects(inputV2));
+
+    tosSdkClientV2.changeCredentials(new StaticCredentials(ENV_ACCESS_KEY, ENV_SECRET_KEY));
+
+    ListObjectsV2Output tosSdkOutput = tosSdkClientV2.listObjects(inputV2);
+    ListObjectsV2Output delegateOutput = delegationClientV2.listObjects(inputV2);
+    int nativeContentSize =
+        tosSdkOutput.getContents() == null ? -1 : tosSdkOutput.getContents().size();
+    int delegateContentSize =
+        delegateOutput.getContents() == null ? -1 : delegateOutput.getContents().size();
+
+    Assert.assertEquals("delegation client must same as native client", nativeContentSize,
+        delegateContentSize);
+    Assert.assertEquals(ENV_ACCESS_KEY, delegationClientV2.usedCredential().getAccessKeyId());
+
+    delegationClientV2.close();
+  }
+
+  @Test
+  public void testCreateClientWithEnvironmentCredentials() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), ENV_ENDPOINT);
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, EnvironmentCredentialsProvider.NAME);
+
+    DelegationClient tosV2 =
+        new DelegationClientBuilder().bucket(TestUtility.bucket()).conf(conf).build();
+    Credential cred = tosV2.usedCredential();
+
+    String assertMsg =
+        String.format("expect %s, but got %s", ENV_ACCESS_KEY, cred.getAccessKeyId());
+    Assert.assertEquals(assertMsg, cred.getAccessKeyId(), ENV_ACCESS_KEY);
+    assertMsg = String.format("expect %s, but got %s", ENV_SECRET_KEY, cred.getAccessKeySecret());
+    Assert.assertEquals(assertMsg, cred.getAccessKeySecret(), ENV_SECRET_KEY);
+
+    tosV2.close();
+  }
+
+  @Test
+  public void testCreateClientWithSimpleCredentials() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), ENV_ENDPOINT);
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(TestUtility.bucket()), ENV_ACCESS_KEY);
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(TestUtility.bucket()), ENV_SECRET_KEY);
+    conf.setInt(TosKeys.FS_TOS_HTTP_MAX_CONNECTIONS, 24);
+    conf.setInt(MAX_RETRY_COUNT_KEY, 24);
+
+    ListObjectsV2Input input =
+        ListObjectsV2Input.builder().bucket(TestUtility.bucket()).prefix(TEST_KEY).marker("")
+            .maxKeys(10).build();
+
+    TOSV2 v2 = new TOSV2ClientBuilder().build(TestUtility.region(), TestUtility.endpoint(),
+        new StaticCredentials(ENV_ACCESS_KEY, ENV_SECRET_KEY));
+    ListObjectsV2Output outputV2 = v2.listObjects(input);
+
+    DelegationClient tosV2 =
+        new DelegationClientBuilder().bucket(TestUtility.bucket()).conf(conf).build();
+
+    ListObjectsV2Output output = tosV2.listObjects(input);
+    Assert.assertEquals("delegation client must be same as native client",
+        outputV2.getContents().size(), output.getContents().size());
+
+    tosV2.close();
+  }
+
+  @Test
+  public void testCachedConcurrently() {
+    String bucketName = name.getMethodName();
+
+    Function<String, Configuration> commonConf = bucket -> {
+      Configuration conf = new Configuration();
+      conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), ENV_ENDPOINT);
+      conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+      conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key(bucket), ENV_ACCESS_KEY);
+      conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key(bucket), ENV_SECRET_KEY);
+      return conf;
+    };
+
+    // enable cache
+    Function<String, Configuration> enableCachedConf = bucket -> {
+      Configuration conf = commonConf.apply(bucket);
+      conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, false);
+      return conf;
+    };
+
+    ExecutorService es = ThreadPools.newWorkerPool("testCachedConcurrently", 32);
+    int bucketCount = 5;
+    int taskCount = 10000;
+
+    AtomicInteger success = new AtomicInteger(0);
+    AtomicInteger failure = new AtomicInteger(0);
+    Tasks.foreach(IntStream.range(0, taskCount).boxed().map(i -> bucketName + (i % bucketCount)))
+        .executeWith(es).run(bucket -> {
+          try {
+            Configuration conf = enableCachedConf.apply(bucket);
+            DelegationClient client = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+            client.close();
+            success.incrementAndGet();
+          } catch (Exception e) {
+            failure.incrementAndGet();
+          }
+        });
+
+    Assert.assertEquals(bucketCount, DelegationClientBuilder.CACHE.size());
+    Assert.assertEquals(taskCount, success.get());
+    Assert.assertEquals(0, failure.get());
+
+    // clear cache
+    DelegationClientBuilder.CACHE.clear();
+
+    // disable cache
+    Function<String, Configuration> disableCachedConf = bucket -> {
+      Configuration conf = commonConf.apply(bucket);
+      conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, true);
+      return conf;
+    };
+
+    success.set(0);
+    failure.set(0);
+    Tasks.foreach(IntStream.range(0, taskCount).boxed().map(i -> bucketName + (i % bucketCount)))
+        .executeWith(es).run(bucket -> {
+          try {
+            Configuration conf = disableCachedConf.apply(bucket);
+            DelegationClient client = new DelegationClientBuilder().bucket(bucket).conf(conf).build();
+            client.close();
+            success.incrementAndGet();
+          } catch (Exception e) {
+            failure.incrementAndGet();
+          }
+        });
+
+    Assert.assertTrue(DelegationClientBuilder.CACHE.isEmpty());
+    Assert.assertEquals(taskCount, success.get());
+    Assert.assertEquals(0, failure.get());
+
+    es.shutdown();
+  }
+
+  @After
+  public void deleteAllTestData() throws IOException {
+    TOSV2 tosSdkClientV2 =
+        new TOSV2ClientBuilder().build(TestUtility.region(), TestUtility.endpoint(),
+            new StaticCredentials(ENV_ACCESS_KEY, ENV_SECRET_KEY));
+    tosSdkClientV2.deleteObject(
+        DeleteObjectInput.builder().bucket(TestUtility.bucket()).key(TEST_KEY).build());
+
+    tosSdkClientV2.close();
+    DelegationClientBuilder.CACHE.clear();
+  }
+
+  @Test
+  public void testRetryableException() {
+    assertTrue(retryableException(new TosServerException(500)));
+    assertTrue(retryableException(new TosServerException(501)));
+    assertTrue(retryableException(new TosServerException(429)));
+    assertFalse(retryableException(new TosServerException(404)));
+
+    assertTrue(retryableException(new TosException(new SocketException())));
+    assertTrue(retryableException(new TosException(new UnknownHostException())));
+    assertTrue(retryableException(new TosException(new SSLException("fake ssl"))));
+    assertTrue(retryableException(new TosException(new SocketTimeoutException())));
+    assertTrue(retryableException(new TosException(new InterruptedException())));
+
+    assertTrue(retryableException(new TosClientException("fake ioe", new IOException())));
+    assertFalse(retryableException(new TosClientException("fake eof", new EOFException())));
+
+    assertTrue(retryableException(new TosServerException(409)));
+    assertTrue(
+        retryableException(new TosServerException(409).setEc(TOSErrorCodes.PATH_LOCK_CONFLICT)));
+    assertFalse(
+        retryableException(new TosServerException(409).setEc(TOSErrorCodes.DELETE_NON_EMPTY_DIR)));
+    assertFalse(
+        retryableException(new TosServerException(409).setEc(TOSErrorCodes.LOCATED_UNDER_A_FILE)));
+    assertFalse(retryableException(
+        new TosServerException(409).setEc(TOSErrorCodes.COPY_BETWEEN_DIR_AND_FILE)));
+    assertFalse(retryableException(
+        new TosServerException(409).setEc(TOSErrorCodes.RENAME_TO_AN_EXISTED_DIR)));
+    assertFalse(
+        retryableException(new TosServerException(409).setEc(TOSErrorCodes.RENAME_TO_SUB_DIR)));
+    assertFalse(retryableException(
+        new TosServerException(409).setEc(TOSErrorCodes.RENAME_BETWEEN_DIR_AND_FILE)));
+  }
+
+  private boolean retryableException(TosException e) {
+    return isRetryableException(e,
+        Arrays.asList(TOSErrorCodes.FAST_FAILURE_CONFLICT_ERROR_CODES.split(",")));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSInputStream.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSInputStream.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos;
+
+import com.volcengine.tos.internal.util.aborthook.AbortInputStreamHook;
+import com.volcengine.tos.model.object.GetObjectBasicOutput;
+import com.volcengine.tos.model.object.GetObjectV2Output;
+import org.apache.hadoop.fs.tosfs.object.Constants;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.thirdparty.com.google.common.io.ByteStreams;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class TestTOSInputStream {
+
+  private static final int DATA_SIZE = 1 << 20;
+  private static final byte[] DATA = TestUtility.rand(DATA_SIZE);
+
+  @Test
+  public void testForceClose() throws IOException {
+    TOSInputStream stream = createStream(DATA, 0, DATA_SIZE - 1, 1024);
+    stream.close();
+    Assert.assertTrue("Expected force close", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, DATA_SIZE - 1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1024 - 1);
+    stream.close();
+    Assert.assertTrue("Expected force close", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, 1024);
+    stream.close();
+    Assert.assertTrue("Expected force close", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1024 - 1);
+    stream.close();
+    Assert.assertTrue("Expected force close", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1024);
+    stream.close();
+    Assert.assertTrue("Expected force close", cast(stream).isForceClose());
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    TOSInputStream stream = createStream(DATA, 0, DATA_SIZE - 1, DATA_SIZE);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, DATA_SIZE - 1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1024);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, DATA_SIZE - 1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1023);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, DATA_SIZE + 1);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE - 1023);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+
+    stream = createStream(DATA, 0, -1, 1024);
+    ByteStreams.skipFully(stream, DATA_SIZE);
+    stream.close();
+    Assert.assertFalse("Expected close by skipping bytes", cast(stream).isForceClose());
+  }
+
+  private TestInputStream cast(TOSInputStream stream) throws IOException {
+    InputStream content = stream.getObjectOutput().verifiedContent(Constants.MAGIC_CHECKSUM);
+    Assert.assertTrue("Not a TestInputStream", content instanceof TestInputStream);
+    return (TestInputStream) content;
+  }
+
+  private TOSInputStream createStream(byte[] data, long startOff, long endOff, long maxDrainSize)
+      throws IOException {
+    TestInputStream stream =
+        new TestInputStream(data, (int) startOff, (int) (data.length - startOff));
+    GetObjectV2Output output = new GetObjectV2Output(new GetObjectBasicOutput(), stream).setHook(
+        new ForceCloseHook(stream));
+
+    return new TOSInputStream(new GetObjectOutput(output, Constants.MAGIC_CHECKSUM), startOff,
+        endOff, maxDrainSize, Constants.MAGIC_CHECKSUM);
+  }
+
+  private static class TestInputStream extends ByteArrayInputStream {
+    // -1 means call close()
+    //  0 means neither call close() nor forceClose()
+    //  1 means call forceClose()
+    private int cloeState = 0;
+
+    private TestInputStream(byte[] buf, int off, int len) {
+      super(buf, off, len);
+    }
+
+    @Override public void close() {
+      cloeState = -1;
+    }
+
+    public void forceClose() {
+      cloeState = 1;
+    }
+
+    boolean isForceClose() {
+      Assert.assertTrue("Neither call close() nor forceClose()", cloeState == -1 || cloeState == 1);
+      return cloeState == 1;
+    }
+  }
+
+  private static class ForceCloseHook implements AbortInputStreamHook {
+    private final TestInputStream in;
+
+    private ForceCloseHook(TestInputStream in) {
+      this.in = in;
+    }
+
+    @Override public void abort() {
+      if (in != null) {
+        in.forceClose();
+      }
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSObjectStorage.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSObjectStorage.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos;
+
+import com.volcengine.tos.internal.model.CRC64Checksum;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.common.Bytes;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.ChecksumType;
+import org.apache.hadoop.fs.tosfs.object.Constants;
+import org.apache.hadoop.fs.tosfs.object.MultipartUpload;
+import org.apache.hadoop.fs.tosfs.object.ObjectInfo;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.Part;
+import org.apache.hadoop.fs.tosfs.object.exceptions.NotAppendableException;
+import org.apache.hadoop.fs.tosfs.object.request.ListObjectsRequest;
+import org.apache.hadoop.fs.tosfs.object.response.ListObjectsResponse;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.util.PureJavaCrc32C;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.zip.Checksum;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Parameterized.class)
+public class TestTOSObjectStorage {
+
+  private final ObjectStorage tos;
+  private final Checksum checksum;
+  private final ChecksumType type;
+
+  public TestTOSObjectStorage(ObjectStorage tos, Checksum checksum, ChecksumType checksumType) {
+    this.tos = tos;
+    this.checksum = checksum;
+    this.type = checksumType;
+  }
+
+  @Parameterized.Parameters(name = "ObjectStorage = {0}, Checksum = {1}, ChecksumType = {2}")
+  public static Iterable<Object[]> collections() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+
+    List<Object[]> values = new ArrayList<>();
+
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_CHECKSUM_TYPE, ChecksumType.CRC64ECMA.name());
+    values.add(new Object[] {
+        ObjectStorageFactory.createWithPrefix(String.format("tos-%s/", UUIDUtils.random()),
+            TOS_SCHEME, TestUtility.bucket(), conf), new CRC64Checksum(), ChecksumType.CRC64ECMA });
+
+    conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_CHECKSUM_TYPE, ChecksumType.CRC32C.name());
+    values.add(new Object[] {
+        ObjectStorageFactory.createWithPrefix(String.format("tos-%s/", UUIDUtils.random()),
+            TOS_SCHEME, TestUtility.bucket(), conf), new PureJavaCrc32C(), ChecksumType.CRC32C });
+
+    return values;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    checksum.reset();
+
+    CommonUtils.runQuietly(() -> tos.deleteAll(""));
+    for (MultipartUpload upload : tos.listUploads("")) {
+      tos.abortMultipartUpload(upload.key(), upload.uploadId());
+    }
+    tos.close();
+  }
+
+  @Test
+  public void testHeadObj() {
+    String key = "testPutChecksum";
+    byte[] data = TestUtility.rand(1024);
+    checksum.update(data, 0, data.length);
+    assertEquals(checksum.getValue(), parseChecksum(tos.put(key, data)));
+
+    ObjectInfo objInfo = tos.head(key);
+    assertEquals(checksum.getValue(), parseChecksum(objInfo.checksum()));
+  }
+
+  @Test
+  public void testGetFileStatus() {
+    Assume.assumeFalse(tos.bucket().isDirectory());
+
+    Configuration conf = new Configuration(tos.conf());
+    conf.setBoolean(TosKeys.FS_TOS_GET_FILE_STATUS_ENABLED, true);
+    tos.initialize(conf, tos.bucket().name());
+
+    String key = "testFileStatus";
+    byte[] data = TestUtility.rand(256);
+    byte[] checksum = tos.put(key, data);
+
+    ObjectInfo obj1 = tos.objectStatus(key);
+    Assert.assertArrayEquals(checksum, obj1.checksum());
+    Assert.assertEquals(key, obj1.key());
+    Assert.assertEquals(obj1, tos.head(key));
+
+    ObjectInfo obj2 = tos.objectStatus(key + "/");
+    Assert.assertNull(obj2);
+
+    String dirKey = "testDirStatus/";
+    checksum = tos.put(dirKey, new byte[0]);
+
+    ObjectInfo obj3 = tos.objectStatus("testDirStatus");
+    Assert.assertArrayEquals(checksum, obj3.checksum());
+    Assert.assertEquals(dirKey, obj3.key());
+    Assert.assertEquals(obj3, tos.head(dirKey));
+    Assert.assertNull(tos.head("testDirStatus"));
+    ObjectInfo obj4 = tos.objectStatus(dirKey);
+    Assert.assertArrayEquals(checksum, obj4.checksum());
+    Assert.assertEquals(dirKey, obj4.key());
+    Assert.assertEquals(obj4, tos.head(dirKey));
+
+    String prefix = "testPrefix/";
+    tos.put(prefix + "subfile", data);
+    ObjectInfo obj5 = tos.objectStatus(prefix);
+    Assert.assertEquals(prefix, obj5.key());
+    Assert.assertArrayEquals(Constants.MAGIC_CHECKSUM, obj5.checksum());
+    Assert.assertNull(tos.head(prefix));
+    ObjectInfo obj6 = tos.objectStatus("testPrefix");
+    Assert.assertEquals(prefix, obj6.key());
+    Assert.assertArrayEquals(Constants.MAGIC_CHECKSUM, obj6.checksum());
+    Assert.assertNull(tos.head("testPrefix"));
+  }
+
+  @Test
+  public void testObjectStatus() {
+    Assume.assumeFalse(tos.bucket().isDirectory());
+
+    String key = "testObjectStatus";
+    byte[] data = TestUtility.rand(1024);
+    checksum.update(data, 0, data.length);
+    assertEquals(checksum.getValue(), parseChecksum(tos.put(key, data)));
+
+    ObjectInfo objInfo = tos.objectStatus(key);
+    assertEquals(checksum.getValue(), parseChecksum(objInfo.checksum()));
+
+    objInfo = tos.head(key);
+    assertEquals(checksum.getValue(), parseChecksum(objInfo.checksum()));
+
+    String dir = key + "/";
+    tos.put(dir, new byte[0]);
+    objInfo = tos.objectStatus(dir);
+    assertEquals(Constants.MAGIC_CHECKSUM, objInfo.checksum());
+
+    objInfo = tos.head(dir);
+    assertEquals(Constants.MAGIC_CHECKSUM, objInfo.checksum());
+  }
+
+  @Test
+  public void testListObjs() {
+    String key = "testListObjs";
+    byte[] data = TestUtility.rand(1024);
+    checksum.update(data, 0, data.length);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(checksum.getValue(), parseChecksum(tos.put(key, data)));
+    }
+
+    ListObjectsRequest request =
+        ListObjectsRequest.builder().prefix(key).startAfter(null).maxKeys(-1).delimiter("/")
+            .build();
+    Iterator<ListObjectsResponse> iter = tos.list(request).iterator();
+    while (iter.hasNext()) {
+      List<ObjectInfo> objs = iter.next().objects();
+      for (ObjectInfo obj : objs) {
+        assertEquals(checksum.getValue(), parseChecksum(obj.checksum()));
+      }
+    }
+  }
+
+  @Test
+  public void testPutChecksum() {
+    String key = "testPutChecksum";
+    byte[] data = TestUtility.rand(1024);
+    checksum.update(data, 0, data.length);
+
+    byte[] checksumStr = tos.put(key, data);
+
+    assertEquals(checksum.getValue(), parseChecksum(checksumStr));
+  }
+
+  @Test
+  public void testMPUChecksum() {
+    int partNumber = 2;
+    String key = "testMPUChecksum";
+    MultipartUpload mpu = tos.createMultipartUpload(key);
+    byte[] data = TestUtility.rand(mpu.minPartSize() * partNumber);
+    checksum.update(data, 0, data.length);
+
+    List<Part> parts = new ArrayList<>();
+    for (int i = 0; i < partNumber; i++) {
+      final int index = i;
+      Part part = tos.uploadPart(key, mpu.uploadId(), index + 1,
+          () -> new ByteArrayInputStream(data, index * mpu.minPartSize(), mpu.minPartSize()),
+          mpu.minPartSize());
+      parts.add(part);
+    }
+
+    byte[] checksumStr = tos.completeUpload(key, mpu.uploadId(), parts);
+    assertEquals(checksum.getValue(), parseChecksum(checksumStr));
+  }
+
+  @Test
+  public void testAppendable() {
+    Assume.assumeFalse(tos.bucket().isDirectory());
+
+    // Test create object with append then append.
+    byte[] data = TestUtility.rand(256);
+    String prefix = "a/testAppendable/";
+    String key = prefix + "object.txt";
+    tos.append(key, data);
+
+    tos.append(key, new byte[0]);
+
+    // Test create object with put then append.
+    data = TestUtility.rand(256);
+    tos.put(key, data);
+
+    assertThrows("Expect not appendable.", NotAppendableException.class,
+        () -> tos.append(key, new byte[0]));
+
+    tos.delete(key);
+  }
+
+  @Test
+  public void testDirectoryBucketAppendable() {
+    Assume.assumeTrue(tos.bucket().isDirectory());
+
+    byte[] data = TestUtility.rand(256);
+    String prefix = "a/testAppendable/";
+    String key = prefix + "object.txt";
+    tos.put(key, data);
+
+    tos.append(key, new byte[1024]);
+
+    tos.delete(key);
+  }
+
+  private long parseChecksum(byte[] checksum) {
+    switch (type) {
+    case CRC32C:
+    case CRC64ECMA:
+      return Bytes.toLong(checksum);
+    default:
+      throw new IllegalArgumentException(
+          String.format("Checksum type %s is not supported by TOS.", type.name()));
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSRetryPolicy.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/TestTOSRetryPolicy.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos;
+
+import com.volcengine.tos.TOSV2;
+import com.volcengine.tos.TosException;
+import com.volcengine.tos.TosServerException;
+import com.volcengine.tos.comm.HttpStatus;
+import com.volcengine.tos.model.RequestInfo;
+import com.volcengine.tos.model.object.PutObjectOutput;
+import com.volcengine.tos.model.object.UploadPartV2Output;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.InputStreamProvider;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.Part;
+import org.apache.hadoop.fs.tosfs.object.tos.auth.SimpleCredentialsProvider;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.SSLException;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestTOSRetryPolicy {
+
+  private final String retryKey = "retryKey.txt";
+  private TOSV2 tosClient;
+  private DelegationClient client;
+
+  @BeforeClass
+  public static void before() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Before
+  public void setUp() {
+    client = createRetryableDelegationClient();
+    tosClient = mock(TOSV2.class);
+    client.setClient(tosClient);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    tosClient.close();
+    client.close();
+  }
+
+  private DelegationClient createRetryableDelegationClient() {
+    Configuration conf = new Configuration();
+    conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(TOS_SCHEME), "https://tos-cn-beijing.ivolces.com");
+    conf.set(TosKeys.FS_TOS_CREDENTIALS_PROVIDER, SimpleCredentialsProvider.NAME);
+    conf.setBoolean(TosKeys.FS_TOS_DISABLE_CLIENT_CACHE, true);
+    conf.set(TosKeys.FS_TOS_ACCESS_KEY_ID, "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY, "SECRET_KEY");
+    return new DelegationClientBuilder().bucket("test").conf(conf).build();
+  }
+
+  @Test
+  public void testShouldThrowExceptionAfterRunOut5RetryTimesIfNoRetryConfigSet()
+      throws IOException {
+    TOS storage =
+        (TOS) ObjectStorageFactory.create(TOS_SCHEME, TestUtility.bucket(), new Configuration());
+    storage.setClient(client);
+    client.setMaxRetryTimes(5);
+
+    PutObjectOutput response = mock(PutObjectOutput.class);
+    InputStreamProvider streamProvider = mock(InputStreamProvider.class);
+
+    when(tosClient.putObject(any())).thenThrow(
+        new TosServerException(HttpStatus.INTERNAL_SERVER_ERROR),
+        new TosServerException(HttpStatus.TOO_MANY_REQUESTS),
+        new TosException(new SocketException("fake msg")),
+        new TosException(new UnknownHostException("fake msg")),
+        new TosException(new SSLException("fake msg")),
+        new TosException(new InterruptedException("fake msg")),
+        new TosException(new InterruptedException("fake msg"))).thenReturn(response);
+
+    // after run out retry times, should throw exception
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> storage.put(retryKey, streamProvider, 0));
+    assertTrue(exception instanceof TosException);
+    assertTrue(exception.getCause() instanceof SSLException);
+
+    // the newStream method of stream provider should be called 5 times
+    verify(streamProvider, times(5)).newStream();
+
+    storage.close();
+  }
+
+  @Test
+  public void testShouldReturnResultAfterRetry8TimesIfConfigured10TimesRetry()
+      throws IOException {
+    TOS storage =
+        (TOS) ObjectStorageFactory.create(TOS_SCHEME, TestUtility.bucket(), new Configuration());
+    DelegationClient delegationClient = createRetryableDelegationClient();
+    delegationClient.setClient(tosClient);
+    delegationClient.setMaxRetryTimes(10);
+    storage.setClient(delegationClient);
+
+    UploadPartV2Output response = new UploadPartV2Output().setPartNumber(1).setEtag("etag");
+
+    InputStream in = mock(InputStream.class);
+    InputStreamProvider streamProvider = mock(InputStreamProvider.class);
+    when(streamProvider.newStream()).thenReturn(in);
+
+    when(tosClient.uploadPart(any())).thenThrow(
+        new TosServerException(HttpStatus.INTERNAL_SERVER_ERROR),
+        new TosServerException(HttpStatus.TOO_MANY_REQUESTS),
+        new TosException(new SocketException("fake msg")),
+        new TosException(new UnknownHostException("fake msg")),
+        new TosException(new SSLException("fake msg")),
+        new TosException(new InterruptedException("fake msg")),
+        new TosException(new InterruptedException("fake msg"))).thenReturn(response);
+
+    // after run out retry times, should throw exception
+    Part part = storage.uploadPart(retryKey, "uploadId", 1, streamProvider, 0);
+    assertEquals(1, part.num());
+    assertEquals("etag", part.eTag());
+
+    // the newStream method of stream provider should be called 8 times
+    verify(streamProvider, times(8)).newStream();
+
+    storage.close();
+  }
+
+  @Test
+  public void testShouldReturnResultIfRetry3TimesSucceed() throws IOException {
+    TOS storage =
+        (TOS) ObjectStorageFactory.create(TOS_SCHEME, TestUtility.bucket(), new Configuration());
+    storage.setClient(client);
+
+    PutObjectOutput response = mock(PutObjectOutput.class);
+    InputStreamProvider streamProvider = mock(InputStreamProvider.class);
+
+    RequestInfo requestInfo = mock(RequestInfo.class);
+    Map<String, String> header = new HashMap<>();
+    when(response.getRequestInfo()).thenReturn(requestInfo);
+    when(requestInfo.getHeader()).thenReturn(header);
+
+    when(tosClient.putObject(any())).thenThrow(
+        new TosServerException(HttpStatus.INTERNAL_SERVER_ERROR),
+        new TosServerException(HttpStatus.TOO_MANY_REQUESTS)).thenReturn(response);
+
+    storage.put(retryKey, streamProvider, 0);
+    // the newStream method of stream provider should be called 3 times
+    verify(streamProvider, times(3)).newStream();
+
+    storage.close();
+  }
+
+  @Test
+  public void testShouldNotRetryIfThrowUnRetryException() throws IOException {
+    TOS storage =
+        (TOS) ObjectStorageFactory.create(TOS_SCHEME, TestUtility.bucket(), new Configuration());
+    storage.setClient(client);
+
+    InputStreamProvider streamProvider = mock(InputStreamProvider.class);
+
+    when(tosClient.putObject(any())).thenThrow(
+        new TosException(new NullPointerException("fake msg.")));
+
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> storage.put(retryKey, streamProvider, 0));
+    assertTrue(exception instanceof TosException);
+    assertTrue(exception.getCause() instanceof NullPointerException);
+
+    // the newStream method of stream provider should be only called once.
+    verify(streamProvider, times(1)).newStream();
+
+    storage.close();
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestAbstractCredentialsProvider.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestAbstractCredentialsProvider.java
@@ -1,0 +1,60 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos.auth;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.object.tos.TOS;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+
+public abstract class TestAbstractCredentialsProvider {
+  private String envAccessKeyId;
+  private String envSecretAccessKey;
+  private String envSessionToken;
+
+  protected Configuration getConf() {
+    return new Configuration();
+  }
+
+  protected void saveOsCredEnv() {
+    if (StringUtils.isNotEmpty(System.getenv(TOS.ENV_TOS_ACCESS_KEY_ID))) {
+      envAccessKeyId = System.getenv(TOS.ENV_TOS_ACCESS_KEY_ID);
+    }
+
+    if (StringUtils.isNotEmpty(System.getenv(TOS.ENV_TOS_SECRET_ACCESS_KEY))) {
+      envSecretAccessKey = System.getenv(TOS.ENV_TOS_SECRET_ACCESS_KEY);
+    }
+
+    if (StringUtils.isNotEmpty(System.getenv(TOS.ENV_TOS_SESSION_TOKEN))) {
+      envSessionToken = System.getenv(TOS.ENV_TOS_SESSION_TOKEN);
+    }
+  }
+
+  protected void resetOsCredEnv() {
+    resetOsCredEnv(TOS.ENV_TOS_ACCESS_KEY_ID, envAccessKeyId);
+    resetOsCredEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY, envSecretAccessKey);
+    resetOsCredEnv(TOS.ENV_TOS_SESSION_TOKEN, envSessionToken);
+  }
+
+  private void resetOsCredEnv(String key, String value) {
+    if (StringUtils.isNotEmpty(value)) {
+      TestUtility.setSystemEnv(key, value);
+    } else {
+      TestUtility.removeSystemEnv(key);
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestDefaultCredentialsProviderChain.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestDefaultCredentialsProviderChain.java
@@ -1,0 +1,213 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos.auth;
+
+import com.volcengine.tos.TosException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.apache.hadoop.fs.tosfs.object.tos.TOS;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.hadoop.fs.tosfs.util.TestUtility.removeSystemEnv;
+import static org.apache.hadoop.fs.tosfs.util.TestUtility.setSystemEnv;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestDefaultCredentialsProviderChain extends TestAbstractCredentialsProvider {
+
+  private static final String MOCK_TEST_AK = "AK";
+  private static final String MOCK_TEST_SK = "SK";
+  private static final String MOCK_TEST_TST_TOKEN = "STS_TOKEN";
+
+  private static final String MOCK_TEST_AK_WITH_BUCKET = "AK_WITH_BUCKET";
+  private static final String MOCK_TEST_SK_WITH_BUCKET = "SK_WITH_BUCKET";
+  private static final String MOCK_TEST_STS_TOKEN_WITH_BUCKET = "STS_TOKEN_WITH_BUCKET";
+
+  private static final String MOCK_TEST_ENV_AK = "ENV_AK";
+  private static final String MOCK_TEST_ENV_SK = "ENV_SK";
+  private static final String MOCK_TEST_ENV_STS_TOKEN = "ENV_STS_TOKEN";
+
+  private static final String MOCK_TEST_BUCKET = "test";
+  private static final String MOCK_TEST_ROLE_NAME = "roleName";
+  private static final String MOCK_PATH = "/volcstack/latest/iam/security_credentials/";
+  private static final String API_ENDPOINT = MOCK_PATH + MOCK_TEST_ROLE_NAME;
+  private static final String EXPIRED_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ssXXX";
+
+  @Override
+  public Configuration getConf() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key("test"), MOCK_TEST_AK_WITH_BUCKET);
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key("test"), MOCK_TEST_SK_WITH_BUCKET);
+    conf.set(TosKeys.FS_TOS_BUCKET_SESSION_TOKEN.key("test"), MOCK_TEST_STS_TOKEN_WITH_BUCKET);
+    conf.set(TosKeys.FS_TOS_ACCESS_KEY_ID, MOCK_TEST_AK);
+    conf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY, MOCK_TEST_SK);
+    conf.set(TosKeys.FS_TOS_SESSION_TOKEN, MOCK_TEST_TST_TOKEN);
+    return conf;
+  }
+
+  @Before
+  public void setUp() {
+    saveOsCredEnv();
+  }
+
+  @Test
+  public void testLoadCredFromEnvProvider() {
+    Configuration conf = getConf();
+    setSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID, MOCK_TEST_ENV_AK);
+    setSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY, MOCK_TEST_ENV_SK);
+    setSystemEnv(TOS.ENV_TOS_SESSION_TOKEN, MOCK_TEST_ENV_STS_TOKEN);
+    DefaultCredentialsProviderChain chain = new DefaultCredentialsProviderChain();
+    chain.initialize(conf, null);
+
+    assertEquals(String.format("expect %s", MOCK_TEST_ENV_AK), chain.credential().getAccessKeyId(),
+        MOCK_TEST_ENV_AK);
+    assertEquals(String.format("expect %s", MOCK_TEST_ENV_SK),
+        chain.credential().getAccessKeySecret(), MOCK_TEST_ENV_SK);
+    assertEquals(String.format("expect %s", MOCK_TEST_ENV_STS_TOKEN),
+        chain.credential().getSecurityToken(), MOCK_TEST_ENV_STS_TOKEN);
+    Assert.assertTrue(chain.lastUsedProvider() instanceof EnvironmentCredentialsProvider);
+  }
+
+  @Test
+  public void testLoadCredFromSimpleProviderWithBucket() {
+    Configuration conf = getConf();
+    removeSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID);
+    removeSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY);
+    removeSystemEnv(TOS.ENV_TOS_SESSION_TOKEN);
+    DefaultCredentialsProviderChain chain = new DefaultCredentialsProviderChain();
+    chain.initialize(conf, MOCK_TEST_BUCKET);
+
+    assertEquals(
+        String.format("expect %s", MOCK_TEST_AK_WITH_BUCKET),
+        chain.credential().getAccessKeyId(), MOCK_TEST_AK_WITH_BUCKET);
+    assertEquals(
+        String.format("expect %s", MOCK_TEST_SK_WITH_BUCKET),
+        chain.credential().getAccessKeySecret(), MOCK_TEST_SK_WITH_BUCKET);
+    assertEquals(
+        String.format("expect %s", MOCK_TEST_STS_TOKEN_WITH_BUCKET),
+        chain.credential().getSecurityToken(), MOCK_TEST_STS_TOKEN_WITH_BUCKET);
+    Assert.assertTrue(chain.lastUsedProvider() instanceof SimpleCredentialsProvider);
+  }
+
+  @Test
+  public void testLoadCredFromSimpleProvider() {
+    Configuration conf = getConf();
+    removeSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID);
+    removeSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY);
+    DefaultCredentialsProviderChain chain = new DefaultCredentialsProviderChain();
+    chain.initialize(conf, "test-bucket");
+
+    assertEquals(String.format("expect %s", MOCK_TEST_AK), chain.credential().getAccessKeyId(),
+        MOCK_TEST_AK);
+    assertEquals(String.format("expect %s", MOCK_TEST_SK), chain.credential().getAccessKeySecret(),
+        MOCK_TEST_SK);
+    Assert.assertTrue(chain.lastUsedProvider() instanceof SimpleCredentialsProvider);
+  }
+
+  @Test
+  public void testNotFoundAnyProvider() {
+    removeSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID);
+    removeSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY);
+    DefaultCredentialsProviderChain chain = new DefaultCredentialsProviderChain();
+    chain.initialize(new Configuration(), MOCK_TEST_BUCKET);
+    Assert.assertThrows(RuntimeException.class, chain::credential);
+  }
+
+  @After
+  public void after() {
+    resetOsCredEnv();
+  }
+
+  @Test
+  public void testShouldReturnAKSKFollowByProviderSequence() {
+    setSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID, "ENV_ACCESS_KEY");
+    setSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY, "ENV_SECRET_KEY");
+
+    // use the simple credential provider at first.
+    String providerClassesStr = SimpleCredentialsProvider.class.getName() + ','
+        + EnvironmentCredentialsProvider.class.getName();
+
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_CUSTOM_CREDENTIAL_PROVIDER_CLASSES, providerClassesStr);
+    conf.set(TosKeys.FS_TOS_ACCESS_KEY_ID, MOCK_TEST_AK);
+    conf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY, MOCK_TEST_SK);
+    conf.set(TosKeys.FS_TOS_SESSION_TOKEN, MOCK_TEST_TST_TOKEN);
+
+    DefaultCredentialsProviderChain provider = new DefaultCredentialsProviderChain();
+    provider.initialize(conf, MOCK_TEST_BUCKET);
+
+    ExpireableCredential cred = provider.createCredential();
+    assertEquals(MOCK_TEST_AK, cred.getAccessKeyId());
+    assertEquals(MOCK_TEST_SK, cred.getAccessKeySecret());
+
+    assertFalse(cred.isExpired());
+
+    // use the env credential provider at first.
+    providerClassesStr = EnvironmentCredentialsProvider.class.getName() + ','
+        + SimpleCredentialsProvider.class.getName();
+    conf.set(TosKeys.FS_TOS_CUSTOM_CREDENTIAL_PROVIDER_CLASSES, providerClassesStr);
+
+    provider = new DefaultCredentialsProviderChain();
+    provider.initialize(conf, MOCK_TEST_BUCKET);
+    cred = provider.createCredential();
+    assertEquals("ENV_ACCESS_KEY", cred.getAccessKeyId());
+    assertEquals("ENV_SECRET_KEY", cred.getAccessKeySecret());
+    assertFalse(cred.isExpired());
+
+    removeSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID);
+    removeSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY);
+  }
+
+  @Test
+  public void testShouldThrowExceptionWhenCustomClassNotFound() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_CUSTOM_CREDENTIAL_PROVIDER_CLASSES,
+        SimpleCredentialsProvider.class.getName() + "NotExist");
+
+    DefaultCredentialsProviderChain provider = new DefaultCredentialsProviderChain();
+    TosException tosException =
+        assertThrows(TosException.class, () -> provider.initialize(conf, null));
+    assertTrue(tosException.getCause() instanceof ClassNotFoundException);
+  }
+
+  @Test
+  public void testShouldThrowExceptionIfNoDefaultConstructorFound() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_CUSTOM_CREDENTIAL_PROVIDER_CLASSES,
+        TestCredentialProviderNoDefaultConstructor.class.getName());
+    DefaultCredentialsProviderChain provider = new DefaultCredentialsProviderChain();
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> provider.initialize(conf, null));
+    Assert.assertTrue(exception.getMessage().contains("java.lang.NoSuchMethodException"));
+  }
+
+  static class TestCredentialProviderNoDefaultConstructor extends AbstractCredentialsProvider {
+
+    TestCredentialProviderNoDefaultConstructor(String fake) {
+    }
+
+    @Override
+    protected ExpireableCredential createCredential() {
+      return null;
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestEnvironmentCredentialsProvider.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestEnvironmentCredentialsProvider.java
@@ -1,0 +1,63 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos.auth;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.object.tos.TOS;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestEnvironmentCredentialsProvider extends TestAbstractCredentialsProvider {
+
+  @Before
+  public void setUp() {
+    saveOsCredEnv();
+  }
+
+  @Test
+  public void testLoadAkSkFromEnvProvider() {
+    TestUtility.setSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID, "AccessKeyId");
+    TestUtility.setSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY, "SecretAccessKey");
+
+    EnvironmentCredentialsProvider provider = new EnvironmentCredentialsProvider();
+    provider.initialize(new Configuration(), null);
+
+    ExpireableCredential oldCred = provider.credential();
+    Assert.assertEquals("provider ak must be equals to env ak", oldCred.getAccessKeyId(), "AccessKeyId");
+    Assert.assertEquals("provider sk must be equals to env sk", oldCred.getAccessKeySecret(), "SecretAccessKey");
+
+    TestUtility.setSystemEnv(TOS.ENV_TOS_ACCESS_KEY_ID, "newAccessKeyId");
+    TestUtility.setSystemEnv(TOS.ENV_TOS_SECRET_ACCESS_KEY, "newSecretAccessKey");
+    TestUtility.setSystemEnv(TOS.ENV_TOS_SESSION_TOKEN, "newSessionToken");
+
+    Assert.assertFalse(oldCred.isExpired());
+
+    ExpireableCredential newCred = provider.credential();
+    Assert.assertEquals("provider ak must be equals to env ak", newCred.getAccessKeyId(), "AccessKeyId");
+    Assert.assertEquals("provider sk must be equals to env sk", newCred.getAccessKeySecret(), "SecretAccessKey");
+
+    Assert.assertFalse(newCred.isExpired());
+  }
+
+  @After
+  public void resetEnv() {
+    resetOsCredEnv();
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestSimpleCredentialsProvider.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/object/tos/auth/TestSimpleCredentialsProvider.java
@@ -1,0 +1,81 @@
+/*
+ * ByteDance Volcengine EMR, Copyright 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.object.tos.auth;
+
+import com.volcengine.tos.auth.Credential;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.conf.TosKeys;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSimpleCredentialsProvider extends TestAbstractCredentialsProvider {
+
+  @Test
+  public void testStaticCredentials() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_ACCESS_KEY_ID, "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY, "SECRET_KEY");
+    conf.set(TosKeys.FS_TOS_SESSION_TOKEN, "STS_TOKEN");
+    SimpleCredentialsProvider provider = new SimpleCredentialsProvider();
+    provider.initialize(conf, "test");
+    Credential credentials = provider.credential();
+    Assert.assertEquals("access key must be ACCESS_KEY", "ACCESS_KEY",
+        credentials.getAccessKeyId());
+    Assert.assertEquals("secret key must be SECRET_KEY", "SECRET_KEY",
+        credentials.getAccessKeySecret());
+    Assert.assertEquals("sts token must be STS_TOKEN", "STS_TOKEN",
+        credentials.getSecurityToken());
+  }
+
+  @Test
+  public void testStaticCredentialsWithBucket() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key("test"), "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key("test"), "SECRET_KEY");
+    conf.set(TosKeys.FS_TOS_BUCKET_SESSION_TOKEN.key("test"), "STS_TOKEN");
+    SimpleCredentialsProvider provider = new SimpleCredentialsProvider();
+    provider.initialize(conf, "test");
+    Credential credentials = provider.credential();
+    Assert.assertEquals("access key must be ACCESS_KEY", "ACCESS_KEY",
+        credentials.getAccessKeyId());
+    Assert.assertEquals("secret key must be SECRET_KEY", "SECRET_KEY",
+        credentials.getAccessKeySecret());
+    Assert.assertEquals("sts token must be STS_TOKEN", "STS_TOKEN",
+        credentials.getSecurityToken());
+  }
+
+  @Test
+  public void testStaticCredentialsWithPriority() {
+    Configuration conf = new Configuration();
+    conf.set(TosKeys.FS_TOS_ACCESS_KEY_ID, "ACCESS_KEY");
+    conf.set(TosKeys.FS_TOS_SECRET_ACCESS_KEY, "SECRET_KEY");
+    conf.set(TosKeys.FS_TOS_SESSION_TOKEN, "STS_TOKEN");
+    conf.set(TosKeys.FS_TOS_BUCKET_ACCESS_KEY_ID.key("test"), "ACCESS_KEY_BUCKET");
+    conf.set(TosKeys.FS_TOS_BUCKET_SECRET_ACCESS_KEY.key("test"), "SECRET_KEY_BUCKET");
+    conf.set(TosKeys.FS_TOS_BUCKET_SESSION_TOKEN.key("test"), "STS_TOKEN_BUCKET");
+
+    SimpleCredentialsProvider provider = new SimpleCredentialsProvider();
+    provider.initialize(conf, "test");
+    Credential credentials = provider.credential();
+    Assert.assertEquals("access key must be ACCESS_KEY_BUCKET", "ACCESS_KEY_BUCKET",
+        credentials.getAccessKeyId());
+    Assert.assertEquals("secret key must be SECRET_KEY_BUCKET", "SECRET_KEY_BUCKET",
+        credentials.getAccessKeySecret());
+    Assert.assertEquals("sts token must be STS_TOKEN_BUCKET", "STS_TOKEN_BUCKET",
+        credentials.getSecurityToken());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestBaseFsOps.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestBaseFsOps.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.ops;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.tosfs.RawFileStatus;
+import org.apache.hadoop.fs.tosfs.object.ObjectInfo;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public abstract class TestBaseFsOps extends TestBaseOps {
+  public TestBaseFsOps(ObjectStorage storage) {
+    super(storage);
+  }
+
+  public abstract FsOps fsOps();
+
+  @After
+  public void tearDown() {
+    CommonUtils.runQuietly(() -> storage.deleteAll(""));
+  }
+
+  @Test
+  public void testDeleteFile() throws IOException {
+    Path path = new Path("/a/b");
+    touchFile(path, TestUtility.rand(8));
+    assertFileExist(path);
+
+    fsOps().deleteFile(path);
+    assertFileDoesNotExist(path);
+  }
+
+  @Test
+  public void testDeleteEmptyDir() throws IOException {
+    Path path = new Path("/a/b/");
+    mkdir(path);
+
+    fsOps().deleteDir(path, false);
+    assertDirDoesNotExist(path);
+  }
+
+  @Test
+  public void testDeleteNonEmptyDir() throws IOException {
+    Path dirPath = new Path("/a/b/");
+    Path subDirPath = new Path("/a/b/c/");
+    Path filePath = new Path("/a/b/file.txt");
+    mkdir(dirPath);
+    mkdir(subDirPath);
+    touchFile(filePath, new byte[10]);
+
+    Assert.assertThrows(PathIsNotEmptyDirectoryException.class, () -> fsOps().deleteDir(dirPath, false));
+    assertDirExist(dirPath);
+    assertDirExist(subDirPath);
+    assertFileExist(filePath);
+
+    fsOps().deleteDir(dirPath, true);
+    assertDirDoesNotExist(dirPath);
+    assertDirDoesNotExist(subDirPath);
+    assertFileDoesNotExist(filePath);
+  }
+
+  @Test
+  public void testCreateDirRecursive() throws IOException {
+    Path path = new Path("/aa/bb/cc");
+    String key = ObjectUtils.pathToKey(path, true);
+    String parentKey = ObjectUtils.pathToKey(path.getParent(), true);
+    String grandparents = ObjectUtils.pathToKey(path.getParent().getParent(), true);
+
+    assertDirDoesNotExist(parentKey);
+    assertDirDoesNotExist(grandparents);
+
+    fsOps().mkdirs(path);
+    assertDirExist(key);
+    assertDirExist(parentKey);
+    assertDirExist(grandparents);
+
+    storage.delete(key);
+    assertDirExist(parentKey);
+    assertDirExist(grandparents);
+  }
+
+  @Test
+  public void testListEmptyDir() {
+    Path dir = path("testListEmptyDir");
+    mkdir(dir);
+
+    Assert.assertFalse(listDir(dir, false).iterator().hasNext());
+    Assert.assertFalse(listDir(dir, true).iterator().hasNext());
+    Assert.assertTrue(fsOps().isEmptyDirectory(dir));
+  }
+
+  @Test
+  public void testListNonExistDir() {
+    Path dir = path("testListNonExistDir");
+    assertDirDoesNotExist(dir);
+
+    Assert.assertFalse(listDir(dir, false).iterator().hasNext());
+    Assert.assertFalse(listDir(dir, false).iterator().hasNext());
+    Assert.assertTrue(fsOps().isEmptyDirectory(dir));
+  }
+
+  private Iterable<RawFileStatus> listDir(Path dir, boolean recursive) {
+    return fsOps().listDir(dir, recursive, s -> true);
+  }
+
+  private Iterable<RawFileStatus> listFiles(Path dir, boolean recursive) {
+    return fsOps().listDir(dir, recursive, s -> !ObjectInfo.isDir(s));
+  }
+
+  @Test
+  public void testListAFileViaListDir() {
+    Path file = new Path("testListFileViaListDir");
+    touchFile(file, TestUtility.rand(8));
+    Assert.assertFalse(listDir(file, false).iterator().hasNext());
+    Assert.assertFalse(listDir(file, true).iterator().hasNext());
+
+    Path nonExistFile = new Path("testListFileViaListDir-nonExist");
+    assertFileDoesNotExist(nonExistFile);
+    Assert.assertFalse(listDir(nonExistFile, false).iterator().hasNext());
+    Assert.assertFalse(listDir(nonExistFile, true).iterator().hasNext());
+  }
+
+  @Test
+  public void testListFiles() {
+    Path dir = path("testListEmptyFiles");
+    mkdir(dir);
+
+    Assert.assertFalse(listFiles(dir, false).iterator().hasNext());
+    Assert.assertFalse(listFiles(dir, true).iterator().hasNext());
+
+    mkdir(new Path(dir, "subDir"));
+    Assert.assertFalse(listFiles(dir, false).iterator().hasNext());
+    Assert.assertFalse(listFiles(dir, true).iterator().hasNext());
+
+    RawFileStatus subDir = listDir(dir, false).iterator().next();
+    Assert.assertFalse(subDir.isFile());
+    Assert.assertEquals("subDir", subDir.getPath().getName());
+
+    ObjectInfo fileObj = touchFile(new Path(dir, "subFile"), TestUtility.rand(8));
+    RawFileStatus subFile = listFiles(dir, false).iterator().next();
+    assertArrayEquals(fileObj.checksum(), subFile.checksum());
+    Assert.assertTrue(subFile.isFile());
+
+    Assert.assertFalse(fsOps().isEmptyDirectory(dir));
+  }
+
+  @Test
+  public void testRecursiveList() {
+    Path root = path("root");
+    Path file1 = path("root", "file1");
+    Path file2 = path("root", "afile2");
+    Path dir1 = path("root", "dir1");
+    Path file3 = path("root", "dir1", "file3");
+
+    mkdir(root);
+    mkdir(dir1);
+    touchFile(file1, TestUtility.rand(8));
+    touchFile(file2, TestUtility.rand(8));
+    touchFile(file3, TestUtility.rand(8));
+
+    // List result is in sorted lexicographical order if recursive is false
+    Assertions.assertThat(listDir(root, false))
+        .hasSize(3)
+        .extracting(f -> f.getPath().getName())
+        .contains("afile2", "dir1", "file1");
+
+    // List result is in sorted lexicographical order if recursive is false
+    Assertions.assertThat(listFiles(root, false))
+        .hasSize(2)
+        .extracting(f -> f.getPath().getName())
+        .contains("afile2", "file1");
+
+    // listDir with recursive=true doesn't guarantee the return result in a sorted order
+    Assertions.assertThat(listDir(root, true))
+        .hasSize(4)
+        .extracting(f -> f.getPath().getName())
+        .containsExactlyInAnyOrder("afile2", "dir1", "file1", "file3");
+
+    // listFiles with recursive=true doesn't guarantee the return result in a sorted order
+    Assertions.assertThat(listFiles(root, true))
+        .hasSize(3)
+        .extracting(f -> f.getPath().getName())
+        .containsExactlyInAnyOrder("afile2", "file1", "file3");
+  }
+
+  @Test
+  public void testRenameFile() throws IOException {
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+
+    int dataSize = 1024 * 1024;
+    String filename = String.format("%sMB.txt", dataSize >> 20);
+    Path srcFile = new Path(renameSrc, filename);
+    byte[] data = writeData(srcFile, dataSize);
+    Path dstFile = new Path(renameDest, filename);
+
+    // The dest file and dest parent don't exist.
+    assertFileExist(srcFile);
+    assertDirDoesNotExist(renameDest);
+    assertFileDoesNotExist(dstFile);
+
+    fsOps().renameFile(srcFile, dstFile, data.length);
+    assertFileDoesNotExist(srcFile);
+    assertDirExist(renameSrc);
+    assertFileExist(dstFile);
+
+    try (InputStream in = storage.get(ObjectUtils.pathToKey(dstFile)).stream()) {
+      assertArrayEquals(data, IOUtils.toByteArray(in));
+    }
+  }
+
+  @Test
+  public void testRenameDir() throws IOException {
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+
+    mkdir(renameSrc);
+    int dataSize = 1024 * 1024;
+    String filename = String.format("%sMB.txt", dataSize >> 20);
+    Path srcFile = new Path(renameSrc, filename);
+    Path dstFile = new Path(renameDest, filename);
+    byte[] data = writeData(srcFile, dataSize);
+
+    assertFileExist(srcFile);
+    assertFileDoesNotExist(dstFile);
+    assertDirExist(renameSrc);
+    assertDirDoesNotExist(renameDest);
+
+    fsOps().renameDir(renameSrc, renameDest);
+    assertFileDoesNotExist(srcFile);
+    assertDirDoesNotExist(renameSrc);
+    assertFileExist(dstFile);
+    assertDirExist(renameDest);
+
+    try (InputStream in = storage.get(ObjectUtils.pathToKey(dstFile)).stream()) {
+      assertArrayEquals(data, IOUtils.toByteArray(in));
+    }
+  }
+
+  private byte[] writeData(Path path, int size) {
+    byte[] data = TestUtility.rand(size);
+    touchFile(path, data);
+    return data;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestBaseOps.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestBaseOps.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.ops;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.RawFileStatus;
+import org.apache.hadoop.fs.tosfs.RawFileSystem;
+import org.apache.hadoop.fs.tosfs.object.ObjectInfo;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public abstract class TestBaseOps {
+  protected ObjectStorage storage;
+
+  public TestBaseOps(ObjectStorage storage) {
+    this.storage = storage;
+  }
+
+  public Path path(String... keys) {
+    return new Path(String.format("/%s", Joiner.on("/").join(keys)));
+  }
+
+  public void assertFileExist(Path file) {
+    assertNotNull(ObjectUtils.pathToKey(file));
+  }
+
+  public void assertFileDoesNotExist(String key) {
+    assertNull(storage.head(key));
+  }
+
+  public void assertFileDoesNotExist(Path file) {
+    assertFileDoesNotExist(ObjectUtils.pathToKey(file));
+  }
+
+  public void assertDirExist(String key) {
+    assertNotNull(storage.head(key));
+  }
+
+  public void assertDirExist(Path path) {
+    assertDirExist(ObjectUtils.pathToKey(path, true));
+  }
+
+  public void assertDirDoesNotExist(String key) {
+    assertNull(storage.head(key));
+  }
+
+  public void assertDirDoesNotExist(Path path) {
+    assertDirDoesNotExist(ObjectUtils.pathToKey(path, true));
+  }
+
+  public void mkdir(Path path) {
+    storage.put(ObjectUtils.pathToKey(path, true), new byte[0]);
+    assertDirExist(path);
+  }
+
+  public ObjectInfo touchFile(Path path, byte[] data) {
+    byte[] checksum = storage.put(ObjectUtils.pathToKey(path), data);
+    ObjectInfo obj = storage.head(ObjectUtils.pathToKey(path));
+    Assert.assertArrayEquals(checksum, obj.checksum());
+    return obj;
+  }
+
+  public FileStatus getFileStatus(Path path) {
+    String key = ObjectUtils.pathToKey(path);
+    return toFileStatus(storage.objectStatus(key));
+  }
+
+  public RawFileStatus toFileStatus(ObjectInfo obj) {
+    long modifiedTime = RawFileSystem.dateToLong(obj.mtime());
+    String path = String.format("%s://%s/%s", storage.scheme(), storage.bucket().name(), obj.key());
+    return new RawFileStatus(obj.size(), obj.isDir(), 0, modifiedTime, new Path(path), "fake", obj.checksum());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestDefaultFsOps.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestDefaultFsOps.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.ops;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.apache.hadoop.util.Lists;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+
+@RunWith(Parameterized.class)
+public class TestDefaultFsOps extends TestBaseFsOps {
+  private static ExecutorService threadPool;
+  private final FsOps fsOps;
+
+  public TestDefaultFsOps(Configuration conf) {
+    super(ObjectStorageFactory.createWithPrefix(
+        String.format("tos-%s/", UUIDUtils.random()), TOS_SCHEME, TestUtility.bucket(), conf));
+
+    this.fsOps = new DefaultFsOps(storage, new Configuration(conf), threadPool, this::toFileStatus);
+  }
+
+  @Parameterized.Parameters(name = "conf = {0}")
+  public static List<Configuration> createConf() {
+    Configuration directRenameConf = new Configuration();
+    directRenameConf.setBoolean(ConfKeys.FS_OBJECT_RENAME_ENABLED.key("tos"), true);
+    directRenameConf.setBoolean(ConfKeys.FS_ASYNC_CREATE_MISSED_PARENT.key("tos"), false);
+
+    Configuration copiedRenameConf = new Configuration();
+    copiedRenameConf.setLong(ConfKeys.FS_MULTIPART_COPY_THRESHOLD.key("tos"), 1L << 20);
+    copiedRenameConf.setBoolean(ConfKeys.FS_ASYNC_CREATE_MISSED_PARENT.key("tos"), false);
+    return Lists.newArrayList(directRenameConf, copiedRenameConf);
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+    threadPool = ThreadPools.newWorkerPool("TestDefaultFsHelper-pool");
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (!TestEnv.checkTestEnabled()) {
+      return;
+    }
+
+    if (!threadPool.isShutdown()) {
+      threadPool.shutdown();
+    }
+  }
+
+  @Override
+  public FsOps fsOps() {
+    return fsOps;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestDirectoryFsOps.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestDirectoryFsOps.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.ops;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.object.DirectoryStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.fs.tosfs.util.UUIDUtils;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+import static org.apache.hadoop.fs.tosfs.object.tos.TOS.TOS_SCHEME;
+
+// TODO change to directory bucket configuration.
+public class TestDirectoryFsOps extends TestBaseFsOps {
+  private final FsOps fsOps;
+
+  public TestDirectoryFsOps() {
+    super(ObjectStorageFactory.createWithPrefix(
+        String.format("tos-%s/", UUIDUtils.random()), TOS_SCHEME, TestUtility.bucket(), new Configuration()));
+    this.fsOps = new DirectoryFsOps((DirectoryStorage) storage, this::toFileStatus);
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+  }
+
+  @Override
+  public void testRenameDir() {
+    // Will remove this test case once test environment support
+    Assume.assumeTrue(storage.bucket().isDirectory());
+  }
+
+  @Override
+  public void testRenameFile() {
+    // Will remove this test case once test environment support
+    Assume.assumeTrue(storage.bucket().isDirectory());
+  }
+
+  @Override
+  public FsOps fsOps() {
+    return fsOps;
+  }
+
+  @Override
+  public void testCreateDirRecursive() {
+    // Will remove this test case once test environment support
+    Assume.assumeTrue(storage.bucket().isDirectory());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestRenameOp.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/ops/TestRenameOp.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.ops;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.tosfs.TestEnv;
+import org.apache.hadoop.fs.tosfs.common.ThreadPools;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectUtils;
+import org.apache.hadoop.fs.tosfs.object.Part;
+import org.apache.hadoop.fs.tosfs.util.CommonUtils;
+import org.apache.hadoop.fs.tosfs.util.TempFiles;
+import org.apache.hadoop.fs.tosfs.util.TestUtility;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TestRenameOp extends TestBaseOps {
+  private static final String FILE_STORE_ROOT = TempFiles.newTempDir("TestRenameOp");
+
+  private final ExecutorService renamePool;
+  private ExtendedRenameOp operation;
+
+  public TestRenameOp(ObjectStorage storage) {
+    super(storage);
+    this.renamePool = ThreadPools.newWorkerPool("renamePool");
+  }
+
+  @Parameterized.Parameters
+  public static List<ObjectStorage> createStorage() {
+    Assume.assumeTrue(TestEnv.checkTestEnabled());
+    return TestUtility.createTestObjectStorage(FILE_STORE_ROOT);
+  }
+
+  @After
+  public void tearDown() {
+    CommonUtils.runQuietly(() -> storage.deleteAll(""));
+    CommonUtils.runQuietly(renamePool::shutdown);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    CommonUtils.runQuietly(() -> TempFiles.deleteDir(FILE_STORE_ROOT));
+  }
+
+  @Test
+  public void testRenameFileDirectly() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setLong(ConfKeys.FS_MULTIPART_COPY_THRESHOLD.key(storage.scheme()), 1L << 20);
+    operation = new ExtendedRenameOp(conf, storage, renamePool);
+
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+
+    int dataSize = 1024 * 1024;
+    String filename = String.format("%sMB.txt", dataSize >> 20);
+    Path srcFile = new Path(renameSrc, filename);
+    Path dstFile = new Path(renameDest, filename);
+    byte[] data = writeData(srcFile, dataSize);
+    mkdir(renameDest);
+
+    assertFileExist(srcFile);
+    assertFileDoesNotExist(dstFile);
+    assertDirExist(renameDest);
+
+    operation.renameFile(srcFile, dstFile, data.length);
+    assertFileDoesNotExist(srcFile);
+    assertFileExist(dstFile);
+    Map<String, List<Part>> uploadInfos = operation.uploadInfos;
+    assertEquals("use put method when rename file, upload info's size should be 0", 0, uploadInfos.size());
+
+    try (InputStream in = storage.get(ObjectUtils.pathToKey(dstFile)).stream()) {
+      assertArrayEquals(data, IOUtils.toByteArray(in));
+    }
+  }
+
+  @Test
+  public void testRenameFileByUploadParts() throws IOException {
+    Assume.assumeFalse(storage.bucket().isDirectory());
+    Configuration conf = new Configuration();
+    conf.setLong(ConfKeys.FS_MULTIPART_COPY_THRESHOLD.key(storage.scheme()), 1L << 20);
+    operation = new ExtendedRenameOp(conf, storage, renamePool);
+
+    Path renameSrc = path("renameSrc");
+    Path renameDest = path("renameDst");
+
+    int dataSize = 10 * 1024 * 1024;
+    String filename = String.format("%sMB.txt", dataSize >> 20);
+    Path srcFile = new Path(renameSrc, filename);
+    Path dstFile = new Path(renameDest, filename);
+    byte[] data = writeData(srcFile, dataSize);
+    mkdir(renameDest);
+
+    assertFileExist(srcFile);
+    assertFileDoesNotExist(dstFile);
+    assertDirExist(renameDest);
+
+    operation.renameFile(srcFile, dstFile, data.length);
+    assertFileDoesNotExist(srcFile);
+    assertFileExist(dstFile);
+    Map<String, List<Part>> uploadInfos = operation.uploadInfos;
+    assertTrue("use upload parts method when rename file, upload info's size should not be 0",
+        uploadInfos.size() != 0);
+    List<Part> parts = uploadInfos.get(ObjectUtils.pathToKey(dstFile));
+    assertNotNull("use upload parts method when rename file, upload info should not be null", parts);
+    assertTrue("use upload parts method when rename file, the num of upload parts should be greater than or equal" +
+        " to 2", parts.size() >= 2);
+    long fileLength = parts.stream().mapToLong(Part::size).sum();
+    assertEquals(dataSize, fileLength);
+
+    try (InputStream in = storage.get(ObjectUtils.pathToKey(dstFile)).stream()) {
+      assertArrayEquals(data, IOUtils.toByteArray(in));
+    }
+  }
+
+  private byte[] writeData(Path path, int size) {
+    byte[] data = TestUtility.rand(size);
+    touchFile(path, data);
+    return data;
+  }
+
+  static class ExtendedRenameOp extends RenameOp {
+    public Map<String, List<Part>> uploadInfos = Maps.newHashMap();
+
+    ExtendedRenameOp(Configuration conf, ObjectStorage storage, ExecutorService pool) {
+      super(conf, storage, pool);
+    }
+
+    @Override
+    protected void finishUpload(String key, String uploadId, List<Part> uploadParts) {
+      super.finishUpload(key, uploadId, uploadParts);
+      if (!uploadInfos.isEmpty()) {
+        uploadInfos.clear();
+      }
+      uploadInfos.put(key, uploadParts);
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TempFiles.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TempFiles.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.util;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.util.Lists;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class TempFiles implements Closeable {
+  private final List<String> files = Lists.newArrayList();
+  private final List<String> dirs = Lists.newArrayList();
+
+  private TempFiles() {
+  }
+
+  public static TempFiles of() {
+    return new TempFiles();
+  }
+
+  public String newFile() {
+    String p = newTempFile();
+    files.add(p);
+    return p;
+  }
+
+  public String newDir() {
+    return newDir(null);
+  }
+
+  public String newDir(String prefix) {
+    String p = newTempDir(prefix);
+    dirs.add(p);
+    return p;
+  }
+
+  @Override
+  public void close() {
+    files.forEach(file -> CommonUtils.runQuietly(() -> TempFiles.deleteFile(file)));
+    files.clear();
+    dirs.forEach(dir -> CommonUtils.runQuietly(() -> TempFiles.deleteDir(dir)));
+    dirs.clear();
+  }
+
+  public static String newTempFile() {
+    return String.join(File.pathSeparator, newTempDir(), UUIDUtils.random());
+  }
+
+  public static String newTempDir() {
+    return newTempDir(null);
+  }
+
+  public static String newTempDir(String prefix) {
+    try {
+      return Files.createTempDirectory(prefix).toFile().getAbsolutePath();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static void deleteFile(String path) {
+    try {
+      Files.deleteIfExists(Paths.get(path));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static void deleteDir(String path) {
+    try {
+      FileUtils.deleteDirectory(new File(path));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestIterables.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestIterables.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.util;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestIterables {
+
+  @Test
+  public void testTransform() {
+    List<Integer> list = Arrays.asList(1, 2, 3, 4, 5);
+    Function<Integer, Integer> transform = i -> i + 10;
+    Iterator<Integer> iter = Iterables.transform(list, transform).iterator();
+
+    for (int i = 0; i < 5; i++) {
+      assertTrue(iter.hasNext());
+      int value = iter.next();
+      assertEquals(10 + i + 1, value);
+    }
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testTransformEmptyIterable() {
+    List<Integer> list = Arrays.asList();
+    Function<Integer, Integer> transform = i -> i + 10;
+    Iterator<Integer> iter = Iterables.transform(list, transform).iterator();
+
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testFilter() {
+    // Filter odd elements.
+    List<Integer> list = Arrays.asList(1, 2, 3, 4, 5);
+    Predicate<Integer> filter = i -> (i % 2) == 0;
+    Iterator<Integer> iter = Iterables.filter(list, filter).iterator();
+
+    for (int i = 0; i < 2; i++) {
+      assertTrue(iter.hasNext());
+      int value = iter.next();
+      assertEquals((i + 1) * 2, value);
+    }
+    assertFalse(iter.hasNext());
+
+    // Ignore all elements.
+    filter = i -> false;
+    iter = Iterables.filter(list, filter).iterator();
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testFilterEmptyIterable() {
+    List<Integer> list = Arrays.asList();
+    Predicate<Integer> filter = i -> (i % 2) == 0;
+    Iterator<Integer> iter = Iterables.filter(list, filter).iterator();
+
+    assertFalse(iter.hasNext());
+  }
+
+  // Full iterators.
+  @Test
+  public void testConcatFullIterators() {
+    List<Integer> expectedList = new ArrayList<>();
+    List<Iterable<Integer>> iterList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      List<Integer> list = new ArrayList<>();
+      for (int j = 0; j < 10; j++) {
+        list.add(i * 10 + j);
+        expectedList.add(i * 10 + j);
+      }
+      iterList.add(list);
+    }
+
+    verifyConcat(expectedList.iterator(), iterList);
+  }
+
+  // Empty iterators.
+  @Test
+  public void testConcatEmptyIterators() {
+    List<Integer> expectedList = new ArrayList<>();
+    List<Iterable<Integer>> iterList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      iterList.add(Collections.emptyList());
+    }
+
+    verifyConcat(expectedList.iterator(), iterList);
+  }
+
+  // Mix full and empty iterators.
+  @Test
+  public void testConcatMixFullAndEmptyIterators() {
+    List<Integer> expectedList = new ArrayList<>();
+    List<Iterable<Integer>> iterList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      List<Integer> list = new ArrayList<>();
+      for (int j = 0; j < 10; j++) {
+        list.add(i * 10 + j);
+        expectedList.add(i * 10 + j);
+      }
+      iterList.add(list);
+      iterList.add(Collections.emptyList());
+      iterList.add(Collections.emptyList());
+    }
+
+    verifyConcat(expectedList.iterator(), iterList);
+  }
+
+  // Invalid iterators.
+  @Test
+  public void testConcatNullMetaIterator() {
+    assertThrows("Expect null verification error.", NullPointerException.class,
+        () -> verifyConcat(Collections.emptyIterator(), null));
+  }
+
+  // Concat null iterators.
+  @Test
+  public void testConcatNullElementIterators() {
+    List<Iterable<Integer>> list = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      list.add(() -> null);
+    }
+    verifyConcat(Collections.emptyIterator(), list);
+  }
+
+  private <T> void verifyConcat(Iterator<T> expectedValues, Iterable<Iterable<T>> metaIter) {
+    Iterator<T> iter = Iterables.concat(metaIter).iterator();
+    while (expectedValues.hasNext()) {
+      assertTrue(iter.hasNext());
+      T v1 = expectedValues.next();
+      T v2 = iter.next();
+      assertEquals(v1, v2);
+    }
+    assertFalse(iter.hasNext());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestLazyReload.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestLazyReload.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class TestLazyReload {
+  @Test
+  public void testLoadWithFilterCondition() {
+    LazyReload<Integer> integers = new LazyReload<>(() -> {
+      Iterator<Integer> source = Arrays.asList(1, 3, 5, 2, 4, 6).iterator();
+      return buf -> {
+        if (!source.hasNext()) {
+          return true;
+        }
+
+        int pollCnt = 2;
+        while (source.hasNext() && pollCnt-- > 0) {
+          Integer item = source.next();
+          if (item % 2 == 0) {
+            buf.add(item);
+          }
+        }
+
+        return !source.hasNext();
+      };
+    });
+
+    Iterator<Integer> iterator = integers.iterator();
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals(2, (int) iterator.next());
+    Assert.assertEquals(4, (int) iterator.next());
+    Assert.assertEquals(6, (int) iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testLoadResultIsIdempotent() {
+    LazyReload<Integer> integers = new LazyReload<>(() -> {
+      Iterator<Integer> source = Arrays.asList(1, 3, 5, 2, 4, 6).iterator();
+      return buf -> {
+        if (!source.hasNext()) {
+          return true;
+        }
+
+        int pollCnt = 2;
+        while (source.hasNext() && pollCnt-- > 0) {
+          Integer item = source.next();
+          buf.add(item);
+        }
+
+        return !source.hasNext();
+      };
+    });
+    Iterator<Integer> iterator1 = integers.iterator();
+    Iterator<Integer> iterator2 = integers.iterator();
+
+    Assert.assertEquals(1, (int) iterator1.next());
+    Assert.assertEquals(1, (int) iterator2.next());
+    Assert.assertEquals(3, (int) iterator1.next());
+    Assert.assertEquals(3, (int) iterator2.next());
+    Assert.assertEquals(5, (int) iterator1.next());
+    Assert.assertEquals(5, (int) iterator2.next());
+
+    Assert.assertEquals(2, (int) iterator1.next());
+    Assert.assertEquals(4, (int) iterator1.next());
+    Assert.assertEquals(6, (int) iterator1.next());
+    Assert.assertEquals(2, (int) iterator2.next());
+    Assert.assertEquals(4, (int) iterator2.next());
+    Assert.assertEquals(6, (int) iterator2.next());
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestRange.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestRange.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.util;
+
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRange {
+
+  @Test
+  public void testInclude() {
+    Object[][] inputs = new Object[][]{
+        new Object[]{Range.of(0, 0), 0L, false},
+        new Object[]{Range.of(0, 1), 0L, true},
+        new Object[]{Range.of(1, 1), 0L, false},
+        new Object[]{Range.of(1, 1), 1L, true},
+        new Object[]{Range.of(1, 1), 2L, false},
+        new Object[]{Range.of(1, 99), 0L, false},
+        new Object[]{Range.of(1, 99), 1L, true},
+        new Object[]{Range.of(1, 99), 99L, true},
+        new Object[]{Range.of(1, 99), 100L, false}
+    };
+
+    for (Object[] input : inputs) {
+      Range r = (Range) input[0];
+      long pos = (long) input[1];
+      boolean expected = (boolean) input[2];
+
+      Assert.assertEquals(expected, r.include(pos));
+    }
+  }
+
+  @Test
+  public void testOverlap() {
+    Object[][] inputs = new Object[][]{
+        new Object[]{Range.of(0, 0), Range.of(0, 0), false},
+        new Object[]{Range.of(0, 1), Range.of(0, 1), true},
+        new Object[]{Range.of(0, 1), Range.of(1, 0), false},
+        new Object[]{Range.of(0, 1), Range.of(1, 1), false},
+        new Object[]{Range.of(0, 2), Range.of(1, 1), true},
+        new Object[]{Range.of(0, 2), Range.of(0, 1), true},
+        new Object[]{Range.of(0, 2), Range.of(1, 2), true},
+        new Object[]{Range.of(0, 2), Range.of(2, 0), false},
+        new Object[]{Range.of(0, 2), Range.of(2, 1), false},
+        new Object[]{Range.of(5, 9), Range.of(0, 5), false},
+        new Object[]{Range.of(5, 9), Range.of(0, 6), true}
+    };
+
+    for (Object[] input : inputs) {
+      Range l = (Range) input[0];
+      Range r = (Range) input[1];
+      boolean expect = (boolean) input[2];
+
+      Assert.assertEquals(expect, l.overlap(r));
+    }
+  }
+
+  @Test
+  public void testSplit() {
+    Assert.assertEquals(Range.split(10, 3),
+        ImmutableList.of(Range.of(0, 3), Range.of(3, 3), Range.of(6, 3), Range.of(9, 1)));
+    Assert.assertEquals(Range.split(10, 5),
+        ImmutableList.of(Range.of(0, 5), Range.of(5, 5)));
+    Assert.assertEquals(Range.split(10, 12),
+        ImmutableList.of(Range.of(0, 10)));
+    Assert.assertEquals(Range.split(2, 1),
+        ImmutableList.of(Range.of(0, 1), Range.of(1, 1)));
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestUtility.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/java/org/apache/hadoop/fs/tosfs/util/TestUtility.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.tosfs.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.tosfs.conf.ConfKeys;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorage;
+import org.apache.hadoop.fs.tosfs.object.ObjectStorageFactory;
+import org.apache.hadoop.fs.tosfs.object.tos.TOS;
+import org.apache.hadoop.util.Lists;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class TestUtility {
+  private static final String ENV_TOS_BUCKET = "TOS_BUCKET";
+  private static final String ENV_TEST_SCHEME = "TEST_SCHEME";
+  private static final Random RND = new Random(System.currentTimeMillis());
+
+  private TestUtility() {
+  }
+
+  public static byte[] rand(int size) {
+    byte[] buffer = new byte[size];
+    RND.nextBytes(buffer);
+    return buffer;
+  }
+
+  public static int randInt(int bound) {
+    return RND.nextInt(bound);
+  }
+
+  public static String randomWithChinese() {
+    return RandomStringUtils.random(10, 0x4e00, 0x9fa5, false, false);
+  }
+
+  public static String createUniquePath(String scheme) {
+    String bucket = bucket();
+    if (bucket != null) {
+      return String.format("%s://%s/%s-%s/", scheme, bucket, scheme, UUIDUtils.random());
+    } else {
+      throw new IllegalStateException("OS test bucket is not available");
+    }
+  }
+
+  public static String defaultFs() {
+    return String.format("%s://%s/", scheme(), bucket());
+  }
+
+  public static String scheme() {
+    return ParseUtils.envAsString(ENV_TEST_SCHEME, "tos");
+  }
+
+  public static String bucket() {
+    String bucket = ParseUtils.envAsString(ENV_TOS_BUCKET);
+    if (bucket != null) {
+      return bucket;
+    }
+
+    // Parse from endpoint if it is formatted like http[s]://<bucket>.<region>.xxx.com
+    String endpoint = ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT);
+    if (endpoint != null) {
+      for (String scheme : Lists.newArrayList("http://", "https://")) {
+        if (endpoint.startsWith(scheme)) {
+          endpoint = endpoint.substring(scheme.length());
+        }
+      }
+
+      String[] elements = endpoint.split("\\.");
+      if (elements.length == 4) {
+        return elements[0];
+      }
+    }
+    throw new RuntimeException("Cannot decide the bucket name for object storage with scheme 'tos'");
+  }
+
+  public static String region() {
+    return TOSClientContextUtils.parseRegion(ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT));
+  }
+
+  public static String endpoint() {
+    return ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void setSystemEnv(String key, String value) {
+    try {
+      Map<String, String> env = System.getenv();
+      Class<?> cl = env.getClass();
+      Field field = cl.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+      writableEnv.put(key, value);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to set environment variable", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void removeSystemEnv(String key) {
+    try {
+      Map<String, String> env = System.getenv();
+      Class<?> cl = env.getClass();
+      Field field = cl.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+      writableEnv.remove(key);
+    } catch (Exception e) {
+      throw new IllegalStateException(String.format("Failed to remove environment variable: %s", key), e);
+    }
+  }
+
+  public static FileContext createTestFileContext(Configuration conf) throws IOException {
+    URI testURI = URI.create(defaultFs());
+    return FileContext.getFileContext(testURI, conf);
+  }
+
+  private static ObjectStorage generalBucketObjectStorage() {
+    Configuration conf = new Configuration();
+    String endpoint = ParseUtils.envAsString(TOS.ENV_TOS_ENDPOINT, "");
+    if (!StringUtils.isEmpty(endpoint)) {
+      conf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key(scheme()), endpoint);
+    }
+
+    return ObjectStorageFactory.createWithPrefix(
+        String.format("%s-%s/", scheme(), UUIDUtils.random()), scheme(), bucket(), conf);
+  }
+
+  public static List<ObjectStorage> createTestObjectStorage(String fileStoreRoot) {
+    List<ObjectStorage> storages = new ArrayList<>();
+
+    // 1. FileStore
+    Configuration fileStoreConf = new Configuration();
+    fileStoreConf.set(ConfKeys.FS_OBJECT_STORAGE_ENDPOINT.key("filestore"), fileStoreRoot);
+    storages.add(ObjectStorageFactory.create("filestore", TestUtility.bucket(), fileStoreConf));
+
+    // 2. General Bucket
+    storages.add(generalBucketObjectStorage());
+
+    return storages;
+  }
+}

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/contract/tos.xml
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/contract/tos.xml
@@ -1,0 +1,113 @@
+<configuration>
+  <property>
+    <name>fs.contract.test.fs.tos</name>
+    <value>tos://{your_bucket}/</value>
+  </property>
+
+  <property>
+    <name>fs.contract.test.random-seek-count</name>
+    <value>10</value>
+  </property>
+
+  <property>
+    <name>fs.contract.is-blobstore</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.create-visibility-delayed</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.is-case-sensitive</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rename-returns-false-if-source-missing</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rename-returns-false-if-dest-exists</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-append</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-atomic-directory-delete</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-atomic-rename</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-block-locality</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-concat</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-unbuffer</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rename-creates-dest-dirs</name>
+    <value>true</value>
+  </property>
+
+  <!--be careful that the root test cases will clean whole bucket-->
+  <property>
+    <name>fs.contract.test.root-tests-enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-getfilestatus</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-seek</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-seek-on-closed-file</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rejects-seek-past-eof</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-strict-exceptions</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-multipartuploader</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>fs.contract.supports-unix-permissions</name>
+    <value>false</value>
+  </property>
+
+</configuration>

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/core-site.xml
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/core-site.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<configuration>
+
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>target/build/test</value>
+    <description>A base for other temporary directories.</description>
+    <final>true</final>
+  </property>
+
+  <!-- Turn security off for tests by default -->
+  <property>
+    <name>hadoop.security.authentication</name>
+    <value>simple</value>
+  </property>
+
+  <property>
+    <name>fs.tos.impl</name>
+    <value>org.apache.hadoop.fs.tosfs.TosFileSystem</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.tos.impl</name>
+    <value>org.apache.hadoop.fs.tosfs.TosFS</value>
+  </property>
+  <property>
+    <name>fs.tos.impl.disable.cache</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.filestore.impl</name>
+    <value>org.apache.hadoop.fs.tosfs.RawFileSystem</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.filestore.impl</name>
+    <value>org.apache.hadoop.fs.tosfs.RawFS</value>
+  </property>
+  <property>
+    <name>fs.filestore.impl.disable.cache</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/log4j.properties
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/test/resources/log4j.properties
@@ -1,0 +1,23 @@
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=info,stdout
+log4j.threshold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n


### PR DESCRIPTION
### Description of PR
Please refer to https://github.com/apache/hadoop/pull/7194.

The tos integration work is too big. Split it into 2 parts and this is the first part.

### How was this patch tested?
With unit tests.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

