### PR TITLE
MAPREDUCE-7415. [JDK17] Upgrade Junit 4 to 5 in hadoop-mapreduce-client-nativetask.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/TestTaskContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/TestTaskContext.java
@@ -22,8 +22,9 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTaskContext {
 
@@ -33,19 +34,19 @@ public class TestTaskContext {
         null);
     
     context.setInputKeyClass(IntWritable.class);
-    Assert.assertEquals(IntWritable.class.getName(), context.getInputKeyClass
+    assertEquals(IntWritable.class.getName(), context.getInputKeyClass
         ().getName());
  
     context.setInputValueClass(Text.class);
-    Assert.assertEquals(Text.class.getName(), context.getInputValueClass()
+    assertEquals(Text.class.getName(), context.getInputValueClass()
         .getName());
    
     context.setOutputKeyClass(LongWritable.class);
-    Assert.assertEquals(LongWritable.class.getName(), context
+    assertEquals(LongWritable.class.getName(), context
         .getOutputKeyClass().getName());
 
     context.setOutputValueClass(FloatWritable.class);
-    Assert.assertEquals(FloatWritable.class.getName(), context
+    assertEquals(FloatWritable.class.getName(), context
         .getOutputValueClass().getName());
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
@@ -39,9 +39,10 @@ import org.apache.hadoop.mapred.nativetask.testutil.TestInput;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput.KV;
 import org.apache.hadoop.util.Progress;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings({ "rawtypes", "unchecked"})
 public class TestBufferPushPull {
@@ -50,7 +51,7 @@ public class TestBufferPushPull {
   public static int INPUT_KV_COUNT = 1000;
   private KV<BytesWritable, BytesWritable>[] dataInput;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.dataInput = TestInput.getMapInputs(INPUT_KV_COUNT);
   }
@@ -70,8 +71,8 @@ public class TestBufferPushPull {
       @Override
       public void write(BytesWritable key, BytesWritable value) throws IOException {
         final KV expect = dataInput[count++];
-        Assert.assertEquals(expect.key.toString(), key.toString());
-        Assert.assertEquals(expect.value.toString(), value.toString());
+        assertEquals(expect.key.toString(), key.toString());
+        assertEquals(expect.value.toString(), value.toString());
       }
     };
 
@@ -130,8 +131,8 @@ public class TestBufferPushPull {
       keyBytes.readFields(key);
       valueBytes.readFields(value);
 
-      Assert.assertEquals(dataInput[count].key.toString(), keyBytes.toString());
-      Assert.assertEquals(dataInput[count].value.toString(), valueBytes.toString());
+      assertEquals(dataInput[count].key.toString(), keyBytes.toString());
+      assertEquals(dataInput[count].value.toString(), valueBytes.toString());
 
       count++;
     }
@@ -178,7 +179,7 @@ public class TestBufferPushPull {
     public void reset() {
       count = 0;
     }
-  };
+  }
 
   public static class NativeHandlerForPull implements NativeDataSource, NativeDataTarget {
 
@@ -274,5 +275,5 @@ public class TestBufferPushPull {
     public Progress getProgress() {
       return null;
     }
-  };
+  }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestBufferPushPull.java
@@ -179,7 +179,7 @@ public class TestBufferPushPull {
     public void reset() {
       count = 0;
     }
-  }
+  };
 
   public static class NativeHandlerForPull implements NativeDataSource, NativeDataTarget {
 
@@ -275,5 +275,5 @@ public class TestBufferPushPull {
     public Progress getProgress() {
       return null;
     }
-  }
+  };
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestByteBufferReadWrite.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.mapred.nativetask.NativeDataTarget;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.mockito.Mockito;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestInputBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestInputBuffer.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.mapred.nativetask.buffer;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestOutputBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/buffer/TestOutputBuffer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapred.nativetask.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/CombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/CombinerTest.java
@@ -35,13 +35,15 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class CombinerTest {
   private FileSystem fs;
@@ -66,10 +68,10 @@ public class CombinerTest {
     ResultVerifier.verifyCounters(normaljob, nativejob, true);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addcombinerConf();
 
@@ -90,7 +92,7 @@ public class CombinerTest {
       "/normalwordcount";
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/LargeKVCombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/LargeKVCombinerTest.java
@@ -30,24 +30,25 @@ import org.apache.hadoop.mapred.nativetask.testutil.ResultVerifier;
 import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 public class LargeKVCombinerTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(LargeKVCombinerTest.class);
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
   @Test
@@ -102,7 +103,7 @@ public class LargeKVCombinerTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/OldAPICombinerTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/combinertest/OldAPICombinerTest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred.nativetask.combinertest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -38,11 +39,10 @@ import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.TaskCounter;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -83,10 +83,10 @@ public class OldAPICombinerTest {
         .isEqualTo(normalReduceGroups.getValue());
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addcombinerConf();
     this.fs = FileSystem.get(conf);
@@ -99,7 +99,7 @@ public class OldAPICombinerTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMBINER_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/compresstest/CompressTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/compresstest/CompressTest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred.nativetask.compresstest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -30,11 +31,10 @@ import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -125,10 +125,10 @@ public class CompressTest {
     ResultVerifier.verifyCounters(hadoopJob, nativeJob);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     final FileSystem fs = FileSystem.get(conf);
     final Path path = new Path(TestConstants.NATIVETASK_COMPRESS_TEST_INPUTDIR);
@@ -142,7 +142,7 @@ public class CompressTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_COMPRESS_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestCombineHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestCombineHandler.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.mapred.nativetask.Command;
 import org.apache.hadoop.mapred.nativetask.INativeHandler;
 import org.apache.hadoop.mapred.nativetask.buffer.BufferType;
 import org.apache.hadoop.mapred.nativetask.buffer.InputBuffer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +40,7 @@ public class TestCombineHandler {
   private BufferPuller puller;
   private CombinerRunner combinerRunner;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.nativeHandler = Mockito.mock(INativeHandler.class);
     this.pusher = Mockito.mock(BufferPusher.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestNativeCollectorOnlyHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/handlers/TestNativeCollectorOnlyHandler.java
@@ -35,12 +35,13 @@ import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.mapred.nativetask.util.OutputUtil;
 import org.apache.hadoop.mapred.nativetask.util.ReadWriteBuffer;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 
@@ -54,7 +55,7 @@ public class TestNativeCollectorOnlyHandler {
   private TaskContext taskContext;
   private static final String LOCAL_DIR = TestConstants.NATIVETASK_TEST_DIR + "/local";
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.nativeHandler = Mockito.mock(INativeHandler.class);
     this.pusher = Mockito.mock(BufferPusher.class);
@@ -74,7 +75,7 @@ public class TestNativeCollectorOnlyHandler {
       new InputBuffer(BufferType.HEAP_BUFFER, 100));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     FileSystem.getLocal(new Configuration()).delete(new Path(LOCAL_DIR));
   }
@@ -100,7 +101,7 @@ public class TestNativeCollectorOnlyHandler {
     Mockito.when(combiner.getId()).thenReturn(100L);
     final ReadWriteBuffer result = handler.onCall(
       NativeCollectorOnlyHandler.GET_COMBINE_HANDLER, null);
-    Assert.assertEquals(100L, result.readLong());
+    assertEquals(100L, result.readLong());
   }
 
   @Test
@@ -112,7 +113,7 @@ public class TestNativeCollectorOnlyHandler {
     } catch(final IOException e) {
       thrown = true;
     }
-    Assert.assertTrue("exception thrown", thrown);
+    assertTrue(thrown, "exception thrown");
 
     final String expectedOutputPath = StringUtils.join(File.separator,
         new String[] {LOCAL_DIR, "output", "file.out"});
@@ -123,14 +124,14 @@ public class TestNativeCollectorOnlyHandler {
 
     final String outputPath = handler.onCall(
       NativeCollectorOnlyHandler.GET_OUTPUT_PATH, null).readString();
-    Assert.assertEquals(expectedOutputPath, outputPath);
+    assertEquals(expectedOutputPath, outputPath);
 
     final String outputIndexPath = handler.onCall(
       NativeCollectorOnlyHandler.GET_OUTPUT_INDEX_PATH, null).readString();
-    Assert.assertEquals(expectedOutputIndexPath, outputIndexPath);
+    assertEquals(expectedOutputIndexPath, outputIndexPath);
 
     final String spillPath = handler.onCall(
       NativeCollectorOnlyHandler.GET_SPILL_PATH, null).readString();
-    Assert.assertEquals(expectedSpillPath, spillPath);
+    assertEquals(expectedSpillPath, spillPath);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
@@ -31,11 +31,11 @@ import org.apache.hadoop.mapred.nativetask.testutil.ResultVerifier;
 import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.util.Lists;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -106,14 +106,14 @@ public class KVTest {
     this.valueclass = valueclass;
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
     Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
     Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
   @Test
-  public void testKVCompability() throws Exception {
+  public void testKVCompatibility() throws Exception {
     final FileSystem fs = FileSystem.get(nativekvtestconf);
     final String jobName = "Test:" + keyclass.getSimpleName() + "--"
         + valueclass.getSimpleName();
@@ -148,7 +148,7 @@ public class KVTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_KVTEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
@@ -97,9 +97,9 @@ public class KVTest {
   private Class<?> keyclass;
   private Class<?> valueclass;
 
-  public void initKVTest(Class<?> keyclass, Class<?> valueclass) {
-    this.keyclass = keyclass;
-    this.valueclass = valueclass;
+  public void initKVTest(Class<?> paramKeyclass, Class<?> paramValueclass) {
+    this.keyclass = paramKeyclass;
+    this.valueclass = paramValueclass;
   }
 
   @BeforeEach
@@ -110,8 +110,8 @@ public class KVTest {
 
   @MethodSource("data")
   @ParameterizedTest(name = "key:{0}\nvalue:{1}")
-  public void testKVCompatibility(Class<?> keyclass, Class<?> valueclass) throws Exception {
-    initKVTest(keyclass, valueclass);
+  public void testKVCompatibility(Class<?> pkeyclass, Class<?> pValueclass) throws Exception {
+    initKVTest(pkeyclass, pValueclass);
     final FileSystem fs = FileSystem.get(nativekvtestconf);
     final String jobName = "Test:" + keyclass.getSimpleName() + "--"
         + valueclass.getSimpleName();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/KVTest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred.nativetask.kvtest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,18 +34,14 @@ import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Splitter;
 
-@RunWith(Parameterized.class)
 public class KVTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(KVTest.class);
@@ -73,7 +70,6 @@ public class KVTest {
   /**
    * Parameterize the test with the specified key and value types.
    */
-  @Parameters(name = "key:{0}\nvalue:{1}")
   public static Iterable<Class<?>[]> data() throws Exception {
     // Parse the config.
     final String valueClassesStr = nativekvtestconf
@@ -98,22 +94,24 @@ public class KVTest {
     return pairs;
   }
 
-  private final Class<?> keyclass;
-  private final Class<?> valueclass;
+  private Class<?> keyclass;
+  private Class<?> valueclass;
 
-  public KVTest(Class<?> keyclass, Class<?> valueclass) {
+  public void initKVTest(Class<?> keyclass, Class<?> valueclass) {
     this.keyclass = keyclass;
     this.valueclass = valueclass;
   }
 
   @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
-  @Test
-  public void testKVCompatibility() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest(name = "key:{0}\nvalue:{1}")
+  public void testKVCompatibility(Class<?> keyclass, Class<?> valueclass) throws Exception {
+    initKVTest(keyclass, valueclass);
     final FileSystem fs = FileSystem.get(nativekvtestconf);
     final String jobName = "Test:" + keyclass.getSimpleName() + "--"
         + valueclass.getSimpleName();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.mapred.nativetask.kvtest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -31,21 +31,20 @@ import org.apache.hadoop.mapred.nativetask.NativeRuntime;
 import org.apache.hadoop.mapred.nativetask.testutil.ResultVerifier;
 import org.apache.hadoop.mapred.nativetask.testutil.ScenarioConfiguration;
 import org.apache.hadoop.mapred.nativetask.testutil.TestConstants;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LargeKVTest {
   private static final Logger LOG = LoggerFactory.getLogger(LargeKVTest.class);
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
   }
 
   private static Configuration nativeConf = ScenarioConfiguration.getNativeConfiguration();
@@ -67,7 +66,7 @@ public class LargeKVTest {
     runKVSizeTests(IntWritable.class, Text.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_KVTEST_DIR), true);
@@ -104,17 +103,17 @@ public class LargeKVTest {
       // if output file exists ,then delete it
       fs.delete(new Path(nativeOutputPath), true);
       final KVJob nativeJob = new KVJob("Test Large Value Size:"
-          + String.valueOf(i), nativeConf, keyClass, valueClass, inputPath,
+          + i, nativeConf, keyClass, valueClass, inputPath,
           nativeOutputPath);
-      assertTrue("job should complete successfully", nativeJob.runJob());
+      assertTrue(nativeJob.runJob(), "job should complete successfully");
 
       final String normalOutputPath = TestConstants.NATIVETASK_KVTEST_NORMAL_OUTPUTDIR
           + "/LargeKV/" + keyClass.getName() + "/" + valueClass.getName();
       // if output file exists ,then delete it
       fs.delete(new Path(normalOutputPath), true);
-      final KVJob normalJob = new KVJob("Test Large Key Size:" + String.valueOf(i),
+      final KVJob normalJob = new KVJob("Test Large Key Size:" + i,
           normalConf, keyClass, valueClass, inputPath, normalOutputPath);
-      assertTrue("job should complete successfully", normalJob.runJob());
+      assertTrue(normalJob.runJob(), "job should complete successfully");
 
       final boolean compareRet = ResultVerifier.verify(normalOutputPath,
           nativeOutputPath);
@@ -123,7 +122,7 @@ public class LargeKVTest {
           + (keyClass.equals(Text.class) ? "key" : "value") + ", min size: " + min
           + ", max size: " + max + ", normal out: " + normalOutputPath
           + ", native Out: " + nativeOutputPath;
-      assertEquals(reason, true, compareRet);
+      assertTrue(compareRet, reason);
       ResultVerifier.verifyCounters(normalJob.job, nativeJob.job);
     }
     fs.close();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/kvtest/LargeKVTest.java
@@ -103,7 +103,7 @@ public class LargeKVTest {
       // if output file exists ,then delete it
       fs.delete(new Path(nativeOutputPath), true);
       final KVJob nativeJob = new KVJob("Test Large Value Size:"
-          + i, nativeConf, keyClass, valueClass, inputPath,
+          + String.valueOf(i), nativeConf, keyClass, valueClass, inputPath,
           nativeOutputPath);
       assertTrue(nativeJob.runJob(), "job should complete successfully");
 
@@ -111,7 +111,7 @@ public class LargeKVTest {
           + "/LargeKV/" + keyClass.getName() + "/" + valueClass.getName();
       // if output file exists ,then delete it
       fs.delete(new Path(normalOutputPath), true);
-      final KVJob normalJob = new KVJob("Test Large Key Size:" + i,
+      final KVJob normalJob = new KVJob("Test Large Key Size:" + String.valueOf(i),
           normalConf, keyClass, valueClass, inputPath, normalOutputPath);
       assertTrue(normalJob.runJob(), "job should complete successfully");
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred.nativetask.nonsorttest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 
@@ -37,11 +38,11 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NonSortTest {
 
@@ -72,10 +73,10 @@ public class NonSortTest {
     ResultVerifier.verifyCounters(hadoopWithSort, nativeNonSort);
   }
 
-  @Before
+  @BeforeEach
   public void startUp() throws Exception {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
-    Assume.assumeTrue(NativeRuntime.isNativeLibraryLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeRuntime.isNativeLibraryLoaded());
     final ScenarioConfiguration conf = new ScenarioConfiguration();
     conf.addNonSortTestConf();
     final FileSystem fs = FileSystem.get(conf);
@@ -88,7 +89,7 @@ public class NonSortTest {
     fs.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     final FileSystem fs = FileSystem.get(new ScenarioConfiguration());
     fs.delete(new Path(TestConstants.NATIVETASK_NONSORT_TEST_DIR), true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/nonsorttest/NonSortTest.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.junit.jupiter.api.AfterAll;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapred.nativetask.serde;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.nativetask.Constants;
@@ -30,16 +30,17 @@ import org.apache.hadoop.mapred.nativetask.buffer.DataOutputStream;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput;
 import org.apache.hadoop.mapred.nativetask.testutil.TestInput.KV;
 import org.apache.hadoop.mapred.nativetask.util.SizedWritable;
-import org.junit.Assert;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TestKVSerializer {
 
-  int inputArraySize = 1000; // 1000 bytesWriable elements
+  int inputArraySize = 1000; // 1000 bytes Writable elements
   int bufferSize = 100; // bytes
   private KV<BytesWritable, BytesWritable>[] inputArray;
 
@@ -48,7 +49,7 @@ public class TestKVSerializer {
   private SizedWritable value;
   private KVSerializer serializer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.inputArray = TestInput.getMapInputs(inputArraySize);
     this.key = new SizedWritable(BytesWritable.class);
@@ -72,7 +73,7 @@ public class TestKVSerializer {
       serializer.updateLength(key, value);
 
       // verify whether the size increase
-      Assert.assertTrue(key.length + value.length > kvLength);
+      assertTrue(key.length + value.length > kvLength);
       kvLength = key.length + value.length;
     }
   }
@@ -92,7 +93,7 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
   }
 
   @Test
@@ -110,7 +111,7 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH);
   }
 
   @Test
@@ -131,7 +132,7 @@ public class TestKVSerializer {
     Mockito.verify(dataOut, Mockito.times(2)).write(any(byte[].class),
         anyInt(), anyInt());
 
-    Assert.assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH
+    assertEquals(written, key.length + value.length + Constants.SIZEOF_KV_LENGTH
         + Constants.SIZEOF_PARTITION_LENGTH);
   }
 
@@ -139,14 +140,14 @@ public class TestKVSerializer {
   public void testDeserializerNoData() throws IOException {
     final DataInputStream in = Mockito.mock(DataInputStream.class);
     Mockito.when(in.hasUnReadData()).thenReturn(false);
-    Assert.assertEquals(0, serializer.deserializeKV(in, key, value));
+    assertEquals(0, serializer.deserializeKV(in, key, value));
   }
 
   @Test
   public void testDeserializer() throws IOException {
     final DataInputStream in = Mockito.mock(DataInputStream.class);
     Mockito.when(in.hasUnReadData()).thenReturn(true);
-    Assert.assertTrue(serializer.deserializeKV(in, key, value) > 0);
+    assertTrue(serializer.deserializeKV(in, key, value) > 0);
 
     Mockito.verify(in, Mockito.times(4)).readInt();
     Mockito.verify(in, Mockito.times(2)).readFully(any(byte[].class),

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestKVSerializer.java
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TestKVSerializer {
 
-  int inputArraySize = 1000; // 1000 bytes Writable elements
+  private int inputArraySize = 1000; // 1000 bytes Writable elements
   int bufferSize = 100; // bytes
   private KV<BytesWritable, BytesWritable>[] inputArray;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestNativeSerialization.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/serde/TestNativeSerialization.java
@@ -23,8 +23,10 @@ import java.io.IOException;
 
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.nativetask.INativeComparable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({ "rawtypes" })
 public class TestNativeSerialization {
@@ -36,10 +38,10 @@ public class TestNativeSerialization {
     serialization.register(WritableKey.class.getName(), ComparableKeySerializer.class);
 
     INativeSerializer serializer = serialization.getSerializer(WritableKey.class);
-    Assert.assertEquals(ComparableKeySerializer.class.getName(), serializer.getClass().getName());
+    assertEquals(ComparableKeySerializer.class.getName(), serializer.getClass().getName());
 
     serializer = serialization.getSerializer(WritableValue.class);
-    Assert.assertEquals(DefaultSerializer.class.getName(), serializer.getClass().getName());
+    assertEquals(DefaultSerializer.class.getName(), serializer.getClass().getName());
 
     boolean ioExceptionThrown = false;
     try {
@@ -47,7 +49,7 @@ public class TestNativeSerialization {
     } catch (final IOException e) {
       ioExceptionThrown = true;
     }
-    Assert.assertTrue(ioExceptionThrown);
+    assertTrue(ioExceptionThrown);
   }
 
   public static class WritableKey implements Writable {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapred.nativetask.testutil;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.zip.CRC32;
@@ -73,9 +73,9 @@ public class ResultVerifier {
         }
       }
       if (samplepath == null) {
-        throw new Exception("cound not find file " +
-                            samplepaths[0].getParent() + "/" + sourcepath.getName()
-                            + " , as sourcepaths has such file");
+        throw new Exception("could not find file " +
+            samplepaths[0].getParent() + "/" + sourcepath.getName() +
+            " , as sourcepaths has such file");
       }
 
       // compare
@@ -92,7 +92,7 @@ public class ResultVerifier {
         samplecrc = new CRC32();
         sourcecrc = new CRC32();
         final byte[] bufin = new byte[1 << 16];
-        int readnum = 0;
+        int readnum;
         int totalRead = 0;
         while (samplein.available() > 0) {
           readnum = samplein.read(bufin);
@@ -114,9 +114,7 @@ public class ResultVerifier {
           throw new Exception("source " + sample + " is empty file");
         }
 
-        if (samplecrc.getValue() == sourcecrc.getValue()) {
-          ;
-        } else {
+        if (!(samplecrc.getValue() == sourcecrc.getValue())) {
           return false;
         }
       } catch (final IOException e) {
@@ -143,16 +141,16 @@ public class ResultVerifier {
       throws IOException {
     Counters normalCounters = normalJob.getCounters();
     Counters nativeCounters = nativeJob.getCounters();
-    assertEquals("Counter MAP_OUTPUT_RECORDS should be equal",
+    assertEquals(
         normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
-        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue());
-    assertEquals("Counter REDUCE_INPUT_GROUPS should be equal",
+        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(), "Counter MAP_OUTPUT_RECORDS should be equal");
+    assertEquals(
         normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
-        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue());
+        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(), "Counter REDUCE_INPUT_GROUPS should be equal");
     if (!hasCombiner) {
-      assertEquals("Counter REDUCE_INPUT_RECORDS should be equal",
+      assertEquals(
           normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
-          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue());
+          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(), "Counter REDUCE_INPUT_RECORDS should be equal");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
@@ -73,9 +73,9 @@ public class ResultVerifier {
         }
       }
       if (samplepath == null) {
-        throw new Exception("could not find file " +
-            samplepaths[0].getParent() + "/" + sourcepath.getName() +
-            " , as sourcepaths has such file");
+        throw new Exception("cound not find file " +
+                            samplepaths[0].getParent() + "/" + sourcepath.getName()
+                            + " , as sourcepaths has such file");
       }
 
       // compare
@@ -92,7 +92,7 @@ public class ResultVerifier {
         samplecrc = new CRC32();
         sourcecrc = new CRC32();
         final byte[] bufin = new byte[1 << 16];
-        int readnum;
+        int readnum = 0;
         int totalRead = 0;
         while (samplein.available() > 0) {
           readnum = samplein.read(bufin);
@@ -114,7 +114,9 @@ public class ResultVerifier {
           throw new Exception("source " + sample + " is empty file");
         }
 
-        if (!(samplecrc.getValue() == sourcecrc.getValue())) {
+        if (samplecrc.getValue() == sourcecrc.getValue()) {
+          ;
+        } else {
           return false;
         }
       } catch (final IOException e) {
@@ -143,14 +145,15 @@ public class ResultVerifier {
     Counters nativeCounters = nativeJob.getCounters();
     assertEquals(
         normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
-        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(), "Counter MAP_OUTPUT_RECORDS should be equal");
-    assertEquals(
-        normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
-        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(), "Counter REDUCE_INPUT_GROUPS should be equal");
+        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(), 
+        "Counter MAP_OUTPUT_RECORDS should be equal");
+    assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
+        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(), 
+        "Counter REDUCE_INPUT_GROUPS should be equal");
     if (!hasCombiner) {
-      assertEquals(
-          normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
-          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(), "Counter REDUCE_INPUT_RECORDS should be equal");
+      assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
+          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(), 
+          "Counter REDUCE_INPUT_RECORDS should be equal");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/testutil/ResultVerifier.java
@@ -143,16 +143,15 @@ public class ResultVerifier {
       throws IOException {
     Counters normalCounters = normalJob.getCounters();
     Counters nativeCounters = nativeJob.getCounters();
-    assertEquals(
-        normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
-        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(), 
+    assertEquals(normalCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
+        nativeCounters.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getValue(),
         "Counter MAP_OUTPUT_RECORDS should be equal");
     assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
-        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(), 
+        nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_GROUPS).getValue(),
         "Counter REDUCE_INPUT_GROUPS should be equal");
     if (!hasCombiner) {
       assertEquals(normalCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
-          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(), 
+          nativeCounters.findCounter(TaskCounter.REDUCE_INPUT_RECORDS).getValue(),
           "Counter REDUCE_INPUT_RECORDS should be equal");
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestBytesUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestBytesUtil.java
@@ -20,10 +20,11 @@ package org.apache.hadoop.mapred.nativetask.utils;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Longs;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.mapred.nativetask.util.BytesUtil;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestBytesUtil {
 
@@ -32,7 +33,7 @@ public class TestBytesUtil {
     final int a = 1000;
     final byte[] intBytes = Ints.toByteArray(a);
 
-    Assert.assertEquals(a, BytesUtil.toInt(intBytes, 0));
+    assertEquals(a, BytesUtil.toInt(intBytes, 0));
   }
 
   @Test
@@ -40,7 +41,7 @@ public class TestBytesUtil {
     final long l = 1000000L;
     final byte[] longBytes = Longs.toByteArray(l);
 
-    Assert.assertEquals(l, BytesUtil.toLong(longBytes, 0));
+    assertEquals(l, BytesUtil.toLong(longBytes, 0));
   }
 
   @Test
@@ -48,7 +49,7 @@ public class TestBytesUtil {
     final float f = 3.14f;
     final byte[] floatBytes = BytesUtil.toBytes(f);
 
-    Assert.assertEquals(f, BytesUtil.toFloat(floatBytes), 0.0f);
+    assertEquals(f, BytesUtil.toFloat(floatBytes), 0.0f);
   }
 
   @Test
@@ -56,14 +57,14 @@ public class TestBytesUtil {
     final double d = 3.14;
     final byte[] doubleBytes = BytesUtil.toBytes(d);
 
-    Assert.assertEquals(d, BytesUtil.toDouble(doubleBytes), 0.0);
+    assertEquals(d, BytesUtil.toDouble(doubleBytes), 0.0);
   }
 
   @Test
   public void testToStringBinary() {
-    Assert.assertEquals("\\x01\\x02ABC",
+    assertEquals("\\x01\\x02ABC",
         BytesUtil.toStringBinary(new byte[] { 1, 2, 65, 66, 67 }));
-    Assert.assertEquals("\\x10\\x11",
+    assertEquals("\\x10\\x11",
         BytesUtil.toStringBinary(new byte[] { 16, 17 }));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestReadWriteBuffer.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestReadWriteBuffer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapred.nativetask.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.mapred.nativetask.util.ReadWriteBuffer;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
@@ -17,11 +17,13 @@
  */
 package org.apache.hadoop.mapred.nativetask.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.nativetask.util.SizedWritable;
-import org.junit.Assert;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TestSizedWritable {
@@ -29,7 +31,7 @@ public class TestSizedWritable {
   @Test
   public void testSizedWritable() {
     final SizedWritable w = new SizedWritable(BytesWritable.class);
-    Assert.assertTrue(w.length == SizedWritable.INVALID_LENGTH);
-    Assert.assertFalse(w.v == null);
+    assertEquals(SizedWritable.INVALID_LENGTH, w.length);
+    assertNotNull(w.v);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/test/java/org/apache/hadoop/mapred/nativetask/utils/TestSizedWritable.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.nativetask.util.SizedWritable;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TestSizedWritable {
@@ -31,7 +31,7 @@ public class TestSizedWritable {
   @Test
   public void testSizedWritable() {
     final SizedWritable w = new SizedWritable(BytesWritable.class);
-    assertEquals(SizedWritable.INVALID_LENGTH, w.length);
-    assertNotNull(w.v);
+    assertTrue(w.length == SizedWritable.INVALID_LENGTH);
+    assertFalse(w.v == null);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

MAPREDUCE-7415. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-nativetask. 


### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

