### PR TITLE
YARN-11758. [UI2] On the Cluster Metrics page make the Resource Usage…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/cluster-overview.hbs
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/app/templates/cluster-overview.hbs
@@ -20,39 +20,24 @@
 
 {{#if model}}
 
-  <div class="col-md-12 container-fluid">
-    <div class="row">
-      <div class="col-lg-6 container-fluid">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            Cluster Resource Usage By Applications
-          </div>
-          <div class="container-fluid donut-chart" id="appusage-donut-chart">
-            {{app-usage-donut-chart data=model.apps
-            showLabels=true
-            parentId="appusage-donut-chart"
-            ratio=0.5
-            maxHeight=400}}
-          </div>
+<div class="col-md-12 container-fluid">
+  <h3>Applications</h3>
+  <div class="row">
+    <div class="col-lg-6 container-fluid">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          Cluster Resource Usage By Applications
         </div>
-      </div>
-
-      <div class="col-lg-6 container-fluid">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            Cluster Resource Usage By Leaf Queues
-          </div>
-          <div class="container-fluid donut-chart" id="queueusage-donut-chart">
-            {{queue-usage-donut-chart data=model.queues
-            showLabels=true
-            parentId="queueusage-donut-chart"
-            ratio=0.5
-            maxHeight=400}}
-          </div>
+        <div class="container-fluid donut-chart" id="appusage-donut-chart">
+          {{app-usage-donut-chart data=model.apps
+          showLabels=true
+          parentId="appusage-donut-chart"
+          ratio=0.5
+          maxHeight=500}}
         </div>
       </div>
     </div>
-    <hr>
+  </div>
 
   <div class="row">
     <div class="col-lg-4 container-fluid">
@@ -88,7 +73,30 @@
     </div>
   </div>
 
-  <hr>
+  <h3>Partitions</h3>
+  <div class="row">
+  {{#each model.queues.firstObject.partitions as | partition index|}}
+    <div class="col-lg-4 container-fluid">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        [{{partition}}] Cluster Resource Usage By Leaf Queues
+      </div>
+
+      <div class="container-fluid donut-chart" id="queueusage-donut-chart-{{index}}">
+        {{queue-usage-donut-chart data=model.queues
+        showLabels=true
+        parentIdPrefix="queueusage-donut-chart-"
+        id=index
+        ratio=0.5
+        maxHeight=350
+        partition=partition}}
+      </div>
+      </div>
+    </div>
+  {{/each}}
+  </div>
+
+  <h3>Resources</h3>
   <div class="row">
     <!-- When getAllResourceTypesDonutChart is not null, use it to show per-resource-type usages. Otherwise only show
          vcore/memory usage from metrics -->
@@ -154,8 +162,8 @@
         </div>
       </div>
     {{/if}}
-
   </div>
+
   <div class="row">
     <div class="col-lg-6 container-fluid">
       <div class="panel panel-default">


### PR DESCRIPTION
… by Leaf Queues chart partition-aware

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When partitions are used, the "Cluster Resource Usage By Leaf Queues" chart shows data only for the default partition and does not display metrics for the other partitions. Adding a separate chart for each partition and to re-structure the page based on categories for more clarity.

### How was this patch tested?
Manually tested in my local environment. Screenshots provided in the Jira.

### For code changes:

- [ x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

