### PR TITLE
HADOOP-19363. Adding IO exception to AAL

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -41,7 +41,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
 
   public static final Logger LOG = LoggerFactory.getLogger(AnalyticsStream.class);
 
-  public AnalyticsStream(final ObjectReadParameters parameters, final S3SeekableInputStreamFactory s3SeekableInputStreamFactory) {
+  public AnalyticsStream(final ObjectReadParameters parameters, final S3SeekableInputStreamFactory s3SeekableInputStreamFactory) throws IOException {
     super(parameters);
     S3ObjectAttributes s3Attributes = parameters.getObjectAttributes();
     this.inputStream = s3SeekableInputStreamFactory.createStream(S3URI.of(s3Attributes.getBucket(), s3Attributes.getKey()));


### PR DESCRIPTION
### Description of PR
We updated AAL https://github.com/awslabs/analytics-accelerator-s3/pull/209/files to throw an IO exception here and we need to update the signature for the class

### How was this patch tested?
Tested with the testNotFoundFirstRead test because I know that test non-existing files. Any other recommend integ tests to run? 

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
   no merging into a feature branch
- [ x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

