### PR TITLE
YARN-11764. yarn tests have stopped running.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEntity.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEntity.java
@@ -55,7 +55,8 @@ import org.apache.hadoop.yarn.util.TimelineServiceHelper;
 @XmlAccessorType(XmlAccessType.NONE)
 @Public
 @Evolving
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true,
+    value = {"relatedEntitiesJAXB", "primaryFiltersJAXB", "otherInfoJAXB"})
 public class TimelineEntity implements Comparable<TimelineEntity> {
 
   private String entityType;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEvent.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.yarn.util.TimelineServiceHelper;
 @XmlAccessorType(XmlAccessType.NONE)
 @Public
 @Evolving
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"eventInfoJAXB"})
 public class TimelineEvent implements Comparable<TimelineEvent> {
 
   private long timestamp;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineEntity.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineEntity.java
@@ -55,7 +55,8 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 @XmlAccessorType(XmlAccessType.NONE)
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true,
+    value = {"infoJAXB", "configsJAXB", "isRelatedToEntitiesJAXB", "relatesToEntitiesJAXB"})
 public class TimelineEntity implements Comparable<TimelineEntity> {
   protected final static String SYSTEM_INFO_KEY_PREFIX = "SYSTEM_INFO_";
   public final static long DEFAULT_ENTITY_PREFIX = 0L;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineEvent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineEvent.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.yarn.api.records.timelineservice;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.util.TimelineServiceHelper;
@@ -38,6 +39,7 @@ import java.util.Map;
 @XmlAccessorType(XmlAccessType.NONE)
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"infoJAXB"})
 public class TimelineEvent implements Comparable<TimelineEvent> {
   public static final long INVALID_TIMESTAMP = 0L;
 
@@ -61,7 +63,6 @@ public class TimelineEvent implements Comparable<TimelineEvent> {
   // required by JAXB
   @InterfaceAudience.Private
   @XmlElement(name = "info")
-  @JsonIgnore
   public HashMap<String, Object> getInfoJAXB() {
     return info;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineMetric.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timelineservice/TimelineMetric.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 @XmlAccessorType(XmlAccessType.NONE)
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"valuesJAXB"})
 public class TimelineMetric {
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
@@ -182,6 +182,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
@@ -289,7 +289,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
@@ -191,6 +191,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/BaseAMRMClientTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/BaseAMRMClientTest.java
@@ -196,7 +196,7 @@ public class BaseAMRMClientTest {
 
   @After
   public void teardown() throws YarnException, IOException {
-    if (yarnClient != null) {
+    if (yarnClient != null && attemptId != null) {
       yarnClient.killApplication(attemptId.getApplicationId());
     }
     attemptId = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -195,6 +195,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
@@ -197,7 +197,7 @@ public class TestLocalityMulticastAMRMProxyPolicy
     checkTotalContainerAllocation(response, 100);
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 8000)
   public void testStressPolicy() throws Exception {
 
     // Tests how the headroom info are used to split based on the capacity

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
@@ -149,6 +149,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/GlobalPolicyGenerator.java
@@ -300,7 +300,8 @@ public class GlobalPolicyGenerator extends CompositeService {
     LOG.info("Instantiating GPGWebApp at {}.", webAppAddress);
     GPGWebApp gpgWebApp = new GPGWebApp(this);
     webApp = WebApps.$for("gpg", GPGContext.class, this.gpgContext,
-        "ws").at(webAppAddress).withResourceConfig(gpgWebApp.resourceConfig()).start(gpgWebApp);
+        "gpg-ws").at(webAppAddress).
+         withResourceConfig(gpgWebApp.resourceConfig()).start(gpgWebApp);
   }
 
   @SuppressWarnings("resource")

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/GPGWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/main/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/GPGWebApp.java
@@ -17,6 +17,7 @@
 */
 package org.apache.hadoop.yarn.server.globalpolicygenerator.webapp;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GlobalPolicyGenerator;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.JAXBContextResolver;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
@@ -59,6 +60,7 @@ public class GPGWebApp extends WebApp {
     @Override
     protected void configure() {
       bind(gpg).to(GlobalPolicyGenerator.class).named("gpg");
+      bind(gpg.getConfig()).to(Configuration.class).named("conf");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -105,6 +105,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -343,30 +343,34 @@ public class ResourceLocalizationService extends CompositeService
       LocalResourceTrackerState state) throws URISyntaxException, IOException {
     try (RecoveryIterator<LocalizedResourceProto> it =
              state.getCompletedResourcesIterator()) {
-      while (it.hasNext()) {
-        LocalizedResourceProto proto = it.next();
-        LocalResource rsrc = new LocalResourcePBImpl(proto.getResource());
-        LocalResourceRequest req = new LocalResourceRequest(rsrc);
-        LOG.debug("Recovering localized resource {} at {}",
-            req, proto.getLocalPath());
-        tracker.handle(new ResourceRecoveredEvent(req,
-            new Path(proto.getLocalPath()), proto.getSize()));
+      if (it != null) {
+        while (it.hasNext()) {
+          LocalizedResourceProto proto = it.next();
+          LocalResource rsrc = new LocalResourcePBImpl(proto.getResource());
+          LocalResourceRequest req = new LocalResourceRequest(rsrc);
+          LOG.debug("Recovering localized resource {} at {}",
+              req, proto.getLocalPath());
+          tracker.handle(new ResourceRecoveredEvent(req,
+              new Path(proto.getLocalPath()), proto.getSize()));
+        }
       }
     }
 
     try (RecoveryIterator<Map.Entry<LocalResourceProto, Path>> it =
              state.getStartedResourcesIterator()) {
-      while (it.hasNext()) {
-        Map.Entry<LocalResourceProto, Path> entry = it.next();
-        LocalResource rsrc = new LocalResourcePBImpl(entry.getKey());
-        LocalResourceRequest req = new LocalResourceRequest(rsrc);
-        Path localPath = entry.getValue();
-        tracker.handle(new ResourceRecoveredEvent(req, localPath, 0));
+      if(it != null) {
+        while (it.hasNext()) {
+          Map.Entry<LocalResourceProto, Path> entry = it.next();
+          LocalResource rsrc = new LocalResourcePBImpl(entry.getKey());
+          LocalResourceRequest req = new LocalResourceRequest(rsrc);
+          Path localPath = entry.getValue();
+          tracker.handle(new ResourceRecoveredEvent(req, localPath, 0));
 
-        // delete any in-progress localizations, containers will request again
-        LOG.info("Deleting in-progress localization for " + req + " at "
-            + localPath);
-        tracker.remove(tracker.getLocalizedResource(req), delService);
+          // delete any in-progress localizations, containers will request again
+          LOG.info("Deleting in-progress localization for " + req + " at "
+               + localPath);
+          tracker.remove(tracker.getLocalizedResource(req), delService);
+        }
       }
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
@@ -159,7 +159,6 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     dirsHandler = new LocalDirsHandlerService();
     nodeHealthChecker = new NodeHealthCheckerService(dirsHandler);
     nodeHealthChecker.init(conf);
-
   }
 
   @Test
@@ -410,8 +409,10 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     NMStateStoreService stateStore = new NMMemoryStateStoreService();
     stateStore.init(conf);
     stateStore.start();
-    Context context = createContext(conf, stateStore);
+    context = createContext(conf, stateStore);
     ContainerManagerImpl cm = createContainerManager(context, delSrvc);
+    ((NMContext) context).setContainerManager(cm);
+    ((NMContext) context).setNodeStatusUpdater(getNodeStatusUpdater());
     cm.init(conf);
     cm.start();
     metrics.addResource(Resource.newInstance(10240, 8));
@@ -423,7 +424,7 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     Map<String, String> containerEnv = Collections.emptyMap();
     Map<String, ByteBuffer> serviceData = Collections.emptyMap();
     Map<String, LocalResource> localResources = Collections.emptyMap();
-    List<String> commands = Arrays.asList("sleep 60s".split(" "));
+    List<String> commands = Arrays.asList("sleep 60".split(" "));
     ContainerLaunchContext clc = ContainerLaunchContext.newInstance(
         localResources, containerEnv, commands, serviceData,
         null, null);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -252,7 +252,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
       String containerIdStr = container11.toString();
       File containerLogDir = new File(app1LogDir, containerIdStr);
-      for (String fileType : new String[]{"stdout", "stderr", "syslog"}) {
+      for (String fileType : new String[]{"stdout", "stderr", "syslog", "zero"}) {
         File f = new File(containerLogDir, fileType);
         GenericTestUtils.waitFor(() -> !f.exists(), 1000, 1000 * 50);
         Assert.assertFalse("File [" + f + "] was not deleted", f.exists());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
@@ -356,6 +356,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/RMWebAppFilter.java
@@ -250,6 +250,7 @@ public class RMWebAppFilter implements Filter {
 
   private boolean shouldRedirect(RMWebApp rmWebApp, String uri) {
     return !uri.equals("/" + rmWebApp.wsName() + "/v1/cluster/info")
+        && !uri.equals("/ws/v1/cluster/info")
         && !uri.equals("/" + rmWebApp.name() + "/cluster")
         && !uri.startsWith(ProxyUriUtils.PROXY_BASE)
         && !NON_REDIRECTED_URIS.contains(uri);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
@@ -183,6 +183,11 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11764. yarn tests have stopped running.

After completing [HADOOP-15984](https://issues.apache.org/jira/browse/HADOOP-15984), we added JUnit5 test dependencies to some modules. These dependencies caused maven-surefire to fail to recognize JUnit4 tests, leading to the cessation of unit tests in some YARN modules. As a result, some YARN unit tests failed and were not detected in time. This JIRA will track and resolve these issues, including the stopped unit tests and test errors.

I have fixed the YARN-related unit test errors and tested them locally. Next, I will provide a detailed explanation of how we resolved these unit test issues.

### 1. hadoop.yarn.server.resourcemanager.metrics.TestSystemMetricsPublisher

These unit test errors were discovered during the integration testing of the ResourceManager module.

The error message is as follows:

https://ci-hadoop.apache.org/job/hadoop-multibranch/job/PR-7345/2/artifact/out/patch-unit-hadoop-yarn-project_hadoop-yarn_hadoop-yarn-server_hadoop-yarn-server-resourcemanager.txt

```
[ERROR] TestSystemMetricsPublisher.testPublishApplicationMetrics  Time elapsed: 1.279 s  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.hadoop.yarn.server.resourcemanager.metrics.TestSystemMetricsPublisher.testPublishApplicationMetrics(TestSystemMetricsPublisher.java:230)
```

The code causing the error is as follows:
```
Assert.assertTrue(verifyAppTags(app.getApplicationTags(), entity.getOtherInfo()));
```

We found that the contents of `app.getApplicationTags()` and `entity.getOtherInfo()` are inconsistent, with `entity.getOtherInfo()` containing duplicate entries.

`app.getApplicationTags()` is expected to contain `2` elements, but `entity.getOtherInfo()` contains `4` elements.

https://github.com/apache/hadoop/blob/44a5cba78ac7d29a72d3452fbd807f31ae90c325/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/metrics/TestSystemMetricsPublisher.java#L555-L558

The cause of this issue is that the data in `TimelineEntity.java` is being serialized twice, as there are two properties in the class representing the same data. As shown in the code below, this results in two identical entries in the serialized JSON, one named `otherinfo` and the other named `otherInfoJAXB`.

https://github.com/apache/hadoop/blob/44a5cba78ac7d29a72d3452fbd807f31ae90c325/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/timeline/TimelineEntity.java#L310-L315

The serialized JSON is as follows:

```
{
    "entities": [
        {
            "entityType": "YARN_APPLICATION",
            "entityId": "application_0_0001",
            "startTime": null,
            "events": [
                {
                    "timestamp": 2147483649,
                    "eventType": "YARN_APPLICATION_CREATED",
                    "eventInfo": {

                    }
                }
            ],
            "relatedEntities": {

            },
            "primaryFilters": {

            },
            "otherInfo": {
                "YARN_APPLICATION_CALLER_CONTEXT": "context",
                "YARN_APPLICATION_NAME": "test app",
                "YARN_APPLICATION_USER": "test user",
                "YARN_APPLICATION_UNMANAGED_APPLICATION": false,
                "YARN_APP_NODE_LABEL_EXPRESSION": "high-cpu",
                "YARN_APPLICATION_SUBMITTED_TIME": 2147483648,
                "YARN_AM_CONTAINER_LAUNCH_COMMAND": [
                    "java -Xmx1024m"
                ],
                "YARN_AM_NODE_LABEL_EXPRESSION": "high-mem",
                "YARN_APPLICATION_QUEUE": "test queue",
                "YARN_APPLICATION_TYPE": "test app type",
                "YARN_APPLICATION_PRIORITY": 10,
                "YARN_APPLICATION_TAGS": [
                    "test",
                    "tags"
                ],
                "YARN_APPLICATION_STATE": "SUBMITTED"
            },
            "domainId": null,
            "relatedEntitiesJAXB": {

            },
            "primaryFiltersJAXB": {

            },
            "otherInfoJAXB": {
                "YARN_APPLICATION_CALLER_CONTEXT": "context",
                "YARN_APPLICATION_NAME": "test app",
                "YARN_APPLICATION_USER": "test user",
                "YARN_APPLICATION_UNMANAGED_APPLICATION": false,
                "YARN_APP_NODE_LABEL_EXPRESSION": "high-cpu",
                "YARN_APPLICATION_SUBMITTED_TIME": 2147483648,
                "YARN_AM_CONTAINER_LAUNCH_COMMAND": [
                    "java -Xmx1024m"
                ],
                "YARN_AM_NODE_LABEL_EXPRESSION": "high-mem",
                "YARN_APPLICATION_QUEUE": "test queue",
                "YARN_APPLICATION_TYPE": "test app type",
                "YARN_APPLICATION_PRIORITY": 10,
                "YARN_APPLICATION_TAGS": [
                    "test",
                    "tags"
                ],
                "YARN_APPLICATION_STATE": "SUBMITTED"
            }
        }
    ]
}
```

The `otherInfo` / `otherInfoJAXB`, `relatedEntities` / `relatedEntitiesJAXB`, and `primaryFilters` / `primaryFiltersJAXB` are three pairs of duplicate data. 

Taking `YARN_APPLICATION_TAGS` as an example, the same data exists in two places, so it was parsed twice, leading to duplicate data. The original data was `["test", "tags"]`, but it was actually converted to `["test", "tags", "test", "tags"]`.

JAXB is an annotation for XML, which has no effect on JSON. Therefore, I used annotations to exclude this property and reviewed all the Timeline classes to ensure that JAXB properties are excluded during JSON parsing.

### 2. TestOpportunisticContainerAllocationE2E /  TestAMRMProxy / TestAMRMClient / TestYarnClient / TestNMClient

These unit test errors were discovered during the integration testing of the `yarn_hadoop-yarn-client` module.

The error message is similar to the following:

```
[ERROR] org.apache.hadoop.yarn.client.api.impl.TestAMRMProxy.testE2ETokenSwap  Time elapsed: 0.957 s  <<< ERROR!
org.apache.hadoop.yarn.exceptions.YarnException: Failed to submit application_1738512061145_0001 to YARN : Application application_1738512061145_0001 submitted by user jenkinsApplication application_1738512061145_0001 submitted by user jenkins to unknown queue: default
```

It was quite strange to see this error, because these tests pass when executed individually locally, but they fail when running `mvn clean test`. 

After debugging, I found that the unit test in `TestSchedConfCLI.java` generates a `capacity-scheduler.xml` file under the `target/classes` directory. This configuration file overwrites the default configuration, causing the unit test to fail to recognize the default `default` queue.

We can solve this issue by simply adding the `@After` annotation to the `cleanUp()` method in `TestSchedConfCLI.java`. This ensures that the generated configuration file is deleted after the unit tests are completed.

### 3. TestContainerManagerRecovery

This unit test error was discovered during the integration testing of the NodeManager module. It seems to be an issue that has existed for quite some time. I rolled back to a version before HADOOP-15984 locally, but the error still persists.

The cause of this error is that the `NodeStatusUpdater` was not set in `testNodeManagerMetricsRecovery`, which leads to a `NullPointerException` when using this class.  We need to inject this class into the context.

https://github.com/apache/hadoop/blob/44a5cba78ac7d29a72d3452fbd807f31ae90c325/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java#L1959-L1988

`NullPointerException` is thrown at L1986, which causes the unit test to terminate. I also found that on macOS, `sleep 60s` is not recognized, but `sleep 60` works fine. Since `sleep 60s` and `sleep 60` are equivalent, I removed the `s` from the command so that the unit test can run properly on macOS as well.

### 4. TestContainerManagerRecovery#testNMRecoveryForAppFinishedWithLogAggregationFailure

```
[ERROR] org.apache.hadoop.yarn.server.nodemanager.containermanager.TestContainerManagerRecovery.testNMRecoveryForAppFinishedWithLogAggregationFailure  Time elapsed: 0.069 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService.recoverTrackerResources(ResourceLocalizationService.java:346)
	at 
......
```

This error is caused by #7317, but I do not intend to revert #7317. Since the iterator should not be null except in unit tests, I added a new check to handle the case when the iterator is null.

#7317 is effective, as we can see from the daily JDK 11 build emails(`Apache Hadoop qbt Report: trunk+JDK11 on Linux/x86_64`).  There are no more yarn spotbugs warnings.

### 5. hadoop.yarn.server.globalpolicygenerator.secure.TestGpgSecureLogins / TestGlobalPolicyGenerator

The errors in these two unit tests are from the integration testing of `GlobalPolicyGenerator`.

The cause of the unit test errors was that we missed injecting the `configuration` object when injecting other dependencies. I have now completed the injection of the class.

### 6. TestAMRMClient

I relaxed some of the testing criteria for the `TestAMRMClient` unit test.

Each method of this unit test runs successfully locally, so we can say that the unit test itself is fine. However, under the integration test conditions, when running in parallel, there are frequent issues with timeouts and failing condition checks.

From my perspective, these unit tests are quite complex because each test needs to initialize a mini YARN cluster. While the containers are ultimately allocated successfully, the exact timing of the allocation is hard to predict. Sometimes, it does take a bit longer. The container release process is similar. While it will eventually release the containers, it's not always guaranteed to happen within the required number of iterations or time frame.

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

