### PR TITLE
HADOOP-19415. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-common Part3.

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -220,6 +220,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <scope>compile</scope>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -222,6 +222,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/DummySharedResource.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/DummySharedResource.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A fake shared resource, for use in automatic failover testing.
@@ -47,6 +47,6 @@ public class DummySharedResource {
   }
   
   public synchronized void assertNoViolations() {
-    Assertions.assertEquals(0, violations);
+    assertEquals(0, violations);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/DummySharedResource.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/DummySharedResource.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * A fake shared resource, for use in automatic failover testing.
@@ -47,6 +47,6 @@ public class DummySharedResource {
   }
   
   public synchronized void assertNoViolations() {
-    Assert.assertEquals(0, violations);
+    Assertions.assertEquals(0, violations);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/MiniZKFCCluster.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/MiniZKFCCluster.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestActiveStandbyElector.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestActiveStandbyElector.java
@@ -36,9 +36,9 @@ import org.apache.zookeeper.common.ClientX509Util;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.ZooDefs.Ids;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -49,6 +49,7 @@ import org.apache.hadoop.ha.ActiveStandbyElector.ActiveNotFoundException;
 import org.apache.hadoop.util.ZKUtil.ZKAuthInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 public class TestActiveStandbyElector {
@@ -92,7 +93,7 @@ public class TestActiveStandbyElector {
   private static final String ZK_BREADCRUMB_NAME = ZK_PARENT_NAME + "/" +
       ActiveStandbyElector.BREADCRUMB_FILENAME;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException, KeeperException {
     count = 0;
     mockZK = Mockito.mock(ZooKeeper.class);
@@ -123,9 +124,10 @@ public class TestActiveStandbyElector {
   /**
    * verify that joinElection checks for null data
    */
-  @Test(expected = HadoopIllegalArgumentException.class)
+  @Test
   public void testJoinElectionException() {
-    elector.joinElection(null);
+    assertThrows(HadoopIllegalArgumentException.class,
+        () -> elector.joinElection(null));
   }
 
   /**
@@ -177,7 +179,7 @@ public class TestActiveStandbyElector {
   public void testFailToBecomeActive() throws Exception {
     mockNoPriorActive();
     elector.joinElection(data);
-    Assert.assertEquals(0, elector.sleptFor);
+    Assertions.assertEquals(0, elector.sleptFor);
     
     Mockito.doThrow(new ServiceFailedException("failed to become active"))
         .when(mockApp).becomeActive();
@@ -189,8 +191,8 @@ public class TestActiveStandbyElector {
     // should re-join
     Mockito.verify(mockZK, Mockito.times(2)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
-    Assert.assertEquals(2, count);
-    Assert.assertTrue(elector.sleptFor > 0);
+    Assertions.assertEquals(2, count);
+    Assertions.assertTrue(elector.sleptFor > 0);
   }
   
   /**
@@ -202,7 +204,7 @@ public class TestActiveStandbyElector {
   public void testFailToBecomeActiveAfterZKDisconnect() throws Exception {
     mockNoPriorActive();
     elector.joinElection(data);
-    Assert.assertEquals(0, elector.sleptFor);
+    Assertions.assertEquals(0, elector.sleptFor);
 
     elector.processResult(Code.CONNECTIONLOSS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
@@ -226,8 +228,8 @@ public class TestActiveStandbyElector {
     // should re-join
     Mockito.verify(mockZK, Mockito.times(3)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
-    Assert.assertEquals(2, count);
-    Assert.assertTrue(elector.sleptFor > 0);
+    Assertions.assertEquals(2, count);
+    Assertions.assertTrue(elector.sleptFor > 0);
   }
 
   
@@ -331,7 +333,7 @@ public class TestActiveStandbyElector {
 
     elector.joinElection(data);
     // recreate connection via getNewZooKeeper
-    Assert.assertEquals(2, count);
+    Assertions.assertEquals(2, count);
     elector.processResult(Code.CONNECTIONLOSS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
     elector.processResult(Code.NODEEXISTS.intValue(), ZK_LOCK_NAME, mockZK,
@@ -457,10 +459,10 @@ public class TestActiveStandbyElector {
         Event.KeeperState.SyncConnected);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(1);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.SESSIONEXPIRED.intValue(), ZK_LOCK_NAME,
         mockZK, new Stat());
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     // session expired should enter safe mode and initiate re-election
     // re-election checked via checking re-creation of new zookeeper and
@@ -471,7 +473,7 @@ public class TestActiveStandbyElector {
     Mockito.verify(mockApp, Mockito.times(1)).enterNeutralMode();
     // called getNewZooKeeper to create new session. first call was in
     // constructor
-    Assert.assertEquals(2, count);
+    Assertions.assertEquals(2, count);
     // once in initial joinElection and one now
     Mockito.verify(mockZK, Mockito.times(2)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
@@ -504,13 +506,13 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
     verifyExistCall(1);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
 
     Stat stat = new Stat();
     stat.setEphemeralOwner(0L);
     Mockito.when(mockZK.getSessionId()).thenReturn(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     WatchedEvent mockEvent = Mockito.mock(WatchedEvent.class);
     Mockito.when(mockEvent.getPath()).thenReturn(ZK_LOCK_NAME);
@@ -520,18 +522,18 @@ public class TestActiveStandbyElector {
         Event.EventType.NodeDataChanged);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(2);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     // monitoring should be setup again after event is received
     Mockito.when(mockEvent.getType()).thenReturn(
         Event.EventType.NodeChildrenChanged);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(3);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     // lock node deletion when in standby mode should create znode again
     // successful znode creation enters active state and sets monitor
@@ -546,10 +548,10 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeActive();
     verifyExistCall(4);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
     stat.setEphemeralOwner(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     // lock node deletion in active mode should enter neutral mode and create
     // znode again successful znode creation enters active state and sets
@@ -564,9 +566,9 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(2)).becomeActive();
     verifyExistCall(5);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     // bad path name results in fatal error
     Mockito.when(mockEvent.getPath()).thenReturn(null);
@@ -574,7 +576,7 @@ public class TestActiveStandbyElector {
     Mockito.verify(mockApp, Mockito.times(1)).notifyFatalError(
         "Unexpected watch error from Zookeeper");
     // fatal error means no new connection other than one from constructor
-    Assert.assertEquals(1, count);
+    Assertions.assertEquals(1, count);
     // no new watches after fatal error
     verifyExistCall(5);
 
@@ -599,13 +601,13 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
     verifyExistCall(1);
-    Assert.assertTrue(elector.isMonitorLockNodePending());
+    Assertions.assertTrue(elector.isMonitorLockNodePending());
 
     Stat stat = new Stat();
     stat.setEphemeralOwner(0L);
     Mockito.when(mockZK.getSessionId()).thenReturn(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assert.assertFalse(elector.isMonitorLockNodePending());
+    Assertions.assertFalse(elector.isMonitorLockNodePending());
 
     WatchedEvent mockEvent = Mockito.mock(WatchedEvent.class);
     Mockito.when(mockEvent.getPath()).thenReturn(ZK_LOCK_NAME);
@@ -644,7 +646,7 @@ public class TestActiveStandbyElector {
     byte[] data = new byte[8];
     elector.joinElection(data);
     // getNewZooKeeper called 2 times. once in constructor and once now
-    Assert.assertEquals(2, count);
+    Assertions.assertEquals(2, count);
     elector.processResult(Code.NODEEXISTS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
@@ -669,7 +671,7 @@ public class TestActiveStandbyElector {
     Mockito.when(
         mockZK.getData(Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false),
             any())).thenReturn(data);
-    Assert.assertEquals(data, elector.getActiveData());
+    Assertions.assertEquals(data, elector.getActiveData());
     Mockito.verify(mockZK, Mockito.times(1)).getData(
         Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
 
@@ -680,7 +682,7 @@ public class TestActiveStandbyElector {
         new KeeperException.NoNodeException());
     try {
       elector.getActiveData();
-      Assert.fail("ActiveNotFoundException expected");
+      Assertions.fail("ActiveNotFoundException expected");
     } catch(ActiveNotFoundException e) {
       Mockito.verify(mockZK, Mockito.times(2)).getData(
           Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
@@ -693,7 +695,7 @@ public class TestActiveStandbyElector {
               any())).thenThrow(
           new KeeperException.AuthFailedException());
       elector.getActiveData();
-      Assert.fail("KeeperException.AuthFailedException expected");
+      Assertions.fail("KeeperException.AuthFailedException expected");
     } catch(KeeperException.AuthFailedException ke) {
       Mockito.verify(mockZK, Mockito.times(3)).getData(
           Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
@@ -762,7 +764,7 @@ public class TestActiveStandbyElector {
           Mockito.eq(Ids.OPEN_ACL_UNSAFE), Mockito.eq(CreateMode.PERSISTENT));
     try {
       elector.ensureParentZNode();
-      Assert.fail("Did not throw!");
+      Assertions.fail("Did not throw!");
     } catch (IOException ioe) {
       if (!(ioe.getCause() instanceof KeeperException.ConnectionLossException)) {
         throw ioe;
@@ -791,7 +793,7 @@ public class TestActiveStandbyElector {
       };
 
 
-      Assert.fail("Did not throw zookeeper connection loss exceptions!");
+      Assertions.fail("Did not throw zookeeper connection loss exceptions!");
     } catch (KeeperException ke) {
       GenericTestUtils.assertExceptionContains( "ConnectionLoss", ke);
     }
@@ -842,14 +844,14 @@ public class TestActiveStandbyElector {
             = ArgumentCaptor.forClass(ZKClientConfig.class);
     Mockito.verify(e).initiateZookeeper(configArgumentCaptor.capture());
     ZKClientConfig clientConfig = configArgumentCaptor.getValue();
-    Assert.assertEquals(defaultConfig.getProperty(ZKClientConfig.SECURE_CLIENT),
+    Assertions.assertEquals(defaultConfig.getProperty(ZKClientConfig.SECURE_CLIENT),
             clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
-    Assert.assertEquals(defaultConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET),
+    Assertions.assertEquals(defaultConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET),
             clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
-    Assert.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
-    Assert.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
-    Assert.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
-    Assert.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
+    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
+    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
+    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
+    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
   }
 
   /**
@@ -882,16 +884,16 @@ public class TestActiveStandbyElector {
             = ArgumentCaptor.forClass(ZKClientConfig.class);
     Mockito.verify(e).initiateZookeeper(configArgumentCaptor.capture());
     ZKClientConfig clientConfig = configArgumentCaptor.getValue();
-    Assert.assertEquals("true", clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
-    Assert.assertEquals("org.apache.zookeeper.ClientCnxnSocketNetty",
+    Assertions.assertEquals("true", clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
+    Assertions.assertEquals("org.apache.zookeeper.ClientCnxnSocketNetty",
             clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
-    Assert.assertEquals("keystore_location",
+    Assertions.assertEquals("keystore_location",
             clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
-    Assert.assertEquals("keystore_password",
+    Assertions.assertEquals("keystore_password",
             clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
-    Assert.assertEquals("truststore_location",
+    Assertions.assertEquals("truststore_location",
             clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
-    Assert.assertEquals("truststore_password",
+    Assertions.assertEquals("truststore_password",
             clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
 
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestActiveStandbyElector.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestActiveStandbyElector.java
@@ -38,7 +38,6 @@ import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -49,8 +48,13 @@ import org.apache.hadoop.ha.ActiveStandbyElector.ActiveNotFoundException;
 import org.apache.hadoop.util.ZKUtil.ZKAuthInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
 
 public class TestActiveStandbyElector {
 
@@ -179,7 +183,7 @@ public class TestActiveStandbyElector {
   public void testFailToBecomeActive() throws Exception {
     mockNoPriorActive();
     elector.joinElection(data);
-    Assertions.assertEquals(0, elector.sleptFor);
+    assertEquals(0, elector.sleptFor);
     
     Mockito.doThrow(new ServiceFailedException("failed to become active"))
         .when(mockApp).becomeActive();
@@ -191,8 +195,8 @@ public class TestActiveStandbyElector {
     // should re-join
     Mockito.verify(mockZK, Mockito.times(2)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
-    Assertions.assertEquals(2, count);
-    Assertions.assertTrue(elector.sleptFor > 0);
+    assertEquals(2, count);
+    assertTrue(elector.sleptFor > 0);
   }
   
   /**
@@ -204,7 +208,7 @@ public class TestActiveStandbyElector {
   public void testFailToBecomeActiveAfterZKDisconnect() throws Exception {
     mockNoPriorActive();
     elector.joinElection(data);
-    Assertions.assertEquals(0, elector.sleptFor);
+    assertEquals(0, elector.sleptFor);
 
     elector.processResult(Code.CONNECTIONLOSS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
@@ -228,8 +232,8 @@ public class TestActiveStandbyElector {
     // should re-join
     Mockito.verify(mockZK, Mockito.times(3)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
-    Assertions.assertEquals(2, count);
-    Assertions.assertTrue(elector.sleptFor > 0);
+    assertEquals(2, count);
+    assertTrue(elector.sleptFor > 0);
   }
 
   
@@ -333,7 +337,7 @@ public class TestActiveStandbyElector {
 
     elector.joinElection(data);
     // recreate connection via getNewZooKeeper
-    Assertions.assertEquals(2, count);
+    assertEquals(2, count);
     elector.processResult(Code.CONNECTIONLOSS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
     elector.processResult(Code.NODEEXISTS.intValue(), ZK_LOCK_NAME, mockZK,
@@ -459,10 +463,10 @@ public class TestActiveStandbyElector {
         Event.KeeperState.SyncConnected);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(1);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.SESSIONEXPIRED.intValue(), ZK_LOCK_NAME,
         mockZK, new Stat());
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     // session expired should enter safe mode and initiate re-election
     // re-election checked via checking re-creation of new zookeeper and
@@ -473,7 +477,7 @@ public class TestActiveStandbyElector {
     Mockito.verify(mockApp, Mockito.times(1)).enterNeutralMode();
     // called getNewZooKeeper to create new session. first call was in
     // constructor
-    Assertions.assertEquals(2, count);
+    assertEquals(2, count);
     // once in initial joinElection and one now
     Mockito.verify(mockZK, Mockito.times(2)).create(ZK_LOCK_NAME, data,
         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, elector, mockZK);
@@ -506,13 +510,13 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
     verifyExistCall(1);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
 
     Stat stat = new Stat();
     stat.setEphemeralOwner(0L);
     Mockito.when(mockZK.getSessionId()).thenReturn(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     WatchedEvent mockEvent = Mockito.mock(WatchedEvent.class);
     Mockito.when(mockEvent.getPath()).thenReturn(ZK_LOCK_NAME);
@@ -522,18 +526,18 @@ public class TestActiveStandbyElector {
         Event.EventType.NodeDataChanged);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(2);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     // monitoring should be setup again after event is received
     Mockito.when(mockEvent.getType()).thenReturn(
         Event.EventType.NodeChildrenChanged);
     elector.processWatchEvent(mockZK, mockEvent);
     verifyExistCall(3);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     // lock node deletion when in standby mode should create znode again
     // successful znode creation enters active state and sets monitor
@@ -548,10 +552,10 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeActive();
     verifyExistCall(4);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
     stat.setEphemeralOwner(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     // lock node deletion in active mode should enter neutral mode and create
     // znode again successful znode creation enters active state and sets
@@ -566,9 +570,9 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(2)).becomeActive();
     verifyExistCall(5);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     // bad path name results in fatal error
     Mockito.when(mockEvent.getPath()).thenReturn(null);
@@ -576,7 +580,7 @@ public class TestActiveStandbyElector {
     Mockito.verify(mockApp, Mockito.times(1)).notifyFatalError(
         "Unexpected watch error from Zookeeper");
     // fatal error means no new connection other than one from constructor
-    Assertions.assertEquals(1, count);
+    assertEquals(1, count);
     // no new watches after fatal error
     verifyExistCall(5);
 
@@ -601,13 +605,13 @@ public class TestActiveStandbyElector {
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
     verifyExistCall(1);
-    Assertions.assertTrue(elector.isMonitorLockNodePending());
+    assertTrue(elector.isMonitorLockNodePending());
 
     Stat stat = new Stat();
     stat.setEphemeralOwner(0L);
     Mockito.when(mockZK.getSessionId()).thenReturn(1L);
     elector.processResult(Code.OK.intValue(), ZK_LOCK_NAME, mockZK, stat);
-    Assertions.assertFalse(elector.isMonitorLockNodePending());
+    assertFalse(elector.isMonitorLockNodePending());
 
     WatchedEvent mockEvent = Mockito.mock(WatchedEvent.class);
     Mockito.when(mockEvent.getPath()).thenReturn(ZK_LOCK_NAME);
@@ -646,7 +650,7 @@ public class TestActiveStandbyElector {
     byte[] data = new byte[8];
     elector.joinElection(data);
     // getNewZooKeeper called 2 times. once in constructor and once now
-    Assertions.assertEquals(2, count);
+    assertEquals(2, count);
     elector.processResult(Code.NODEEXISTS.intValue(), ZK_LOCK_NAME, mockZK,
         ZK_LOCK_NAME);
     Mockito.verify(mockApp, Mockito.times(1)).becomeStandby();
@@ -671,7 +675,7 @@ public class TestActiveStandbyElector {
     Mockito.when(
         mockZK.getData(Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false),
             any())).thenReturn(data);
-    Assertions.assertEquals(data, elector.getActiveData());
+    assertEquals(data, elector.getActiveData());
     Mockito.verify(mockZK, Mockito.times(1)).getData(
         Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
 
@@ -682,7 +686,7 @@ public class TestActiveStandbyElector {
         new KeeperException.NoNodeException());
     try {
       elector.getActiveData();
-      Assertions.fail("ActiveNotFoundException expected");
+      fail("ActiveNotFoundException expected");
     } catch(ActiveNotFoundException e) {
       Mockito.verify(mockZK, Mockito.times(2)).getData(
           Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
@@ -695,7 +699,7 @@ public class TestActiveStandbyElector {
               any())).thenThrow(
           new KeeperException.AuthFailedException());
       elector.getActiveData();
-      Assertions.fail("KeeperException.AuthFailedException expected");
+      fail("KeeperException.AuthFailedException expected");
     } catch(KeeperException.AuthFailedException ke) {
       Mockito.verify(mockZK, Mockito.times(3)).getData(
           Mockito.eq(ZK_LOCK_NAME), Mockito.eq(false), any());
@@ -764,7 +768,7 @@ public class TestActiveStandbyElector {
           Mockito.eq(Ids.OPEN_ACL_UNSAFE), Mockito.eq(CreateMode.PERSISTENT));
     try {
       elector.ensureParentZNode();
-      Assertions.fail("Did not throw!");
+      fail("Did not throw!");
     } catch (IOException ioe) {
       if (!(ioe.getCause() instanceof KeeperException.ConnectionLossException)) {
         throw ioe;
@@ -793,7 +797,7 @@ public class TestActiveStandbyElector {
       };
 
 
-      Assertions.fail("Did not throw zookeeper connection loss exceptions!");
+      fail("Did not throw zookeeper connection loss exceptions!");
     } catch (KeeperException ke) {
       GenericTestUtils.assertExceptionContains( "ConnectionLoss", ke);
     }
@@ -844,14 +848,14 @@ public class TestActiveStandbyElector {
             = ArgumentCaptor.forClass(ZKClientConfig.class);
     Mockito.verify(e).initiateZookeeper(configArgumentCaptor.capture());
     ZKClientConfig clientConfig = configArgumentCaptor.getValue();
-    Assertions.assertEquals(defaultConfig.getProperty(ZKClientConfig.SECURE_CLIENT),
-            clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
-    Assertions.assertEquals(defaultConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET),
-            clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
-    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
-    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
-    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
-    Assertions.assertNull(clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
+    assertEquals(defaultConfig.getProperty(ZKClientConfig.SECURE_CLIENT),
+        clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
+    assertEquals(defaultConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET),
+        clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
+    assertNull(clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
+    assertNull(clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
+    assertNull(clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
+    assertNull(clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
   }
 
   /**
@@ -884,17 +888,17 @@ public class TestActiveStandbyElector {
             = ArgumentCaptor.forClass(ZKClientConfig.class);
     Mockito.verify(e).initiateZookeeper(configArgumentCaptor.capture());
     ZKClientConfig clientConfig = configArgumentCaptor.getValue();
-    Assertions.assertEquals("true", clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
-    Assertions.assertEquals("org.apache.zookeeper.ClientCnxnSocketNetty",
-            clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
-    Assertions.assertEquals("keystore_location",
-            clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
-    Assertions.assertEquals("keystore_password",
-            clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
-    Assertions.assertEquals("truststore_location",
-            clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
-    Assertions.assertEquals("truststore_password",
-            clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
+    assertEquals("true", clientConfig.getProperty(ZKClientConfig.SECURE_CLIENT));
+    assertEquals("org.apache.zookeeper.ClientCnxnSocketNetty",
+        clientConfig.getProperty(ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET));
+    assertEquals("keystore_location",
+        clientConfig.getProperty(clientX509Util.getSslKeystoreLocationProperty()));
+    assertEquals("keystore_password",
+        clientConfig.getProperty(clientX509Util.getSslKeystorePasswdProperty()));
+    assertEquals("truststore_location",
+        clientConfig.getProperty(clientX509Util.getSslTruststoreLocationProperty()));
+    assertEquals("truststore_password",
+        clientConfig.getProperty(clientX509Util.getSslTruststorePasswdProperty()));
 
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestFailoverController.java
@@ -38,7 +38,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFailoverController {
   private InetSocketAddress svc1Addr = new InetSocketAddress("svc1", 1234); 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestFailoverController.java
@@ -34,11 +34,11 @@ import org.apache.hadoop.ha.TestNodeFencer.AlwaysFailFencer;
 import static org.apache.hadoop.ha.TestNodeFencer.setupFencer;
 import org.apache.hadoop.security.AccessControlException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestFailoverController {
   private InetSocketAddress svc1Addr = new InetSocketAddress("svc1", 1234); 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
@@ -17,7 +17,8 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHAAdmin.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,8 +28,8 @@ import java.nio.charset.StandardCharsets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.slf4j.Logger;
@@ -44,7 +44,7 @@ public class TestHAAdmin {
   private String errOutput;
   private String output;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     tool = new HAAdmin() {
       @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
@@ -17,7 +17,8 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestHealthMonitor.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -30,8 +30,9 @@ import org.apache.hadoop.ha.HealthMonitor.Callback;
 import org.apache.hadoop.ha.HealthMonitor.State;
 import org.apache.hadoop.util.Time;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public class TestHealthMonitor {
 
   private DummyHAService svc;
   
-  @Before
+  @BeforeEach
   public void setupHM() throws InterruptedException, IOException {
     Configuration conf = new Configuration();
     conf.setInt(CommonConfigurationKeys.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY, 1);
@@ -78,7 +79,8 @@ public class TestHealthMonitor {
         new InetSocketAddress("0.0.0.0", 0), true);
   }
 
-  @Test(timeout=15000)
+  @Test
+  @Timeout(value = 15)
   public void testMonitor() throws Exception {
     LOG.info("Mocking bad health check, waiting for UNHEALTHY");
     svc.isHealthy = false;
@@ -112,7 +114,8 @@ public class TestHealthMonitor {
    * Test that the proper state is propagated when the health monitor
    * sees an uncaught exception in its thread.
    */
-  @Test(timeout=15000)
+  @Test
+  @Timeout(value = 15)
   public void testHealthMonitorDies() throws Exception {
     LOG.info("Mocking RTE in health monitor, waiting for FAILED");
     throwOOMEOnCreate = true;
@@ -128,7 +131,8 @@ public class TestHealthMonitor {
    * health monitor and thus change its state to FAILED
    * @throws Exception
    */
-  @Test(timeout=15000)
+  @Test
+  @Timeout(value = 15)
   public void testCallbackThrowsRTE() throws Exception {
     hm.addCallback(new Callback() {
       @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestNodeFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestNodeFencer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -26,8 +26,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Shell;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestNodeFencer {
@@ -40,7 +40,7 @@ public class TestNodeFencer {
   private static String FENCER_TRUE_COMMAND_UNIX = "shell(true)";
   private static String FENCER_TRUE_COMMAND_WINDOWS = "shell(rem)";
 
-  @Before
+  @BeforeEach
   public void clearMockState() {
     AlwaysSucceedFencer.fenceCalled = 0;
     AlwaysSucceedFencer.callArgs.clear();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestNodeFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestNodeFencer.java
@@ -17,7 +17,12 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -28,7 +33,6 @@ import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Shell;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class TestNodeFencer {
 
@@ -47,9 +51,9 @@ public class TestNodeFencer {
     AlwaysFailFencer.fenceCalled = 0;
     AlwaysFailFencer.callArgs.clear();
     
-    MOCK_TARGET = Mockito.mock(HAServiceTarget.class);
-    Mockito.doReturn("my mock").when(MOCK_TARGET).toString();
-    Mockito.doReturn(new InetSocketAddress("host", 1234))
+    MOCK_TARGET = mock(HAServiceTarget.class);
+    doReturn("my mock").when(MOCK_TARGET).toString();
+    doReturn(new InetSocketAddress("host", 1234))
         .when(MOCK_TARGET).getAddress();
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
@@ -45,8 +45,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 
-import static org.mockito.Mockito.mock;
-
 public class TestShellCommandFencer {
   private ShellCommandFencer fencer = createFencer();
   private static final HAServiceTarget TEST_TARGET =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
@@ -28,10 +28,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -46,17 +47,17 @@ public class TestShellCommandFencer {
           new InetSocketAddress("dummyhost", 1234));
   private static final Logger LOG = ShellCommandFencer.LOG;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupLogMock() {
     ShellCommandFencer.LOG = mock(Logger.class, new LogAnswer());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownLogMock() throws Exception {
     ShellCommandFencer.LOG = LOG;
   }
 
-  @Before
+  @BeforeEach
   public void resetLogSpy() {
     Mockito.reset(ShellCommandFencer.LOG);
   }
@@ -89,8 +90,8 @@ public class TestShellCommandFencer {
       fail("Didn't throw when passing no args to shell");
     } catch (BadFencingConfigurationException confe) {
       assertTrue(
-        "Unexpected exception:" + StringUtils.stringifyException(confe),
-        confe.getMessage().contains("No argument passed"));    
+      
+       confe.getMessage().contains("No argument passed"), "Unexpected exception:" + StringUtils.stringifyException(confe));    
     }
   }
 
@@ -102,8 +103,8 @@ public class TestShellCommandFencer {
       fail("Didn't throw when passing no args to shell");
     } catch (BadFencingConfigurationException confe) {
       assertTrue(
-        "Unexpected exception:" + StringUtils.stringifyException(confe),
-        confe.getMessage().contains("Unable to parse line: 'shell()'"));
+      
+       confe.getMessage().contains("Unable to parse line: 'shell()'"), "Unexpected exception:" + StringUtils.stringifyException(confe));
     }
   }
 
@@ -201,7 +202,8 @@ public class TestShellCommandFencer {
    * so that, if we use 'ssh', it won't try to prompt for a password
    * and block forever, for example.
    */
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testSubprocessInputIsClosed() {
     assertFalse(fencer.tryFence(TEST_TARGET, "read"));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestShellCommandFencer.java
@@ -17,7 +17,15 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.endsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.reset;
 
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
@@ -33,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -59,7 +66,7 @@ public class TestShellCommandFencer {
 
   @BeforeEach
   public void resetLogSpy() {
-    Mockito.reset(ShellCommandFencer.LOG);
+    reset(ShellCommandFencer.LOG);
   }
   
   private static ShellCommandFencer createFencer() {
@@ -89,9 +96,8 @@ public class TestShellCommandFencer {
       new NodeFencer(conf, "shell");
       fail("Didn't throw when passing no args to shell");
     } catch (BadFencingConfigurationException confe) {
-      assertTrue(
-      
-       confe.getMessage().contains("No argument passed"), "Unexpected exception:" + StringUtils.stringifyException(confe));    
+      assertTrue(confe.getMessage().contains("No argument passed"),
+          "Unexpected exception:" + StringUtils.stringifyException(confe));
     }
   }
 
@@ -102,9 +108,8 @@ public class TestShellCommandFencer {
       new NodeFencer(conf, "shell()");
       fail("Didn't throw when passing no args to shell");
     } catch (BadFencingConfigurationException confe) {
-      assertTrue(
-      
-       confe.getMessage().contains("Unable to parse line: 'shell()'"), "Unexpected exception:" + StringUtils.stringifyException(confe));
+      assertTrue(confe.getMessage().contains("Unable to parse line: 'shell()'"),
+          "Unexpected exception:" + StringUtils.stringifyException(confe));
     }
   }
 
@@ -115,8 +120,8 @@ public class TestShellCommandFencer {
   @Test
   public void testStdoutLogging() {
     assertTrue(fencer.tryFence(TEST_TARGET, "echo hello"));
-    Mockito.verify(ShellCommandFencer.LOG).info(
-        Mockito.endsWith("echo hello: hello"));
+    verify(ShellCommandFencer.LOG).info(
+        endsWith("echo hello: hello"));
   }
    
   /**
@@ -126,8 +131,8 @@ public class TestShellCommandFencer {
   @Test
   public void testStderrLogging() {
     assertTrue(fencer.tryFence(TEST_TARGET, "echo hello>&2"));
-    Mockito.verify(ShellCommandFencer.LOG).warn(
-        Mockito.endsWith("echo hello>&2: hello"));
+    verify(ShellCommandFencer.LOG).warn(
+        endsWith("echo hello>&2: hello"));
   }
 
   /**
@@ -138,12 +143,12 @@ public class TestShellCommandFencer {
   public void testConfAsEnvironment() {
     if (!Shell.WINDOWS) {
       fencer.tryFence(TEST_TARGET, "echo $in_fencing_tests");
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.endsWith("echo $in...ing_tests: yessir"));
+      verify(ShellCommandFencer.LOG).info(
+          endsWith("echo $in...ing_tests: yessir"));
     } else {
       fencer.tryFence(TEST_TARGET, "echo %in_fencing_tests%");
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.endsWith("echo %in...ng_tests%: yessir"));
+      verify(ShellCommandFencer.LOG).info(
+          endsWith("echo %in...ng_tests%: yessir"));
     }
   }
   
@@ -155,12 +160,12 @@ public class TestShellCommandFencer {
   public void testTargetAsEnvironment() {
     if (!Shell.WINDOWS) {
       fencer.tryFence(TEST_TARGET, "echo $target_host $target_port");
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.endsWith("echo $ta...rget_port: dummyhost 1234"));
+      verify(ShellCommandFencer.LOG).info(
+          endsWith("echo $ta...rget_port: dummyhost 1234"));
     } else {
       fencer.tryFence(TEST_TARGET, "echo %target_host% %target_port%");
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.endsWith("echo %ta...get_port%: dummyhost 1234"));
+      verify(ShellCommandFencer.LOG).info(
+          endsWith("echo %ta...get_port%: dummyhost 1234"));
     }
   }
 
@@ -180,18 +185,18 @@ public class TestShellCommandFencer {
         + "echo $source_host $source_port";
     if (!Shell.WINDOWS) {
       fencer.tryFence(target, cmd);
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.contains("echo $ta...rget_port: dummytarget 1111"));
+      verify(ShellCommandFencer.LOG).info(
+          contains("echo $ta...rget_port: dummytarget 1111"));
       fencer.tryFence(source, cmd);
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.contains("echo $so...urce_port: dummysource 2222"));
+      verify(ShellCommandFencer.LOG).info(
+          contains("echo $so...urce_port: dummysource 2222"));
     } else {
       fencer.tryFence(target, cmd);
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.contains("echo %ta...get_port%: dummytarget 1111"));
+      verify(ShellCommandFencer.LOG).info(
+          contains("echo %ta...get_port%: dummytarget 1111"));
       fencer.tryFence(source, cmd);
-      Mockito.verify(ShellCommandFencer.LOG).info(
-          Mockito.contains("echo %so...urce_port%: dummysource 2222"));
+      verify(ShellCommandFencer.LOG).info(
+          contains("echo %so...urce_port%: dummysource 2222"));
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestSshFenceByTcpPort.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestSshFenceByTcpPort.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.InetSocketAddress;
 
@@ -26,7 +26,8 @@ import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import org.apache.hadoop.ha.SshFenceByTcpPort.Args;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 public class TestSshFenceByTcpPort {
@@ -55,7 +56,8 @@ public class TestSshFenceByTcpPort {
     new DummyHAService(HAServiceState.ACTIVE,
         new InetSocketAddress("8.8.8.8", 1234));
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testFence() throws BadFencingConfigurationException {
     Assume.assumeTrue(isConfigured());
     Configuration conf = new Configuration();
@@ -72,7 +74,8 @@ public class TestSshFenceByTcpPort {
    * Make sure that it times out and returns false, but doesn't throw
    * any exception
    */
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testConnectTimeout() throws BadFencingConfigurationException {
     Configuration conf = new Configuration();
     conf.setInt(SshFenceByTcpPort.CONF_CONNECT_TIMEOUT_KEY, 3000);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestSshFenceByTcpPort.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ha/TestSshFenceByTcpPort.java
@@ -17,7 +17,11 @@
  */
 package org.apache.hadoop.ha;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.net.InetSocketAddress;
 
@@ -25,7 +29,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 import org.apache.hadoop.ha.SshFenceByTcpPort.Args;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
@@ -59,7 +62,7 @@ public class TestSshFenceByTcpPort {
   @Test
   @Timeout(value = 20)
   public void testFence() throws BadFencingConfigurationException {
-    Assume.assumeTrue(isConfigured());
+    assumeTrue(isConfigured());
     Configuration conf = new Configuration();
     conf.set(SshFenceByTcpPort.CONF_IDENTITIES_KEY, TEST_KEYFILE);
     SshFenceByTcpPort fence = new SshFenceByTcpPort();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/HttpServerFunctionalTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/HttpServerFunctionalTest.java
@@ -49,7 +49,7 @@ public class HttpServerFunctionalTest extends Assertions {
     public void doGet(HttpServletRequest request,
                       HttpServletResponse response
     ) throws ServletException, IOException {
-      Assertions.assertEquals(63 * 1024, request.getHeader("longheader").length());
+      assertEquals(63 * 1024, request.getHeader("longheader").length());
       response.setStatus(HttpServletResponse.SC_OK);
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/HttpServerFunctionalTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/HttpServerFunctionalTest.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.http;
 
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpServer2.Builder;
 
@@ -42,14 +42,14 @@ import javax.servlet.http.HttpServletResponse;
  * This is a base class for functional tests of the {@link HttpServer2}.
  * The methods are static for other classes to import statically.
  */
-public class HttpServerFunctionalTest extends Assert {
+public class HttpServerFunctionalTest extends Assertions {
   @SuppressWarnings("serial")
   public static class LongHeaderServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request,
                       HttpServletResponse response
     ) throws ServletException, IOException {
-      Assert.assertEquals(63 * 1024, request.getHeader("longheader").length());
+      Assertions.assertEquals(63 * 1024, request.getHeader("longheader").length());
       response.setStatus(HttpServletResponse.SC_OK);
     }
   }
@@ -244,7 +244,7 @@ public class HttpServerFunctionalTest extends Assert {
    */
   public static URL getServerURL(HttpServer2 server)
       throws MalformedURLException {
-    assertNotNull("No server", server);
+    assertNotNull(server, "No server");
     return new URL("http://"
         + NetUtils.getHostPortString(server.getConnectorAddress(0)));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
@@ -13,15 +13,15 @@
  */
 package org.apache.hadoop.http;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.util.log.Log;
 
 import javax.servlet.*;
@@ -149,10 +149,10 @@ public class TestAuthenticationSessionCookie {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assert.assertTrue(!cookies.isEmpty());
+    Assertions.assertTrue(!cookies.isEmpty());
     Log.getLog().info(header);
-    Assert.assertFalse(header.contains("; Expires="));
-    Assert.assertTrue("token".equals(cookies.get(0).getValue()));
+    Assertions.assertFalse(header.contains("; Expires="));
+    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
   }
   
   @Test
@@ -171,13 +171,13 @@ public class TestAuthenticationSessionCookie {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assert.assertTrue(!cookies.isEmpty());
+    Assertions.assertTrue(!cookies.isEmpty());
     Log.getLog().info(header);
-    Assert.assertTrue(header.contains("; Expires="));
-    Assert.assertTrue("token".equals(cookies.get(0).getValue()));
+    Assertions.assertTrue(header.contains("; Expires="));
+    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     server.stop();
     FileUtil.fullyDelete(new File(BASEDIR));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestAuthenticationSessionCookie.java
@@ -13,7 +13,6 @@
  */
 package org.apache.hadoop.http;
 
-import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.net.NetUtils;
@@ -35,6 +34,9 @@ import java.net.URL;
 import java.net.HttpCookie;
 import java.util.HashMap;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestAuthenticationSessionCookie {
   private static final String BASEDIR =
@@ -149,10 +151,10 @@ public class TestAuthenticationSessionCookie {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assertions.assertTrue(!cookies.isEmpty());
+    assertTrue(!cookies.isEmpty());
     Log.getLog().info(header);
-    Assertions.assertFalse(header.contains("; Expires="));
-    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
+    assertFalse(header.contains("; Expires="));
+    assertTrue("token".equals(cookies.get(0).getValue()));
   }
   
   @Test
@@ -171,10 +173,10 @@ public class TestAuthenticationSessionCookie {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assertions.assertTrue(!cookies.isEmpty());
+    assertTrue(!cookies.isEmpty());
     Log.getLog().info(header);
-    Assertions.assertTrue(header.contains("; Expires="));
-    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
+    assertTrue(header.contains("; Expires="));
+    assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
   @AfterEach

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestDisabledProfileServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestDisabledProfileServlet.java
@@ -23,9 +23,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Small test to cover default disabled prof endpoint.
@@ -35,14 +35,14 @@ public class TestDisabledProfileServlet extends HttpServerFunctionalTest {
   private static HttpServer2 server;
   private static URL baseUrl;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     server = createTestServer();
     server.start();
     baseUrl = getServerURL(server);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     server.stop();
   }
@@ -68,20 +68,20 @@ public class TestDisabledProfileServlet extends HttpServerFunctionalTest {
   @Test
   public void testRequestMethods() throws IOException {
     HttpURLConnection connection = getConnection("PUT");
-    assertEquals("Unexpected response code", HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-        connection.getResponseCode());
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
+,         connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("POST");
-    assertEquals("Unexpected response code", HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-        connection.getResponseCode());
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
+,         connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("DELETE");
-    assertEquals("Unexpected response code", HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-        connection.getResponseCode());
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
+,         connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("GET");
-    assertEquals("Unexpected response code", HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-        connection.getResponseCode());
+    assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR
+,         connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestDisabledProfileServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestDisabledProfileServlet.java
@@ -68,20 +68,20 @@ public class TestDisabledProfileServlet extends HttpServerFunctionalTest {
   @Test
   public void testRequestMethods() throws IOException {
     HttpURLConnection connection = getConnection("PUT");
-    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
-,         connection.getResponseCode(), "Unexpected response code");
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+        connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("POST");
-    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
-,         connection.getResponseCode(), "Unexpected response code");
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+        connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("DELETE");
-    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED
-,         connection.getResponseCode(), "Unexpected response code");
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+        connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
     connection = getConnection("GET");
-    assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR
-,         connection.getResponseCode(), "Unexpected response code");
+    assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+        connection.getResponseCode(), "Unexpected response code");
     connection.disconnect();
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestGlobalFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestGlobalFilter.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHtmlQuoting.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHtmlQuoting.java
@@ -17,7 +17,10 @@
  */
 package org.apache.hadoop.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -72,19 +75,18 @@ public class TestHtmlQuoting {
       new HttpServer2.QuotingInputFilter.RequestQuoter(mockReq);
     
     Mockito.doReturn("a<b").when(mockReq).getParameter("x");
-    assertEquals("Test simple param quoting",
-        "a&lt;b", quoter.getParameter("x"));
+    assertEquals("a&lt;b", quoter.getParameter("x"), "Test simple param quoting");
     
     Mockito.doReturn(null).when(mockReq).getParameter("x");
-    assertEquals(
-       null, quoter.getParameter("x"), "Test that missing parameters dont cause NPE");
+    assertEquals(null, quoter.getParameter("x"),
+        "Test that missing parameters dont cause NPE");
 
     Mockito.doReturn(new String[]{"a<b", "b"}).when(mockReq).getParameterValues("x");
-    assertArrayEquals(
-       new String[]{"a&lt;b", "b"}, quoter.getParameterValues("x"), "Test escaping of an array");
+    assertArrayEquals(new String[]{"a&lt;b", "b"}, quoter.getParameterValues("x"),
+        "Test escaping of an array");
 
     Mockito.doReturn(null).when(mockReq).getParameterValues("x");
-    assertArrayEquals(
-       null, quoter.getParameterValues("x"), "Test that missing parameters dont cause NPE for array");
+    assertArrayEquals(null, quoter.getParameterValues("x"),
+        "Test that missing parameters dont cause NPE for array");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHtmlQuoting.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHtmlQuoting.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.http;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestHtmlQuoting {
@@ -76,15 +76,15 @@ public class TestHtmlQuoting {
         "a&lt;b", quoter.getParameter("x"));
     
     Mockito.doReturn(null).when(mockReq).getParameter("x");
-    assertEquals("Test that missing parameters dont cause NPE",
-        null, quoter.getParameter("x"));
+    assertEquals(
+       null, quoter.getParameter("x"), "Test that missing parameters dont cause NPE");
 
     Mockito.doReturn(new String[]{"a<b", "b"}).when(mockReq).getParameterValues("x");
-    assertArrayEquals("Test escaping of an array",
-        new String[]{"a&lt;b", "b"}, quoter.getParameterValues("x"));
+    assertArrayEquals(
+       new String[]{"a&lt;b", "b"}, quoter.getParameterValues("x"), "Test escaping of an array");
 
     Mockito.doReturn(null).when(mockReq).getParameterValues("x");
-    assertArrayEquals("Test that missing parameters dont cause NPE for array",
-        null, quoter.getParameterValues("x"));
+    assertArrayEquals(
+       null, quoter.getParameterValues("x"), "Test that missing parameters dont cause NPE for array");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
@@ -13,7 +13,6 @@
  */
 package org.apache.hadoop.http;
 
-import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.net.NetUtils;
@@ -36,6 +35,8 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.net.HttpCookie;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHttpCookieFlag {
   private static final String BASEDIR =
@@ -120,9 +121,9 @@ public class TestHttpCookieFlag {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assertions.assertTrue(!cookies.isEmpty());
-    Assertions.assertTrue(header.contains("; HttpOnly"));
-    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
+    assertTrue(!cookies.isEmpty());
+    assertTrue(header.contains("; HttpOnly"));
+    assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
   @Test
@@ -135,10 +136,10 @@ public class TestHttpCookieFlag {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assertions.assertTrue(!cookies.isEmpty());
-    Assertions.assertTrue(header.contains("; HttpOnly"));
-    Assertions.assertTrue(cookies.get(0).getSecure());
-    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
+    assertTrue(!cookies.isEmpty());
+    assertTrue(header.contains("; HttpOnly"));
+    assertTrue(cookies.get(0).getSecure());
+    assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
   @AfterAll

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpCookieFlag.java
@@ -13,7 +13,7 @@
  */
 package org.apache.hadoop.http;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.net.NetUtils;
@@ -21,9 +21,9 @@ import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.servlet.*;
@@ -74,7 +74,7 @@ public class TestHttpCookieFlag {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Configuration conf = new Configuration();
     conf.set(HttpServer2.FILTER_INITIALIZER_PROPERTY,
@@ -120,9 +120,9 @@ public class TestHttpCookieFlag {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assert.assertTrue(!cookies.isEmpty());
-    Assert.assertTrue(header.contains("; HttpOnly"));
-    Assert.assertTrue("token".equals(cookies.get(0).getValue()));
+    Assertions.assertTrue(!cookies.isEmpty());
+    Assertions.assertTrue(header.contains("; HttpOnly"));
+    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
   @Test
@@ -135,13 +135,13 @@ public class TestHttpCookieFlag {
 
     String header = conn.getHeaderField("Set-Cookie");
     List<HttpCookie> cookies = HttpCookie.parse(header);
-    Assert.assertTrue(!cookies.isEmpty());
-    Assert.assertTrue(header.contains("; HttpOnly"));
-    Assert.assertTrue(cookies.get(0).getSecure());
-    Assert.assertTrue("token".equals(cookies.get(0).getValue()));
+    Assertions.assertTrue(!cookies.isEmpty());
+    Assertions.assertTrue(header.contains("; HttpOnly"));
+    Assertions.assertTrue(cookies.get(0).getSecure());
+    Assertions.assertTrue("token".equals(cookies.get(0).getValue()));
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     server.stop();
     FileUtil.fullyDelete(new File(BASEDIR));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpRequestLog.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpRequestLog.java
@@ -18,24 +18,23 @@
 package org.apache.hadoop.http;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHttpRequestLog {
 
   @Test
   public void testAppenderDefined() {
     RequestLog requestLog = HttpRequestLog.getRequestLog("test");
-    assertNotNull("RequestLog should not be null", requestLog);
-    assertThat(requestLog, instanceOf(CustomRequestLog.class));
+    assertNotNull(requestLog, "RequestLog should not be null");
+    //assertThat(requestLog, instanceOf(CustomRequestLog.class));
     CustomRequestLog crl = (CustomRequestLog) requestLog;
-    assertThat(crl.getWriter(), instanceOf(Slf4jRequestLogWriter.class));
+    //assertThat(crl.getWriter(), instanceOf(Slf4jRequestLogWriter.class));
     assertEquals(CustomRequestLog.EXTENDED_NCSA_FORMAT, crl.getFormatString());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpRequestLog.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpRequestLog.java
@@ -17,14 +17,14 @@
  */
 package org.apache.hadoop.http;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestHttpRequestLog {
 
@@ -32,9 +32,9 @@ public class TestHttpRequestLog {
   public void testAppenderDefined() {
     RequestLog requestLog = HttpRequestLog.getRequestLog("test");
     assertNotNull(requestLog, "RequestLog should not be null");
-    //assertThat(requestLog, instanceOf(CustomRequestLog.class));
+    assertInstanceOf(CustomRequestLog.class, requestLog);
     CustomRequestLog crl = (CustomRequestLog) requestLog;
-    //assertThat(crl.getWriter(), instanceOf(Slf4jRequestLogWriter.class));
+    assertInstanceOf(Slf4jRequestLogWriter.class, crl.getWriter());
     assertEquals(CustomRequestLog.EXTENDED_NCSA_FORMAT, crl.getFormatString());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
@@ -34,10 +34,9 @@ import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.util.ajax.JSON;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,7 +142,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     }
   }
 
-  @BeforeClass public static void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(HttpServer2.HTTP_MAX_THREADS_KEY, MAX_THREADS);
     conf.setBoolean(
@@ -160,7 +160,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     LOG.info("HTTP server started: "+ baseUrl);
   }
   
-  @AfterClass public static void cleanup() throws Exception {
+  @AfterAll
+  public static void cleanup() throws Exception {
     server.stop();
   }
   
@@ -181,8 +182,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
             assertEquals("a:b\nc:d\n",
                          readOutput(new URL(baseUrl, "/echo?a=b&c=d")));
             int serverThreads = server.webServer.getThreadPool().getThreads();
-            assertTrue("More threads are started than expected, Server Threads count: "
-                    + serverThreads, serverThreads <= MAX_THREADS);
+            assertTrue(serverThreads <= MAX_THREADS, "More threads are started than expected, Server Threads count: "
+                    + serverThreads);
             System.out.println("Number of threads = " + serverThreads +
                 " which is less or equal than the max = " + MAX_THREADS);
           } catch (Exception e) {
@@ -329,7 +330,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     try {
       HttpURLConnection conn = getHttpURLConnection(httpServer);
       String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-      assertTrue("X-FRAME-OPTIONS is absent in the header", xfoHeader != null);
+      assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
       assertTrue(xfoHeader.endsWith(option.toString()));
     } finally {
       httpServer.stop();
@@ -345,7 +346,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     try {
       HttpURLConnection conn = getHttpURLConnection(httpServer);
       String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-      assertTrue("Unexpected X-FRAME-OPTIONS in header", xfoHeader == null);
+      assertTrue(xfoHeader == null, "Unexpected X-FRAME-OPTIONS in header");
     } finally {
       httpServer.stop();
     }
@@ -542,9 +543,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Mockito.doReturn(null).when(request).getParameterValues("dummy");
     RequestQuoter requestQuoter = new RequestQuoter(request);
     String[] parameterValues = requestQuoter.getParameterValues("dummy");
-    Assert.assertNull(
-        "It should return null " + "when there are no values for the parameter",
-        parameterValues);
+    assertNull(
+        parameterValues, "It should return null " + "when there are no values for the parameter");
   }
 
   @Test
@@ -554,8 +554,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Mockito.doReturn(values).when(request).getParameterValues("dummy");
     RequestQuoter requestQuoter = new RequestQuoter(request);
     String[] parameterValues = requestQuoter.getParameterValues("dummy");
-    Assert.assertTrue("It should return Parameter Values", Arrays.equals(
-        values, parameterValues));
+    assertTrue(Arrays.equals(
+        values, parameterValues), "It should return Parameter Values");
   }
 
   @SuppressWarnings("unchecked")
@@ -585,32 +585,32 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
     //authorization OFF
-    Assert.assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
+    assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
 
     //authorization ON & user NULL
     response = Mockito.mock(HttpServletResponse.class);
     conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION, true);
-    Assert.assertFalse(HttpServer2.hasAdministratorAccess(context, request, response));
+    assertFalse(HttpServer2.hasAdministratorAccess(context, request, response));
     Mockito.verify(response).sendError(Mockito.eq(HttpServletResponse.SC_FORBIDDEN), Mockito.anyString());
 
     //authorization ON & user NOT NULL & ACLs NULL
     response = Mockito.mock(HttpServletResponse.class);
     Mockito.when(request.getRemoteUser()).thenReturn("foo");
-    Assert.assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
+    assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
 
     //authorization ON & user NOT NULL & ACLs NOT NULL & user not in ACLs
     response = Mockito.mock(HttpServletResponse.class);
     AccessControlList acls = Mockito.mock(AccessControlList.class);
     Mockito.when(acls.isUserAllowed(Mockito.<UserGroupInformation>any())).thenReturn(false);
     Mockito.when(context.getAttribute(HttpServer2.ADMINS_ACL)).thenReturn(acls);
-    Assert.assertFalse(HttpServer2.hasAdministratorAccess(context, request, response));
+    assertFalse(HttpServer2.hasAdministratorAccess(context, request, response));
     Mockito.verify(response).sendError(Mockito.eq(HttpServletResponse.SC_FORBIDDEN), Mockito.anyString());
 
     //authorization ON & user NOT NULL & ACLs NOT NULL & user in in ACLs
     response = Mockito.mock(HttpServletResponse.class);
     Mockito.when(acls.isUserAllowed(Mockito.<UserGroupInformation>any())).thenReturn(true);
     Mockito.when(context.getAttribute(HttpServer2.ADMINS_ACL)).thenReturn(acls);
-    Assert.assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
+    assertTrue(HttpServer2.hasAdministratorAccess(context, request, response));
 
   }
 
@@ -623,7 +623,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
     //requires admin access to instrumentation, FALSE by default
-    Assert.assertTrue(HttpServer2.isInstrumentationAccessAllowed(context, request, response));
+    assertTrue(HttpServer2.isInstrumentationAccessAllowed(context, request, response));
 
     //requires admin access to instrumentation, TRUE
     conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_INSTRUMENTATION_REQUIRES_ADMIN, true);
@@ -631,7 +631,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     AccessControlList acls = Mockito.mock(AccessControlList.class);
     Mockito.when(acls.isUserAllowed(Mockito.<UserGroupInformation>any())).thenReturn(false);
     Mockito.when(context.getAttribute(HttpServer2.ADMINS_ACL)).thenReturn(acls);
-    Assert.assertFalse(HttpServer2.isInstrumentationAccessAllowed(context, request, response));
+    assertFalse(HttpServer2.isInstrumentationAccessAllowed(context, request, response));
   }
 
   @Test public void testBindAddress() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServer.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.security.ShellBasedUnixGroupsMapping;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.util.ajax.JSON;
@@ -71,6 +70,8 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpServer extends HttpServerFunctionalTest {
   static final Logger LOG = LoggerFactory.getLogger(TestHttpServer.class);
@@ -182,8 +183,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
             assertEquals("a:b\nc:d\n",
                          readOutput(new URL(baseUrl, "/echo?a=b&c=d")));
             int serverThreads = server.webServer.getThreadPool().getThreads();
-            assertTrue(serverThreads <= MAX_THREADS, "More threads are started than expected, Server Threads count: "
-                    + serverThreads);
+            assertTrue(serverThreads <= MAX_THREADS,
+                "More threads are started than expected, Server Threads count: " + serverThreads);
             System.out.println("Number of threads = " + serverThreads +
                 " which is less or equal than the max = " + MAX_THREADS);
           } catch (Exception e) {
@@ -281,9 +282,9 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     final HttpURLConnection conn =
         (HttpURLConnection)servletUrl.openConnection();
     conn.connect();
-    Assertions.assertThat(conn.getResponseCode()).isEqualTo(200);
+    assertThat(conn.getResponseCode()).isEqualTo(200);
     final int after = metrics.responses2xx();
-    Assertions.assertThat(after).isGreaterThan(before);
+    assertThat(after).isGreaterThan(before);
   }
 
   /**
@@ -543,8 +544,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Mockito.doReturn(null).when(request).getParameterValues("dummy");
     RequestQuoter requestQuoter = new RequestQuoter(request);
     String[] parameterValues = requestQuoter.getParameterValues("dummy");
-    assertNull(
-        parameterValues, "It should return null " + "when there are no values for the parameter");
+    assertNull(parameterValues,
+        "It should return null when there are no values for the parameter");
   }
 
   @Test
@@ -554,8 +555,8 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Mockito.doReturn(values).when(request).getParameterValues("dummy");
     RequestQuoter requestQuoter = new RequestQuoter(request);
     String[] parameterValues = requestQuoter.getParameterValues("dummy");
-    assertTrue(Arrays.equals(
-        values, parameterValues), "It should return Parameter Values");
+    assertTrue(Arrays.equals(values, parameterValues),
+        "It should return Parameter Values");
   }
 
   @SuppressWarnings("unchecked")

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
@@ -73,8 +73,8 @@ public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
    */
   private void assertToStringContains(HttpServer2 server, String text) {
     String description = server.toString();
-    assertTrue(
-              description.contains(text), "Did not find \"" + text + "\" in \"" + description + "\"");
+    assertTrue(description.contains(text),
+        "Did not find \"" + text + "\" in \"" + description + "\"");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLifecycle.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.http;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
 
@@ -27,12 +27,12 @@ public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
    * @param server server
    */
   private void assertAlive(HttpServer2 server) {
-    assertTrue("Server is not alive", server.isAlive());
+    assertTrue(server.isAlive(), "Server is not alive");
     assertToStringContains(server, HttpServer2.STATE_DESCRIPTION_ALIVE);
   }
 
   private void assertNotLive(HttpServer2 server) {
-    assertTrue("Server should not be live", !server.isAlive());
+    assertTrue(!server.isAlive(), "Server should not be live");
     assertToStringContains(server, HttpServer2.STATE_DESCRIPTION_NOT_LIVE);
   }
 
@@ -73,8 +73,8 @@ public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
    */
   private void assertToStringContains(HttpServer2 server, String text) {
     String description = server.toString();
-    assertTrue("Did not find \"" + text + "\" in \"" + description + "\"",
-               description.contains(text));
+    assertTrue(
+              description.contains(text), "Did not find \"" + text + "\" in \"" + description + "\"");
   }
 
   /**
@@ -121,6 +121,6 @@ public class TestHttpServerLifecycle extends HttpServerFunctionalTest {
     assertAlive(server);
     assertEquals(value, server.getAttribute(key));
     stop(server);
-    assertNull("Server context should have cleared", server.getAttribute(key));
+    assertNull(server.getAttribute(key), "Server context should have cleared");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLogs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerLogs.java
@@ -21,9 +21,9 @@ import org.apache.http.HttpStatus;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ public class TestHttpServerLogs extends HttpServerFunctionalTest {
   static final Logger LOG = LoggerFactory.getLogger(TestHttpServerLogs.class);
   private static HttpServer2 server;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
   }
 
@@ -47,7 +47,7 @@ public class TestHttpServerLogs extends HttpServerFunctionalTest {
     LOG.info("HTTP server started: "+ baseUrl);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     if (server != null && server.isAlive()) {
       server.stop();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWebapps.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWebapps.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.http;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWithSpnego.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWithSpnego.java
@@ -34,10 +34,10 @@ import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
 import org.apache.hadoop.security.authentication.util.StringSignerSecretProviderCreator;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.security.authorize.ProxyUsers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -46,7 +46,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class is tested for http server with SPNEGO authentication.
@@ -69,7 +69,7 @@ public class TestHttpServerWithSpnego {
   private static MiniKdc testMiniKDC;
   private static File secretFile = new File(testRootDir, SECRET_STR);
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     try {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), testRootDir);
@@ -77,14 +77,14 @@ public class TestHttpServerWithSpnego {
       testMiniKDC.createPrincipal(
           httpSpnegoKeytabFile, HTTP_USER + "/localhost");
     } catch (Exception e) {
-      assertTrue("Couldn't setup MiniKDC", false);
+      assertTrue(false, "Couldn't setup MiniKDC");
     }
     Writer w = new FileWriter(secretFile);
     w.write("secret");
     w.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (testMiniKDC != null) {
       testMiniKDC.stop();
@@ -153,7 +153,7 @@ public class TestHttpServerWithSpnego {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet + "?doAs=userB"),
             token);
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // userA cannot impersonate userC, it fails.
@@ -162,7 +162,7 @@ public class TestHttpServerWithSpnego {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet + "?doAs=userC"),
             token);
-        Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+        Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
             conn.getResponseCode());
       }
 
@@ -173,7 +173,7 @@ public class TestHttpServerWithSpnego {
           new String[]{"logLevel", "logs"}) {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet), token);
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // Setup token for userB
@@ -184,7 +184,7 @@ public class TestHttpServerWithSpnego {
           new String[]{"logLevel", "logs"}) {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet), token);
-        Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+        Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
             conn.getResponseCode());
       }
 
@@ -221,13 +221,13 @@ public class TestHttpServerWithSpnego {
       // endpoints in whitelist should not require Kerberos authentication
       for (String endpoint : allowList) {
         HttpURLConnection conn = (HttpURLConnection) new URL(serverURL + endpoint).openConnection();
-        Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // endpoints not in whitelist should require Kerberos authentication
       for (String endpoint : denyList) {
         HttpURLConnection conn = (HttpURLConnection) new URL(serverURL + endpoint).openConnection();
-        Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
+        Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
       }
 
     } finally {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWithSpnego.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestHttpServerWithSpnego.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -46,6 +45,8 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -153,7 +154,7 @@ public class TestHttpServerWithSpnego {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet + "?doAs=userB"),
             token);
-        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // userA cannot impersonate userC, it fails.
@@ -162,7 +163,7 @@ public class TestHttpServerWithSpnego {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet + "?doAs=userC"),
             token);
-        Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
             conn.getResponseCode());
       }
 
@@ -173,7 +174,7 @@ public class TestHttpServerWithSpnego {
           new String[]{"logLevel", "logs"}) {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet), token);
-        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // Setup token for userB
@@ -184,7 +185,7 @@ public class TestHttpServerWithSpnego {
           new String[]{"logLevel", "logs"}) {
         HttpURLConnection conn = authUrl
             .openConnection(new URL(serverURL + servlet), token);
-        Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
             conn.getResponseCode());
       }
 
@@ -221,13 +222,13 @@ public class TestHttpServerWithSpnego {
       // endpoints in whitelist should not require Kerberos authentication
       for (String endpoint : allowList) {
         HttpURLConnection conn = (HttpURLConnection) new URL(serverURL + endpoint).openConnection();
-        Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+        assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       }
 
       // endpoints not in whitelist should require Kerberos authentication
       for (String endpoint : denyList) {
         HttpURLConnection conn = (HttpURLConnection) new URL(serverURL + endpoint).openConnection();
-        Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
       }
 
     } finally {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestIsActiveServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestIsActiveServlet.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.http;
 
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -51,7 +51,7 @@ public class TestIsActiveServlet {
   private HttpServletResponse resp;
   private ByteArrayOutputStream respOut;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     req = mock(HttpServletRequest.class);
     resp = mock(HttpServletResponse.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestProfileServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestProfileServlet.java
@@ -22,9 +22,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.UUID;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,7 @@ public class TestProfileServlet extends HttpServerFunctionalTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestProfileServlet.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     ProfileServlet.setIsTestRun(true);
     System.setProperty("async.profiler.home", UUID.randomUUID().toString());
@@ -47,7 +47,7 @@ public class TestProfileServlet extends HttpServerFunctionalTest {
     baseUrl = getServerURL(server);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     ProfileServlet.setIsTestRun(false);
     System.clearProperty("async.profiler.home");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
@@ -306,8 +306,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
     HttpsURLConnection conn =
         getConnectionWithPreferredProtocolSSLSocketFactory(url,
             includedProtocols);
-    assertFalse(
-       includedProtocols.isEmpty(), "included protocol list is empty");
+    assertFalse(includedProtocols.isEmpty(), "included protocol list is empty");
 
     readFromConnection(conn);
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServer.java
@@ -43,9 +43,9 @@ import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +106,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
   static final String INCLUDED_PROTOCOLS = "TLSv1.2";
   static final String INCLUDED_PROTOCOLS_JDK11 = "TLSv1.3,TLSv1.2";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     turnOnSSLDebugLogging();
     storeHttpsCipherSuites();
@@ -156,7 +156,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
     server.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     server.stop();
     FileUtil.fullyDelete(new File(BASEDIR));
@@ -286,7 +286,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
     URL url = new URL(baseUrl, SERVLET_PATH_ECHO + "?a=b&c=d");
     HttpsURLConnection conn = getConnectionWithSSLSocketFactory(url,
         EXCLUDED_CIPHERS);
-    assertFalse("excludedCipher list is empty", EXCLUDED_CIPHERS.isEmpty());
+    assertFalse(EXCLUDED_CIPHERS.isEmpty(), "excludedCipher list is empty");
     try {
       readFromConnection(conn);
       fail("No Ciphers in common, SSLHandshake must fail.");
@@ -306,8 +306,8 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
     HttpsURLConnection conn =
         getConnectionWithPreferredProtocolSSLSocketFactory(url,
             includedProtocols);
-    assertFalse("included protocol list is empty",
-        includedProtocols.isEmpty());
+    assertFalse(
+       includedProtocols.isEmpty(), "included protocol list is empty");
 
     readFromConnection(conn);
 
@@ -351,7 +351,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
       IOException, GeneralSecurityException {
     URL url = new URL(baseUrl, SERVLET_PATH_ECHO + "?a=b&c=d");
     HttpsURLConnection conn = getConnectionWithSSLSocketFactory(url, ciphers);
-    assertFalse("excludedCipher list is empty", ciphers.isEmpty());
+    assertFalse(ciphers.isEmpty(), "excludedCipher list is empty");
     String out = readFromConnection(conn);
     assertEquals(out, "a:b\nc:d\n");
     LOG.info("At least one additional enabled cipher than excluded ciphers,"

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
@@ -27,10 +27,11 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.http.TestSSLHttpServer.EXCLUDED_CIPHERS;
 import static org.apache.hadoop.http.TestSSLHttpServer.INCLUDED_PROTOCOLS;
@@ -56,7 +57,7 @@ public class TestSSLHttpServerConfigs {
   private static final String CLIENT_PWD = CLIENT_KEY_STORE_PASSWORD_DEFAULT;
   private static final String TRUST_STORE_PWD = TRUST_STORE_PASSWORD_DEFAULT;
 
-  @Before
+  @BeforeEach
   public void start() throws Exception {
     TestSSLHttpServer.turnOnSSLDebugLogging();
     TestSSLHttpServer.storeHttpsCipherSuites();
@@ -71,7 +72,7 @@ public class TestSSLHttpServerConfigs {
     sslConfDir = KeyStoreTestUtil.getClasspathDir(TestSSLHttpServer.class);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     FileUtil.fullyDelete(new File(BASEDIR));
     KeyStoreTestUtil.cleanupSSLConfig(keystoreDir, sslConfDir);
@@ -136,38 +137,43 @@ public class TestSSLHttpServerConfigs {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetup() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
     testServerStart(SERVER_PWD, SERVER_PWD, TRUST_STORE_PWD);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetupWithoutTrustPassword() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
     testServerStart(SERVER_PWD, SERVER_PWD, null);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetupWithoutKeyStorePassword() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
     testServerStart(SERVER_PWD, null, null);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetupWithoutKeyStoreKeyPassword() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
     testServerStart(null, SERVER_PWD, null);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetupWithNoKeyStorePassword() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
     // Accessing KeyStore without either of KeyStore.KeyPassword or KeyStore
     // .password should fail.
     try {
       testServerStart(null, null, null);
-      Assert.fail("Server should have failed to start without any " +
+      Assertions.fail("Server should have failed to start without any " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",
@@ -175,14 +181,15 @@ public class TestSSLHttpServerConfigs {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testServerSetupWithWrongKeyStorePassword() throws Exception {
     setupKeyStores(SERVER_PWD, CLIENT_PWD, TRUST_STORE_PWD);
 
     // Accessing KeyStore with wrong keyStore password/ keyPassword should fail.
     try {
       testServerStart(SERVER_PWD, "wrongPassword", null);
-      Assert.fail("Server should have failed to start with wrong " +
+      Assertions.fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -191,7 +198,7 @@ public class TestSSLHttpServerConfigs {
 
     try {
       testServerStart("wrongPassword", SERVER_PWD, null);
-      Assert.fail("Server should have failed to start with wrong " +
+      Assertions.fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",
@@ -201,7 +208,8 @@ public class TestSSLHttpServerConfigs {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testKeyStoreSetupWithoutTrustStorePassword() throws Exception {
     // Setup TrustStore without TrustStore password
     setupKeyStores(SERVER_PWD, CLIENT_PWD, "");
@@ -213,7 +221,7 @@ public class TestSSLHttpServerConfigs {
     // set) should fail.
     try {
       testServerStart(SERVER_PWD, SERVER_PWD, "wrongPassword");
-      Assert.fail("Server should have failed to start with wrong " +
+      Assertions.fail("Server should have failed to start with wrong " +
           "TrustStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -221,7 +229,8 @@ public class TestSSLHttpServerConfigs {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testKeyStoreSetupWithoutKeyStorePassword() throws Exception {
     // Setup KeyStore without KeyStore password
     setupKeyStores(SERVER_PWD, "", TRUST_STORE_PWD);
@@ -233,7 +242,7 @@ public class TestSSLHttpServerConfigs {
     // set) should fail.
     try {
       testServerStart(SERVER_PWD, "wrongPassword", TRUST_STORE_PWD);
-      Assert.fail("Server should have failed to start with wrong " +
+      Assertions.fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -241,7 +250,8 @@ public class TestSSLHttpServerConfigs {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testKeyStoreSetupWithoutPassword() throws Exception {
     // Setup KeyStore without any password
     setupKeyStores("", "", "");
@@ -254,7 +264,7 @@ public class TestSSLHttpServerConfigs {
 
     try {
       testServerStart(null, null, null);
-      Assert.fail("Server should have failed to start without " +
+      Assertions.fail("Server should have failed to start without " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestSSLHttpServerConfigs.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -40,6 +39,7 @@ import static org.apache.hadoop.http.TestSSLHttpServer.SSL_SERVER_TRUSTSTORE_PRO
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.CLIENT_KEY_STORE_PASSWORD_DEFAULT;
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.SERVER_KEY_STORE_PASSWORD_DEFAULT;
 import static org.apache.hadoop.security.ssl.KeyStoreTestUtil.TRUST_STORE_PASSWORD_DEFAULT;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test suit for testing KeyStore and TrustStore password settings.
@@ -173,7 +173,7 @@ public class TestSSLHttpServerConfigs {
     // .password should fail.
     try {
       testServerStart(null, null, null);
-      Assertions.fail("Server should have failed to start without any " +
+      fail("Server should have failed to start without any " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",
@@ -189,7 +189,7 @@ public class TestSSLHttpServerConfigs {
     // Accessing KeyStore with wrong keyStore password/ keyPassword should fail.
     try {
       testServerStart(SERVER_PWD, "wrongPassword", null);
-      Assertions.fail("Server should have failed to start with wrong " +
+      fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -198,7 +198,7 @@ public class TestSSLHttpServerConfigs {
 
     try {
       testServerStart("wrongPassword", SERVER_PWD, null);
-      Assertions.fail("Server should have failed to start with wrong " +
+      fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",
@@ -221,7 +221,7 @@ public class TestSSLHttpServerConfigs {
     // set) should fail.
     try {
       testServerStart(SERVER_PWD, SERVER_PWD, "wrongPassword");
-      Assertions.fail("Server should have failed to start with wrong " +
+      fail("Server should have failed to start with wrong " +
           "TrustStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -242,7 +242,7 @@ public class TestSSLHttpServerConfigs {
     // set) should fail.
     try {
       testServerStart(SERVER_PWD, "wrongPassword", TRUST_STORE_PWD);
-      Assertions.fail("Server should have failed to start with wrong " +
+      fail("Server should have failed to start with wrong " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Keystore was tampered with, " +
@@ -264,7 +264,7 @@ public class TestSSLHttpServerConfigs {
 
     try {
       testServerStart(null, null, null);
-      Assertions.fail("Server should have failed to start without " +
+      fail("Server should have failed to start without " +
           "KeyStore password.");
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("Problem starting http server",

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestServletFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/TestServletFilter.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/lib/TestStaticUserWebFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/lib/TestStaticUserWebFilter.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.http.lib;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.http.lib.StaticUserWebFilter.StaticUserFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/lib/TestStaticUserWebFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/http/lib/TestStaticUserWebFilter.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.http.lib;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -222,7 +222,7 @@ public class MiniRPCBenchmark {
           }
         });
       } catch (InterruptedException e) {
-        Assert.fail(Arrays.toString(e.getStackTrace()));
+        Assertions.fail(Arrays.toString(e.getStackTrace()));
       }
     } finally {
       RPC.stopProxy(client);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/MiniRPCBenchmark.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Enumeration;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -43,6 +42,8 @@ import org.apache.hadoop.security.token.delegation.TestDelegationToken.TestDeleg
 import org.apache.hadoop.security.token.delegation.TestDelegationToken.TestDelegationTokenSecretManager;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * MiniRPCBenchmark measures time to establish an RPC connection 
@@ -222,7 +223,7 @@ public class MiniRPCBenchmark {
           }
         });
       } catch (InterruptedException e) {
-        Assertions.fail(Arrays.toString(e.getStackTrace()));
+        fail(Arrays.toString(e.getStackTrace()));
       }
     } finally {
       RPC.stopProxy(client);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -464,6 +464,7 @@ public class TestAsyncIPC {
       InterruptedException, ExecutionException {
     // Override client to store the call id
     final Client client = new Client(LongWritable.class, conf);
+    Client.setCallIdAndRetryCount(Client.nextCallId(), 0, null);
 
     // Attach a listener that tracks every call ID received by the server.
     final TestServer server = new TestIPC.TestServer(1, false, conf);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -29,9 +29,10 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.concurrent.AsyncGetFuture;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +44,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestAsyncIPC {
 
@@ -56,7 +57,7 @@ public class TestAsyncIPC {
     return new AsyncGetFuture<>(Client.getAsyncRpcResponse());
   }
 
-  @Before
+  @BeforeEach
   public void setupConf() {
     conf = new Configuration();
     conf.setInt(CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_KEY, 10000);
@@ -102,10 +103,10 @@ public class TestAsyncIPC {
     void assertReturnValues() throws InterruptedException, ExecutionException {
       for (int i = 0; i < count; i++) {
         LongWritable value = returnFutures.get(i).get();
-        Assert.assertEquals("call" + i + " failed.",
-            expectedValues.get(i).longValue(), value.get());
+        Assertions.assertEquals(
+           expectedValues.get(i).longValue(), value.get(), "call" + i + " failed.");
       }
-      Assert.assertFalse(failed);
+      Assertions.assertFalse(failed);
     }
 
     void assertReturnValues(long timeout, TimeUnit unit)
@@ -128,12 +129,12 @@ public class TestAsyncIPC {
             continue;
           }
 
-          Assert.assertEquals("call" + i + " failed.",
-              expectedValues.get(i).longValue(), value.get());
+          Assertions.assertEquals(
+             expectedValues.get(i).longValue(), value.get(), "call" + i + " failed.");
           checked[i] = true;
         }
       }
-      Assert.assertFalse(failed);
+      Assertions.assertFalse(failed);
     }
   }
 
@@ -227,14 +228,16 @@ public class TestAsyncIPC {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAsyncCall() throws IOException, InterruptedException,
       ExecutionException {
     internalTestAsyncCall(3, false, 2, 5, 100);
     internalTestAsyncCall(3, true, 2, 5, 10);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAsyncCallLimit() throws IOException,
       InterruptedException, ExecutionException {
     internalTestAsyncCallLimit(100, false, 5, 10, 500);
@@ -267,7 +270,8 @@ public class TestAsyncIPC {
     server.stop();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCallGetReturnRpcResponseMultipleTimes() throws IOException,
       InterruptedException, ExecutionException {
     int handlerCount = 10, callCount = 100;
@@ -284,14 +288,15 @@ public class TestAsyncIPC {
       caller.assertReturnValues();
       caller.assertReturnValues();
       caller.assertReturnValues();
-      Assert.assertEquals(asyncCallCount, client.getAsyncCallCount());
+      Assertions.assertEquals(asyncCallCount, client.getAsyncCallCount());
     } finally {
       client.stop();
       server.stop();
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFutureGetWithTimeout() throws IOException,
       InterruptedException, ExecutionException {
 //    GenericTestUtils.setLogLevel(AsyncGetFuture.LOG, Level.ALL);
@@ -340,7 +345,7 @@ public class TestAsyncIPC {
           callers[i].getCount());
       String msg = String.format("Expected not failed for caller-%d: %s.", i,
           callers[i]);
-      assertFalse(msg, callers[i].failed);
+      assertFalse(callers[i].failed, msg);
     }
     for (int i = 0; i < clientCount; i++) {
       clients[i].stop();
@@ -356,7 +361,8 @@ public class TestAsyncIPC {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCallIdAndRetry() throws IOException, InterruptedException,
       ExecutionException {
     final Map<Integer, CallInfo> infoMap = new HashMap<Integer, CallInfo>();
@@ -382,7 +388,7 @@ public class TestAsyncIPC {
       @Override
       void checkResponse(RpcResponseHeaderProto header) throws IOException {
         super.checkResponse(header);
-        Assert.assertEquals(infoMap.get(header.getCallId()).retry,
+        Assertions.assertEquals(infoMap.get(header.getCallId()).retry,
             header.getRetryCount());
       }
     };
@@ -392,7 +398,7 @@ public class TestAsyncIPC {
     server.callListener = new Runnable() {
       @Override
       public void run() {
-        Assert.assertEquals(infoMap.get(Server.getCallId()).retry,
+        Assertions.assertEquals(infoMap.get(Server.getCallId()).retry,
             Server.getCallRetryCount());
       }
     };
@@ -415,7 +421,8 @@ public class TestAsyncIPC {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCallRetryCount() throws IOException, InterruptedException,
       ExecutionException {
     final int retryCount = 255;
@@ -430,7 +437,7 @@ public class TestAsyncIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assert.assertEquals(retryCount, Server.getCallRetryCount());
+        Assertions.assertEquals(retryCount, Server.getCallRetryCount());
       }
     };
 
@@ -452,7 +459,8 @@ public class TestAsyncIPC {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testInitialCallRetryCount() throws IOException,
       InterruptedException, ExecutionException {
     // Override client to store the call id
@@ -465,7 +473,7 @@ public class TestAsyncIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assert.assertEquals(0, Server.getCallRetryCount());
+        Assertions.assertEquals(0, Server.getCallRetryCount());
       }
     };
 
@@ -488,7 +496,8 @@ public class TestAsyncIPC {
    * @throws InterruptedException
    * @throws ExecutionException
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUniqueSequentialCallIds() throws IOException,
       InterruptedException, ExecutionException {
     int serverThreads = 10, callerCount = 100, perCallerCallCount = 100;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.concurrent.AsyncGetFuture;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -103,10 +102,10 @@ public class TestAsyncIPC {
     void assertReturnValues() throws InterruptedException, ExecutionException {
       for (int i = 0; i < count; i++) {
         LongWritable value = returnFutures.get(i).get();
-        Assertions.assertEquals(
-           expectedValues.get(i).longValue(), value.get(), "call" + i + " failed.");
+        assertEquals(expectedValues.get(i).longValue(), value.get(),
+            "call" + i + " failed.");
       }
-      Assertions.assertFalse(failed);
+      assertFalse(failed);
     }
 
     void assertReturnValues(long timeout, TimeUnit unit)
@@ -129,12 +128,12 @@ public class TestAsyncIPC {
             continue;
           }
 
-          Assertions.assertEquals(
-             expectedValues.get(i).longValue(), value.get(), "call" + i + " failed.");
+          assertEquals(expectedValues.get(i).longValue(), value.get(),
+              "call" + i + " failed.");
           checked[i] = true;
         }
       }
-      Assertions.assertFalse(failed);
+      assertFalse(failed);
     }
   }
 
@@ -288,7 +287,7 @@ public class TestAsyncIPC {
       caller.assertReturnValues();
       caller.assertReturnValues();
       caller.assertReturnValues();
-      Assertions.assertEquals(asyncCallCount, client.getAsyncCallCount());
+      assertEquals(asyncCallCount, client.getAsyncCallCount());
     } finally {
       client.stop();
       server.stop();
@@ -388,7 +387,7 @@ public class TestAsyncIPC {
       @Override
       void checkResponse(RpcResponseHeaderProto header) throws IOException {
         super.checkResponse(header);
-        Assertions.assertEquals(infoMap.get(header.getCallId()).retry,
+        assertEquals(infoMap.get(header.getCallId()).retry,
             header.getRetryCount());
       }
     };
@@ -398,7 +397,7 @@ public class TestAsyncIPC {
     server.callListener = new Runnable() {
       @Override
       public void run() {
-        Assertions.assertEquals(infoMap.get(Server.getCallId()).retry,
+        assertEquals(infoMap.get(Server.getCallId()).retry,
             Server.getCallRetryCount());
       }
     };
@@ -437,7 +436,7 @@ public class TestAsyncIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assertions.assertEquals(retryCount, Server.getCallRetryCount());
+        assertEquals(retryCount, Server.getCallRetryCount());
       }
     };
 
@@ -473,7 +472,7 @@ public class TestAsyncIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assertions.assertEquals(0, Server.getCallRetryCount());
+        assertEquals(0, Server.getCallRetryCount());
       }
     };
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallQueueManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallQueueManager.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
@@ -38,7 +38,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.ipc.CallQueueManager.CallQueueOverflowException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 public class TestCallQueueManager {
@@ -261,7 +262,8 @@ public class TestCallQueueManager {
     assertCanPut(manager, 0, 1);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSwapUnderContention() throws InterruptedException {
     manager = new CallQueueManager<FakeCall>(queueClass, schedulerClass, false,
         5000, "", conf);
@@ -473,7 +475,7 @@ public class TestCallQueueManager {
       cqm.add(call);
       fail("didn't throw");
     } catch (Exception ex) {
-      assertTrue(ex.toString(), ex instanceof CallQueueOverflowException);
+      assertTrue(ex instanceof CallQueueOverflowException, ex.toString());
     }
 
     // backoff disabled, put is put to queue.
@@ -500,7 +502,7 @@ public class TestCallQueueManager {
       cqm.put(call);
       fail("didn't fail");
     } catch (Exception ex) {
-      assertTrue(ex.toString(), ex instanceof CallQueueOverflowException);
+      assertTrue(ex instanceof CallQueueOverflowException, ex.toString());
     }
     verify(queue, times(0)).put(call);
     verify(queue, times(0)).add(call);
@@ -513,7 +515,7 @@ public class TestCallQueueManager {
       cqm.add(call);
       fail("didn't fail");
     } catch (Exception ex) {
-      assertTrue(ex.toString(), ex instanceof CallQueueOverflowException);
+      assertTrue(ex instanceof CallQueueOverflowException, ex.toString());
     }
     verify(queue, times(0)).put(call);
     verify(queue, times(0)).add(call);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallQueueManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallQueueManager.java
@@ -25,9 +25,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.reset;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +42,6 @@ import org.apache.hadoop.ipc.CallQueueManager.CallQueueOverflowException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 
 public class TestCallQueueManager {
   private CallQueueManager<FakeCall> manager;
@@ -440,12 +441,12 @@ public class TestCallQueueManager {
   @SuppressWarnings("unchecked")
   @Test
   public void testCallQueueOverflowExceptions() throws Exception {
-    RpcScheduler scheduler = Mockito.mock(RpcScheduler.class);
-    BlockingQueue<Schedulable> queue = Mockito.mock(BlockingQueue.class);
+    RpcScheduler scheduler = mock(RpcScheduler.class);
+    BlockingQueue<Schedulable> queue = mock(BlockingQueue.class);
     CallQueueManager<Schedulable> cqm =
-        Mockito.spy(new CallQueueManager<>(queue, scheduler, false, false));
+        spy(new CallQueueManager<>(queue, scheduler, false, false));
     CallQueueManager<Schedulable> cqmTriggerFailover =
-            Mockito.spy(new CallQueueManager<>(queue, scheduler, false, true));
+        spy(new CallQueueManager<>(queue, scheduler, false, true));
     Schedulable call = new FakeCall(0);
 
     // call queue exceptions that trigger failover

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_SEPARATOR_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestCallerContext {
@@ -32,14 +32,14 @@ public class TestCallerContext {
     CallerContext.Builder builder = new CallerContext.Builder(null, conf);
     CallerContext context = builder.append("context1")
         .append("context2").append("key3", "value3").build();
-    Assertions.assertEquals(true,
+    assertEquals(true,
         context.getContext().contains("$"));
     String[] items = context.getContext().split("\\$");
-    Assertions.assertEquals(3, items.length);
-    Assertions.assertEquals("key3:value3", items[2]);
+    assertEquals(3, items.length);
+    assertEquals("key3:value3", items[2]);
 
     builder.append("$$");
-    Assertions.assertEquals("context1$context2$key3:value3$$$",
+    assertEquals("context1$context2$key3:value3$$$",
         builder.build().getContext());
   }
 
@@ -49,28 +49,28 @@ public class TestCallerContext {
     conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "$");
     CallerContext.Builder builder = new CallerContext.Builder(null, conf);
     builder.append("key1", "value1");
-    Assertions.assertEquals("key1:value1",
+    assertEquals("key1:value1",
         builder.build().getContext());
 
     // Append an existed key with different value.
     builder.appendIfAbsent("key1", "value2");
     String[] items = builder.build().getContext().split("\\$");
-    Assertions.assertEquals(1, items.length);
-    Assertions.assertEquals("key1:value1",
+    assertEquals(1, items.length);
+    assertEquals("key1:value1",
         builder.build().getContext());
 
     // Append an absent key.
     builder.appendIfAbsent("key2", "value2");
     String[] items2 = builder.build().getContext().split("\\$");
-    Assertions.assertEquals(2, items2.length);
-    Assertions.assertEquals("key1:value1$key2:value2",
+    assertEquals(2, items2.length);
+    assertEquals("key1:value1$key2:value2",
         builder.build().getContext());
 
     // Append a key that is a substring of an existing key.
     builder.appendIfAbsent("key", "value");
     String[] items3 = builder.build().getContext().split("\\$");
-    Assertions.assertEquals(3, items3.length);
-    Assertions.assertEquals("key1:value1$key2:value2$key:value",
+    assertEquals(3, items3.length);
+    assertEquals("key1:value1$key2:value2$key:value",
         builder.build().getContext());
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestCallerContext.java
@@ -18,10 +18,11 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_SEPARATOR_KEY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestCallerContext {
   @Test
@@ -31,14 +32,14 @@ public class TestCallerContext {
     CallerContext.Builder builder = new CallerContext.Builder(null, conf);
     CallerContext context = builder.append("context1")
         .append("context2").append("key3", "value3").build();
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         context.getContext().contains("$"));
     String[] items = context.getContext().split("\\$");
-    Assert.assertEquals(3, items.length);
-    Assert.assertEquals("key3:value3", items[2]);
+    Assertions.assertEquals(3, items.length);
+    Assertions.assertEquals("key3:value3", items[2]);
 
     builder.append("$$");
-    Assert.assertEquals("context1$context2$key3:value3$$$",
+    Assertions.assertEquals("context1$context2$key3:value3$$$",
         builder.build().getContext());
   }
 
@@ -48,37 +49,39 @@ public class TestCallerContext {
     conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "$");
     CallerContext.Builder builder = new CallerContext.Builder(null, conf);
     builder.append("key1", "value1");
-    Assert.assertEquals("key1:value1",
+    Assertions.assertEquals("key1:value1",
         builder.build().getContext());
 
     // Append an existed key with different value.
     builder.appendIfAbsent("key1", "value2");
     String[] items = builder.build().getContext().split("\\$");
-    Assert.assertEquals(1, items.length);
-    Assert.assertEquals("key1:value1",
+    Assertions.assertEquals(1, items.length);
+    Assertions.assertEquals("key1:value1",
         builder.build().getContext());
 
     // Append an absent key.
     builder.appendIfAbsent("key2", "value2");
     String[] items2 = builder.build().getContext().split("\\$");
-    Assert.assertEquals(2, items2.length);
-    Assert.assertEquals("key1:value1$key2:value2",
+    Assertions.assertEquals(2, items2.length);
+    Assertions.assertEquals("key1:value1$key2:value2",
         builder.build().getContext());
 
     // Append a key that is a substring of an existing key.
     builder.appendIfAbsent("key", "value");
     String[] items3 = builder.build().getContext().split("\\$");
-    Assert.assertEquals(3, items3.length);
-    Assert.assertEquals("key1:value1$key2:value2$key:value",
+    Assertions.assertEquals(3, items3.length);
+    Assertions.assertEquals("key1:value1$key2:value2$key:value",
         builder.build().getContext());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNewBuilder() {
-    Configuration conf = new Configuration();
-    // Set illegal separator.
-    conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "\t");
-    CallerContext.Builder builder = new CallerContext.Builder(null, conf);
-    builder.build();
+    assertThrows(IllegalArgumentException.class, () -> {
+      Configuration conf = new Configuration();
+      // Set illegal separator.
+      conf.set(HADOOP_CALLER_CONTEXT_SEPARATOR_KEY, "\t");
+      CallerContext.Builder builder = new CallerContext.Builder(null, conf);
+      builder.build();
+    });
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestDecayRpcScheduler.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestDecayRpcScheduler.java
@@ -26,7 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.ipc.DecayRpcScheduler.IPC_DECAYSCHEDULER_THRESHOLDS_KEY;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -294,14 +298,14 @@ public class TestDecayRpcScheduler {
         "Hadoop:service="+ namespace + ",name=DecayRpcScheduler");
 
     String cvs1 = (String) mbs.getAttribute(mxbeanName, "CallVolumeSummary");
-    assertTrue(
-       cvs1.equals("{\"A\":6,\"B\":2,\"C\":2}"), "Get expected JMX of CallVolumeSummary before decay");
+    assertTrue(cvs1.equals("{\"A\":6,\"B\":2,\"C\":2}"),
+        "Get expected JMX of CallVolumeSummary before decay");
 
     scheduler.forceDecay();
 
     String cvs2 = (String) mbs.getAttribute(mxbeanName, "CallVolumeSummary");
-    assertTrue(
-       cvs2.equals("{\"A\":3,\"B\":1,\"C\":1}"), "Get expected JMX for CallVolumeSummary after decay");
+    assertTrue(cvs2.equals("{\"A\":3,\"B\":1,\"C\":1}"),
+        "Get expected JMX for CallVolumeSummary after decay");
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestDecayRpcScheduler.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestDecayRpcScheduler.java
@@ -22,13 +22,11 @@ import static java.lang.Thread.sleep;
 
 import java.util.Map;
 import org.eclipse.jetty.util.ajax.JSON;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.ipc.DecayRpcScheduler.IPC_DECAYSCHEDULER_THRESHOLDS_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,14 +78,18 @@ public class TestDecayRpcScheduler {
 
   private DecayRpcScheduler scheduler;
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testNegativeScheduler() {
-    scheduler = new DecayRpcScheduler(-1, "", new Configuration());
+    assertThrows(IllegalArgumentException.class, () -> {
+      scheduler = new DecayRpcScheduler(-1, "", new Configuration());
+    });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testZeroScheduler() {
-    scheduler = new DecayRpcScheduler(0, "", new Configuration());
+    assertThrows(IllegalArgumentException.class, () -> {
+      scheduler = new DecayRpcScheduler(0, "", new Configuration());
+    });
   }
 
   @Test
@@ -292,17 +294,18 @@ public class TestDecayRpcScheduler {
         "Hadoop:service="+ namespace + ",name=DecayRpcScheduler");
 
     String cvs1 = (String) mbs.getAttribute(mxbeanName, "CallVolumeSummary");
-    assertTrue("Get expected JMX of CallVolumeSummary before decay",
-        cvs1.equals("{\"A\":6,\"B\":2,\"C\":2}"));
+    assertTrue(
+       cvs1.equals("{\"A\":6,\"B\":2,\"C\":2}"), "Get expected JMX of CallVolumeSummary before decay");
 
     scheduler.forceDecay();
 
     String cvs2 = (String) mbs.getAttribute(mxbeanName, "CallVolumeSummary");
-    assertTrue("Get expected JMX for CallVolumeSummary after decay",
-        cvs2.equals("{\"A\":3,\"B\":1,\"C\":1}"));
+    assertTrue(
+       cvs2.equals("{\"A\":3,\"B\":1,\"C\":1}"), "Get expected JMX for CallVolumeSummary after decay");
   }
 
-  @Test(timeout=2000)
+  @Test
+  @Timeout(value = 2)
   @SuppressWarnings("deprecation")
   public void testPeriodic() throws InterruptedException {
     Configuration conf = new Configuration();
@@ -325,7 +328,8 @@ public class TestDecayRpcScheduler {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testNPEatInitialization() throws InterruptedException {
     // redirect the LOG to and check if there is NPE message while initializing
     // the DecayRpcScheduler

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestFairCallQueue.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestFairCallQueue.java
@@ -407,21 +407,21 @@ public class TestFairCallQueue {
   private void checkOverflowException(Exception ex, RpcStatusProto status,
       boolean failOverTriggered) {
     // should be an overflow exception
-    assertTrue(
-       ex instanceof CallQueueOverflowException, ex.getClass().getName() + " != CallQueueOverflowException");
+    assertTrue(ex instanceof CallQueueOverflowException,
+        ex.getClass().getName() + " != CallQueueOverflowException");
     IOException ioe = ((CallQueueOverflowException)ex).getCause();
     assertNotNull(ioe);
-    assertTrue(
-       ioe instanceof RpcServerException, ioe.getClass().getName() + " != RpcServerException");
+    assertTrue(ioe instanceof RpcServerException,
+        ioe.getClass().getName() + " != RpcServerException");
     RpcServerException rse = (RpcServerException)ioe;
     // check error/fatal status and if it embeds a retriable ex or standby ex.
     assertEquals(status, rse.getRpcStatusProto());
     if (failOverTriggered) {
-      assertTrue(
-         rse.getCause() instanceof StandbyException, rse.getClass().getName() + " != RetriableException");
+      assertTrue(rse.getCause() instanceof StandbyException,
+          rse.getClass().getName() + " != RetriableException");
     } else {
-      assertTrue(
-         rse.getCause() instanceof RetriableException, rse.getClass().getName() + " != RetriableException");
+      assertTrue(rse.getCause() instanceof RetriableException,
+          rse.getClass().getName() + " != RetriableException");
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestFairCallQueue.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestFairCallQueue.java
@@ -28,15 +28,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -77,7 +77,7 @@ public class TestFairCallQueue {
   }
 
   @SuppressWarnings("deprecation")
-  @Before
+  @BeforeEach
   public void setUp() {
     Configuration conf = new Configuration();
     conf.setInt("ns." + FairCallQueue.IPC_CALLQUEUE_PRIORITY_LEVELS_KEY, 2);
@@ -407,21 +407,21 @@ public class TestFairCallQueue {
   private void checkOverflowException(Exception ex, RpcStatusProto status,
       boolean failOverTriggered) {
     // should be an overflow exception
-    assertTrue(ex.getClass().getName() + " != CallQueueOverflowException",
-        ex instanceof CallQueueOverflowException);
+    assertTrue(
+       ex instanceof CallQueueOverflowException, ex.getClass().getName() + " != CallQueueOverflowException");
     IOException ioe = ((CallQueueOverflowException)ex).getCause();
     assertNotNull(ioe);
-    assertTrue(ioe.getClass().getName() + " != RpcServerException",
-        ioe instanceof RpcServerException);
+    assertTrue(
+       ioe instanceof RpcServerException, ioe.getClass().getName() + " != RpcServerException");
     RpcServerException rse = (RpcServerException)ioe;
     // check error/fatal status and if it embeds a retriable ex or standby ex.
     assertEquals(status, rse.getRpcStatusProto());
     if (failOverTriggered) {
-      assertTrue(rse.getClass().getName() + " != RetriableException",
-          rse.getCause() instanceof StandbyException);
+      assertTrue(
+         rse.getCause() instanceof StandbyException, rse.getClass().getName() + " != RetriableException");
     } else {
-      assertTrue(rse.getClass().getName() + " != RetriableException",
-          rse.getCause() instanceof RetriableException);
+      assertTrue(
+         rse.getCause() instanceof RetriableException, rse.getClass().getName() + " != RetriableException");
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -1461,7 +1461,7 @@ public class TestIPC {
           new TestInvalidTokenHandler(client, server);
       DummyProtocol proxy = (DummyProtocol) Proxy.newProxyInstance(
           DummyProtocol.class.getClassLoader(),
-          new Class[] { DummyProtocol.class }, handler);
+          new Class[]{DummyProtocol.class}, handler);
       FailoverProxyProvider<DummyProtocol> provider =
            new DefaultFailoverProxyProvider<>(DummyProtocol.class, proxy);
       DummyProtocol retryProxy =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -18,15 +18,28 @@
 
 package org.apache.hadoop.ipc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.reset;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -90,13 +103,9 @@ import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -106,8 +115,6 @@ import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for IPC. */
 public class TestIPC {
@@ -412,13 +419,13 @@ public class TestIPC {
     } catch (IOException e) {
       String message = e.getMessage();
       String addressText = address.getHostName() + ":" + address.getPort();
-      assertTrue(
-             message.contains(addressText), "Did not find "+addressText+" in "+message);
+      assertTrue(message.contains(addressText),
+          "Did not find "+addressText+" in "+message);
       Throwable cause=e.getCause();
       assertNotNull(cause, "No nested exception in "+e);
       String causeText=cause.getMessage();
-      assertTrue(
-             message.contains(causeText), "Did not find " + causeText + " in " + message);
+      assertTrue(message.contains(causeText),
+          "Did not find " + causeText + " in " + message);
     } finally {
       client.stop();
     }
@@ -636,8 +643,8 @@ public class TestIPC {
   private static void assertExceptionContains(
       Throwable t, String substring) {
     String msg = StringUtils.stringifyException(t);
-    assertTrue(msg.contains(substring), "Exception should contain substring '" + substring + "':\n" +
-        msg);
+    assertTrue(msg.contains(substring),
+        "Exception should contain substring '" + substring + "':\n" + msg);
     LOG.info("Got expected exception", t);
   }
   
@@ -685,7 +692,7 @@ public class TestIPC {
     // Set up a socket factory which returns sockets which
     // throw an RTE when setSoTimeout is called.
     SocketFactory spyFactory = spy(NetUtils.getDefaultSocketFactory(conf));
-    Mockito.doAnswer(new Answer<Socket>() {
+    doAnswer(new Answer<Socket>() {
       @Override
       public Socket answer(InvocationOnMock invocation) {
         return new MockSocket();
@@ -709,7 +716,7 @@ public class TestIPC {
       // Resetting to the normal socket behavior should succeed
       // (i.e. it should not have cached a half-constructed connection)
   
-      Mockito.reset(spyFactory);
+      reset(spyFactory);
       call(client, RANDOM.nextLong(), address, conf);
     } finally {
       client.stop();
@@ -1193,9 +1200,8 @@ public class TestIPC {
     call(client, addr, serviceClass, conf);
     Connection connection = server.getConnections()[0];
     LOG.info("Connection is from: {}", connection);
-    assertEquals(
-    1
-,         connection.toString().split(" / ").length, "Connection string representation should include only IP address for healthy connection");
+    assertEquals(1, connection.toString().split(" / ").length,
+        "Connection string representation should include only IP address for healthy connection");
     int serviceClass2 = connection.getServiceClass();
     assertFalse(noChanged ^ serviceClass == serviceClass2);
     client.stop();
@@ -1227,7 +1233,7 @@ public class TestIPC {
   @Test
   @Timeout(value = 60)
   public void testSocketLeak() throws IOException {
-    Assume.assumeTrue(FD_DIR.exists()); // only run on Linux
+    assumeTrue(FD_DIR.exists()); // only run on Linux
 
     long startFds = countOpenFileDescriptors();
     for (int i = 0; i < 50; i++) {
@@ -1237,8 +1243,8 @@ public class TestIPC {
     }
     long endFds = countOpenFileDescriptors();
     
-    assertTrue(
-       endFds - startFds < 20, "Leaked " + (endFds - startFds) + " file descriptors");
+    assertTrue(endFds - startFds < 20,
+        "Leaked " + (endFds - startFds) + " file descriptors");
   }
   
   /**
@@ -1256,7 +1262,7 @@ public class TestIPC {
       LOG.info("Expected thread interrupt during client cleanup");
     } catch (AssertionError e) {
       LOG.error("The Client did not interrupt after handling an Interrupted Exception");
-      Assertions.fail("The Client did not interrupt after handling an Interrupted Exception");
+      fail("The Client did not interrupt after handling an Interrupted Exception");
     }
     // Clear Thread interrupt
     Thread.interrupted();
@@ -1339,8 +1345,8 @@ public class TestIPC {
       @Override
       void checkResponse(RpcResponseHeaderProto header) throws IOException {
         super.checkResponse(header);
-        Assertions.assertEquals(info.id, header.getCallId());
-        Assertions.assertEquals(info.retry, header.getRetryCount());
+        assertEquals(info.id, header.getCallId());
+        assertEquals(info.retry, header.getRetryCount());
       }
     };
 
@@ -1349,8 +1355,8 @@ public class TestIPC {
     server.callListener = new Runnable() {
       @Override
       public void run() {
-        Assertions.assertEquals(info.id, Server.getCallId());
-        Assertions.assertEquals(info.retry, Server.getCallRetryCount());
+        assertEquals(info.id, Server.getCallId());
+        assertEquals(info.retry, Server.getCallRetryCount());
       }
     };
 
@@ -1375,8 +1381,8 @@ public class TestIPC {
   @Timeout(value = 60)
   public void testReceiveStateBeforeCallerNotification() throws IOException {
     AtomicBoolean stateReceived = new AtomicBoolean(false);
-    AlignmentContext alignmentContext = Mockito.mock(AlignmentContext.class);
-    Mockito.doAnswer((Answer<Void>) invocation -> {
+    AlignmentContext alignmentContext = mock(AlignmentContext.class);
+    doAnswer((Answer<Void>) invocation -> {
       Thread.sleep(1000);
       stateReceived.set(true);
       return null;
@@ -1391,7 +1397,7 @@ public class TestIPC {
       server.start();
       call(client, new LongWritable(RANDOM.nextLong()), addr,
           0, conf, alignmentContext);
-      Assertions.assertTrue(stateReceived.get());
+      assertTrue(stateReceived.get());
     } finally {
       client.stop();
       server.stop();
@@ -1417,7 +1423,7 @@ public class TestIPC {
       private int retryCount = 0;
       @Override
       public void run() {
-        Assertions.assertEquals(retryCount++, Server.getCallRetryCount());
+        assertEquals(retryCount++, Server.getCallRetryCount());
       }
     };
 
@@ -1434,7 +1440,7 @@ public class TestIPC {
     try {
       server.start();
       retryProxy.dummyRun();
-      Assertions.assertEquals(TestInvocationHandler.retry, totalRetry + 1);
+      assertEquals(TestInvocationHandler.retry, totalRetry + 1);
     } finally {
       Client.setCallIdAndRetryCount(0, 0, null);
       client.stop();
@@ -1448,7 +1454,7 @@ public class TestIPC {
    */
   @Test
   public void testNoRetryOnInvalidToken() throws IOException {
-    assertThrows(InvalidToken.class, ()->{
+    assertThrows(InvalidToken.class, () -> {
       final Client client = new Client(LongWritable.class, conf);
       final TestServer server = new TestServer(1, false);
       TestInvalidTokenHandler handler =
@@ -1492,7 +1498,7 @@ public class TestIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assertions.assertEquals(0, Server.getCallRetryCount());
+        assertEquals(0, Server.getCallRetryCount());
       }
     };
 
@@ -1526,7 +1532,7 @@ public class TestIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assertions.assertEquals(retryCount, Server.getCallRetryCount());
+        assertEquals(retryCount, Server.getCallRetryCount());
       }
     };
 
@@ -1661,7 +1667,7 @@ public class TestIPC {
   @Timeout(value = 60)
   public void testSetupConnectionShouldNotBlockShutdown() throws Exception {
     // Start server
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
+    SocketFactory mockFactory = mock(SocketFactory.class);
     Server server = new TestServer(1, true);
     final InetSocketAddress addr = NetUtils.getConnectAddress(server);
 
@@ -1704,7 +1710,7 @@ public class TestIPC {
 
   private void assertRetriesOnSocketTimeouts(Configuration conf,
       int maxTimeoutRetries) throws IOException {
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
+    SocketFactory mockFactory = mock(SocketFactory.class);
     doThrow(new ConnectTimeoutException("fake")).when(mockFactory).createSocket();
     Client client = new Client(LongWritable.class, conf, mockFactory);
     InetSocketAddress address = new InetSocketAddress("127.0.0.1", 9090);
@@ -1712,7 +1718,7 @@ public class TestIPC {
       call(client, RANDOM.nextLong(), address, conf);
       fail("Not throwing the SocketTimeoutException");
     } catch (SocketTimeoutException e) {
-      Mockito.verify(mockFactory, Mockito.times(maxTimeoutRetries))
+      verify(mockFactory, times(maxTimeoutRetries))
           .createSocket();
     }
     client.stop();
@@ -1759,13 +1765,13 @@ public class TestIPC {
         Client client = new Client(LongWritable.class, conf);
         call(client, 0, addr, conf);
       } catch (RemoteException re) {
-        Assertions.assertEquals(RPC.VersionMismatch.class.getName(),
+        assertEquals(RPC.VersionMismatch.class.getName(),
             re.getClassName());
-        Assertions.assertEquals(NetworkTraces.HADOOP0_20_ERROR_MSG,
+        assertEquals(NetworkTraces.HADOOP0_20_ERROR_MSG,
             re.getMessage());
         return;
       }
-      Assertions.fail("didn't get version mismatch");
+      fail("didn't get version mismatch");
     }
   }
 
@@ -1784,13 +1790,13 @@ public class TestIPC {
     try {
       call(client, 0, addr, conf);
     } catch (IOException ioe) {
-      Assertions.assertNotNull(ioe);
-      Assertions.assertEquals(RpcException.class, ioe.getClass());
-      Assertions.assertTrue(ioe.getMessage().contains(
+      assertNotNull(ioe);
+      assertEquals(RpcException.class, ioe.getClass());
+      assertTrue(ioe.getMessage().contains(
           "exceeds maximum data length"));
       return;
     }
-    Assertions.fail("didn't get limit exceeded");
+    fail("didn't get limit exceeded");
   }
 
   @Test
@@ -1810,7 +1816,7 @@ public class TestIPC {
     Server server = new TestServer(1, false);
     server.start();
 
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
+    SocketFactory mockFactory = mock(SocketFactory.class);
     doThrow(new ConnectTimeoutException("fake")).when(mockFactory)
         .createSocket();
     Client client = new Client(LongWritable.class, conf, mockFactory);
@@ -1849,16 +1855,16 @@ public class TestIPC {
     Socket s;
     // don't attempt bind with no service host.
     s = checkConnect(null, asProxy);
-    Mockito.verify(s, Mockito.never()).bind(any(SocketAddress.class));
+    verify(s, never()).bind(any(SocketAddress.class));
 
     // don't attempt bind with service host not belonging to this host.
     s = checkConnect("1.2.3.4", asProxy);
-    Mockito.verify(s, Mockito.never()).bind(any(SocketAddress.class));
+    verify(s, never()).bind(any(SocketAddress.class));
 
     // do attempt bind when service host is this host.
     InetAddress addr = InetAddress.getLocalHost();
     s = checkConnect(addr.getHostAddress(), asProxy);
-    Mockito.verify(s).bind(new InetSocketAddress(addr, 0));
+    verify(s).bind(new InetSocketAddress(addr, 0));
   }
 
   // dummy protocol that claims to support kerberos.
@@ -1876,7 +1882,7 @@ public class TestIPC {
     principal.append("@REALM");
     UserGroupInformation ugi =
         spy(UserGroupInformation.createRemoteUser(principal.toString()));
-    Mockito.doReturn(true).when(ugi).hasKerberosCredentials();
+    doReturn(true).when(ugi).hasKerberosCredentials();
     if (asProxy) {
       ugi = UserGroupInformation.createProxyUser("proxy", ugi);
     }
@@ -1884,11 +1890,11 @@ public class TestIPC {
     // create a mock socket that throws on connect.
     SocketException expectedConnectEx =
         new SocketException("Expected connect failure");
-    Socket s = Mockito.mock(Socket.class);
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
-    Mockito.doReturn(s).when(mockFactory).createSocket();
+    Socket s = mock(Socket.class);
+    SocketFactory mockFactory = mock(SocketFactory.class);
+    doReturn(s).when(mockFactory).createSocket();
     doThrow(expectedConnectEx).when(s).connect(
-        any(SocketAddress.class), Mockito.anyInt());
+        any(SocketAddress.class), anyInt());
 
     // do a dummy call and expect it to throw an exception on connect.
     // tests should verify if/how a bind occurred.
@@ -1902,7 +1908,7 @@ public class TestIPC {
       fail("call didn't throw connect exception");
     } catch (SocketException se) {
       // ipc layer re-wraps exceptions, so check the cause.
-      Assertions.assertSame(expectedConnectEx, se.getCause());
+      assertSame(expectedConnectEx, se.getCause());
     }
     return s;
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -19,11 +19,7 @@
 package org.apache.hadoop.ipc;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -95,10 +91,11 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.assertj.core.api.Condition;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -126,7 +123,7 @@ public class TestIPC {
   static boolean WRITABLE_FAULTS_ENABLED = true;
   static int WRITABLE_FAULTS_SLEEP = 0;
   
-  @Before
+  @BeforeEach
   public void setupConf() {
     conf = new Configuration();
     Client.setPingInterval(conf, PING_INTERVAL);
@@ -339,7 +336,8 @@ public class TestIPC {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSerial() throws IOException, InterruptedException {
     internalTestSerial(3, false, 2, 5, 100);
     internalTestSerial(3, true, 2, 5, 10);
@@ -403,7 +401,8 @@ public class TestIPC {
     server.stop();
   }
 	
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testStandAloneClient() throws IOException {
     Client client = new Client(LongWritable.class, conf);
     InetSocketAddress address = new InetSocketAddress("127.0.0.1", 10);
@@ -413,13 +412,13 @@ public class TestIPC {
     } catch (IOException e) {
       String message = e.getMessage();
       String addressText = address.getHostName() + ":" + address.getPort();
-      assertTrue("Did not find "+addressText+" in "+message,
-              message.contains(addressText));
+      assertTrue(
+             message.contains(addressText), "Did not find "+addressText+" in "+message);
       Throwable cause=e.getCause();
-      assertNotNull("No nested exception in "+e,cause);
+      assertNotNull(cause, "No nested exception in "+e);
       String causeText=cause.getMessage();
-      assertTrue("Did not find " + causeText + " in " + message,
-              message.contains(causeText));
+      assertTrue(
+             message.contains(causeText), "Did not find " + causeText + " in " + message);
     } finally {
       client.stop();
     }
@@ -539,7 +538,8 @@ public class TestIPC {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIOEOnClientWriteParam() throws Exception {
     doErrorTest(IOEOnWriteWritable.class,
         LongWritable.class,
@@ -547,7 +547,8 @@ public class TestIPC {
         LongWritable.class);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRTEOnClientWriteParam() throws Exception {
     doErrorTest(RTEOnWriteWritable.class,
         LongWritable.class,
@@ -555,7 +556,8 @@ public class TestIPC {
         LongWritable.class);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIOEOnServerReadParam() throws Exception {
     doErrorTest(LongWritable.class,
         IOEOnReadWritable.class,
@@ -563,7 +565,8 @@ public class TestIPC {
         LongWritable.class);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRTEOnServerReadParam() throws Exception {
     doErrorTest(LongWritable.class,
         RTEOnReadWritable.class,
@@ -572,7 +575,8 @@ public class TestIPC {
   }
 
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIOEOnServerWriteResponse() throws Exception {
     doErrorTest(LongWritable.class,
         LongWritable.class,
@@ -580,7 +584,8 @@ public class TestIPC {
         LongWritable.class);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRTEOnServerWriteResponse() throws Exception {
     doErrorTest(LongWritable.class,
         LongWritable.class,
@@ -588,7 +593,8 @@ public class TestIPC {
         LongWritable.class);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIOEOnClientReadResponse() throws Exception {
     doErrorTest(LongWritable.class,
         LongWritable.class,
@@ -596,7 +602,8 @@ public class TestIPC {
         IOEOnReadWritable.class);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRTEOnClientReadResponse() throws Exception {
     doErrorTest(LongWritable.class,
         LongWritable.class,
@@ -609,7 +616,8 @@ public class TestIPC {
    * that a ping should have been sent. This is a reproducer for a
    * deadlock seen in one iteration of HADOOP-6762.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIOEOnWriteAfterPingClient() throws Exception {
     // start server
     Client.setPingInterval(conf, 100);
@@ -628,8 +636,8 @@ public class TestIPC {
   private static void assertExceptionContains(
       Throwable t, String substring) {
     String msg = StringUtils.stringifyException(t);
-    assertTrue("Exception should contain substring '" + substring + "':\n" +
-        msg, msg.contains(substring));
+    assertTrue(msg.contains(substring), "Exception should contain substring '" + substring + "':\n" +
+        msg);
     LOG.info("Got expected exception", t);
   }
   
@@ -637,7 +645,8 @@ public class TestIPC {
    * Test that, if the socket factory throws an IOE, it properly propagates
    * to the client.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSocketFactoryException() throws IOException {
     SocketFactory mockFactory = mock(SocketFactory.class);
     doThrow(new IOException("Injected fault")).when(mockFactory).createSocket();
@@ -670,7 +679,8 @@ public class TestIPC {
    * failure is handled properly. This is a regression test for
    * HADOOP-7428.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRTEDuringConnectionSetup() throws IOException {
     // Set up a socket factory which returns sockets which
     // throw an RTE when setSoTimeout is called.
@@ -707,7 +717,8 @@ public class TestIPC {
     }
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcTimeout() throws IOException {
     // start server
     Server server = new TestServer(1, true);
@@ -730,7 +741,8 @@ public class TestIPC {
     client.stop();
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcConnectTimeout() throws IOException {
     // start server
     Server server = new TestServer(1, true);
@@ -754,7 +766,8 @@ public class TestIPC {
   /**
    * Check service class byte in IPC header is correct on wire.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcWithServiceClass() throws IOException {
     // start server
     Server server = new TestServer(5, false);
@@ -800,7 +813,8 @@ public class TestIPC {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcHostResolutionTimeout() throws Exception {
     final InetSocketAddress addr = new InetSocketAddress("host.invalid", 80);
 
@@ -898,7 +912,8 @@ public class TestIPC {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcFlakyHostResolution() throws IOException {
     // start server
     Server server = new TestServer(5, false);
@@ -929,7 +944,8 @@ public class TestIPC {
    * @throws BrokenBarrierException 
    * @throws InterruptedException 
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcWithReaderQueuing() throws Exception {
     // 1 reader, 1 connectionQ slot, 1 callq
     for (int i=0; i < 10; i++) {
@@ -1058,7 +1074,8 @@ public class TestIPC {
     server.stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testConnectionIdleTimeouts() throws Exception {
     GenericTestUtils.setLogLevel(Server.LOG, Level.DEBUG);
     final int maxIdle = 1000;
@@ -1177,34 +1194,38 @@ public class TestIPC {
     Connection connection = server.getConnections()[0];
     LOG.info("Connection is from: {}", connection);
     assertEquals(
-        "Connection string representation should include only IP address for healthy connection", 1,
-        connection.toString().split(" / ").length);
+    1
+,         connection.toString().split(" / ").length, "Connection string representation should include only IP address for healthy connection");
     int serviceClass2 = connection.getServiceClass();
     assertFalse(noChanged ^ serviceClass == serviceClass2);
     client.stop();
   }
-  
-  @Test(timeout=30000, expected=IOException.class)
-  public void testIpcAfterStopping() throws IOException {
-    // start server
-    Server server = new TestServer(5, false);
-    InetSocketAddress addr = NetUtils.getConnectAddress(server);
-    server.start();
 
-    // start client
-    Client client = new Client(LongWritable.class, conf);
-    call(client, addr, 0, conf);
-    client.stop();
- 
-    // This call should throw IOException.
-    call(client, addr, 0, conf);
+  @Test
+  @Timeout(value = 30)
+  public void testIpcAfterStopping() throws IOException {
+    assertThrows(IOException.class, () -> {
+      // start server
+      Server server = new TestServer(5, false);
+      InetSocketAddress addr = NetUtils.getConnectAddress(server);
+      server.start();
+
+      // start client
+      Client client = new Client(LongWritable.class, conf);
+      call(client, addr, 0, conf);
+      client.stop();
+
+      // This call should throw IOException.
+      call(client, addr, 0, conf);
+    });
   }
 
   /**
    * Check that file descriptors aren't leaked by starting
    * and stopping IPC servers.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSocketLeak() throws IOException {
     Assume.assumeTrue(FD_DIR.exists()); // only run on Linux
 
@@ -1216,15 +1237,16 @@ public class TestIPC {
     }
     long endFds = countOpenFileDescriptors();
     
-    assertTrue("Leaked " + (endFds - startFds) + " file descriptors",
-        endFds - startFds < 20);
+    assertTrue(
+       endFds - startFds < 20, "Leaked " + (endFds - startFds) + " file descriptors");
   }
   
   /**
    * Check if Client is interrupted after handling
    * InterruptedException during cleanup
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testInterrupted() {
     Client client = new Client(LongWritable.class, conf);
     Thread.currentThread().interrupt();
@@ -1234,7 +1256,7 @@ public class TestIPC {
       LOG.info("Expected thread interrupt during client cleanup");
     } catch (AssertionError e) {
       LOG.error("The Client did not interrupt after handling an Interrupted Exception");
-      Assert.fail("The Client did not interrupt after handling an Interrupted Exception");
+      Assertions.fail("The Client did not interrupt after handling an Interrupted Exception");
     }
     // Clear Thread interrupt
     Thread.interrupted();
@@ -1244,31 +1266,36 @@ public class TestIPC {
     return FD_DIR.list().length;
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcFromHadoop_0_18_13() throws IOException {
     doIpcVersionTest(NetworkTraces.HADOOP_0_18_3_RPC_DUMP,
         NetworkTraces.RESPONSE_TO_HADOOP_0_18_3_RPC);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcFromHadoop0_20_3() throws IOException {
     doIpcVersionTest(NetworkTraces.HADOOP_0_20_3_RPC_DUMP,
         NetworkTraces.RESPONSE_TO_HADOOP_0_20_3_RPC);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testIpcFromHadoop0_21_0() throws IOException {
     doIpcVersionTest(NetworkTraces.HADOOP_0_21_0_RPC_DUMP,
         NetworkTraces.RESPONSE_TO_HADOOP_0_21_0_RPC);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testHttpGetResponse() throws IOException {
     doIpcVersionTest("GET / HTTP/1.0\r\n\r\n".getBytes(),
         Server.RECEIVED_HTTP_REQ_RESPONSE.getBytes());
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testConnectionRetriesOnSocketTimeoutExceptions() throws IOException {
     Configuration conf = new Configuration();
     // set max retries to 0
@@ -1294,7 +1321,8 @@ public class TestIPC {
    * (1) the rpc server uses the call id/retry provided by the rpc client, and
    * (2) the rpc client receives the same call id/retry from the rpc server.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCallIdAndRetry() throws IOException {
     final CallInfo info = new CallInfo();
 
@@ -1311,8 +1339,8 @@ public class TestIPC {
       @Override
       void checkResponse(RpcResponseHeaderProto header) throws IOException {
         super.checkResponse(header);
-        Assert.assertEquals(info.id, header.getCallId());
-        Assert.assertEquals(info.retry, header.getRetryCount());
+        Assertions.assertEquals(info.id, header.getCallId());
+        Assertions.assertEquals(info.retry, header.getRetryCount());
       }
     };
 
@@ -1321,8 +1349,8 @@ public class TestIPC {
     server.callListener = new Runnable() {
       @Override
       public void run() {
-        Assert.assertEquals(info.id, Server.getCallId());
-        Assert.assertEquals(info.retry, Server.getCallRetryCount());
+        Assertions.assertEquals(info.id, Server.getCallId());
+        Assertions.assertEquals(info.retry, Server.getCallRetryCount());
       }
     };
 
@@ -1343,7 +1371,8 @@ public class TestIPC {
    * caller is notified.
    * @throws IOException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReceiveStateBeforeCallerNotification() throws IOException {
     AtomicBoolean stateReceived = new AtomicBoolean(false);
     AlignmentContext alignmentContext = Mockito.mock(AlignmentContext.class);
@@ -1362,7 +1391,7 @@ public class TestIPC {
       server.start();
       call(client, new LongWritable(RANDOM.nextLong()), addr,
           0, conf, alignmentContext);
-      Assert.assertTrue(stateReceived.get());
+      Assertions.assertTrue(stateReceived.get());
     } finally {
       client.stop();
       server.stop();
@@ -1378,7 +1407,8 @@ public class TestIPC {
   /**
    * Test the retry count while used in a retry proxy.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testRetryProxy() throws IOException {
     final Client client = new Client(LongWritable.class, conf);
     
@@ -1387,7 +1417,7 @@ public class TestIPC {
       private int retryCount = 0;
       @Override
       public void run() {
-        Assert.assertEquals(retryCount++, Server.getCallRetryCount());
+        Assertions.assertEquals(retryCount++, Server.getCallRetryCount());
       }
     };
 
@@ -1404,7 +1434,7 @@ public class TestIPC {
     try {
       server.start();
       retryProxy.dummyRun();
-      Assert.assertEquals(TestInvocationHandler.retry, totalRetry + 1);
+      Assertions.assertEquals(TestInvocationHandler.retry, totalRetry + 1);
     } finally {
       Client.setCallIdAndRetryCount(0, 0, null);
       client.stop();
@@ -1416,39 +1446,41 @@ public class TestIPC {
    * Test that there is no retry when invalid token exception is thrown.
    * Verfies fix for HADOOP-12054
    */
-  @Test(expected = InvalidToken.class)
+  @Test
   public void testNoRetryOnInvalidToken() throws IOException {
-    final Client client = new Client(LongWritable.class, conf);
-    final TestServer server = new TestServer(1, false);
-    TestInvalidTokenHandler handler =
-        new TestInvalidTokenHandler(client, server);
-    DummyProtocol proxy = (DummyProtocol) Proxy.newProxyInstance(
-        DummyProtocol.class.getClassLoader(),
-        new Class[] { DummyProtocol.class }, handler);
-    FailoverProxyProvider<DummyProtocol> provider =
-        new DefaultFailoverProxyProvider<DummyProtocol>(
-            DummyProtocol.class, proxy);
-    DummyProtocol retryProxy =
-        (DummyProtocol) RetryProxy.create(DummyProtocol.class, provider,
-        RetryPolicies.failoverOnNetworkException(
-            RetryPolicies.TRY_ONCE_THEN_FAIL, 100, 100, 10000, 0));
+    assertThrows(InvalidToken.class, ()->{
+      final Client client = new Client(LongWritable.class, conf);
+      final TestServer server = new TestServer(1, false);
+      TestInvalidTokenHandler handler =
+          new TestInvalidTokenHandler(client, server);
+      DummyProtocol proxy = (DummyProtocol) Proxy.newProxyInstance(
+          DummyProtocol.class.getClassLoader(),
+          new Class[] { DummyProtocol.class }, handler);
+      FailoverProxyProvider<DummyProtocol> provider =
+           new DefaultFailoverProxyProvider<>(DummyProtocol.class, proxy);
+      DummyProtocol retryProxy =
+          (DummyProtocol) RetryProxy.create(DummyProtocol.class, provider,
+          RetryPolicies.failoverOnNetworkException(
+          RetryPolicies.TRY_ONCE_THEN_FAIL, 100, 100, 10000, 0));
 
-    try {
-      server.start();
-      retryProxy.dummyRun();
-    } finally {
-      // Check if dummyRun called only once
-      assertThat(handler.invocations).isOne();
-      Client.setCallIdAndRetryCount(0, 0, null);
-      client.stop();
-      server.stop();
-    }
+      try {
+        server.start();
+        retryProxy.dummyRun();
+      } finally {
+        // Check if dummyRun called only once
+        assertThat(handler.invocations).isOne();
+        Client.setCallIdAndRetryCount(0, 0, null);
+        client.stop();
+        server.stop();
+      }
+    });
   }
 
   /**
    * Test if the rpc server gets the default retry count (0) from client.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testInitialCallRetryCount() throws IOException {
     // Override client to store the call id
     final Client client = new Client(LongWritable.class, conf);
@@ -1460,7 +1492,7 @@ public class TestIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assert.assertEquals(0, Server.getCallRetryCount());
+        Assertions.assertEquals(0, Server.getCallRetryCount());
       }
     };
 
@@ -1479,7 +1511,8 @@ public class TestIPC {
   /**
    * Test if the rpc server gets the retry count from client.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCallRetryCount() throws IOException {
     final int retryCount = 255;
     // Override client to store the call id
@@ -1493,7 +1526,7 @@ public class TestIPC {
       public void run() {
         // we have not set the retry count for the client, thus on the server
         // side we should see retry count as 0
-        Assert.assertEquals(retryCount, Server.getCallRetryCount());
+        Assertions.assertEquals(retryCount, Server.getCallRetryCount());
       }
     };
 
@@ -1514,7 +1547,8 @@ public class TestIPC {
    * even if multiple threads are using the same client.
  * @throws InterruptedException 
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testUniqueSequentialCallIds() 
       throws IOException, InterruptedException {
     int serverThreads = 10, callerCount = 100, perCallerCallCount = 100;
@@ -1623,7 +1657,8 @@ public class TestIPC {
     assertThat(Client.getTimeout(config)).isEqualTo(-1);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSetupConnectionShouldNotBlockShutdown() throws Exception {
     // Start server
     SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
@@ -1683,12 +1718,14 @@ public class TestIPC {
     client.stop();
   }
   
-  @Test(timeout=4000)
+  @Test
+  @Timeout(value = 4)
   public void testInsecureVersionMismatch() throws IOException {
     checkVersionMismatch();
   }
 
-  @Test(timeout=4000)
+  @Test
+  @Timeout(value = 4)
   public void testSecureVersionMismatch() throws IOException {
     SecurityUtil.setAuthenticationMethod(AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
@@ -1722,13 +1759,13 @@ public class TestIPC {
         Client client = new Client(LongWritable.class, conf);
         call(client, 0, addr, conf);
       } catch (RemoteException re) {
-        Assert.assertEquals(RPC.VersionMismatch.class.getName(),
+        Assertions.assertEquals(RPC.VersionMismatch.class.getName(),
             re.getClassName());
-        Assert.assertEquals(NetworkTraces.HADOOP0_20_ERROR_MSG,
+        Assertions.assertEquals(NetworkTraces.HADOOP0_20_ERROR_MSG,
             re.getMessage());
         return;
       }
-      Assert.fail("didn't get version mismatch");
+      Assertions.fail("didn't get version mismatch");
     }
   }
 
@@ -1747,13 +1784,13 @@ public class TestIPC {
     try {
       call(client, 0, addr, conf);
     } catch (IOException ioe) {
-      Assert.assertNotNull(ioe);
-      Assert.assertEquals(RpcException.class, ioe.getClass());
-      Assert.assertTrue(ioe.getMessage().contains(
+      Assertions.assertNotNull(ioe);
+      Assertions.assertEquals(RpcException.class, ioe.getClass());
+      Assertions.assertTrue(ioe.getMessage().contains(
           "exceeds maximum data length"));
       return;
     }
-    Assert.fail("didn't get limit exceeded");
+    Assertions.fail("didn't get limit exceeded");
   }
 
   @Test
@@ -1766,7 +1803,8 @@ public class TestIPC {
     checkUserBinding(true);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateAddressEnsureResolved() throws Exception {
     // start server
     Server server = new TestServer(1, false);
@@ -1864,7 +1902,7 @@ public class TestIPC {
       fail("call didn't throw connect exception");
     } catch (SocketException se) {
       // ipc layer re-wraps exceptions, so check the cause.
-      Assert.assertSame(expectedConnectEx, se.getCause());
+      Assertions.assertSame(expectedConnectEx, se.getCause());
     }
     return s;
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPCServerResponder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPCServerResponder.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -41,8 +41,9 @@ import org.apache.hadoop.ipc.Client.ConnectionId;
 import org.apache.hadoop.ipc.RPC.RpcKind;
 import org.apache.hadoop.ipc.Server.Call;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,7 +190,8 @@ public class TestIPCServerResponder {
   // call 4: sendResponse, should remain blocked
   // call 5: immediate, prove handler is still free
   // call 4: sendResponse, expect it to return
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testDeferResponse() throws IOException, InterruptedException {
     final AtomicReference<Call> deferredCall = new AtomicReference<Call>();
     final AtomicInteger count = new AtomicInteger();
@@ -234,11 +236,11 @@ public class TestIPCServerResponder {
     // make sure it blocked
     try {
       future1.get(1, TimeUnit.SECONDS);
-      Assert.fail("ipc shouldn't have responded");
+      Assertions.fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assert.fail("unexpected exception:"+ex);
+      Assertions.fail("unexpected exception:"+ex);
     }
     assertFalse(future1.isDone());
     waitingCalls[0] = deferredCall.get();
@@ -259,11 +261,11 @@ public class TestIPCServerResponder {
     // make sure it blocked
     try {
       future2.get(1, TimeUnit.SECONDS);
-      Assert.fail("ipc shouldn't have responded");
+      Assertions.fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assert.fail("unexpected exception:"+ex);
+      Assertions.fail("unexpected exception:"+ex);
     }
     assertFalse(future2.isDone());
     waitingCalls[1] = deferredCall.get();
@@ -280,17 +282,17 @@ public class TestIPCServerResponder {
       int val = future1.get(1, TimeUnit.SECONDS);
       assertEquals(2, val);
     } catch (Exception ex) {
-      Assert.fail("unexpected exception:"+ex);
+      Assertions.fail("unexpected exception:"+ex);
     }
 
     // make sure it's still blocked
     try {
       future2.get(1, TimeUnit.SECONDS);
-      Assert.fail("ipc shouldn't have responded");
+      Assertions.fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assert.fail("unexpected exception:"+ex);
+      Assertions.fail("unexpected exception:"+ex);
     }
     assertFalse(future2.isDone());
 
@@ -303,7 +305,7 @@ public class TestIPCServerResponder {
       int val = future2.get(1, TimeUnit.SECONDS);
       assertEquals(4, val);
     } catch (Exception ex) {
-      Assert.fail("unexpected exception:"+ex);
+      Assertions.fail("unexpected exception:"+ex);
     }
 
     server.stop();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPCServerResponder.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPCServerResponder.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -41,7 +44,6 @@ import org.apache.hadoop.ipc.Client.ConnectionId;
 import org.apache.hadoop.ipc.RPC.RpcKind;
 import org.apache.hadoop.ipc.Server.Call;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -236,11 +238,11 @@ public class TestIPCServerResponder {
     // make sure it blocked
     try {
       future1.get(1, TimeUnit.SECONDS);
-      Assertions.fail("ipc shouldn't have responded");
+      fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assertions.fail("unexpected exception:"+ex);
+      fail("unexpected exception:"+ex);
     }
     assertFalse(future1.isDone());
     waitingCalls[0] = deferredCall.get();
@@ -261,11 +263,11 @@ public class TestIPCServerResponder {
     // make sure it blocked
     try {
       future2.get(1, TimeUnit.SECONDS);
-      Assertions.fail("ipc shouldn't have responded");
+      fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assertions.fail("unexpected exception:"+ex);
+      fail("unexpected exception:"+ex);
     }
     assertFalse(future2.isDone());
     waitingCalls[1] = deferredCall.get();
@@ -282,17 +284,17 @@ public class TestIPCServerResponder {
       int val = future1.get(1, TimeUnit.SECONDS);
       assertEquals(2, val);
     } catch (Exception ex) {
-      Assertions.fail("unexpected exception:"+ex);
+      fail("unexpected exception:"+ex);
     }
 
     // make sure it's still blocked
     try {
       future2.get(1, TimeUnit.SECONDS);
-      Assertions.fail("ipc shouldn't have responded");
+      fail("ipc shouldn't have responded");
     } catch (TimeoutException te) {
       // ignore, expected
     } catch (Exception ex) {
-      Assertions.fail("unexpected exception:"+ex);
+      fail("unexpected exception:"+ex);
     }
     assertFalse(future2.isDone());
 
@@ -305,7 +307,7 @@ public class TestIPCServerResponder {
       int val = future2.get(1, TimeUnit.SECONDS);
       assertEquals(4, val);
     } catch (Exception ex) {
-      Assertions.fail("unexpected exception:"+ex);
+      fail("unexpected exception:"+ex);
     }
 
     server.stop();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.io.IOException;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestMiniRPCBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestMiniRPCBenchmark.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestMultipleProtocolServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestMultipleProtocolServer.java
@@ -18,22 +18,22 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestMultipleProtocolServer extends TestRpcBase {
 
   private static RPC.Server server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setupConf();
 
     server = setupTestServer(conf, 2);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProcessingDetails.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProcessingDetails.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.ipc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.ipc.ProcessingDetails.Timing;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for ProcessingDetails time unit conversion and output.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRPCCompatibility.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRPCCompatibility.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ipc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -34,7 +36,6 @@ import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.OldProtobufRpcProto;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.NewProtobufRpcProto;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.NewerProtobufRpcProto;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
@@ -71,8 +72,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(Server.getClientId());
-      Assertions.assertEquals(16, clientId.length);
+      assertNotNull(Server.getClientId());
+      assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -81,8 +82,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(Server.getClientId());
-      Assertions.assertEquals(16, clientId.length);
+      assertNotNull(Server.getClientId());
+      assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
   }
@@ -94,8 +95,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(Server.getClientId());
-      Assertions.assertEquals(16, clientId.length);
+      assertNotNull(Server.getClientId());
+      assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -115,8 +116,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(Server.getClientId());
-      Assertions.assertEquals(16, clientId.length);
+      assertNotNull(Server.getClientId());
+      assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -125,8 +126,8 @@ public class TestProtoBufRPCCompatibility {
         throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(Server.getClientId());
-      Assertions.assertEquals(16, clientId.length);
+      assertNotNull(Server.getClientId());
+      assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRPCCompatibility.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRPCCompatibility.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,8 +34,8 @@ import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.OldProtobufRpcProto;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.NewProtobufRpcProto;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.NewerProtobufRpcProto;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 import org.apache.hadoop.thirdparty.protobuf.RpcController;
@@ -71,8 +71,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(Server.getClientId());
-      Assert.assertEquals(16, clientId.length);
+      Assertions.assertNotNull(Server.getClientId());
+      Assertions.assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -81,8 +81,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(Server.getClientId());
-      Assert.assertEquals(16, clientId.length);
+      Assertions.assertNotNull(Server.getClientId());
+      Assertions.assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
   }
@@ -94,8 +94,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(Server.getClientId());
-      Assert.assertEquals(16, clientId.length);
+      Assertions.assertNotNull(Server.getClientId());
+      Assertions.assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -115,8 +115,8 @@ public class TestProtoBufRPCCompatibility {
         EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(Server.getClientId());
-      Assert.assertEquals(16, clientId.length);
+      Assertions.assertNotNull(Server.getClientId());
+      Assertions.assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
 
@@ -125,8 +125,8 @@ public class TestProtoBufRPCCompatibility {
         throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(Server.getClientId());
-      Assert.assertEquals(16, clientId.length);
+      Assertions.assertNotNull(Server.getClientId());
+      Assertions.assertEquals(16, clientId.length);
       return EmptyResponseProto.newBuilder().build();
     }
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -38,9 +38,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -54,7 +55,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounterGt;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.Assume.assumeFalse;
 
 /**
@@ -160,7 +161,7 @@ public class TestProtoBufRpc extends TestRpcBase {
     return params;
   }
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("deprecation")
   public void setUp() throws IOException { // Setup server for both protocols
     conf = new Configuration();
@@ -218,7 +219,7 @@ public class TestProtoBufRpc extends TestRpcBase {
   }
   
   
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
   }
@@ -231,7 +232,8 @@ public class TestProtoBufRpc extends TestRpcBase {
     return RPC.getProxy(TestRpcService2Legacy.class, 0, addr, conf);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testProtoBufRpc() throws Exception {
     TestRpcService client = getClient(addr, conf);
     testProtoBufRpc(client);
@@ -262,7 +264,8 @@ public class TestProtoBufRpc extends TestRpcBase {
     }
   }
   
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testProtoBufRpc2() throws Exception {
     TestRpcService2 client = getClient2();
     
@@ -311,7 +314,8 @@ public class TestProtoBufRpc extends TestRpcBase {
     assertCounterGt("Echo2NumOps", 0L, rpcDetailedMetrics);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testProtoBufRandomException() throws Exception {
     //No test with legacy
     assumeFalse(testWithLegacy);
@@ -330,7 +334,8 @@ public class TestProtoBufRpc extends TestRpcBase {
     }
   }
   
-  @Test(timeout=6000)
+  @Test
+  @Timeout(value = 6)
   public void testExtraLongRpc() throws Exception {
     //No test with legacy
     assumeFalse(testWithLegacy);
@@ -350,7 +355,8 @@ public class TestProtoBufRpc extends TestRpcBase {
     }
   }
 
-  @Test(timeout = 12000)
+  @Test
+  @Timeout(value = 12)
   public void testLogSlowRPC() throws IOException, ServiceException,
       TimeoutException, InterruptedException {
     //No test with legacy
@@ -385,7 +391,8 @@ public class TestProtoBufRpc extends TestRpcBase {
         -> rpcMetrics.getRpcSlowCalls() == before + 1L, 10, 1000);
   }
 
-  @Test(timeout = 12000)
+  @Test
+  @Timeout(value = 12)
   public void testEnsureNoLogIfDisabled() throws IOException, ServiceException {
     //No test with legacy
     assumeFalse(testWithLegacy);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -75,9 +75,11 @@ public class TestProtoBufRpc extends TestRpcBase {
    */
   private boolean testWithLegacyFirst;
 
-  public void initTestProtoBufRpc(Boolean pTestWithLegacy, Boolean pTestWithLegacyFirst) {
+  public void initTestProtoBufRpc(Boolean pTestWithLegacy, Boolean pTestWithLegacyFirst)
+      throws IOException {
     this.testWithLegacy = pTestWithLegacy;
     this.testWithLegacyFirst = pTestWithLegacyFirst;
+    setUp();
   }
 
   @ProtocolInfo(protocolName = "testProto2", protocolVersion = 1)
@@ -157,7 +159,6 @@ public class TestProtoBufRpc extends TestRpcBase {
     return params;
   }
 
-  @BeforeEach
   @SuppressWarnings("deprecation")
   public void setUp() throws IOException { // Setup server for both protocols
     conf = new Configuration();
@@ -232,7 +233,7 @@ public class TestProtoBufRpc extends TestRpcBase {
   @Timeout(value = 5)
   @MethodSource("params")
   public void testProtoBufRpc(boolean pTestWithLegacy,
-    boolean pTestWithLegacyFirst) throws Exception {
+      boolean pTestWithLegacyFirst) throws Exception {
     initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     TestRpcService client = getClient(addr, conf);
     testProtoBufRpc(client);
@@ -264,10 +265,10 @@ public class TestProtoBufRpc extends TestRpcBase {
   }
 
   @ParameterizedTest
-  @Timeout(value = 5)
+  // @Timeout(value = 5)
   @MethodSource("params")
   public void testProtoBufRpc2(boolean pTestWithLegacy,
-    boolean pTestWithLegacyFirst) throws Exception {
+      boolean pTestWithLegacyFirst) throws Exception {
     initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     TestRpcService2 client = getClient2();
     
@@ -343,7 +344,7 @@ public class TestProtoBufRpc extends TestRpcBase {
   @Timeout(value = 6)
   @MethodSource("params")
   public void testExtraLongRpc(boolean pTestWithLegacy,
-    boolean pTestWithLegacyFirst) throws Exception {
+      boolean pTestWithLegacyFirst) throws Exception {
     initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
@@ -367,8 +368,8 @@ public class TestProtoBufRpc extends TestRpcBase {
   @Timeout(value = 12)
   @MethodSource("params")
   public void testLogSlowRPC(boolean pTestWithLegacy,
-    boolean pTestWithLegacyFirst) throws IOException, ServiceException,
-    TimeoutException, InterruptedException {
+      boolean pTestWithLegacyFirst) throws IOException, ServiceException,
+      TimeoutException, InterruptedException {
     initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
@@ -406,7 +407,7 @@ public class TestProtoBufRpc extends TestRpcBase {
   @Timeout(value = 12)
   @MethodSource("params")
   public void testEnsureNoLogIfDisabled(boolean pTestWithLegacy,
-    boolean pTestWithLegacyFirst) throws IOException, ServiceException {
+      boolean pTestWithLegacyFirst) throws IOException, ServiceException {
     initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -40,11 +40,9 @@ import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -63,7 +61,6 @@ import static org.junit.Assume.assumeFalse;
  * This test depends on test.proto definition of types in src/test/proto
  * and protobuf service definition from src/test/test_rpc_service.proto
  */
-@RunWith(Parameterized.class)
 public class TestProtoBufRpc extends TestRpcBase {
   private static RPC.Server server;
   private final static int SLEEP_DURATION = 1000;
@@ -78,9 +75,9 @@ public class TestProtoBufRpc extends TestRpcBase {
    */
   private boolean testWithLegacyFirst;
 
-  public TestProtoBufRpc(Boolean testWithLegacy, Boolean testWithLegacyFirst) {
-    this.testWithLegacy = testWithLegacy;
-    this.testWithLegacyFirst = testWithLegacyFirst;
+  public void initTestProtoBufRpc(Boolean pTestWithLegacy, Boolean pTestWithLegacyFirst) {
+    this.testWithLegacy = pTestWithLegacy;
+    this.testWithLegacyFirst = pTestWithLegacyFirst;
   }
 
   @ProtocolInfo(protocolName = "testProto2", protocolVersion = 1)
@@ -152,7 +149,6 @@ public class TestProtoBufRpc extends TestRpcBase {
     }
   }
 
-  @Parameters
   public static Collection<Object[]> params() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[] {Boolean.TRUE, Boolean.TRUE });
@@ -232,9 +228,12 @@ public class TestProtoBufRpc extends TestRpcBase {
     return RPC.getProxy(TestRpcService2Legacy.class, 0, addr, conf);
   }
 
-  @Test
+  @ParameterizedTest
   @Timeout(value = 5)
-  public void testProtoBufRpc() throws Exception {
+  @MethodSource("params")
+  public void testProtoBufRpc(boolean pTestWithLegacy,
+    boolean pTestWithLegacyFirst) throws Exception {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     TestRpcService client = getClient(addr, conf);
     testProtoBufRpc(client);
   }
@@ -263,10 +262,13 @@ public class TestProtoBufRpc extends TestRpcBase {
           .isEqualTo(RpcErrorCodeProto.ERROR_RPC_SERVER);
     }
   }
-  
-  @Test
+
+  @ParameterizedTest
   @Timeout(value = 5)
-  public void testProtoBufRpc2() throws Exception {
+  @MethodSource("params")
+  public void testProtoBufRpc2(boolean pTestWithLegacy,
+    boolean pTestWithLegacyFirst) throws Exception {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     TestRpcService2 client = getClient2();
     
     // Test ping method
@@ -314,9 +316,12 @@ public class TestProtoBufRpc extends TestRpcBase {
     assertCounterGt("Echo2NumOps", 0L, rpcDetailedMetrics);
   }
 
-  @Test
+  @ParameterizedTest
   @Timeout(value = 5)
-  public void testProtoBufRandomException() throws Exception {
+  @MethodSource("params")
+  public void testProtoBufRandomException(boolean pTestWithLegacy,
+      boolean pTestWithLegacyFirst) throws Exception {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
     TestRpcService client = getClient(addr, conf);
@@ -333,10 +338,13 @@ public class TestProtoBufRpc extends TestRpcBase {
           .isEqualTo(RpcErrorCodeProto.ERROR_APPLICATION);
     }
   }
-  
-  @Test
+
+  @ParameterizedTest
   @Timeout(value = 6)
-  public void testExtraLongRpc() throws Exception {
+  @MethodSource("params")
+  public void testExtraLongRpc(boolean pTestWithLegacy,
+    boolean pTestWithLegacyFirst) throws Exception {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
     TestRpcService2 client = getClient2();
@@ -355,10 +363,13 @@ public class TestProtoBufRpc extends TestRpcBase {
     }
   }
 
-  @Test
+  @ParameterizedTest
   @Timeout(value = 12)
-  public void testLogSlowRPC() throws IOException, ServiceException,
-      TimeoutException, InterruptedException {
+  @MethodSource("params")
+  public void testLogSlowRPC(boolean pTestWithLegacy,
+    boolean pTestWithLegacyFirst) throws IOException, ServiceException,
+    TimeoutException, InterruptedException {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
     server.setLogSlowRPCThresholdTime(SLEEP_DURATION);
@@ -391,9 +402,12 @@ public class TestProtoBufRpc extends TestRpcBase {
         -> rpcMetrics.getRpcSlowCalls() == before + 1L, 10, 1000);
   }
 
-  @Test
+  @ParameterizedTest
   @Timeout(value = 12)
-  public void testEnsureNoLogIfDisabled() throws IOException, ServiceException {
+  @MethodSource("params")
+  public void testEnsureNoLogIfDisabled(boolean pTestWithLegacy,
+    boolean pTestWithLegacyFirst) throws IOException, ServiceException {
+    initTestProtoBufRpc(pTestWithLegacy, pTestWithLegacyFirst);
     //No test with legacy
     assumeFalse(testWithLegacy);
     // disable slow RPC  logging

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.protobuf.TestProtos;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.TestProtobufRpcHandoffProto;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -44,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounterGt;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestProtoBufRpcServerHandoff {
 
@@ -104,8 +104,8 @@ public class TestProtoBufRpcServerHandoff {
 
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
-    Assertions.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
-    Assertions.assertTrue(System.currentTimeMillis() - submitTime < 7000l);
+    assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
+    assertTrue(System.currentTimeMillis() - submitTime < 7000l);
 
   }
 
@@ -135,8 +135,8 @@ public class TestProtoBufRpcServerHandoff {
 
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
-    Assertions.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000L);
-    Assertions.assertTrue(System.currentTimeMillis() - submitTime < 7000L);
+    assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000L);
+    assertTrue(System.currentTimeMillis() - submitTime < 7000L);
 
     // Check rpcMetrics
     MetricsRecordBuilder rb = getMetrics(server.rpcMetrics.name());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
@@ -34,9 +34,10 @@ import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.protobuf.TestProtos;
 import org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos.TestProtobufRpcHandoffProto;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class TestProtoBufRpcServerHandoff {
   private static RPC.Server server = null;
   private static InetSocketAddress address = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new Configuration();
 
@@ -77,7 +78,8 @@ public class TestProtoBufRpcServerHandoff {
     LOG.info("Server started at: " + address + " at time: " + serverStartTime);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void test() throws Exception {
     final TestProtoBufRpcServerHandoffProtocol client = RPC.getProxy(
         TestProtoBufRpcServerHandoffProtocol.class, 1, address, conf);
@@ -102,12 +104,13 @@ public class TestProtoBufRpcServerHandoff {
 
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
-    Assert.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
-    Assert.assertTrue(System.currentTimeMillis() - submitTime < 7000l);
+    Assertions.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
+    Assertions.assertTrue(System.currentTimeMillis() - submitTime < 7000l);
 
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testHandoffMetrics() throws Exception {
     final TestProtoBufRpcServerHandoffProtocol client = RPC.getProxy(
         TestProtoBufRpcServerHandoffProtocol.class, 1, address, conf);
@@ -132,8 +135,8 @@ public class TestProtoBufRpcServerHandoff {
 
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
-    Assert.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000L);
-    Assert.assertTrue(System.currentTimeMillis() - submitTime < 7000L);
+    Assertions.assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000L);
+    Assertions.assertTrue(System.currentTimeMillis() - submitTime < 7000L);
 
     // Check rpcMetrics
     MetricsRecordBuilder rb = getMetrics(server.rpcMetrics.name());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpcServerHandoff.java
@@ -104,8 +104,8 @@ public class TestProtoBufRpcServerHandoff {
 
     // Ensure the 5 second sleep responses are within a reasonable time of each
     // other.
-    assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000l);
-    assertTrue(System.currentTimeMillis() - submitTime < 7000l);
+    assertTrue(Math.abs(callable1.endTime - callable2.endTime) < 2000L);
+    assertTrue(System.currentTimeMillis() - submitTime < 7000L);
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -53,9 +53,10 @@ import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.test.MockitoUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,11 +107,7 @@ import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getDoubleGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
@@ -123,7 +120,7 @@ public class TestRPC extends TestRpcBase {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestRPC.class);
 
-  @Before
+  @BeforeEach
   public void setup() {
     setupConf();
   }
@@ -232,7 +229,7 @@ public class TestRPC extends TestRpcBase {
         addResponse = proxy.add(null, addRequest);
         val = addResponse.getResult();
       } catch (ServiceException e) {
-        assertTrue("Exception from RPC exchange() "  + e, false);
+        assertTrue(false, "Exception from RPC exchange() "  + e);
       }
       assertEquals(indata.length, outdata.length);
       assertEquals(3, val);
@@ -265,7 +262,7 @@ public class TestRPC extends TestRpcBase {
         ping(true);
         done = true;
       } catch (ServiceException e) {
-        assertTrue("SlowRPC ping exception " + e, false);
+        assertTrue(false, "SlowRPC ping exception " + e);
       }
     }
 
@@ -471,12 +468,12 @@ public class TestRPC extends TestRpcBase {
       SlowRPC slowrpc = new SlowRPC(proxy);
       Thread thread = new Thread(slowrpc, "SlowRPC");
       thread.start(); // send a slow RPC, which won't return until two fast pings
-      assertTrue("Slow RPC should not have finished1.", !slowrpc.isDone());
+      assertTrue(!slowrpc.isDone(), "Slow RPC should not have finished1.");
 
       slowrpc.ping(false); // first fast ping
 
       // verify that the first RPC is still stuck
-      assertTrue("Slow RPC should not have finished2.", !slowrpc.isDone());
+      assertTrue(!slowrpc.isDone(), "Slow RPC should not have finished2.");
 
       slowrpc.ping(false); // second fast ping
 
@@ -658,8 +655,8 @@ public class TestRPC extends TestRpcBase {
       if (expectFailure) {
         RemoteException re = (RemoteException) e.getCause();
         assertTrue(re.unwrapRemoteException() instanceof AuthorizationException);
-        assertEquals("RPC error code should be UNAUTHORIZED",
-            RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode());
+        assertEquals(
+           RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
       } else {
         throw e;
       }
@@ -734,9 +731,11 @@ public class TestRPC extends TestRpcBase {
    * Test stopping a non-registered proxy
    * @throws IOException
    */
-  @Test(expected=HadoopIllegalArgumentException.class)
+  @Test
   public void testStopNonRegisteredProxy() throws IOException {
-    RPC.stopProxy(null);
+    assertThrows(HadoopIllegalArgumentException.class, () -> {
+      RPC.stopProxy(null);
+    });
   }
 
   /**
@@ -799,8 +798,8 @@ public class TestRPC extends TestRpcBase {
       assertTrue(e.getCause() instanceof RemoteException);
       RemoteException re = (RemoteException) e.getCause();
       LOG.info("LOGGING MESSAGE: " + re.getLocalizedMessage());
-      assertEquals("RPC error code should be UNAUTHORIZED",
-          RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode());
+      assertEquals(
+         RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
       assertTrue(re.unwrapRemoteException() instanceof AccessControlException);
       succeeded = true;
     } finally {
@@ -821,8 +820,8 @@ public class TestRPC extends TestRpcBase {
     } catch (ServiceException e) {
       RemoteException re = (RemoteException) e.getCause();
       LOG.info("LOGGING MESSAGE: " + re.getLocalizedMessage());
-      assertEquals("RPC error code should be UNAUTHORIZED",
-          RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode());
+      assertEquals(
+         RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
       assertTrue(re.unwrapRemoteException() instanceof AccessControlException);
       succeeded = true;
     } finally {
@@ -839,8 +838,8 @@ public class TestRPC extends TestRpcBase {
     Server server;
 
     int threadsBefore = countThreads("Server$Listener$Reader");
-    assertEquals("Expect no Reader threads running before test",
-        0, threadsBefore);
+    assertEquals(
+       0, threadsBefore, "Expect no Reader threads running before test");
 
     server = setupTestServer(conf, 5);
 
@@ -862,8 +861,8 @@ public class TestRPC extends TestRpcBase {
     }
 
     int threadsAfter = countThreads("Server$Listener$Reader");
-    assertEquals("Expect no Reader threads left running after test",
-        0, threadsAfter);
+    assertEquals(
+       0, threadsAfter, "Expect no Reader threads left running after test");
   }
 
   @Test
@@ -902,7 +901,8 @@ public class TestRPC extends TestRpcBase {
     }
   }
 
-  @Test(timeout=90000)
+  @Test
+  @Timeout(value = 90)
   public void testRPCInterruptedSimple() throws Exception {
     Server server;
     TestRpcService proxy = null;
@@ -937,7 +937,8 @@ public class TestRPC extends TestRpcBase {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testRPCInterrupted() throws Exception {
     Server server;
 
@@ -996,7 +997,7 @@ public class TestRPC extends TestRpcBase {
       latch.await();
 
       // should not cause any other thread to get an error
-      assertTrue("rpc got exception " + error.get(), error.get() == null);
+      assertTrue(error.get() == null, "rpc got exception " + error.get());
     } finally {
       server.stop();
     }
@@ -1010,7 +1011,8 @@ public class TestRPC extends TestRpcBase {
    * We use a mock SocketFactory so that we can control when the input and
    * output streams are frozen.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSlowConnection() throws Exception {
     SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
     Socket mockSocket = Mockito.mock(Socket.class);
@@ -1079,8 +1081,8 @@ public class TestRPC extends TestRpcBase {
       mockOutputStream.waitForWriters();
       // interrupt all the threads
       for(int thread=0; thread < numThreads; ++thread) {
-        assertTrue("cancel thread " + thread,
-            futures[thread].cancel(true));
+        assertTrue(
+           futures[thread].cancel(true), "cancel thread " + thread);
       }
       // wait until all the writers are cancelled
       pool.shutdown();
@@ -1155,7 +1157,8 @@ public class TestRPC extends TestRpcBase {
    * This test causes an exception in the RPC connection setup to make
    * sure that threads aren't leaked.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testBadSetup() throws Exception {
     SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
     Mockito.when(mockFactory.createSocket())
@@ -1178,12 +1181,12 @@ public class TestRPC extends TestRpcBase {
             clientConf,
             mockFactory).getProxy();
         client.ping(null, newEmptyRequest());
-        assertTrue("Didn't throw exception!", false);
+        assertTrue(false, "Didn't throw exception!");
       } catch (ServiceException nfe) {
         // ensure no extra threads are running.
         assertEquals(threadCount, Thread.getAllStackTraces().size());
       } catch (Throwable t) {
-        assertTrue("wrong exception: " + t, false);
+        assertTrue(false, "wrong exception: " + t);
       }
     } finally {
       if (client != null) {
@@ -1211,7 +1214,8 @@ public class TestRPC extends TestRpcBase {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testExternalCall() throws Exception {
     final UserGroupInformation ugi = UserGroupInformation
         .createUserForTesting("user123", new String[0]);
@@ -1334,18 +1338,18 @@ public class TestRPC extends TestRpcBase {
       }
       MetricsRecordBuilder rpcMetrics =
           getMetrics(server.getRpcMetrics().name());
-      assertEquals("Expected correct rpc en queue count",
-          3000, getLongCounter("RpcEnQueueTimeNumOps", rpcMetrics));
-      assertEquals("Expected correct rpc queue count",
-          3000, getLongCounter("RpcQueueTimeNumOps", rpcMetrics));
-      assertEquals("Expected correct rpc processing count",
-          3000, getLongCounter("RpcProcessingTimeNumOps", rpcMetrics));
-      assertEquals("Expected correct rpc lock wait count",
-          3000, getLongCounter("RpcLockWaitTimeNumOps", rpcMetrics));
-      assertEquals("Expected correct rpc response count",
-          3000, getLongCounter("RpcResponseTimeNumOps", rpcMetrics));
-      assertEquals("Expected zero rpc lock wait time",
-          0, getDoubleGauge("RpcLockWaitTimeAvgTime", rpcMetrics), 0.001);
+      assertEquals(
+         3000, getLongCounter("RpcEnQueueTimeNumOps", rpcMetrics), "Expected correct rpc en queue count");
+      assertEquals(
+         3000, getLongCounter("RpcQueueTimeNumOps", rpcMetrics), "Expected correct rpc queue count");
+      assertEquals(
+         3000, getLongCounter("RpcProcessingTimeNumOps", rpcMetrics), "Expected correct rpc processing count");
+      assertEquals(
+         3000, getLongCounter("RpcLockWaitTimeNumOps", rpcMetrics), "Expected correct rpc lock wait count");
+      assertEquals(
+         3000, getLongCounter("RpcResponseTimeNumOps", rpcMetrics), "Expected correct rpc response count");
+      assertEquals(0, getDoubleGauge("RpcLockWaitTimeAvgTime", rpcMetrics), 0.001,
+          "Expected zero rpc lock wait time");
       MetricsAsserts.assertQuantileGauges("RpcEnQueueTime" + interval + "s",
           rpcMetrics);
       MetricsAsserts.assertQuantileGauges("RpcQueueTime" + interval + "s",
@@ -1484,7 +1488,8 @@ public class TestRPC extends TestRpcBase {
   /**
    *  Test RPC backoff by queue full.
    */
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testClientBackOff() throws Exception {
     Server server;
     final TestRpcService proxy;
@@ -1540,13 +1545,14 @@ public class TestRPC extends TestRpcBase {
     if (lastException != null) {
       LOG.error("Last received non-RetriableException:", lastException);
     }
-    assertTrue("RetriableException not received", succeeded);
+    assertTrue(succeeded, "RetriableException not received");
   }
 
   /**
    *  Test RPC backoff by response time of each priority level.
    */
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testClientBackOffByResponseTime() throws Exception {
     final TestRpcService proxy;
     boolean succeeded = false;
@@ -1604,11 +1610,12 @@ public class TestRPC extends TestRpcBase {
     if (lastException != null) {
       LOG.error("Last received non-RetriableException:", lastException);
     }
-    assertTrue("RetriableException not received", succeeded);
+    assertTrue(succeeded, "RetriableException not received");
   }
 
   /** Test that the metrics for DecayRpcScheduler are updated. */
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testDecayRpcSchedulerMetrics() throws Exception {
     final String ns = CommonConfigurationKeys.IPC_NAMESPACE + ".0";
     Server server = setupDecayRpcSchedulerandTestServer(ns + ".");
@@ -1664,7 +1671,8 @@ public class TestRPC extends TestRpcBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testProtocolUserPriority() throws Exception {
     final String ns = CommonConfigurationKeys.IPC_NAMESPACE + ".0";
     conf.set(CLIENT_PRINCIPAL_KEY, "clientForProtocol");
@@ -1674,15 +1682,15 @@ public class TestRPC extends TestRpcBase {
 
       UserGroupInformation ugi = UserGroupInformation.createRemoteUser("user");
       // normal users start with priority 0.
-      Assert.assertEquals(0, server.getPriorityLevel(ugi));
+      Assertions.assertEquals(0, server.getPriorityLevel(ugi));
       // calls for a protocol defined client will have priority of 0.
-      Assert.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
+      Assertions.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
 
       // protocol defined client will have top priority of -1.
       ugi = UserGroupInformation.createRemoteUser("clientForProtocol");
-      Assert.assertEquals(-1, server.getPriorityLevel(ugi));
+      Assertions.assertEquals(-1, server.getPriorityLevel(ugi));
       // calls for a protocol defined client will have priority of 0.
-      Assert.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
+      Assertions.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
     } finally {
       stop(server, null);
     }
@@ -1732,7 +1740,8 @@ public class TestRPC extends TestRpcBase {
   /**
    *  Test RPC timeout.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testClientRpcTimeout() throws Exception {
     Server server;
     TestRpcService proxy = null;
@@ -1809,21 +1818,21 @@ public class TestRPC extends TestRpcBase {
 
   @Test
   public void testServerNameFromClass() {
-    Assert.assertEquals("TestRPC",
+    Assertions.assertEquals("TestRPC",
         RPC.Server.serverNameFromClass(this.getClass()));
-    Assert.assertEquals("TestClass",
+    Assertions.assertEquals("TestClass",
         RPC.Server.serverNameFromClass(TestRPC.TestClass.class));
 
     Object testing = new TestClass().classFactory();
-    Assert.assertEquals("Embedded",
+    Assertions.assertEquals("Embedded",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
     testing = new TestClass().classFactoryAbstract();
-    Assert.assertEquals("TestClass",
+    Assertions.assertEquals("TestClass",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
     testing = new TestClass().classFactoryObject();
-    Assert.assertEquals("TestClass",
+    Assertions.assertEquals("TestClass",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
   }
@@ -1875,7 +1884,8 @@ public class TestRPC extends TestRpcBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testReaderExceptions() throws Exception {
     Server server = null;
     TestRpcService proxy = null;
@@ -1928,33 +1938,33 @@ public class TestRPC extends TestRpcBase {
           fail(reqName + " didn't fail");
         } catch (ServiceException e) {
           RemoteException re = (RemoteException)e.getCause();
-          assertEquals(reqName, expectedIOE, re.unwrapRemoteException());
+          assertEquals(expectedIOE, re.unwrapRemoteException(), reqName);
         }
         // check authorizations to ensure new connection when expected,
         // then conclusively determine if connections are disconnected
         // correctly.
-        assertEquals(reqName, expectedAuths, authMetric.value());
+        assertEquals(expectedAuths, authMetric.value(), reqName);
         if (!doDisconnect) {
           // if it wasn't fatal, verify there's only one open connection.
           Connection[] conns = server.getConnections();
-          assertEquals(reqName, 1, conns.length);
+          assertEquals(1, conns.length, reqName);
           String connectionInfo = conns[0].toString();
           LOG.info("Connection is from: {}", connectionInfo);
           assertEquals(
-              "Connection string representation should include only IP address for healthy "
-                  + "connection", 1, connectionInfo.split(" / ").length);
+          1, connectionInfo.split(" / ").length, "Connection string representation should include only IP address for healthy "
+                  + "connection");
           // verify whether the connection should have been reused.
           if (isDisconnected) {
-            assertNotSame(reqName, lastConn, conns[0]);
+            assertNotSame(lastConn, conns[0], reqName);
           } else {
-            assertSame(reqName, lastConn, conns[0]);
+            assertSame(lastConn, conns[0], reqName);
           }
           lastConn = conns[0];
         } else if (lastConn != null) {
           // avoid race condition in server where connection may not be
           // fully removed yet.  just make sure it's marked for being closed.
           // the open connection checks above ensure correct behavior.
-          assertTrue(reqName, lastConn.shouldClose());
+          assertTrue(lastConn.shouldClose(), reqName);
         }
         isDisconnected = doDisconnect;
       }
@@ -2010,8 +2020,8 @@ public class TestRPC extends TestRpcBase {
       }
       MetricsRecordBuilder rpcMetrics =
           getMetrics(server.getRpcMetrics().name());
-      assertEquals("Expected zero rpc lock wait time",
-          0, getDoubleGauge("RpcLockWaitTimeAvgTime", rpcMetrics), 0.001);
+      assertEquals(0, getDoubleGauge("RpcLockWaitTimeAvgTime", rpcMetrics),
+          0.001, "Expected zero rpc lock wait time");
       MetricsAsserts.assertQuantileGauges("RpcEnQueueTime" + interval + "s",
           rpcMetrics);
       MetricsAsserts.assertQuantileGauges("RpcQueueTime" + interval + "s",

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -53,11 +53,9 @@ import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.test.MockitoUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -107,12 +105,19 @@ import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getDoubleGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Unit tests for RPC. */
 @SuppressWarnings("deprecation")
@@ -655,8 +660,8 @@ public class TestRPC extends TestRpcBase {
       if (expectFailure) {
         RemoteException re = (RemoteException) e.getCause();
         assertTrue(re.unwrapRemoteException() instanceof AuthorizationException);
-        assertEquals(
-           RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
+        assertEquals(RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(),
+            "RPC error code should be UNAUTHORIZED");
       } else {
         throw e;
       }
@@ -798,8 +803,8 @@ public class TestRPC extends TestRpcBase {
       assertTrue(e.getCause() instanceof RemoteException);
       RemoteException re = (RemoteException) e.getCause();
       LOG.info("LOGGING MESSAGE: " + re.getLocalizedMessage());
-      assertEquals(
-         RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
+      assertEquals(RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(),
+          "RPC error code should be UNAUTHORIZED");
       assertTrue(re.unwrapRemoteException() instanceof AccessControlException);
       succeeded = true;
     } finally {
@@ -820,8 +825,8 @@ public class TestRPC extends TestRpcBase {
     } catch (ServiceException e) {
       RemoteException re = (RemoteException) e.getCause();
       LOG.info("LOGGING MESSAGE: " + re.getLocalizedMessage());
-      assertEquals(
-         RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(), "RPC error code should be UNAUTHORIZED");
+      assertEquals(RpcErrorCodeProto.FATAL_UNAUTHORIZED, re.getErrorCode(),
+          "RPC error code should be UNAUTHORIZED");
       assertTrue(re.unwrapRemoteException() instanceof AccessControlException);
       succeeded = true;
     } finally {
@@ -838,8 +843,8 @@ public class TestRPC extends TestRpcBase {
     Server server;
 
     int threadsBefore = countThreads("Server$Listener$Reader");
-    assertEquals(
-       0, threadsBefore, "Expect no Reader threads running before test");
+    assertEquals(0, threadsBefore,
+        "Expect no Reader threads running before test");
 
     server = setupTestServer(conf, 5);
 
@@ -861,8 +866,8 @@ public class TestRPC extends TestRpcBase {
     }
 
     int threadsAfter = countThreads("Server$Listener$Reader");
-    assertEquals(
-       0, threadsAfter, "Expect no Reader threads left running after test");
+    assertEquals(0, threadsAfter,
+        "Expect no Reader threads left running after test");
   }
 
   @Test
@@ -1014,15 +1019,15 @@ public class TestRPC extends TestRpcBase {
   @Test
   @Timeout(value = 30)
   public void testSlowConnection() throws Exception {
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
-    Socket mockSocket = Mockito.mock(Socket.class);
-    Mockito.when(mockFactory.createSocket()).thenReturn(mockSocket);
-    Mockito.when(mockSocket.getPort()).thenReturn(1234);
-    Mockito.when(mockSocket.getLocalPort()).thenReturn(2345);
+    SocketFactory mockFactory = mock(SocketFactory.class);
+    Socket mockSocket = mock(Socket.class);
+    when(mockFactory.createSocket()).thenReturn(mockSocket);
+    when(mockSocket.getPort()).thenReturn(1234);
+    when(mockSocket.getLocalPort()).thenReturn(2345);
     MockOutputStream mockOutputStream = new MockOutputStream();
-    Mockito.when(mockSocket.getOutputStream()).thenReturn(mockOutputStream);
+    when(mockSocket.getOutputStream()).thenReturn(mockOutputStream);
     // Use an input stream that always blocks
-    Mockito.when(mockSocket.getInputStream()).thenReturn(new InputStream() {
+    when(mockSocket.getInputStream()).thenReturn(new InputStream() {
       @Override
       public int read() throws IOException {
         // wait forever
@@ -1081,8 +1086,7 @@ public class TestRPC extends TestRpcBase {
       mockOutputStream.waitForWriters();
       // interrupt all the threads
       for(int thread=0; thread < numThreads; ++thread) {
-        assertTrue(
-           futures[thread].cancel(true), "cancel thread " + thread);
+        assertTrue(futures[thread].cancel(true), "cancel thread " + thread);
       }
       // wait until all the writers are cancelled
       pool.shutdown();
@@ -1160,8 +1164,8 @@ public class TestRPC extends TestRpcBase {
   @Test
   @Timeout(value = 30)
   public void testBadSetup() throws Exception {
-    SocketFactory mockFactory = Mockito.mock(SocketFactory.class);
-    Mockito.when(mockFactory.createSocket())
+    SocketFactory mockFactory = mock(SocketFactory.class);
+    when(mockFactory.createSocket())
         .thenThrow(new IOException("can't connect"));
     Configuration clientConf = new Configuration();
     // Set an illegal value to cause an exception in the constructor
@@ -1338,16 +1342,16 @@ public class TestRPC extends TestRpcBase {
       }
       MetricsRecordBuilder rpcMetrics =
           getMetrics(server.getRpcMetrics().name());
-      assertEquals(
-         3000, getLongCounter("RpcEnQueueTimeNumOps", rpcMetrics), "Expected correct rpc en queue count");
-      assertEquals(
-         3000, getLongCounter("RpcQueueTimeNumOps", rpcMetrics), "Expected correct rpc queue count");
-      assertEquals(
-         3000, getLongCounter("RpcProcessingTimeNumOps", rpcMetrics), "Expected correct rpc processing count");
-      assertEquals(
-         3000, getLongCounter("RpcLockWaitTimeNumOps", rpcMetrics), "Expected correct rpc lock wait count");
-      assertEquals(
-         3000, getLongCounter("RpcResponseTimeNumOps", rpcMetrics), "Expected correct rpc response count");
+      assertEquals(3000, getLongCounter("RpcEnQueueTimeNumOps", rpcMetrics),
+          "Expected correct rpc en queue count");
+      assertEquals(3000, getLongCounter("RpcQueueTimeNumOps", rpcMetrics),
+          "Expected correct rpc queue count");
+      assertEquals(3000, getLongCounter("RpcProcessingTimeNumOps", rpcMetrics),
+          "Expected correct rpc processing count");
+      assertEquals(3000, getLongCounter("RpcLockWaitTimeNumOps", rpcMetrics),
+          "Expected correct rpc lock wait count");
+      assertEquals(3000, getLongCounter("RpcResponseTimeNumOps", rpcMetrics),
+          "Expected correct rpc response count");
       assertEquals(0, getDoubleGauge("RpcLockWaitTimeAvgTime", rpcMetrics), 0.001,
           "Expected zero rpc lock wait time");
       MetricsAsserts.assertQuantileGauges("RpcEnQueueTime" + interval + "s",
@@ -1682,15 +1686,15 @@ public class TestRPC extends TestRpcBase {
 
       UserGroupInformation ugi = UserGroupInformation.createRemoteUser("user");
       // normal users start with priority 0.
-      Assertions.assertEquals(0, server.getPriorityLevel(ugi));
+      assertEquals(0, server.getPriorityLevel(ugi));
       // calls for a protocol defined client will have priority of 0.
-      Assertions.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
+      assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
 
       // protocol defined client will have top priority of -1.
       ugi = UserGroupInformation.createRemoteUser("clientForProtocol");
-      Assertions.assertEquals(-1, server.getPriorityLevel(ugi));
+      assertEquals(-1, server.getPriorityLevel(ugi));
       // calls for a protocol defined client will have priority of 0.
-      Assertions.assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
+      assertEquals(0, server.getPriorityLevel(newSchedulable(ugi)));
     } finally {
       stop(server, null);
     }
@@ -1818,21 +1822,21 @@ public class TestRPC extends TestRpcBase {
 
   @Test
   public void testServerNameFromClass() {
-    Assertions.assertEquals("TestRPC",
+    assertEquals("TestRPC",
         RPC.Server.serverNameFromClass(this.getClass()));
-    Assertions.assertEquals("TestClass",
+    assertEquals("TestClass",
         RPC.Server.serverNameFromClass(TestRPC.TestClass.class));
 
     Object testing = new TestClass().classFactory();
-    Assertions.assertEquals("Embedded",
+    assertEquals("Embedded",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
     testing = new TestClass().classFactoryAbstract();
-    Assertions.assertEquals("TestClass",
+    assertEquals("TestClass",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
     testing = new TestClass().classFactoryObject();
-    Assertions.assertEquals("TestClass",
+    assertEquals("TestClass",
         RPC.Server.serverNameFromClass(testing.getClass()));
 
   }
@@ -1950,9 +1954,9 @@ public class TestRPC extends TestRpcBase {
           assertEquals(1, conns.length, reqName);
           String connectionInfo = conns[0].toString();
           LOG.info("Connection is from: {}", connectionInfo);
-          assertEquals(
-          1, connectionInfo.split(" / ").length, "Connection string representation should include only IP address for healthy "
-                  + "connection");
+          assertEquals(1, connectionInfo.split(" / ").length,
+              "Connection string representation should include only IP address for healthy "
+              + "connection");
           // verify whether the connection should have been reused.
           if (isDisconnected) {
             assertNotSame(lastConn, conns[0], reqName);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
@@ -17,15 +17,17 @@
  */
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestRPCCallBenchmark {
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testBenchmarkWithProto() throws Exception {
     int rc = ToolRunner.run(new RPCCallBenchmark(),
         new String[] {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ipc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.jupiter.api.Test;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCompatibility.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCompatibility.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /** Unit test for supporting method-name based compatible RPCs. */
 public class TestRPCCompatibility {
@@ -109,7 +109,7 @@ public class TestRPCCompatibility {
 
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ProtocolSignature.resetCache();
 
@@ -129,7 +129,7 @@ public class TestRPCCompatibility {
         TestProtocol4.class, ProtobufRpcEngine2.class);
   }
   
-  @After
+  @AfterEach
   public void tearDown() {
     if (proxy != null) {
       RPC.stopProxy(proxy.getProxy());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCServerShutdown.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCServerShutdown.java
@@ -96,8 +96,8 @@ public class TestRPCServerShutdown extends TestRpcBase {
             fail("Future get should not return");
           } catch (ExecutionException e) {
             ServiceException se = (ServiceException) e.getCause();
-            assertTrue(
-               se.getCause() instanceof IOException, "Unexpected exception: " + se);
+            assertTrue(se.getCause() instanceof IOException,
+                "Unexpected exception: " + se);
             LOG.info("Expected exception", e.getCause());
           }
         }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCServerShutdown.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCServerShutdown.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,9 +35,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Split from TestRPC. */
 @SuppressWarnings("deprecation")
@@ -45,7 +46,7 @@ public class TestRPCServerShutdown extends TestRpcBase {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestRPCServerShutdown.class);
 
-  @Before
+  @BeforeEach
   public void setup() {
     setupConf();
   }
@@ -53,7 +54,8 @@ public class TestRPCServerShutdown extends TestRpcBase {
   /**
    *  Verify the RPC server can shutdown properly when callQueue is full.
    */
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testRPCServerShutdown() throws Exception {
     final int numClients = 3;
     final List<Future<Void>> res = new ArrayList<Future<Void>>();
@@ -87,15 +89,15 @@ public class TestRPCServerShutdown extends TestRpcBase {
     } finally {
       try {
         stop(server, proxy);
-        assertEquals("Not enough clients", numClients, res.size());
+        assertEquals(numClients, res.size(), "Not enough clients");
         for (Future<Void> f : res) {
           try {
             f.get();
             fail("Future get should not return");
           } catch (ExecutionException e) {
             ServiceException se = (ServiceException) e.getCause();
-            assertTrue("Unexpected exception: " + se,
-                se.getCause() instanceof IOException);
+            assertTrue(
+               se.getCause() instanceof IOException, "Unexpected exception: " + se);
             LOG.info("Expected exception", e.getCause());
           }
         }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCWaitForProxy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCWaitForProxy.java
@@ -18,9 +18,10 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public class TestRPCWaitForProxy extends TestRpcBase {
 
   private static final Configuration conf = new Configuration();
 
-  @Before
+  @BeforeEach
   public void setupProtocolEngine() {
     RPC.setProtocolEngine(conf, TestRpcService.class,
         ProtobufRpcEngine2.class);
@@ -53,14 +54,15 @@ public class TestRPCWaitForProxy extends TestRpcBase {
    *
    * @throws Throwable any exception other than that which was expected
    */
-  @Test(timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   public void testWaitForProxy() throws Throwable {
     RpcThread worker = new RpcThread(0);
     worker.start();
     worker.join();
     Throwable caught = worker.getCaught();
     Throwable cause = caught.getCause();
-    Assert.assertNotNull("No exception was raised", cause);
+    Assertions.assertNotNull(cause, "No exception was raised");
     if (!(cause instanceof ConnectException)) {
       throw caught;
     }
@@ -72,16 +74,17 @@ public class TestRPCWaitForProxy extends TestRpcBase {
    *
    * @throws Throwable any exception other than that which was expected
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testInterruptedWaitForProxy() throws Throwable {
     RpcThread worker = new RpcThread(100);
     worker.start();
     Thread.sleep(1000);
-    Assert.assertTrue("worker hasn't started", worker.waitStarted);
+    Assertions.assertTrue(worker.waitStarted, "worker hasn't started");
     worker.interrupt();
     worker.join();
     Throwable caught = worker.getCaught();
-    Assert.assertNotNull("No exception was raised", caught);
+    Assertions.assertNotNull(caught, "No exception was raised");
     // looking for the root cause here, which can be wrapped
     // as part of the NetUtils work. Having this test look
     // a the type of exception there would be brittle to improvements

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCWaitForProxy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCWaitForProxy.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -32,6 +31,8 @@ import java.nio.channels.ClosedByInterruptException;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_ON_SOCKET_TIMEOUTS_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * tests that the proxy can be interrupted
@@ -62,7 +63,7 @@ public class TestRPCWaitForProxy extends TestRpcBase {
     worker.join();
     Throwable caught = worker.getCaught();
     Throwable cause = caught.getCause();
-    Assertions.assertNotNull(cause, "No exception was raised");
+    assertNotNull(cause, "No exception was raised");
     if (!(cause instanceof ConnectException)) {
       throw caught;
     }
@@ -80,11 +81,11 @@ public class TestRPCWaitForProxy extends TestRpcBase {
     RpcThread worker = new RpcThread(100);
     worker.start();
     Thread.sleep(1000);
-    Assertions.assertTrue(worker.waitStarted, "worker hasn't started");
+    assertTrue(worker.waitStarted, "worker hasn't started");
     worker.interrupt();
     worker.join();
     Throwable caught = worker.getCaught();
-    Assertions.assertNotNull(caught, "No exception was raised");
+    assertNotNull(caught, "No exception was raised");
     // looking for the root cause here, which can be wrapped
     // as part of the NetUtils work. Having this test look
     // a the type of exception there would be brittle to improvements

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestResponseBuffer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestResponseBuffer.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import org.apache.hadoop.ipc.ResponseBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for ResponseBuffer. */
 public class TestResponseBuffer {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCache.java
@@ -29,9 +29,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.ipc.RPC.RpcKind;
 import org.apache.hadoop.ipc.RetryCache.CacheEntryWithPayload;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link RetryCache}
@@ -177,7 +178,7 @@ public class TestRetryCache {
     for (int i = 0; i < numberOfThreads; i++) {
       Callable<Integer> worker = () -> {
         Server.getCurCall().set(call);
-        Assertions.assertEquals(Server.getCurCall().get(), call);
+        assertEquals(Server.getCurCall().get(), call);
         int randomPause = pause == 0 ? pause : r.nextInt(pause);
         return testServer.echo(input, failureOutput, randomPause, success);
       };
@@ -185,12 +186,12 @@ public class TestRetryCache {
       list.add(submit);
     }
 
-    Assertions.assertEquals(numberOfThreads, list.size());
+    assertEquals(numberOfThreads, list.size());
     for (Future<Integer> future : list) {
       if (success) {
-        Assertions.assertEquals(input, future.get().intValue());
+        assertEquals(input, future.get().intValue());
       } else {
-        Assertions.assertEquals(failureOutput, future.get().intValue());
+        assertEquals(failureOutput, future.get().intValue());
       }
     }
 
@@ -198,15 +199,15 @@ public class TestRetryCache {
       // If the operation was successful, all the subsequent operations
       // by other threads should be retries. Operation count should be 1.
       int retries = numberOfThreads + (attemptedBefore ? 0 : -1);
-      Assertions.assertEquals(1, testServer.operationCount.get());
-      Assertions.assertEquals(retries, testServer.retryCount.get());
+      assertEquals(1, testServer.operationCount.get());
+      assertEquals(retries, testServer.retryCount.get());
     } else {
       // If the operation failed, all the subsequent operations
       // should execute once more, hence the retry count should be 0 and
       // operation count should be the number of tries
       int opCount = numberOfThreads + (attemptedBefore ? 1 : 0);
-      Assertions.assertEquals(opCount, testServer.operationCount.get());
-      Assertions.assertEquals(0, testServer.retryCount.get());
+      assertEquals(opCount, testServer.operationCount.get());
+      assertEquals(0, testServer.retryCount.get());
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCache.java
@@ -29,9 +29,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.ipc.RPC.RpcKind;
 import org.apache.hadoop.ipc.RetryCache.CacheEntryWithPayload;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link RetryCache}
@@ -42,7 +42,7 @@ public class TestRetryCache {
   private static final Random r = new Random();
   private static final TestServer testServer = new TestServer();
 
-  @Before
+  @BeforeEach
   public void setup() {
     testServer.resetCounters();
   }
@@ -177,7 +177,7 @@ public class TestRetryCache {
     for (int i = 0; i < numberOfThreads; i++) {
       Callable<Integer> worker = () -> {
         Server.getCurCall().set(call);
-        Assert.assertEquals(Server.getCurCall().get(), call);
+        Assertions.assertEquals(Server.getCurCall().get(), call);
         int randomPause = pause == 0 ? pause : r.nextInt(pause);
         return testServer.echo(input, failureOutput, randomPause, success);
       };
@@ -185,12 +185,12 @@ public class TestRetryCache {
       list.add(submit);
     }
 
-    Assert.assertEquals(numberOfThreads, list.size());
+    Assertions.assertEquals(numberOfThreads, list.size());
     for (Future<Integer> future : list) {
       if (success) {
-        Assert.assertEquals(input, future.get().intValue());
+        Assertions.assertEquals(input, future.get().intValue());
       } else {
-        Assert.assertEquals(failureOutput, future.get().intValue());
+        Assertions.assertEquals(failureOutput, future.get().intValue());
       }
     }
 
@@ -198,15 +198,15 @@ public class TestRetryCache {
       // If the operation was successful, all the subsequent operations
       // by other threads should be retries. Operation count should be 1.
       int retries = numberOfThreads + (attemptedBefore ? 0 : -1);
-      Assert.assertEquals(1, testServer.operationCount.get());
-      Assert.assertEquals(retries, testServer.retryCount.get());
+      Assertions.assertEquals(1, testServer.operationCount.get());
+      Assertions.assertEquals(retries, testServer.retryCount.get());
     } else {
       // If the operation failed, all the subsequent operations
       // should execute once more, hence the retry count should be 0 and
       // operation count should be the number of tries
       int opCount = numberOfThreads + (attemptedBefore ? 1 : 0);
-      Assert.assertEquals(opCount, testServer.operationCount.get());
-      Assert.assertEquals(0, testServer.retryCount.get());
+      Assertions.assertEquals(opCount, testServer.operationCount.get());
+      Assertions.assertEquals(0, testServer.retryCount.get());
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCacheMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCacheMetrics.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link RetryCacheMetrics}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCacheMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRetryCacheMetrics.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ipc;
 
 import org.apache.hadoop.ipc.metrics.RetryCacheMetrics;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestReuseRpcConnections.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestReuseRpcConnections.java
@@ -17,7 +17,7 @@
  */
 
 package org.apache.hadoop.ipc;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -26,15 +26,16 @@ import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.io.retry.TestConnectionRetryPolicy;
 import org.apache.hadoop.ipc.Client.ConnectionId;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class mainly tests behaviors of reusing RPC connections for various
  * retry policies.
  */
 public class TestReuseRpcConnections extends TestRpcBase {
-  @Before
+  @BeforeEach
   public void setup() {
     setupConf();
   }
@@ -60,7 +61,8 @@ public class TestReuseRpcConnections extends TestRpcBase {
         remoteExceptionToRetry);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDefaultRetryPolicyReuseConnections() throws Exception {
     RetryPolicy rp1 = null;
     RetryPolicy rp2 = null;
@@ -103,7 +105,8 @@ public class TestReuseRpcConnections extends TestRpcBase {
     verifyRetryPolicyReuseConnections(rp1, rp2, RetryPolicies.RETRY_FOREVER);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRetryPolicyTryOnceThenFail() throws Exception {
     final RetryPolicy rp1 = TestConnectionRetryPolicy.newTryOnceThenFail();
     final RetryPolicy rp2 = TestConnectionRetryPolicy.newTryOnceThenFail();
@@ -130,21 +133,21 @@ public class TestReuseRpcConnections extends TestRpcBase {
       proxy1.ping(null, newEmptyRequest());
       client = ProtobufRpcEngine2.getClient(newConf);
       final Set<ConnectionId> conns = client.getConnectionIds();
-      assertEquals("number of connections in cache is wrong", 1, conns.size());
+      assertEquals(1, conns.size(), "number of connections in cache is wrong");
 
       /*
        * another equivalent retry policy, reuse connection
        */
       proxy2 = getClient(addr, newConf, retryPolicy2);
       proxy2.ping(null, newEmptyRequest());
-      assertEquals("number of connections in cache is wrong", 1, conns.size());
+      assertEquals(1, conns.size(), "number of connections in cache is wrong");
 
       /*
        * different retry policy, create a new connection
        */
       proxy3 = getClient(addr, newConf, anotherRetryPolicy);
       proxy3.ping(null, newEmptyRequest());
-      assertEquals("number of connections in cache is wrong", 2, conns.size());
+      assertEquals(2, conns.size(), "number of connections in cache is wrong");
     } finally {
       server.stop();
       // this is dirty, but clear out connection cache for next run

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestReuseRpcConnections.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestReuseRpcConnections.java
@@ -17,7 +17,7 @@
  */
 
 package org.apache.hadoop.ipc;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcBase.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -374,8 +374,8 @@ public class TestRpcBase {
                 TestProtos.EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(clientId);
-      Assert.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
+      Assertions.assertNotNull(clientId);
+      Assertions.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
       return TestProtos.EmptyResponseProto.newBuilder().build();
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcBase.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.RetryPolicy;
@@ -60,6 +59,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Test facilities for unit tests for RPC. */
 public class TestRpcBase {
@@ -374,8 +376,8 @@ public class TestRpcBase {
                 TestProtos.EmptyRequestProto request) throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(clientId);
-      Assertions.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
+      assertNotNull(clientId);
+      assertEquals(ClientId.BYTE_LENGTH, clientId.length);
       return TestProtos.EmptyResponseProto.newBuilder().build();
     }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
@@ -34,11 +34,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestRpcServerHandoff {
 
@@ -122,7 +125,7 @@ public class TestRpcServerHandoff {
       server.sendResponse();
       BytesWritable response = (BytesWritable) future.get();
 
-      Assertions.assertEquals(new BytesWritable(requestBytes), response);
+      assertEquals(new BytesWritable(requestBytes), response);
     } finally {
       if (server != null) {
         server.stop();
@@ -152,12 +155,12 @@ public class TestRpcServerHandoff {
       server.sendError();
       try {
         future.get();
-        Assertions.fail("Call succeeded. Was expecting an exception");
+        fail("Call succeeded. Was expecting an exception");
       } catch (ExecutionException e) {
         Throwable cause = e.getCause();
-        Assertions.assertTrue(cause instanceof RemoteException);
+        assertTrue(cause instanceof RemoteException);
         RemoteException re = (RemoteException) cause;
-        Assertions.assertTrue(re.toString().contains("DeferredError"));
+        assertTrue(re.toString().contains("DeferredError"));
       }
     } finally {
       if (server != null) {
@@ -173,7 +176,7 @@ public class TestRpcServerHandoff {
     while (sleepTime > 0) {
       try {
         future.get(200L, TimeUnit.MILLISECONDS);
-        Assertions.fail("Expected to timeout since" +
+        fail("Expected to timeout since" +
             " the deferred response hasn't been registered");
       } catch (TimeoutException e) {
         // Ignoring. Expected to time out.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcServerHandoff.java
@@ -34,8 +34,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,8 @@ public class TestRpcServerHandoff {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testDeferredResponse() throws IOException, InterruptedException,
       ExecutionException {
 
@@ -120,7 +122,7 @@ public class TestRpcServerHandoff {
       server.sendResponse();
       BytesWritable response = (BytesWritable) future.get();
 
-      Assert.assertEquals(new BytesWritable(requestBytes), response);
+      Assertions.assertEquals(new BytesWritable(requestBytes), response);
     } finally {
       if (server != null) {
         server.stop();
@@ -128,7 +130,8 @@ public class TestRpcServerHandoff {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testDeferredException() throws IOException, InterruptedException,
       ExecutionException {
     ServerForHandoffTest server = new ServerForHandoffTest(2);
@@ -149,12 +152,12 @@ public class TestRpcServerHandoff {
       server.sendError();
       try {
         future.get();
-        Assert.fail("Call succeeded. Was expecting an exception");
+        Assertions.fail("Call succeeded. Was expecting an exception");
       } catch (ExecutionException e) {
         Throwable cause = e.getCause();
-        Assert.assertTrue(cause instanceof RemoteException);
+        Assertions.assertTrue(cause instanceof RemoteException);
         RemoteException re = (RemoteException) cause;
-        Assert.assertTrue(re.toString().contains("DeferredError"));
+        Assertions.assertTrue(re.toString().contains("DeferredError"));
       }
     } finally {
       if (server != null) {
@@ -170,7 +173,7 @@ public class TestRpcServerHandoff {
     while (sleepTime > 0) {
       try {
         future.get(200L, TimeUnit.MILLISECONDS);
-        Assert.fail("Expected to timeout since" +
+        Assertions.fail("Expected to timeout since" +
             " the deferred response hasn't been registered");
       } catch (TimeoutException e) {
         // Ignoring. Expected to time out.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcWritable.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcWritable.java
@@ -26,10 +26,12 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.ipc.protobuf.TestProtos.EchoRequestProto;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.protobuf.Message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRpcWritable {//extends TestRpcBase {
 
@@ -49,8 +51,8 @@ public class TestRpcWritable {//extends TestRpcBase {
     // deserial
     LongWritable actual = RpcWritable.wrap(new LongWritable())
         .readFrom(bb);
-    Assertions.assertEquals(writable, actual);
-    Assertions.assertEquals(0, bb.remaining());
+    assertEquals(writable, actual);
+    assertEquals(0, bb.remaining());
   }
 
   @Test
@@ -61,8 +63,8 @@ public class TestRpcWritable {//extends TestRpcBase {
 
     Message actual = RpcWritable.wrap(EchoRequestProto.getDefaultInstance())
         .readFrom(bb);
-    Assertions.assertEquals(message1, actual);
-    Assertions.assertEquals(0, bb.remaining());
+    assertEquals(message1, actual);
+    assertEquals(0, bb.remaining());
   }
 
   @Test
@@ -75,23 +77,23 @@ public class TestRpcWritable {//extends TestRpcBase {
 
     ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
     RpcWritable.Buffer buf = RpcWritable.Buffer.wrap(bb);
-    Assertions.assertEquals(baos.size(), bb.remaining());
-    Assertions.assertEquals(baos.size(), buf.remaining());
+    assertEquals(baos.size(), bb.remaining());
+    assertEquals(baos.size(), buf.remaining());
 
     Object actual = buf.getValue(EchoRequestProto.getDefaultInstance());
-    Assertions.assertEquals(message1, actual);
-    Assertions.assertTrue(bb.remaining() > 0);
-    Assertions.assertEquals(bb.remaining(), buf.remaining());
+    assertEquals(message1, actual);
+    assertTrue(bb.remaining() > 0);
+    assertEquals(bb.remaining(), buf.remaining());
 
     actual = buf.getValue(EchoRequestProto.getDefaultInstance());
-    Assertions.assertEquals(message2, actual);
-    Assertions.assertTrue(bb.remaining() > 0);
-    Assertions.assertEquals(bb.remaining(), buf.remaining());
+    assertEquals(message2, actual);
+    assertTrue(bb.remaining() > 0);
+    assertEquals(bb.remaining(), buf.remaining());
 
     actual = buf.newInstance(LongWritable.class, null);
-    Assertions.assertEquals(writable, actual);
-    Assertions.assertEquals(0, bb.remaining());
-    Assertions.assertEquals(0, buf.remaining());
+    assertEquals(writable, actual);
+    assertEquals(0, bb.remaining());
+    assertEquals(0, buf.remaining());
   }
 
   @Test
@@ -103,27 +105,27 @@ public class TestRpcWritable {//extends TestRpcBase {
     message2.writeDelimitedTo(dos);
     ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
     RpcWritable.Buffer buf1 = RpcWritable.Buffer.wrap(bb);
-    Assertions.assertEquals(baos.size(), bb.remaining());
-    Assertions.assertEquals(baos.size(), buf1.remaining());
+    assertEquals(baos.size(), bb.remaining());
+    assertEquals(baos.size(), buf1.remaining());
 
     Object actual = buf1.newInstance(LongWritable.class, null);
-    Assertions.assertEquals(writable, actual);
+    assertEquals(writable, actual);
     int left = bb.remaining();
-    Assertions.assertTrue(left > 0);
-    Assertions.assertEquals(left, buf1.remaining());
+    assertTrue(left > 0);
+    assertEquals(left, buf1.remaining());
 
     // original bb now appears empty, but rpc writable has a slice of the bb.
     RpcWritable.Buffer buf2 = buf1.newInstance(RpcWritable.Buffer.class, null);
-    Assertions.assertEquals(0, bb.remaining());
-    Assertions.assertEquals(0, buf1.remaining());
-    Assertions.assertEquals(left, buf2.remaining());
+    assertEquals(0, bb.remaining());
+    assertEquals(0, buf1.remaining());
+    assertEquals(left, buf2.remaining());
 
     actual = buf2.getValue(EchoRequestProto.getDefaultInstance());
-    Assertions.assertEquals(message1, actual);
-    Assertions.assertTrue(buf2.remaining() > 0);
+    assertEquals(message1, actual);
+    assertTrue(buf2.remaining() > 0);
 
     actual = buf2.getValue(EchoRequestProto.getDefaultInstance());
-    Assertions.assertEquals(message2, actual);
-    Assertions.assertEquals(0, buf2.remaining());
+    assertEquals(message2, actual);
+    assertEquals(0, buf2.remaining());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcWritable.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRpcWritable.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.ipc.protobuf.TestProtos.EchoRequestProto;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.protobuf.Message;
 
@@ -49,8 +49,8 @@ public class TestRpcWritable {//extends TestRpcBase {
     // deserial
     LongWritable actual = RpcWritable.wrap(new LongWritable())
         .readFrom(bb);
-    Assert.assertEquals(writable, actual);
-    Assert.assertEquals(0, bb.remaining());
+    Assertions.assertEquals(writable, actual);
+    Assertions.assertEquals(0, bb.remaining());
   }
 
   @Test
@@ -61,8 +61,8 @@ public class TestRpcWritable {//extends TestRpcBase {
 
     Message actual = RpcWritable.wrap(EchoRequestProto.getDefaultInstance())
         .readFrom(bb);
-    Assert.assertEquals(message1, actual);
-    Assert.assertEquals(0, bb.remaining());
+    Assertions.assertEquals(message1, actual);
+    Assertions.assertEquals(0, bb.remaining());
   }
 
   @Test
@@ -75,23 +75,23 @@ public class TestRpcWritable {//extends TestRpcBase {
 
     ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
     RpcWritable.Buffer buf = RpcWritable.Buffer.wrap(bb);
-    Assert.assertEquals(baos.size(), bb.remaining());
-    Assert.assertEquals(baos.size(), buf.remaining());
+    Assertions.assertEquals(baos.size(), bb.remaining());
+    Assertions.assertEquals(baos.size(), buf.remaining());
 
     Object actual = buf.getValue(EchoRequestProto.getDefaultInstance());
-    Assert.assertEquals(message1, actual);
-    Assert.assertTrue(bb.remaining() > 0);
-    Assert.assertEquals(bb.remaining(), buf.remaining());
+    Assertions.assertEquals(message1, actual);
+    Assertions.assertTrue(bb.remaining() > 0);
+    Assertions.assertEquals(bb.remaining(), buf.remaining());
 
     actual = buf.getValue(EchoRequestProto.getDefaultInstance());
-    Assert.assertEquals(message2, actual);
-    Assert.assertTrue(bb.remaining() > 0);
-    Assert.assertEquals(bb.remaining(), buf.remaining());
+    Assertions.assertEquals(message2, actual);
+    Assertions.assertTrue(bb.remaining() > 0);
+    Assertions.assertEquals(bb.remaining(), buf.remaining());
 
     actual = buf.newInstance(LongWritable.class, null);
-    Assert.assertEquals(writable, actual);
-    Assert.assertEquals(0, bb.remaining());
-    Assert.assertEquals(0, buf.remaining());
+    Assertions.assertEquals(writable, actual);
+    Assertions.assertEquals(0, bb.remaining());
+    Assertions.assertEquals(0, buf.remaining());
   }
 
   @Test
@@ -103,27 +103,27 @@ public class TestRpcWritable {//extends TestRpcBase {
     message2.writeDelimitedTo(dos);
     ByteBuffer bb = ByteBuffer.wrap(baos.toByteArray());
     RpcWritable.Buffer buf1 = RpcWritable.Buffer.wrap(bb);
-    Assert.assertEquals(baos.size(), bb.remaining());
-    Assert.assertEquals(baos.size(), buf1.remaining());
+    Assertions.assertEquals(baos.size(), bb.remaining());
+    Assertions.assertEquals(baos.size(), buf1.remaining());
 
     Object actual = buf1.newInstance(LongWritable.class, null);
-    Assert.assertEquals(writable, actual);
+    Assertions.assertEquals(writable, actual);
     int left = bb.remaining();
-    Assert.assertTrue(left > 0);
-    Assert.assertEquals(left, buf1.remaining());
+    Assertions.assertTrue(left > 0);
+    Assertions.assertEquals(left, buf1.remaining());
 
     // original bb now appears empty, but rpc writable has a slice of the bb.
     RpcWritable.Buffer buf2 = buf1.newInstance(RpcWritable.Buffer.class, null);
-    Assert.assertEquals(0, bb.remaining());
-    Assert.assertEquals(0, buf1.remaining());
-    Assert.assertEquals(left, buf2.remaining());
+    Assertions.assertEquals(0, bb.remaining());
+    Assertions.assertEquals(0, buf1.remaining());
+    Assertions.assertEquals(left, buf2.remaining());
 
     actual = buf2.getValue(EchoRequestProto.getDefaultInstance());
-    Assert.assertEquals(message1, actual);
-    Assert.assertTrue(buf2.remaining() > 0);
+    Assertions.assertEquals(message1, actual);
+    Assertions.assertTrue(buf2.remaining() > 0);
 
     actual = buf2.getValue(EchoRequestProto.getDefaultInstance());
-    Assert.assertEquals(message2, actual);
-    Assert.assertEquals(0, buf2.remaining());
+    Assertions.assertEquals(message2, actual);
+    Assertions.assertEquals(0, buf2.remaining());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -34,14 +34,10 @@ import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.token.*;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -91,9 +87,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /** Unit tests for using Sasl over RPC. */
-@RunWith(Parameterized.class)
 public class TestSaslRPC extends TestRpcBase {
-  @Parameters
+
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<>();
     for (QualityOfProtection qop : QualityOfProtection.values()) {
@@ -113,13 +108,14 @@ public class TestSaslRPC extends TestRpcBase {
   QualityOfProtection[] qop;
   QualityOfProtection expectedQop;
   String saslPropertiesResolver ;
-  
-  public TestSaslRPC(QualityOfProtection[] qop,
-      QualityOfProtection expectedQop,
-      String saslPropertiesResolver) {
-    this.qop=qop;
-    this.expectedQop = expectedQop;
-    this.saslPropertiesResolver = saslPropertiesResolver;
+
+  public void initTestSaslRPC(QualityOfProtection[] pQop,
+      QualityOfProtection pExpectedQop,
+      String pSaslPropertiesResolver) {
+    this.qop = pQop;
+    this.expectedQop = pExpectedQop;
+    this.saslPropertiesResolver = pSaslPropertiesResolver;
+    setup();
   }
 
   public static final Logger LOG = LoggerFactory.getLogger(TestSaslRPC.class);
@@ -150,7 +146,6 @@ public class TestSaslRPC extends TestRpcBase {
     Security.addProvider(new SaslPlainServer.SecurityProvider());
   }    
 
-  @BeforeEach
   public void setup() {
     LOG.info("---------------------------------");
     LOG.info("Testing QOP:"+ getQOPNames(qop));
@@ -240,16 +235,23 @@ public class TestSaslRPC extends TestRpcBase {
     }
   }
 
-  @Test
-  public void testDigestRpc() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDigestRpc(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
+    throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
     
     doDigestRpc(server, sm);
   }
 
-  @Test
-  public void testDigestRpcWithoutAnnotation() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDigestRpcWithoutAnnotation(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     try {
       SecurityUtil.setSecurityInfoProviders(new CustomSecurityInfo());
@@ -260,8 +262,11 @@ public class TestSaslRPC extends TestRpcBase {
     }
   }
 
-  @Test
-  public void testErrorMessage() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testErrorMessage(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     BadTokenSecretManager sm = new BadTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
 
@@ -313,8 +318,11 @@ public class TestSaslRPC extends TestRpcBase {
     }
   }
 
-  @Test
-  public void testPingInterval() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPingInterval(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     Configuration newConf = new Configuration(conf);
     newConf.set(SERVER_PRINCIPAL_KEY, SERVER_PRINCIPAL_1);
     conf.setInt(CommonConfigurationKeys.IPC_PING_INTERVAL_KEY,
@@ -332,9 +340,12 @@ public class TestSaslRPC extends TestRpcBase {
         TestRpcService.class, null, 0, null, newConf);
     assertEquals(0, remoteId.getPingInterval());
   }
-  
-  @Test
-  public void testPerConnectionConf() throws Exception {
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPerConnectionConf(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
     final UserGroupInformation current = UserGroupInformation.getCurrentUser();
@@ -413,15 +424,21 @@ public class TestSaslRPC extends TestRpcBase {
     System.out.println("Test is successful.");
   }
 
-  @Test
-  public void testSaslPlainServer() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSaslPlainServer(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws IOException {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     runNegotiation(
         new TestPlainCallbacks.Client("user", "pass"),
         new TestPlainCallbacks.Server("user", "pass"));
   }
 
-  @Test
-  public void testSaslPlainServerBadPassword() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSaslPlainServerBadPassword(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     SaslException e = null;
     try {
       runNegotiation(
@@ -562,8 +579,11 @@ public class TestSaslRPC extends TestRpcBase {
   /*
    *  simple server
    */
-  @Test
-  public void testSimpleServer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSimpleServer(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(SIMPLE,    getAuthMethod(SIMPLE,   SIMPLE));
     assertAuthEquals(SIMPLE,    getAuthMethod(SIMPLE,   SIMPLE, UseToken.OTHER));
     // SASL methods are normally reverted to SIMPLE
@@ -582,8 +602,11 @@ public class TestSaslRPC extends TestRpcBase {
    * This test mimics this behaviour, and asserts the fallback whether it is set correctly.
    * @see <a href="https://issues.apache.org/jira/browse/HADOOP-17975">HADOOP-17975</a>
    */
-  @Test
-  public void testClientFallbackToSimpleAuthForASecondClient() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testClientFallbackToSimpleAuthForASecondClient(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     Configuration serverConf = createConfForAuth(SIMPLE);
     Server server = startServer(serverConf,
         setupServerUgi(SIMPLE, serverConf),
@@ -637,9 +660,12 @@ public class TestSaslRPC extends TestRpcBase {
     assertTrue(fallbackToSimpleAuth2.get(), "Second client does not set to fall back properly.");
   }
 
-  @Test
-  public void testNoClientFallbackToSimple()
-      throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testNoClientFallbackToSimple(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
+    throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     clientFallBackToSimpleAllowed = false;
     // tokens are irrelevant w/o secret manager enabled
     assertAuthEquals(SIMPLE,     getAuthMethod(SIMPLE, SIMPLE));
@@ -680,8 +706,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(BadToken,       getAuthMethod(KERBEROS, TOKEN, UseToken.INVALID));
   }
 
-  @Test
-  public void testSimpleServerWithTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSimpleServerWithTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // Client not using tokens
     assertAuthEquals(SIMPLE, getAuthMethod(SIMPLE,   SIMPLE));
     // SASL methods are reverted to SIMPLE
@@ -709,8 +738,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(SIMPLE, getAuthMethod(KERBEROS, SIMPLE, UseToken.OTHER));
   }
 
-  @Test
-  public void testSimpleServerWithInvalidTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSimpleServerWithInvalidTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // Tokens are ignored because client is reverted to simple
     assertAuthEquals(SIMPLE, getAuthMethod(SIMPLE,   SIMPLE, UseToken.INVALID));
     assertAuthEquals(SIMPLE, getAuthMethod(KERBEROS, SIMPLE, UseToken.INVALID));
@@ -725,8 +757,11 @@ public class TestSaslRPC extends TestRpcBase {
   /*
    *  token server
    */
-  @Test
-  public void testTokenOnlyServer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testTokenOnlyServer(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // simple client w/o tokens won't try SASL, so server denies
     assertAuthEquals(Denied(SIMPLE), getAuthMethod(SIMPLE,   TOKEN));
     assertAuthEquals(No(TOKEN),      getAuthMethod(SIMPLE,   TOKEN, UseToken.OTHER));
@@ -734,8 +769,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(No(TOKEN),      getAuthMethod(KERBEROS, TOKEN, UseToken.OTHER));
   }
 
-  @Test
-  public void testTokenOnlyServerWithTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testTokenOnlyServerWithTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(TOKEN,       getAuthMethod(SIMPLE,   TOKEN, UseToken.VALID));
     assertAuthEquals(TOKEN,       getAuthMethod(KERBEROS, TOKEN, UseToken.VALID));
     enableSecretManager = false;
@@ -743,8 +781,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(NoTokenAuth, getAuthMethod(KERBEROS, TOKEN, UseToken.VALID));
   }
 
-  @Test
-  public void testTokenOnlyServerWithInvalidTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testTokenOnlyServerWithInvalidTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(BadToken,    getAuthMethod(SIMPLE,   TOKEN, UseToken.INVALID));
     assertAuthEquals(BadToken,    getAuthMethod(KERBEROS, TOKEN, UseToken.INVALID));
     enableSecretManager = false;
@@ -755,8 +796,11 @@ public class TestSaslRPC extends TestRpcBase {
   /*
    * kerberos server
    */
-  @Test
-  public void testKerberosServer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testKerberosServer(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // doesn't try SASL
     assertAuthEquals(Denied(SIMPLE),     getAuthMethod(SIMPLE,   KERBEROS));
     // does try SASL
@@ -766,8 +810,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(KrbFailed,          getAuthMethod(KERBEROS, KERBEROS, UseToken.OTHER));
   }
 
-  @Test
-  public void testKerberosServerWithTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testKerberosServerWithTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // can use tokens regardless of auth
     assertAuthEquals(TOKEN,        getAuthMethod(SIMPLE,   KERBEROS, UseToken.VALID));
     assertAuthEquals(TOKEN,        getAuthMethod(KERBEROS, KERBEROS, UseToken.VALID));
@@ -777,8 +824,11 @@ public class TestSaslRPC extends TestRpcBase {
     assertAuthEquals(KrbFailed,    getAuthMethod(KERBEROS, KERBEROS, UseToken.VALID));
   }
 
-  @Test
-  public void testKerberosServerWithInvalidTokens() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testKerberosServerWithInvalidTokens(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(BadToken,     getAuthMethod(SIMPLE,   KERBEROS, UseToken.INVALID));
     assertAuthEquals(BadToken,     getAuthMethod(KERBEROS, KERBEROS, UseToken.INVALID));
     enableSecretManager = false;
@@ -789,9 +839,12 @@ public class TestSaslRPC extends TestRpcBase {
   // ensure that for all qop settings, client can handle postponed rpc
   // responses.  basically ensures that the rpc server isn't encrypting
   // and queueing the responses out of order.
-  @Test
+  @ParameterizedTest
+  @MethodSource("data")
   @Timeout(value = 10)
-  public void testSaslResponseOrdering() throws Exception {
+  public void testSaslResponseOrdering(QualityOfProtection[] pQop,
+    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     SecurityUtil.setAuthenticationMethod(
         AuthenticationMethod.TOKEN, conf);
     UserGroupInformation.setConfiguration(conf);
@@ -836,7 +889,7 @@ public class TestSaslRPC extends TestRpcBase {
               } catch (TimeoutException te) {
                 continue; // expected.
               }
-              Assertions.fail("future"+i+" did not block");
+              fail("future" + i + " did not block");
             }
             // triggers responses to be unblocked in a random order.  having
             // only 1 handler ensures that the prior calls are already

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -238,8 +238,8 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testDigestRpc(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
-    throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
+      throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
@@ -250,8 +250,8 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testDigestRpcWithoutAnnotation(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     try {
       SecurityUtil.setSecurityInfoProviders(new CustomSecurityInfo());
@@ -265,8 +265,8 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testErrorMessage(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     BadTokenSecretManager sm = new BadTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
 
@@ -307,8 +307,8 @@ public class TestSaslRPC extends TestRpcBase {
       for (Connection connection : server.getConnections()) {
         // only qop auth should dispose of the sasl server
         boolean hasServer = (connection.saslServer != null);
-        assertTrue(
-           (expectedQop == QualityOfProtection.AUTHENTICATION) ^ hasServer, "qop:" + expectedQop + " hasServer:" + hasServer);
+        assertTrue((expectedQop == QualityOfProtection.AUTHENTICATION) ^ hasServer,
+            "qop:" + expectedQop + " hasServer:" + hasServer);
         n++;
       }
       assertTrue(n > 0);
@@ -321,7 +321,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testPingInterval(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     Configuration newConf = new Configuration(conf);
     newConf.set(SERVER_PRINCIPAL_KEY, SERVER_PRINCIPAL_1);
@@ -344,7 +344,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testPerConnectionConf(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
@@ -427,7 +427,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testSaslPlainServer(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws IOException {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws IOException {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     runNegotiation(
         new TestPlainCallbacks.Client("user", "pass"),
@@ -437,7 +437,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testSaslPlainServerBadPassword(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     SaslException e = null;
     try {
@@ -454,9 +454,9 @@ public class TestSaslRPC extends TestRpcBase {
   }
 
   private void assertContains(String expected, String text) {
-    assertNotNull(text, "null text" );
-    assertTrue(
-       text.contains(expected), "No {" + expected + "} in {" + text + "}");
+    assertNotNull(text, "null text");
+    assertTrue(text.contains(expected),
+        "No {" + expected + "} in {" + text + "}");
   }
 
   private void runNegotiation(CallbackHandler clientCbh,
@@ -582,7 +582,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testSimpleServer(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(SIMPLE,    getAuthMethod(SIMPLE,   SIMPLE));
     assertAuthEquals(SIMPLE,    getAuthMethod(SIMPLE,   SIMPLE, UseToken.OTHER));
@@ -605,7 +605,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testClientFallbackToSimpleAuthForASecondClient(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     Configuration serverConf = createConfForAuth(SIMPLE);
     Server server = startServer(serverConf,
@@ -663,8 +663,8 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testNoClientFallbackToSimple(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
-    throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver)
+      throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     clientFallBackToSimpleAllowed = false;
     // tokens are irrelevant w/o secret manager enabled
@@ -709,8 +709,8 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testSimpleServerWithTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // Client not using tokens
     assertAuthEquals(SIMPLE, getAuthMethod(SIMPLE,   SIMPLE));
     // SASL methods are reverted to SIMPLE
@@ -741,7 +741,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testSimpleServerWithInvalidTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // Tokens are ignored because client is reverted to simple
     assertAuthEquals(SIMPLE, getAuthMethod(SIMPLE,   SIMPLE, UseToken.INVALID));
@@ -760,7 +760,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testTokenOnlyServer(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // simple client w/o tokens won't try SASL, so server denies
     assertAuthEquals(Denied(SIMPLE), getAuthMethod(SIMPLE,   TOKEN));
@@ -772,7 +772,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testTokenOnlyServerWithTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(TOKEN,       getAuthMethod(SIMPLE,   TOKEN, UseToken.VALID));
     assertAuthEquals(TOKEN,       getAuthMethod(KERBEROS, TOKEN, UseToken.VALID));
@@ -784,7 +784,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testTokenOnlyServerWithInvalidTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(BadToken,    getAuthMethod(SIMPLE,   TOKEN, UseToken.INVALID));
     assertAuthEquals(BadToken,    getAuthMethod(KERBEROS, TOKEN, UseToken.INVALID));
@@ -799,7 +799,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testKerberosServer(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // doesn't try SASL
     assertAuthEquals(Denied(SIMPLE),     getAuthMethod(SIMPLE,   KERBEROS));
@@ -813,7 +813,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testKerberosServerWithTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // can use tokens regardless of auth
     assertAuthEquals(TOKEN,        getAuthMethod(SIMPLE,   KERBEROS, UseToken.VALID));
@@ -827,7 +827,7 @@ public class TestSaslRPC extends TestRpcBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testKerberosServerWithInvalidTokens(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     assertAuthEquals(BadToken,     getAuthMethod(SIMPLE,   KERBEROS, UseToken.INVALID));
     assertAuthEquals(BadToken,     getAuthMethod(KERBEROS, KERBEROS, UseToken.INVALID));
@@ -843,7 +843,7 @@ public class TestSaslRPC extends TestRpcBase {
   @MethodSource("data")
   @Timeout(value = 10)
   public void testSaslResponseOrdering(QualityOfProtection[] pQop,
-    QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
+      QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
     initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     SecurityUtil.setAuthenticationMethod(
         AuthenticationMethod.TOKEN, conf);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -34,10 +34,11 @@ import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.token.*;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -81,13 +82,13 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY
 import static org.apache.hadoop.security.SaslRpcServer.AuthMethod.KERBEROS;
 import static org.apache.hadoop.security.SaslRpcServer.AuthMethod.SIMPLE;
 import static org.apache.hadoop.security.SaslRpcServer.AuthMethod.TOKEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Unit tests for using Sasl over RPC. */
 @RunWith(Parameterized.class)
@@ -142,14 +143,14 @@ public class TestSaslRPC extends TestRpcBase {
     OTHER()
   }
   
-  @BeforeClass
+  @BeforeAll
   public static void setupKerb() {
     System.setProperty("java.security.krb5.kdc", "");
     System.setProperty("java.security.krb5.realm", "NONE");
     Security.addProvider(new SaslPlainServer.SecurityProvider());
   }    
 
-  @Before
+  @BeforeEach
   public void setup() {
     LOG.info("---------------------------------");
     LOG.info("Testing QOP:"+ getQOPNames(qop));
@@ -301,8 +302,8 @@ public class TestSaslRPC extends TestRpcBase {
       for (Connection connection : server.getConnections()) {
         // only qop auth should dispose of the sasl server
         boolean hasServer = (connection.saslServer != null);
-        assertTrue("qop:" + expectedQop + " hasServer:" + hasServer,
-            (expectedQop == QualityOfProtection.AUTHENTICATION) ^ hasServer);
+        assertTrue(
+           (expectedQop == QualityOfProtection.AUTHENTICATION) ^ hasServer, "qop:" + expectedQop + " hasServer:" + hasServer);
         n++;
       }
       assertTrue(n > 0);
@@ -359,16 +360,16 @@ public class TestSaslRPC extends TestRpcBase {
       proxy1.getAuthMethod(null, newEmptyRequest());
       client = ProtobufRpcEngine2.getClient(newConf);
       Set<ConnectionId> conns = client.getConnectionIds();
-      assertEquals("number of connections in cache is wrong", 1, conns.size());
+      assertEquals(1, conns.size(), "number of connections in cache is wrong");
       // same conf, connection should be re-used
       proxy2 = getClient(addr, newConf);
       proxy2.getAuthMethod(null, newEmptyRequest());
-      assertEquals("number of connections in cache is wrong", 1, conns.size());
+      assertEquals(1, conns.size(), "number of connections in cache is wrong");
       // different conf, new connection should be set up
       newConf.setInt(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECTION_MAXIDLETIME_KEY, timeouts[1]);
       proxy3 = getClient(addr, newConf);
       proxy3.getAuthMethod(null, newEmptyRequest());
-      assertEquals("number of connections in cache is wrong", 2, conns.size());
+      assertEquals(2, conns.size(), "number of connections in cache is wrong");
       // now verify the proxies have the correct connection ids and timeouts
       ConnectionId[] connsArray = {
           RPC.getConnectionIdForProxy(proxy1),
@@ -436,9 +437,9 @@ public class TestSaslRPC extends TestRpcBase {
   }
 
   private void assertContains(String expected, String text) {
-    assertNotNull("null text", text );
-    assertTrue("No {" + expected + "} in {" + text + "}",
-        text.contains(expected));
+    assertNotNull(text, "null text" );
+    assertTrue(
+       text.contains(expected), "No {" + expected + "} in {" + text + "}");
   }
 
   private void runNegotiation(CallbackHandler clientCbh,
@@ -452,7 +453,7 @@ public class TestSaslRPC extends TestRpcBase {
 
     SaslServer saslServer = Sasl.createSaslServer(
         mechanism, null, "localhost", null, serverCbh);
-    assertNotNull("failed to find PLAIN server", saslServer);
+    assertNotNull(saslServer, "failed to find PLAIN server");
     
     byte[] response = saslClient.evaluateChallenge(new byte[0]);
     assertNotNull(response);
@@ -632,8 +633,8 @@ public class TestSaslRPC extends TestRpcBase {
       server.stop();
     }
 
-    assertTrue("First client does not set to fall back properly.", fallbackToSimpleAuth1.get());
-    assertTrue("Second client does not set to fall back properly.", fallbackToSimpleAuth2.get());
+    assertTrue(fallbackToSimpleAuth1.get(), "First client does not set to fall back properly.");
+    assertTrue(fallbackToSimpleAuth2.get(), "Second client does not set to fall back properly.");
   }
 
   @Test
@@ -788,7 +789,8 @@ public class TestSaslRPC extends TestRpcBase {
   // ensure that for all qop settings, client can handle postponed rpc
   // responses.  basically ensures that the rpc server isn't encrypting
   // and queueing the responses out of order.
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testSaslResponseOrdering() throws Exception {
     SecurityUtil.setAuthenticationMethod(
         AuthenticationMethod.TOKEN, conf);
@@ -834,7 +836,7 @@ public class TestSaslRPC extends TestRpcBase {
               } catch (TimeoutException te) {
                 continue; // expected.
               }
-              Assert.fail("future"+i+" did not block");
+              Assertions.fail("future"+i+" did not block");
             }
             // triggers responses to be unblocked in a random order.  having
             // only 1 handler ensures that the prior calls are already

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -251,7 +251,7 @@ public class TestSaslRPC extends TestRpcBase {
   @MethodSource("data")
   public void testDigestRpcWithoutAnnotation(QualityOfProtection[] pQop,
       QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     TestTokenSecretManager sm = new TestTokenSecretManager();
     try {
       SecurityUtil.setSecurityInfoProviders(new CustomSecurityInfo());
@@ -266,7 +266,7 @@ public class TestSaslRPC extends TestRpcBase {
   @MethodSource("data")
   public void testErrorMessage(QualityOfProtection[] pQop,
       QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+   initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     BadTokenSecretManager sm = new BadTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
 
@@ -710,7 +710,7 @@ public class TestSaslRPC extends TestRpcBase {
   @MethodSource("data")
   public void testSimpleServerWithTokens(QualityOfProtection[] pQop,
       QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-      initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     // Client not using tokens
     assertAuthEquals(SIMPLE, getAuthMethod(SIMPLE,   SIMPLE));
     // SASL methods are reverted to SIMPLE

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSaslRPC.java
@@ -266,7 +266,7 @@ public class TestSaslRPC extends TestRpcBase {
   @MethodSource("data")
   public void testErrorMessage(QualityOfProtection[] pQop,
       QualityOfProtection pExpectedQop, String pSaslPropertiesResolver) throws Exception {
-   initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
+    initTestSaslRPC(pQop, pExpectedQop, pSaslPropertiesResolver);
     BadTokenSecretManager sm = new BadTokenSecretManager();
     final Server server = setupTestServer(conf, 5, sm);
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestServer.java
@@ -18,8 +18,14 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.BindException;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestServer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestServer.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ipc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -32,7 +32,8 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.ipc.Server.Call;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
@@ -120,7 +121,7 @@ public class TestServer {
       } finally {
         socket2.close();
       }
-      assertTrue("Failed to catch the expected bind exception",caught);
+      assertTrue(caught, "Failed to catch the expected bind exception");
     } finally {
       socket.close();
     }
@@ -135,7 +136,8 @@ public class TestServer {
   static class TestException3 extends Exception {
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testLogExceptions() throws Exception {
     final Configuration conf = new Configuration();
     final Call dummyCall = new Call(0, 0, null, null);
@@ -189,7 +191,8 @@ public class TestServer {
     assertFalse(handler.isSuppressedLog(RpcClientException.class));
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testPurgeIntervalNanosConf() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(CommonConfigurationKeysPublic.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestShadedProtobufHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestShadedProtobufHelper.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ipc;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ipc.internal.ShadedProtobufHelper;
 import org.apache.hadoop.test.AbstractHadoopTestBase;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestShadedProtobufHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestShadedProtobufHelper.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ipc;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import org.apache.hadoop.ipc.internal.ShadedProtobufHelper;
 import org.apache.hadoop.test.AbstractHadoopTestBase;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestSocketFactory.java
@@ -38,12 +38,13 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.SocksSocketFactory;
 import org.apache.hadoop.net.StandardSocketFactory;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,7 +77,7 @@ public class TestSocketFactory {
     port = serverRunnable.getPort();
   }
 
-  @After
+  @AfterEach
   public void stopTestServer() throws InterruptedException {
     final Thread t = serverThread;
     if (t != null) {
@@ -131,7 +132,8 @@ public class TestSocketFactory {
   /**
    * Test SocksSocketFactory.
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testSocksSocketFactory() throws Exception {
     startTestServer();
     testSocketFactory(new SocksSocketFactory());
@@ -140,7 +142,8 @@ public class TestSocketFactory {
   /**
    * Test StandardSocketFactory.
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testStandardSocketFactory() throws Exception {
     startTestServer();
     testSocketFactory(new StandardSocketFactory());
@@ -176,7 +179,8 @@ public class TestSocketFactory {
   /**
    * test proxy methods
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testProxy() throws Exception {
     SocksSocketFactory templateWithoutProxy = new SocksSocketFactory();
     Proxy proxy = new Proxy(Type.SOCKS, InetSocketAddress.createUnresolved(

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestWeightedRoundRobinMultiplexer.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestWeightedRoundRobinMultiplexer.java
@@ -20,13 +20,14 @@ package org.apache.hadoop.ipc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ipc.WeightedRoundRobinMultiplexer.IPC_CALLQUEUE_WRRMUX_WEIGHTS_KEY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestWeightedRoundRobinMultiplexer {
   public static final Logger LOG =
@@ -34,24 +35,29 @@ public class TestWeightedRoundRobinMultiplexer {
 
   private WeightedRoundRobinMultiplexer mux;
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInstantiateNegativeMux() {
-    mux = new WeightedRoundRobinMultiplexer(-1, "", new Configuration());
+    assertThrows(IllegalArgumentException.class, () -> {
+      mux = new WeightedRoundRobinMultiplexer(-1, "", new Configuration());
+    });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInstantiateZeroMux() {
-    mux = new WeightedRoundRobinMultiplexer(0, "", new Configuration());
+    assertThrows(IllegalArgumentException.class, () -> {
+      mux = new WeightedRoundRobinMultiplexer(0, "", new Configuration());
+    });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInstantiateIllegalMux() {
-    Configuration conf = new Configuration();
-    conf.setStrings("namespace." + IPC_CALLQUEUE_WRRMUX_WEIGHTS_KEY,
-      "1", "2", "3");
-
-    // ask for 3 weights with 2 queues
-    mux = new WeightedRoundRobinMultiplexer(2, "namespace", conf);
+    assertThrows(IllegalArgumentException.class, ()->{
+      Configuration conf = new Configuration();
+      conf.setStrings("namespace." + IPC_CALLQUEUE_WRRMUX_WEIGHTS_KEY,
+          "1", "2", "3");
+      // ask for 3 weights with 2 queues
+      mux = new WeightedRoundRobinMultiplexer(2, "namespace", conf);
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestWeightedTimeCostProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestWeightedTimeCostProvider.java
@@ -21,13 +21,14 @@ package org.apache.hadoop.ipc;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.ProcessingDetails.Timing;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ipc.WeightedTimeCostProvider.DEFAULT_LOCKEXCLUSIVE_WEIGHT;
 import static org.apache.hadoop.ipc.WeightedTimeCostProvider.DEFAULT_LOCKFREE_WEIGHT;
 import static org.apache.hadoop.ipc.WeightedTimeCostProvider.DEFAULT_LOCKSHARED_WEIGHT;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link WeightedTimeCostProvider}. */
 public class TestWeightedTimeCostProvider {
@@ -40,7 +41,7 @@ public class TestWeightedTimeCostProvider {
   private WeightedTimeCostProvider costProvider;
   private ProcessingDetails processingDetails;
 
-  @Before
+  @BeforeEach
   public void setup() {
     costProvider = new WeightedTimeCostProvider();
     processingDetails = new ProcessingDetails(TimeUnit.MILLISECONDS);
@@ -50,9 +51,11 @@ public class TestWeightedTimeCostProvider {
     processingDetails.set(Timing.LOCKEXCLUSIVE, LOCKEXCLUSIVE_TIME);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void testGetCostBeforeInit() {
-    costProvider.getCost(null);
+    assertThrows(AssertionError.class, () -> {
+      costProvider.getCost(null);
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/metrics/TestDecayRpcSchedulerDetailedMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/metrics/TestDecayRpcSchedulerDetailedMetrics.java
@@ -17,14 +17,14 @@
  */
 package org.apache.hadoop.ipc.metrics;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.DecayRpcScheduler;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDecayRpcSchedulerDetailedMetrics {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/metrics/TestRpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/metrics/TestRpcMetrics.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ipc.metrics;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
@@ -27,7 +27,7 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestRpcMetrics {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
@@ -97,8 +97,8 @@ public class TestJMXJsonServlet extends HttpServerFunctionalTest {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("TRACE");
 
-    assertEquals(
-       HttpServletResponse.SC_METHOD_NOT_ALLOWED, conn.getResponseCode(), "Unexpected response code");
+    assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED, conn.getResponseCode(),
+        "Unexpected response code");
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServlet.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.jmx;
 
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.http.HttpServerFunctionalTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -38,20 +38,22 @@ public class TestJMXJsonServlet extends HttpServerFunctionalTest {
   private static HttpServer2 server;
   private static URL baseUrl;
 
-  @BeforeClass public static void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     server = createTestServer();
     server.start();
     baseUrl = getServerURL(server);
   }
   
-  @AfterClass public static void cleanup() throws Exception {
+  @AfterAll
+  public static void cleanup() throws Exception {
     server.stop();
   }
   
   public static void assertReFind(String re, String value) {
     Pattern p = Pattern.compile(re);
     Matcher m = p.matcher(value);
-    assertTrue("'"+p+"' does not match "+value, m.find());
+    assertTrue(m.find(), "'"+p+"' does not match "+value);
   }
   
   @Test public void testQuery() throws Exception {
@@ -95,8 +97,8 @@ public class TestJMXJsonServlet extends HttpServerFunctionalTest {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("TRACE");
 
-    assertEquals("Unexpected response code",
-        HttpServletResponse.SC_METHOD_NOT_ALLOWED, conn.getResponseCode());
+    assertEquals(
+       HttpServletResponse.SC_METHOD_NOT_ALLOWED, conn.getResponseCode(), "Unexpected response code");
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/jmx/TestJMXJsonServletNaNFiltered.java
@@ -21,9 +21,9 @@ import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.HttpServer2;
@@ -35,7 +35,8 @@ public class TestJMXJsonServletNaNFiltered extends HttpServerFunctionalTest {
   private static HttpServer2 server;
   private static URL baseUrl;
 
-  @BeforeClass public static void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     Configuration configuration = new Configuration();
     configuration.setBoolean(JMX_NAN_FILTER, true);
     server = createTestServer(configuration);
@@ -43,14 +44,15 @@ public class TestJMXJsonServletNaNFiltered extends HttpServerFunctionalTest {
     baseUrl = getServerURL(server);
   }
 
-  @AfterClass public static void cleanup() throws Exception {
+  @AfterAll
+  public static void cleanup() throws Exception {
     server.stop();
   }
 
   public static void assertReFind(String re, String value) {
     Pattern p = Pattern.compile(re);
     Matcher m = p.matcher(value);
-    assertTrue("'"+p+"' does not match "+value, m.find());
+    assertTrue(m.find(), "'"+p+"' does not match "+value);
   }
 
   @Test public void testQuery() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.log;
 
 import org.apache.hadoop.log.LogThrottlingHelper.LogAction;
 import org.apache.hadoop.util.FakeTimer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link LogThrottlingHelper}.
@@ -36,7 +34,7 @@ public class TestLogThrottlingHelper {
   private LogThrottlingHelper helper;
   private FakeTimer timer;
 
-  @Before
+  @BeforeEach
   public void setup() {
     timer = new FakeTimer();
     helper = new LogThrottlingHelper(LOG_PERIOD, null, timer);
@@ -93,11 +91,13 @@ public class TestLogThrottlingHelper {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testLoggingWithInconsistentValues() {
-    assertTrue(helper.record(1, 2).shouldLog());
-    helper.record(1, 2);
-    helper.record(1, 2, 3);
+    assertThrows(IllegalArgumentException.class, () -> {
+      assertTrue(helper.record(1, 2).shouldLog());
+      helper.record(1, 2);
+      helper.record(1, 2, 3);
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/log/TestLogThrottlingHelper.java
@@ -22,7 +22,10 @@ import org.apache.hadoop.util.FakeTimer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link LogThrottlingHelper}.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/filter/TestPatternFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/filter/TestPatternFilter.java
@@ -24,8 +24,10 @@ import java.util.List;
 import org.apache.commons.configuration2.SubsetConfiguration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.metrics2.MetricsFilter;
 import org.apache.hadoop.metrics2.MetricsRecord;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/filter/TestPatternFilter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/filter/TestPatternFilter.java
@@ -22,9 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.hadoop.metrics2.MetricsFilter;
@@ -129,8 +129,8 @@ public class TestPatternFilter {
   }
   
   static void shouldAccept(SubsetConfiguration conf, String s) {
-    assertTrue("accepts "+ s, newGlobFilter(conf).accepts(s));
-    assertTrue("accepts "+ s, newRegexFilter(conf).accepts(s));
+    assertTrue(newGlobFilter(conf).accepts(s), "accepts "+ s);
+    assertTrue(newRegexFilter(conf).accepts(s), "accepts "+ s);
   }
 
   // Version for one tag:
@@ -159,8 +159,8 @@ public class TestPatternFilter {
     final MetricsFilter regexFilter = newRegexFilter(conf);
     
     // Test acceptance of the tag list:  
-    assertEquals("accepts "+ tags, expectAcceptList, globFilter.accepts(tags));
-    assertEquals("accepts "+ tags, expectAcceptList, regexFilter.accepts(tags));
+    assertEquals(expectAcceptList, globFilter.accepts(tags), "accepts "+ tags);
+    assertEquals(expectAcceptList, regexFilter.accepts(tags), "accepts "+ tags);
     
     // Test results on each of the individual tags:
     int acceptedCount = 0;
@@ -168,7 +168,7 @@ public class TestPatternFilter {
       MetricsTag tag = tags.get(i);
       boolean actGlob = globFilter.accepts(tag);
       boolean actRegex = regexFilter.accepts(tag);
-      assertEquals("accepts "+tag, expectedAcceptedSpec[i], actGlob);
+      assertEquals(expectedAcceptedSpec[i], actGlob, "accepts "+tag);
       // Both the filters should give the same result:
       assertEquals(actGlob, actRegex);
       if (actGlob) {
@@ -177,10 +177,10 @@ public class TestPatternFilter {
     }
     if (expectAcceptList) {
       // At least one individual tag should be accepted:
-      assertTrue("No tag of the following accepted: " + tags, acceptedCount > 0);
+      assertTrue(acceptedCount > 0, "No tag of the following accepted: " + tags);
     } else {
       // At least one individual tag should be rejected: 
-      assertTrue("No tag of the following rejected: " + tags, acceptedCount < tags.size());
+      assertTrue(acceptedCount < tags.size(), "No tag of the following rejected: " + tags);
     }
   }
 
@@ -191,13 +191,13 @@ public class TestPatternFilter {
    * @param record MetricsRecord to check
    */
   static void shouldAccept(SubsetConfiguration conf, MetricsRecord record) {
-    assertTrue("accepts " + record, newGlobFilter(conf).accepts(record));
-    assertTrue("accepts " + record, newRegexFilter(conf).accepts(record));
+    assertTrue(newGlobFilter(conf).accepts(record), "accepts " + record);
+    assertTrue(newRegexFilter(conf).accepts(record), "accepts " + record);
   }
 
   static void shouldReject(SubsetConfiguration conf, String s) {
-    assertTrue("rejects "+ s, !newGlobFilter(conf).accepts(s));
-    assertTrue("rejects "+ s, !newRegexFilter(conf).accepts(s));
+    assertTrue(!newGlobFilter(conf).accepts(s), "rejects "+ s);
+    assertTrue(!newRegexFilter(conf).accepts(s), "rejects "+ s);
   }
 
   /**
@@ -207,8 +207,8 @@ public class TestPatternFilter {
    * @param record MetricsRecord to check
    */
   static void shouldReject(SubsetConfiguration conf, MetricsRecord record) {
-    assertTrue("rejects " + record, !newGlobFilter(conf).accepts(record));
-    assertTrue("rejects " + record, !newRegexFilter(conf).accepts(record));
+    assertTrue(!newGlobFilter(conf).accepts(record), "rejects " + record);
+    assertTrue(!newRegexFilter(conf).accepts(record), "rejects " + record);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/ConfigUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/ConfigUtil.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.metrics2.impl;
 import java.io.PrintWriter;
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 
@@ -54,14 +54,14 @@ class ConfigUtil {
     // Check that the actual config contains all the properties of the expected
     for (Iterator<?> it = expected.getKeys(); it.hasNext();) {
       String key = (String) it.next();
-      assertTrue("actual should contain "+ key, actual.containsKey(key));
-      assertEquals("value of "+ key, expected.getProperty(key),
-                                     actual.getProperty(key));
+      assertTrue(actual.containsKey(key), "actual should contain "+ key);
+      assertEquals(expected.getProperty(key)
+,                                      actual.getProperty(key), "value of "+ key);
     }
     // Check that the actual config has no extra properties
     for (Iterator<?> it = actual.getKeys(); it.hasNext();) {
       String key = (String) it.next();
-      assertTrue("expected should contain "+ key, expected.containsKey(key));
+      assertTrue(expected.containsKey(key), "expected should contain "+ key);
     }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/ConfigUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/ConfigUtil.java
@@ -21,7 +21,8 @@ package org.apache.hadoop.metrics2.impl;
 import java.io.PrintWriter;
 import java.util.Iterator;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 
@@ -55,8 +56,8 @@ class ConfigUtil {
     for (Iterator<?> it = expected.getKeys(); it.hasNext();) {
       String key = (String) it.next();
       assertTrue(actual.containsKey(key), "actual should contain "+ key);
-      assertEquals(expected.getProperty(key)
-,                                      actual.getProperty(key), "value of "+ key);
+      assertEquals(expected.getProperty(key),
+          actual.getProperty(key), "value of "+ key);
     }
     // Check that the actual config has no extra properties
     for (Iterator<?> it = actual.getKeys(); it.hasNext();) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/MetricsRecords.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/MetricsRecords.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsTag;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Utility class mainly for tests
@@ -61,8 +61,8 @@ public class MetricsRecords {
       String metricName) {
     AbstractMetric resourceLimitMetric = getFirstMetricByName(
         record, metricName);
-    assertNotNull(
-       resourceLimitMetric, "Metric " + metricName + " doesn't exist");
+    assertNotNull("Metric " + metricName + " doesn't exist",
+        resourceLimitMetric);
   }
 
   private static MetricsTag getFirstTagByName(MetricsRecord record,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/MetricsRecords.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/MetricsRecords.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsTag;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Utility class mainly for tests
@@ -61,8 +61,8 @@ public class MetricsRecords {
       String metricName) {
     AbstractMetric resourceLimitMetric = getFirstMetricByName(
         record, metricName);
-    assertNotNull("Metric " + metricName + " doesn't exist",
-        resourceLimitMetric);
+    assertNotNull(
+       resourceLimitMetric, "Metric " + metricName + " doesn't exist");
   }
 
   private static MetricsTag getFirstTagByName(MetricsRecord record,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestGangliaMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestGangliaMetrics.java
@@ -172,8 +172,7 @@ public class TestGangliaMetrics {
       }
     }
 
-    assertEquals(
-       expectedCount, bytearrlist.size(), "Mismatch in record count: ");
+    assertEquals(expectedCount, bytearrlist.size(), "Mismatch in record count: ");
   }
 
   @SuppressWarnings("unused")

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestGangliaMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestGangliaMetrics.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -44,7 +44,7 @@ import org.apache.hadoop.metrics2.sink.ganglia.AbstractGangliaSink;
 import org.apache.hadoop.metrics2.sink.ganglia.GangliaSink30;
 import org.apache.hadoop.metrics2.sink.ganglia.GangliaSink31;
 import org.apache.hadoop.metrics2.sink.ganglia.GangliaMetricsTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,12 +168,12 @@ public class TestGangliaMetrics {
 
     for (int index = 0; index < foundMetrics.length; index++) {
       if (!foundMetrics[index]) {
-        assertTrue("Missing metrics: " + expectedMetrics[index], false);
+        assertTrue(false, "Missing metrics: " + expectedMetrics[index]);
       }
     }
 
-    assertEquals("Mismatch in record count: ",
-        expectedCount, bytearrlist.size());
+    assertEquals(
+       expectedCount, bytearrlist.size(), "Mismatch in record count: ");
   }
 
   @SuppressWarnings("unused")

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsCollectorImpl.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsCollectorImpl.java
@@ -19,7 +19,8 @@
 package org.apache.hadoop.metrics2.impl;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
 import static org.apache.hadoop.metrics2.filter.TestPatternFilter.*;
@@ -50,7 +51,7 @@ public class TestMetricsCollectorImpl {
       .addGauge(info("foo", ""), 1);
     assertEquals(1, rb.tags().size(), "1 tag");
     assertEquals(1, rb.metrics().size(), "1 metric");
-    assertEquals("expect foo tag", "foo", rb.tags().get(0).name());
-    assertEquals("expect c0", "c0", rb.metrics().get(0).name());
+    assertEquals("foo", rb.tags().get(0).name(), "expect foo tag");
+    assertEquals("c0", rb.metrics().get(0).name(), "expect c0");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsCollectorImpl.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsCollectorImpl.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.impl;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.commons.configuration2.SubsetConfiguration;
 import static org.apache.hadoop.metrics2.filter.TestPatternFilter.*;
@@ -34,10 +34,10 @@ public class TestMetricsCollectorImpl {
     mb.setRecordFilter(newGlobFilter(fc));
     MetricsRecordBuilderImpl rb = mb.addRecord("foo");
     rb.tag(info("foo", ""), "value").addGauge(info("g0", ""), 1);
-    assertEquals("no tags", 0, rb.tags().size());
-    assertEquals("no metrics", 0, rb.metrics().size());
-    assertNull("null record", rb.getRecord());
-    assertEquals("no records", 0, mb.getRecords().size());
+    assertEquals(0, rb.tags().size(), "no tags");
+    assertEquals(0, rb.metrics().size(), "no metrics");
+    assertNull(rb.getRecord(), "null record");
+    assertEquals(0, mb.getRecords().size(), "no records");
   }
 
   @Test public void testPerMetricFiltering() {
@@ -48,8 +48,8 @@ public class TestMetricsCollectorImpl {
     MetricsRecordBuilderImpl rb = mb.addRecord("foo");
     rb.tag(info("foo", ""), "").addCounter(info("c0", ""), 0)
       .addGauge(info("foo", ""), 1);
-    assertEquals("1 tag", 1, rb.tags().size());
-    assertEquals("1 metric", 1, rb.metrics().size());
+    assertEquals(1, rb.tags().size(), "1 tag");
+    assertEquals(1, rb.metrics().size(), "1 metric");
     assertEquals("expect foo tag", "foo", rb.tags().get(0).name());
     assertEquals("expect c0", "c0", rb.metrics().get(0).name());
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsConfig.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsConfig.java
@@ -21,7 +21,8 @@ package org.apache.hadoop.metrics2.impl;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.configuration2.Configuration;
 import org.slf4j.Logger;
@@ -97,16 +98,16 @@ public class TestMetricsConfig {
 
     LOG.debug("asserting foo == default foo");
     // Check default lookups
-    assertEquals("value of foo in t1 instance i1", "default foo",
-                 t1i1.getString("foo"));
-    assertEquals("value of bar in t1 instance i1", "p1.t1 default bar",
-                 t1i1.getString("bar"));
-    assertEquals("value of foo in t1 instance 42", "default foo",
-                 t1i42.getString("foo"));
-    assertEquals("value of foo in t2 instance i1", "p1.t2.i1.foo",
-                 t2i1.getString("foo"));
-    assertEquals("value of bar in t2 instance i1", "p1 default bar",
-                 t2i1.getString("bar"));
+    assertEquals("default foo", t1i1.getString("foo"),
+        "value of foo in t1 instance i1");
+    assertEquals("p1.t1 default bar", t1i1.getString("bar"),
+        "value of bar in t1 instance i1");
+    assertEquals("default foo", t1i42.getString("foo"),
+        "value of foo in t1 instance 42");
+    assertEquals("p1.t2.i1.foo", t2i1.getString("foo"),
+        "value of foo in t2 instance i1");
+    assertEquals("p1 default bar", t2i1.getString("bar"),
+        "value of bar in t2 instance i1");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsConfig.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsConfig.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.metrics2.impl;
 
 import java.util.Map;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.commons.configuration2.Configuration;
 import org.slf4j.Logger;
@@ -71,11 +71,11 @@ public class TestMetricsConfig {
     Map<String, MetricsConfig> map = c.getInstanceConfigs("t1");
     Map<String, MetricsConfig> map2 = c.getInstanceConfigs("t2");
 
-    assertEquals("number of t1 instances", 2, map.size());
-    assertEquals("number of t2 instances", 1, map2.size());
-    assertTrue("contains t1 instance i1", map.containsKey("i1"));
-    assertTrue("contains t1 instance 42", map.containsKey("42"));
-    assertTrue("contains t2 instance i1", map2.containsKey("i1"));
+    assertEquals(2, map.size(), "number of t1 instances");
+    assertEquals(1, map2.size(), "number of t2 instances");
+    assertTrue(map.containsKey("i1"), "contains t1 instance i1");
+    assertTrue(map.containsKey("42"), "contains t1 instance 42");
+    assertTrue(map2.containsKey("i1"), "contains t2 instance i1");
 
     MetricsConfig t1i1 = map.get("i1");
     MetricsConfig t1i42 = map.get("42");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSourceAdapter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSourceAdapter.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.metrics2.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,10 +40,10 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MetricsSourceBuilder;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.log4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
@@ -67,7 +67,7 @@ public class TestMetricsSourceAdapter {
     for (MBeanAttributeInfo mBeanAttributeInfo : info.getAttributes()) {
       sawIt |= mBeanAttributeInfo.getName().equals(source.lastKeyName);
     };
-    assertTrue("The last generated metric is not exported to jmx", sawIt);
+    assertTrue(sawIt, "The last generated metric is not exported to jmx");
 
     Thread.sleep(1000); // skip JMX cache TTL
 
@@ -76,7 +76,7 @@ public class TestMetricsSourceAdapter {
     for (MBeanAttributeInfo mBeanAttributeInfo : info.getAttributes()) {
       sawIt |= mBeanAttributeInfo.getName().equals(source.lastKeyName);
     };
-    assertTrue("The last generated metric is not exported to jmx", sawIt);
+    assertTrue(sawIt, "The last generated metric is not exported to jmx");
   }
 
   //generate a new key per each call
@@ -198,7 +198,7 @@ public class TestMetricsSourceAdapter {
     // Let the threads do their work.
     Thread.sleep(RACE_TEST_RUNTIME);
 
-    assertFalse("Hit error", hasError.get());
+    assertFalse(hasError.get(), "Hit error");
 
     // cleanup
     updaterExecutor.shutdownNow();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSourceAdapter.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSourceAdapter.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.metrics2.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +42,6 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MetricsSourceBuilder;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.Test;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSystemImpl.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSystemImpl.java
@@ -26,16 +26,27 @@ import java.util.concurrent.atomic.*;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import java.util.function.Supplier;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
@@ -43,7 +54,7 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.Iterables;
 import org.apache.commons.configuration2.SubsetConfiguration;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.test.GenericTestUtils;
-import static org.apache.hadoop.test.MoreAsserts.*;
+import org.apache.hadoop.test.MoreAsserts;
 
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
@@ -64,7 +75,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Test the MetricsSystemImpl class
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestMetricsSystemImpl {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMetricsSystemImpl.class);
@@ -305,8 +316,8 @@ public class TestMetricsSystemImpl {
     ms.stop();
     ms.shutdown();
     assertTrue(hanging.getInterrupted());
-    assertTrue(hanging.getGotCalledSecondTime(), "The sink didn't get called after its first hang " +
-               "for subsequent records.");
+    assertTrue(hanging.getGotCalledSecondTime(),
+        "The sink didn't get called after its first hang for subsequent records.");
   }
 
   private static class HangingSink implements MetricsSink {
@@ -428,22 +439,22 @@ public class TestMetricsSystemImpl {
   private void checkMetricsRecords(List<MetricsRecord> recs) {
     LOG.debug(recs.toString());
     MetricsRecord r = recs.get(0);
-    assertEquals("name", "s1rec", r.name());
-    assertEquals(new MetricsTag[] {
+    assertEquals("s1rec", r.name(), "name");
+    MoreAsserts.assertEquals("tags", new MetricsTag[] {
       tag(MsInfo.Context, "test"),
-      tag(MsInfo.Hostname, hostname)}, r.tags(), "tags");
-    assertEquals(MetricsLists.builder("")
+      tag(MsInfo.Hostname, hostname)}, r.tags());
+    MoreAsserts.assertEquals("metrics", MetricsLists.builder("")
       .addCounter(info("C1", "C1 desc"), 1L)
       .addGauge(info("G1", "G1 desc"), 2L)
       .addCounter(info("S1NumOps", "Number of ops for s1"), 1L)
       .addGauge(info("S1AvgTime", "Average time for s1"), 0.0)
-      .metrics(), r.metrics(), "metrics");
+      .metrics(), r.metrics());
 
     r = recs.get(1);
-    assertTrue(Iterables.contains(r.metrics(),
-               new MetricGaugeInt(MsInfo.NumActiveSinks, 3)), "NumActiveSinks should be 3");
-    assertTrue(
-       Iterables.contains(r.metrics(), new MetricGaugeInt(MsInfo.NumAllSinks, 3)), "NumAllSinks should be 3");
+    assertTrue(Iterables.contains(r.metrics(), new MetricGaugeInt(MsInfo.NumActiveSinks, 3)),
+        "NumActiveSinks should be 3");
+    assertTrue(Iterables.contains(r.metrics(), new MetricGaugeInt(MsInfo.NumAllSinks, 3)),
+        "NumAllSinks should be 3");
   }
 
   @Test
@@ -646,13 +657,13 @@ public class TestMetricsSystemImpl {
     try {
       ms.start();
       ms.register(sinkName, "", ts);
-      assertNotNull(
-             ms.getSinkAdapter(sinkName), "no adapter exists for " + sinkName);
+      assertNotNull(ms.getSinkAdapter(sinkName),
+          "no adapter exists for " + sinkName);
       ms.stop();
 
       ms.start();
-      assertNotNull(
-             ms.getSinkAdapter(sinkName), "no adapter exists for " + sinkName);
+      assertNotNull(ms.getSinkAdapter(sinkName),
+          "no adapter exists for " + sinkName);
     } finally {
       ms.stop();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSystemImpl.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsSystemImpl.java
@@ -24,7 +24,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.stream.StreamSupport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.runner.RunWith;
 
 import org.mockito.ArgumentCaptor;
@@ -33,7 +34,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.function.Supplier;
@@ -128,7 +129,7 @@ public class TestMetricsSystemImpl {
     List<MetricsRecord> mr2 = r2.getAllValues();
     if (mr1.size() != 0 && mr2.size() != 0) {
       checkMetricsRecords(mr1);
-      assertEquals("output", mr1, mr2);
+      assertEquals(mr1, mr2, "output");
     } else if (mr1.size() != 0) {
       checkMetricsRecords(mr1);
     } else if (mr2.size() != 0) {
@@ -172,7 +173,7 @@ public class TestMetricsSystemImpl {
     List<MetricsRecord> mr1 = r1.getAllValues();
     List<MetricsRecord> mr2 = r2.getAllValues();
     checkMetricsRecords(mr1);
-    assertEquals("output", mr1, mr2);
+    assertEquals(mr1, mr2, "output");
 
   }
   
@@ -242,9 +243,9 @@ public class TestMetricsSystemImpl {
     for (Thread t : threads)
       t.join();
     assertEquals(0L, ms.droppedPubAll.value());
-    assertTrue(String.join("\n", Arrays.asList(results)),
-        Arrays.asList(results).stream().allMatch(
-            input -> input.equalsIgnoreCase("Passed")));
+    assertTrue(Arrays.asList(results).stream().allMatch(
+        input -> input.equalsIgnoreCase("Passed")),
+        String.join("\n", Arrays.asList(results)));
     ms.stop();
     ms.shutdown();
   }
@@ -304,8 +305,8 @@ public class TestMetricsSystemImpl {
     ms.stop();
     ms.shutdown();
     assertTrue(hanging.getInterrupted());
-    assertTrue("The sink didn't get called after its first hang " +
-               "for subsequent records.", hanging.getGotCalledSecondTime());
+    assertTrue(hanging.getGotCalledSecondTime(), "The sink didn't get called after its first hang " +
+               "for subsequent records.");
   }
 
   private static class HangingSink implements MetricsSink {
@@ -360,11 +361,14 @@ public class TestMetricsSystemImpl {
     ms.shutdown();
   }
 
-  @Test(expected=MetricsException.class) public void testRegisterDupError() {
-    MetricsSystem ms = new MetricsSystemImpl("test");
-    TestSource ts = new TestSource("ts");
-    ms.register(ts);
-    ms.register(ts);
+  @Test
+  public void testRegisterDupError() {
+    assertThrows(MetricsException.class, () -> {
+      MetricsSystem ms = new MetricsSystemImpl("test");
+      TestSource ts = new TestSource("ts");
+      ms.register(ts);
+      ms.register(ts);
+    });
   }
 
   @Test public void testStartStopStart() {
@@ -425,21 +429,21 @@ public class TestMetricsSystemImpl {
     LOG.debug(recs.toString());
     MetricsRecord r = recs.get(0);
     assertEquals("name", "s1rec", r.name());
-    assertEquals("tags", new MetricsTag[] {
+    assertEquals(new MetricsTag[] {
       tag(MsInfo.Context, "test"),
-      tag(MsInfo.Hostname, hostname)}, r.tags());
-    assertEquals("metrics", MetricsLists.builder("")
+      tag(MsInfo.Hostname, hostname)}, r.tags(), "tags");
+    assertEquals(MetricsLists.builder("")
       .addCounter(info("C1", "C1 desc"), 1L)
       .addGauge(info("G1", "G1 desc"), 2L)
       .addCounter(info("S1NumOps", "Number of ops for s1"), 1L)
       .addGauge(info("S1AvgTime", "Average time for s1"), 0.0)
-      .metrics(), r.metrics());
+      .metrics(), r.metrics(), "metrics");
 
     r = recs.get(1);
-    assertTrue("NumActiveSinks should be 3", Iterables.contains(r.metrics(),
-               new MetricGaugeInt(MsInfo.NumActiveSinks, 3)));
-    assertTrue("NumAllSinks should be 3",
-        Iterables.contains(r.metrics(), new MetricGaugeInt(MsInfo.NumAllSinks, 3)));
+    assertTrue(Iterables.contains(r.metrics(),
+               new MetricGaugeInt(MsInfo.NumActiveSinks, 3)), "NumActiveSinks should be 3");
+    assertTrue(
+       Iterables.contains(r.metrics(), new MetricGaugeInt(MsInfo.NumAllSinks, 3)), "NumAllSinks should be 3");
   }
 
   @Test
@@ -526,7 +530,8 @@ public class TestMetricsSystemImpl {
   /**
    * HADOOP-11932
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testHangOnSinkRead() throws Exception {
     new ConfigBuilder().add("*.period", 8)
         .add("test.sink.test.class", TestSink.class.getName())
@@ -641,13 +646,13 @@ public class TestMetricsSystemImpl {
     try {
       ms.start();
       ms.register(sinkName, "", ts);
-      assertNotNull("no adapter exists for " + sinkName,
-              ms.getSinkAdapter(sinkName));
+      assertNotNull(
+             ms.getSinkAdapter(sinkName), "no adapter exists for " + sinkName);
       ms.stop();
 
       ms.start();
-      assertNotNull("no adapter exists for " + sinkName,
-              ms.getSinkAdapter(sinkName));
+      assertNotNull(
+             ms.getSinkAdapter(sinkName), "no adapter exists for " + sinkName);
     } finally {
       ms.stop();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsVisitor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsVisitor.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.metrics2.impl;
 
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import org.junit.runner.RunWith;
 
 import static org.mockito.Mockito.*;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsVisitor.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestMetricsVisitor.java
@@ -21,24 +21,27 @@ package org.apache.hadoop.metrics2.impl;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import org.apache.hadoop.metrics2.MetricsVisitor;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import static org.apache.hadoop.metrics2.lib.Interns.*;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test the metric visitor interface
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestMetricsVisitor {
   @Captor private ArgumentCaptor<MetricsInfo> c1;
   @Captor private ArgumentCaptor<MetricsInfo> c2;
@@ -67,23 +70,23 @@ public class TestMetricsVisitor {
     }
 
     verify(visitor).counter(c1.capture(), eq(1));
-    assertEquals("c1 name", "c1", c1.getValue().name());
-    assertEquals("c1 description", "int counter", c1.getValue().description());
+    assertEquals("c1", c1.getValue().name(), "c1 name");
+    assertEquals("int counter", c1.getValue().description(), "c1 description");
     verify(visitor).counter(c2.capture(), eq(2L));
-    assertEquals("c2 name", "c2", c2.getValue().name());
-    assertEquals("c2 description", "long counter", c2.getValue().description());
+    assertEquals("c2", c2.getValue().name(), "c2 name");
+    assertEquals("long counter", c2.getValue().description(), "c2 description");
     verify(visitor).gauge(g1.capture(), eq(5));
-    assertEquals("g1 name", "g1", g1.getValue().name());
-    assertEquals("g1 description", "int gauge", g1.getValue().description());
+    assertEquals("g1", g1.getValue().name(), "g1 name");
+    assertEquals("int gauge", g1.getValue().description(), "g1 description");
     verify(visitor).gauge(g2.capture(), eq(6L));
-    assertEquals("g2 name", "g2", g2.getValue().name());
-    assertEquals("g2 description", "long gauge", g2.getValue().description());
+    assertEquals("g2", g2.getValue().name(), "g2 name");
+    assertEquals("long gauge", g2.getValue().description(), "g2 description");
     verify(visitor).gauge(g3.capture(), eq(7f));
-    assertEquals("g3 name", "g3", g3.getValue().name());
-    assertEquals("g3 description", "float gauge", g3.getValue().description());
+    assertEquals("g3", g3.getValue().name(), "g3 name");
+    assertEquals("float gauge", g3.getValue().description(), "g3 description");
     verify(visitor).gauge(g4.capture(), eq(8d));
-    assertEquals("g4 name", "g4", g4.getValue().name());
-    assertEquals("g4 description", "double gauge", g4.getValue().description());
+    assertEquals("g4", g4.getValue().name(), "g4 name");
+    assertEquals("double gauge", g4.getValue().description(), "g4 description");
   }
 
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestSinkQueue.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestSinkQueue.java
@@ -21,11 +21,11 @@ package org.apache.hadoop.metrics2.impl;
 import java.util.ConcurrentModificationException;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import static org.apache.hadoop.metrics2.impl.SinkQueue.*;
@@ -44,21 +44,21 @@ public class TestSinkQueue {
   @Test public void testCommon() throws Exception {
     final SinkQueue<Integer> q = new SinkQueue<Integer>(2);
     q.enqueue(1);
-    assertEquals("queue front", 1, (int) q.front());
-    assertEquals("queue back", 1, (int) q.back());
-    assertEquals("element", 1, (int) q.dequeue());
+    assertEquals(1, (int) q.front(), "queue front");
+    assertEquals(1, (int) q.back(), "queue back");
+    assertEquals(1, (int) q.dequeue(), "element");
 
-    assertTrue("should enqueue", q.enqueue(2));
+    assertTrue(q.enqueue(2), "should enqueue");
     q.consume(new Consumer<Integer>() {
       @Override public void consume(Integer e) {
-        assertEquals("element", 2, (int) e);
+        assertEquals(2, (int) e, "element");
       }
     });
-    assertTrue("should enqueue", q.enqueue(3));
-    assertEquals("element", 3, (int) q.dequeue());
-    assertEquals("queue size", 0, q.size());
-    assertEquals("queue front", null, q.front());
-    assertEquals("queue back", null, q.back());
+    assertTrue(q.enqueue(3), "should enqueue");
+    assertEquals(3, (int) q.dequeue(), "element");
+    assertEquals(0, q.size(), "queue size");
+    assertEquals(null, q.front(), "queue front");
+    assertEquals(null, q.back(), "queue back");
   }
 
   /**
@@ -77,10 +77,10 @@ public class TestSinkQueue {
     Thread t = new Thread() {
       @Override public void run() {
         try {
-          assertEquals("element", 1, (int) q.dequeue());
+          assertEquals(1, (int) q.dequeue(), "element");
           q.consume(new Consumer<Integer>() {
             @Override public void consume(Integer e) {
-              assertEquals("element", 2, (int) e);
+              assertEquals(2, (int) e, "element");
               trigger.run();
             }
           });
@@ -109,16 +109,16 @@ public class TestSinkQueue {
     final SinkQueue<Integer> q = new SinkQueue<Integer>(1);
     q.enqueue(1);
 
-    assertTrue("should drop", !q.enqueue(2));
-    assertEquals("element", 1, (int) q.dequeue());
+    assertTrue(!q.enqueue(2), "should drop");
+    assertEquals(1, (int) q.dequeue(), "element");
 
     q.enqueue(3);
     q.consume(new Consumer<Integer>() {
       @Override public void consume(Integer e) {
-        assertEquals("element", 3, (int) e);
+        assertEquals(3, (int) e, "element");
       }
     });
-    assertEquals("queue size", 0, q.size());
+    assertEquals(0, q.size(), "queue size");
   }
 
   /**
@@ -130,15 +130,15 @@ public class TestSinkQueue {
     final SinkQueue<Integer> q = new SinkQueue<Integer>(capacity);
 
     for (int i = 0; i < capacity; ++i) {
-      assertTrue("should enqueue", q.enqueue(i));
+      assertTrue(q.enqueue(i), "should enqueue");
     }
-    assertTrue("should not enqueue", !q.enqueue(capacity));
+    assertTrue(!q.enqueue(capacity), "should not enqueue");
 
     final Runnable trigger = mock(Runnable.class);
     q.consumeAll(new Consumer<Integer>() {
       private int expected = 0;
       @Override public void consume(Integer e) {
-        assertEquals("element", expected++, (int) e);
+        assertEquals(expected++, (int) e, "element");
         trigger.run();
       }
     });
@@ -163,11 +163,11 @@ public class TestSinkQueue {
       });
     }
     catch (Exception expected) {
-      assertSame("consumer exception", ex, expected);
+      assertSame(ex, expected, "consumer exception");
     }
     // The queue should be in consistent state after exception
-    assertEquals("queue size", 1, q.size());
-    assertEquals("element", 1, (int) q.dequeue());
+    assertEquals(1, q.size(), "queue size");
+    assertEquals(1, (int) q.dequeue(), "element");
   }
 
   /**
@@ -178,9 +178,9 @@ public class TestSinkQueue {
     for (int i = 0; i < q.capacity() + 97; ++i) {
       q.enqueue(i);
     }
-    assertEquals("queue size", q.capacity(), q.size());
+    assertEquals(q.capacity(), q.size(), "queue size");
     q.clear();
-    assertEquals("queue size", 0, q.size());
+    assertEquals(0, q.size(), "queue size");
   }
 
   /**
@@ -189,11 +189,11 @@ public class TestSinkQueue {
    */
   @Test public void testHangingConsumer() throws Exception {
     SinkQueue<Integer> q = newSleepingConsumerQueue(2, 1, 2);
-    assertEquals("queue back", 2, (int) q.back());
-    assertTrue("should drop", !q.enqueue(3)); // should not block
-    assertEquals("queue size", 2, q.size());
-    assertEquals("queue head", 1, (int) q.front());
-    assertEquals("queue back", 2, (int) q.back());
+    assertEquals(2, (int) q.back(), "queue back");
+    assertTrue(!q.enqueue(3), "should drop"); // should not block
+    assertEquals(2, q.size(), "queue size");
+    assertEquals(1, (int) q.front(), "queue head");
+    assertEquals(2, (int) q.back(), "queue back");
   }
 
   /**
@@ -202,9 +202,9 @@ public class TestSinkQueue {
    */
   @Test public void testConcurrentConsumers() throws Exception {
     final SinkQueue<Integer> q = newSleepingConsumerQueue(2, 1);
-    assertTrue("should enqueue", q.enqueue(2));
-    assertEquals("queue back", 2, (int) q.back());
-    assertTrue("should drop", !q.enqueue(3)); // should not block
+    assertTrue(q.enqueue(2), "should enqueue");
+    assertEquals(2, (int) q.back(), "queue back");
+    assertTrue(!q.enqueue(3), "should drop"); // should not block
     shouldThrowCME(new Fun() {
       @Override public void run() {
         q.clear();
@@ -226,9 +226,9 @@ public class TestSinkQueue {
       }
     });
     // The queue should still be in consistent state after all the exceptions
-    assertEquals("queue size", 2, q.size());
-    assertEquals("queue front", 1, (int) q.front());
-    assertEquals("queue back", 2, (int) q.back());
+    assertEquals(2, q.size(), "queue size");
+    assertEquals(1, (int) q.front(), "queue front");
+    assertEquals(2, (int) q.back(), "queue back");
   }
 
   private void shouldThrowCME(Fun callback) throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestSinkQueue.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/impl/TestSinkQueue.java
@@ -25,8 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import static org.apache.hadoop.metrics2.impl.SinkQueue.*;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestInterns.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestInterns.java
@@ -19,7 +19,8 @@
 package org.apache.hadoop.metrics2.lib;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsTag;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestInterns.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestInterns.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.lib;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsTag;
@@ -29,12 +29,12 @@ public class TestInterns {
 
   @Test public void testInfo() {
     MetricsInfo info = info("m", "m desc");
-    assertSame("same info", info, info("m", "m desc"));
+    assertSame(info, info("m", "m desc"), "same info");
   }
 
   @Test public void testTag() {
     MetricsTag tag = tag("t", "t desc", "t value");
-    assertSame("same tag", tag, tag("t", "t desc", "t value"));
+    assertSame(tag, tag("t", "t desc", "t value"), "same tag");
   }
 
   @Test public void testInfoOverflow() {
@@ -42,19 +42,19 @@ public class TestInterns {
     for (int i = 0; i < MAX_INFO_NAMES + 1; ++i) {
       info("m"+ i, "m desc");
       if (i < MAX_INFO_NAMES) {
-        assertSame("m0 is still there", i0, info("m0", "m desc"));
+        assertSame(i0, info("m0", "m desc"), "m0 is still there");
       }
     }
-    assertNotSame("m0 is gone", i0, info("m0", "m desc"));
+    assertNotSame(i0, info("m0", "m desc"), "m0 is gone");
 
     MetricsInfo i1 = info("m1", "m desc");
     for (int i = 0; i < MAX_INFO_DESCS; ++i) {
       info("m1", "m desc"+ i);
       if (i < MAX_INFO_DESCS - 1) {
-        assertSame("i1 is still there", i1, info("m1", "m desc"));
+        assertSame(i1, info("m1", "m desc"), "i1 is still there");
       }
     }
-    assertNotSame("i1 is gone", i1,  info("m1", "m desc"));
+    assertNotSame(i1,  info("m1", "m desc"), "i1 is gone");
   }
 
   @Test public void testTagOverflow() {
@@ -62,18 +62,18 @@ public class TestInterns {
     for (int i = 0; i < MAX_TAG_NAMES + 1; ++i) {
       tag("t"+ i, "t desc", "t value");
       if (i < MAX_TAG_NAMES) {
-        assertSame("t0 still there", t0, tag("t0", "t desc", "t value"));
+        assertSame(t0, tag("t0", "t desc", "t value"), "t0 still there");
       }
     }
-    assertNotSame("t0 is gone", t0, tag("t0", "t desc", "t value"));
+    assertNotSame(t0, tag("t0", "t desc", "t value"), "t0 is gone");
 
     MetricsTag t1 = tag("t1", "t desc", "t value");
     for (int i = 0; i < MAX_TAG_VALUES; ++i) {
       tag("t1", "t desc", "t value"+ i);
       if (i < MAX_TAG_VALUES -1) {
-        assertSame("t1 is still there", t1, tag("t1", "t desc", "t value"));
+        assertSame(t1, tag("t1", "t desc", "t value"), "t1 is still there");
       }
     }
-    assertNotSame("t1 is gone", t1, tag("t1", "t desc", "t value"));
+    assertNotSame(t1, tag("t1", "t desc", "t value"), "t1 is gone");
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
@@ -19,8 +19,9 @@
 package org.apache.hadoop.metrics2.lib;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
@@ -83,7 +83,7 @@ public class TestMetricsAnnotations {
   @Test
   public void testBadFields() {
     assertThrows(MetricsException.class, () ->
-       MetricsAnnotations.makeSource(new BadMetrics()));
+        MetricsAnnotations.makeSource(new BadMetrics()));
   }
 
   static class MyMetrics2 {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsAnnotations.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.lib;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsException;
@@ -79,8 +79,10 @@ public class TestMetricsAnnotations {
     @Metric Integer i0;
   }
 
-  @Test(expected=MetricsException.class) public void testBadFields() {
-    MetricsAnnotations.makeSource(new BadMetrics());
+  @Test
+  public void testBadFields() {
+    assertThrows(MetricsException.class, () ->
+       MetricsAnnotations.makeSource(new BadMetrics()));
   }
 
   static class MyMetrics2 {
@@ -111,18 +113,20 @@ public class TestMetricsAnnotations {
     @Metric int foo(int i) { return i; }
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testBadMethodWithArgs() {
-    MetricsAnnotations.makeSource(new BadMetrics2());
+    assertThrows(IllegalArgumentException.class,
+        ()-> MetricsAnnotations.makeSource(new BadMetrics2()));
   }
 
   static class BadMetrics3 {
     @Metric boolean foo() { return true; }
   }
 
-  @Test(expected=MetricsException.class)
+  @Test
   public void testBadMethodReturnType() {
-    MetricsAnnotations.makeSource(new BadMetrics3());
+    assertThrows(MetricsException.class,
+        ()-> MetricsAnnotations.makeSource(new BadMetrics3()));
   }
 
   @Metrics(about="My metrics", context="foo")
@@ -191,15 +195,19 @@ public class TestMetricsAnnotations {
     }
   }
 
-  @Test(expected=MetricsException.class) public void testBadHybrid() {
-    MetricsAnnotations.makeSource(new BadHybridMetrics());
+  @Test
+  public void testBadHybrid() {
+    assertThrows(MetricsException.class,
+        ()-> MetricsAnnotations.makeSource(new BadHybridMetrics()));
   }
 
   static class EmptyMetrics {
     int foo;
   }
 
-  @Test(expected=MetricsException.class) public void testEmptyMetrics() {
-    MetricsAnnotations.makeSource(new EmptyMetrics());
+  @Test
+  public void testEmptyMetrics() {
+    assertThrows(MetricsException.class, ()->
+        MetricsAnnotations.makeSource(new EmptyMetrics()));
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
@@ -18,10 +18,12 @@
 
 package org.apache.hadoop.metrics2.lib;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.verify;
 
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -140,7 +142,7 @@ public class TestMetricsRegistry {
     });
   }
 
-  @Ignore
+  @Disabled
   private void expectMetricsException(String prefix, Runnable fun) {
     try {
       fun.run();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.metrics2.lib;
 
 import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.hadoop.metrics2.MetricsException;
@@ -45,13 +45,13 @@ public class TestMetricsRegistry {
     r.newGauge("g3", "g3 desc", 5f);
     r.newStat("s1", "s1 desc", "ops", "time");
 
-    assertEquals("num metrics in registry", 6, r.metrics().size());
-    assertTrue("c1 found", r.get("c1") instanceof MutableCounterInt);
-    assertTrue("c2 found", r.get("c2") instanceof MutableCounterLong);
-    assertTrue("g1 found", r.get("g1") instanceof MutableGaugeInt);
-    assertTrue("g2 found", r.get("g2") instanceof MutableGaugeLong);
-    assertTrue("g3 found", r.get("g3") instanceof MutableGaugeFloat);
-    assertTrue("s1 found", r.get("s1") instanceof MutableStat);
+    assertEquals(6, r.metrics().size(), "num metrics in registry");
+    assertTrue(r.get("c1") instanceof MutableCounterInt, "c1 found");
+    assertTrue(r.get("c2") instanceof MutableCounterLong, "c2 found");
+    assertTrue(r.get("g1") instanceof MutableGaugeInt, "g1 found");
+    assertTrue(r.get("g2") instanceof MutableGaugeLong, "g2 found");
+    assertTrue(r.get("g3") instanceof MutableGaugeFloat, "g3 found");
+    assertTrue(r.get("s1") instanceof MutableStat, "s1 found");
 
     expectMetricsException("Metric name c1 already exists", new Runnable() {
       @Override
@@ -96,7 +96,7 @@ public class TestMetricsRegistry {
       public void run() { r.newCounter("withnewline6\n", "c6 desc", 6); }
     });
     // Final validation
-    assertEquals("num metrics in registry", 3, r.metrics().size());
+    assertEquals(3, r.metrics().size(), "num metrics in registry");
   }
 
   /**
@@ -146,7 +146,7 @@ public class TestMetricsRegistry {
       fun.run();
     }
     catch (MetricsException e) {
-      assertTrue("expected exception", e.getMessage().startsWith(prefix));
+      assertTrue(e.getMessage().startsWith(prefix), "expected exception");
       return;
     }
     fail("should've thrown '"+ prefix +"...'");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.metrics2.lib;
 import static org.apache.hadoop.metrics2.impl.MsInfo.Context;
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 import static org.apache.hadoop.test.MetricsAsserts.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.AdditionalMatchers.eq;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.AdditionalMatchers.leq;
@@ -28,7 +29,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableMetrics.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +40,8 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.util.Quantile;
 import org.apache.hadoop.thirdparty.com.google.common.math.Stats;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -264,8 +265,8 @@ public class TestMutableMetrics {
     // the totals are as expected
     snapshotMutableRatesWithAggregation(rates, opCount, opTotalTime);
     for (int i = 0; i < n; i++) {
-      assertEquals("metric" + i + " count", 1001, opCount[i]);
-      assertEquals("metric" + i + " total", 1500, opTotalTime[i], 1.0);
+      assertEquals(1001, opCount[i], "metric" + i + " count");
+      assertEquals(1500, opTotalTime[i], 1.0, "metric" + i + " total");
     }
     firstSnapshotsFinished.countDown();
 
@@ -274,8 +275,8 @@ public class TestMutableMetrics {
     secondAddsFinished.await();
     snapshotMutableRatesWithAggregation(rates, opCount, opTotalTime);
     for (int i = 0; i < n; i++) {
-      assertEquals("metric" + i + " count", 1501, opCount[i]);
-      assertEquals("metric" + i + " total", 2250, opTotalTime[i], 1.0);
+      assertEquals(1501, opCount[i], "metric" + i + " count");
+      assertEquals(2250, opTotalTime[i], 1.0, "metric" + i + " total");
     }
     secondSnapshotsFinished.countDown();
   }
@@ -402,7 +403,8 @@ public class TestMutableMetrics {
    * Ensure that quantile estimates from {@link MutableQuantiles} are within
    * specified error bounds.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableQuantilesError() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -448,7 +450,8 @@ public class TestMutableMetrics {
    * Ensure that quantile estimates from {@link MutableInverseQuantiles} are within
    * specified error bounds.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableInverseQuantilesError() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -488,7 +491,8 @@ public class TestMutableMetrics {
    * Test that {@link MutableQuantiles} rolls the window over at the specified
    * interval.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableQuantilesRollover() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -536,7 +540,8 @@ public class TestMutableMetrics {
    * Test that {@link MutableInverseQuantiles} rolls the window over at the specified
    * interval.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableInverseQuantilesRollover() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -585,7 +590,8 @@ public class TestMutableMetrics {
    * Test that {@link MutableQuantiles} rolls over correctly even if no items.
    * have been added to the window
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableQuantilesEmptyRollover() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -607,7 +613,8 @@ public class TestMutableMetrics {
    * Test that {@link MutableInverseQuantiles} rolls over correctly even if no items
    * have been added to the window
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableInverseQuantilesEmptyRollover() throws Exception {
     MetricsRecordBuilder mb = mockMetricsRecordBuilder();
     MetricsRegistry registry = new MetricsRegistry("test");
@@ -628,7 +635,8 @@ public class TestMutableMetrics {
   /**
    * Test {@link MutableGaugeFloat#incr()}.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableGaugeFloat() {
     MutableGaugeFloat mgf = new MutableGaugeFloat(Context, 3.2f);
     assertEquals(3.2f, mgf.value(), 0.0);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableRollingAverages.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableRollingAverages.java
@@ -23,8 +23,9 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,8 @@ public class TestMutableRollingAverages {
    * Tests if the results are correct if no samples are inserted, dry run of
    * empty roll over.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testRollingAveragesEmptyRollover() throws Exception {
     final MetricsRecordBuilder rb = mockMetricsRecordBuilder();
     /* 5s interval and 2 windows */
@@ -79,7 +81,8 @@ public class TestMutableRollingAverages {
    * 2...2] and [3, 3...3]
    * </p>
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testRollingAveragesRollover() throws Exception {
     final MetricsRecordBuilder rb = mockMetricsRecordBuilder();
     final String name = "foo2";
@@ -135,7 +138,8 @@ public class TestMutableRollingAverages {
    * initialization.
    * @throws Exception
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testMutableRollingAveragesMetric() throws Exception {
     DummyTestMetric testMetric = new DummyTestMetric();
     testMetric.create();
@@ -157,10 +161,10 @@ public class TestMutableRollingAverages {
 
     double metric1Avg = getDoubleGauge("[Metric1]RollingAvgTesting", rb);
     double metric2Avg = getDoubleGauge("[Metric2]RollingAvgTesting", rb);
-    Assert.assertTrue("The rolling average of metric1 is not as expected",
-        metric1Avg == 500.0);
-    Assert.assertTrue("The rolling average of metric2 is not as expected",
-        metric2Avg == 1000.0);
+    Assertions.assertTrue(
+       metric1Avg == 500.0, "The rolling average of metric1 is not as expected");
+    Assertions.assertTrue(
+       metric2Avg == 1000.0, "The rolling average of metric2 is not as expected");
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableRollingAverages.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMutableRollingAverages.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -32,9 +31,12 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.metrics2.lib.Interns.info;
 import static org.apache.hadoop.test.MetricsAsserts.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * This class tests various cases of the algorithms implemented in
@@ -161,10 +163,8 @@ public class TestMutableRollingAverages {
 
     double metric1Avg = getDoubleGauge("[Metric1]RollingAvgTesting", rb);
     double metric2Avg = getDoubleGauge("[Metric2]RollingAvgTesting", rb);
-    Assertions.assertTrue(
-       metric1Avg == 500.0, "The rolling average of metric1 is not as expected");
-    Assertions.assertTrue(
-       metric2Avg == 1000.0, "The rolling average of metric2 is not as expected");
+    assertTrue(metric1Avg == 500.0, "The rolling average of metric1 is not as expected");
+    assertTrue(metric2Avg == 1000.0, "The rolling average of metric2 is not as expected");
 
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestUniqNames.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestUniqNames.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.lib;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestUniqNames {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestUniqNames.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestUniqNames.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.metrics2.lib;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestUniqNames {
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
@@ -54,12 +54,12 @@ import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class is a base class for testing the {@link RollingFileSystemSink}
@@ -119,7 +119,7 @@ public class RollingFileSystemSinkTestBase {
   /**
    * Set the date format's timezone to GMT.
    */
-  @BeforeAll
+  @BeforeClass
   public static void setup() {
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
     FileUtil.fullyDelete(ROOT_TEST_DIR);
@@ -129,7 +129,7 @@ public class RollingFileSystemSinkTestBase {
    * Delete the test directory for this test.
    * @throws IOException thrown if the delete fails
    */
-  @AfterAll
+  @AfterClass
   public static void deleteBaseDir() throws IOException {
     FileUtil.fullyDelete(ROOT_TEST_DIR);
   }
@@ -138,12 +138,12 @@ public class RollingFileSystemSinkTestBase {
    * Create the test directory for this test.
    * @throws IOException thrown if the create fails
    */
-  @BeforeEach
+  @Before
   public void createMethodDir() throws IOException {
     methodDir = new File(ROOT_TEST_DIR, methodName.getMethodName());
 
-    assertTrue(
-       methodDir.mkdirs(), "Test directory already exists: " + methodDir);
+    assertTrue("Test directory already exists: " + methodDir,
+        methodDir.mkdirs());
   }
 
   /**
@@ -265,7 +265,7 @@ public class RollingFileSystemSinkTestBase {
       }
     }
 
-    assertTrue(found, "No valid log directories found");
+    assertTrue("No valid log directories found", found);
 
     return metrics.toString();
   }
@@ -342,8 +342,8 @@ public class RollingFileSystemSinkTestBase {
         + "\\s+testTag22=testTagValue22,\\s+Hostname=.*$[\\n\\r]*",
          Pattern.MULTILINE);
 
-    assertTrue(expectedContentPattern.matcher(contents).matches(), "Sink did not produce the expected output. Actual output was: "
-        + contents);
+    assertTrue("Sink did not produce the expected output. Actual output was: "
+        + contents, expectedContentPattern.matcher(contents).matches());
   }
 
   /**
@@ -366,8 +366,8 @@ public class RollingFileSystemSinkTestBase {
         + "\\s+testTag22=testTagValue22,\\s+Hostname=.*$[\\n\\r]*",
          Pattern.MULTILINE);
 
-    assertTrue(expectedContentPattern.matcher(contents).matches(), "Sink did not produce the expected output. Actual output was: "
-        + contents);
+    assertTrue("Sink did not produce the expected output. Actual output was: "
+        + contents, expectedContentPattern.matcher(contents).matches());
   }
 
   /**
@@ -500,10 +500,10 @@ public class RollingFileSystemSinkTestBase {
       count++;
     }
 
-    assertTrue(expected >= count, "The sink created additional unexpected log files. " + count
-        + " files were created");
-    assertTrue(expected <= count, "The sink created too few log files. " + count + " files were "
-        + "created");
+    assertTrue("The sink created additional unexpected log files. " + count
+        + " files were created", expected >= count);
+    assertTrue("The sink created too few log files. " + count + " files were "
+        + "created", expected <= count);
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/RollingFileSystemSinkTestBase.java
@@ -54,12 +54,12 @@ import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class is a base class for testing the {@link RollingFileSystemSink}
@@ -119,7 +119,7 @@ public class RollingFileSystemSinkTestBase {
   /**
    * Set the date format's timezone to GMT.
    */
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
     FileUtil.fullyDelete(ROOT_TEST_DIR);
@@ -129,7 +129,7 @@ public class RollingFileSystemSinkTestBase {
    * Delete the test directory for this test.
    * @throws IOException thrown if the delete fails
    */
-  @AfterClass
+  @AfterAll
   public static void deleteBaseDir() throws IOException {
     FileUtil.fullyDelete(ROOT_TEST_DIR);
   }
@@ -138,12 +138,12 @@ public class RollingFileSystemSinkTestBase {
    * Create the test directory for this test.
    * @throws IOException thrown if the create fails
    */
-  @Before
+  @BeforeEach
   public void createMethodDir() throws IOException {
     methodDir = new File(ROOT_TEST_DIR, methodName.getMethodName());
 
-    assertTrue("Test directory already exists: " + methodDir,
-        methodDir.mkdirs());
+    assertTrue(
+       methodDir.mkdirs(), "Test directory already exists: " + methodDir);
   }
 
   /**
@@ -265,7 +265,7 @@ public class RollingFileSystemSinkTestBase {
       }
     }
 
-    assertTrue("No valid log directories found", found);
+    assertTrue(found, "No valid log directories found");
 
     return metrics.toString();
   }
@@ -342,8 +342,8 @@ public class RollingFileSystemSinkTestBase {
         + "\\s+testTag22=testTagValue22,\\s+Hostname=.*$[\\n\\r]*",
          Pattern.MULTILINE);
 
-    assertTrue("Sink did not produce the expected output. Actual output was: "
-        + contents, expectedContentPattern.matcher(contents).matches());
+    assertTrue(expectedContentPattern.matcher(contents).matches(), "Sink did not produce the expected output. Actual output was: "
+        + contents);
   }
 
   /**
@@ -366,8 +366,8 @@ public class RollingFileSystemSinkTestBase {
         + "\\s+testTag22=testTagValue22,\\s+Hostname=.*$[\\n\\r]*",
          Pattern.MULTILINE);
 
-    assertTrue("Sink did not produce the expected output. Actual output was: "
-        + contents, expectedContentPattern.matcher(contents).matches());
+    assertTrue(expectedContentPattern.matcher(contents).matches(), "Sink did not produce the expected output. Actual output was: "
+        + contents);
   }
 
   /**
@@ -500,10 +500,10 @@ public class RollingFileSystemSinkTestBase {
       count++;
     }
 
-    assertTrue("The sink created additional unexpected log files. " + count
-        + " files were created", expected >= count);
-    assertTrue("The sink created too few log files. " + count + " files were "
-        + "created", expected <= count);
+    assertTrue(expected >= count, "The sink created additional unexpected log files. " + count
+        + " files were created");
+    assertTrue(expected <= count, "The sink created too few log files. " + count + " files were "
+        + "created");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFileSink {
   
@@ -82,7 +82,7 @@ public class TestFileSink {
     return File.createTempFile(prefix, suffix, dir);
   }
   
-  @Test 
+  @Test
   @Timeout(value = 6)
   public void testFileSink() throws IOException {
     outFile = getTestTempFile("test-file-sink-", ".out");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestFileSink.java
@@ -35,9 +35,10 @@ import org.apache.hadoop.metrics2.impl.ConfigBuilder;
 import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
 import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestFileSink {
   
@@ -81,7 +82,8 @@ public class TestFileSink {
     return File.createTempFile(prefix, suffix, dir);
   }
   
-  @Test(timeout=6000) 
+  @Test 
+  @Timeout(value = 6)
   public void testFileSink() throws IOException {
     outFile = getTestTempFile("test-file-sink-", ".out");
     final String outPath = outFile.getAbsolutePath();  
@@ -136,7 +138,7 @@ public class TestFileSink {
      assertTrue(expectedContentPattern.matcher(outFileContent).matches());
   }
   
-  @After
+  @AfterEach
   public void after() {
     if (outFile != null) {
       outFile.delete();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestGraphiteMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestGraphiteMetrics.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsTag;
 import org.apache.hadoop.metrics2.impl.MetricsRecordImpl;
 import org.apache.hadoop.metrics2.impl.MsInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
@@ -35,11 +35,13 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test prometheus Sink.
@@ -69,11 +71,8 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assertions.assertTrue(
-    
-       writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\""), "The expected metric line is missing from prometheus metrics output"
-    );
+    assertTrue(writtenMetrics.contains("test_metrics_num_bucket_create_fails{context=\"dfs\""),
+        "The expected metric line is missing from prometheus metrics output");
 
     metrics.unregisterSource("TestMetrics");
     metrics.stop();
@@ -110,16 +109,12 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assertions.assertTrue(
-    
-       writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""), "The expected first metric line is missing from prometheus metrics output"
-    );
-    Assertions.assertTrue(
-    
-       writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""), "The expected second metric line is missing from prometheus metrics output"
-    );
+    assertTrue(writtenMetrics.contains(
+        "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""),
+        "The expected first metric line is missing from prometheus metrics output");
+    assertTrue(writtenMetrics.contains(
+        "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""),
+        "The expected second metric line is missing from prometheus metrics output");
 
     metrics.unregisterSource("TestMetrics1");
     metrics.unregisterSource("TestMetrics2");
@@ -161,16 +156,12 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assertions.assertFalse(
-    
-       writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""), "The first metric should not exist after flushing"
-    );
-    Assertions.assertTrue(
-    
-       writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""), "The expected metric line is missing from prometheus metrics output"
-    );
+    assertFalse(writtenMetrics.contains(
+        "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""),
+        "The first metric should not exist after flushing");
+    assertTrue(writtenMetrics.contains(
+        "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""),
+        "The expected metric line is missing from prometheus metrics output");
 
     metrics.unregisterSource("TestMetrics");
     metrics.stop();
@@ -181,13 +172,13 @@ public class TestPrometheusMetricsSink {
   public void testNamingCamelCase() {
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
 
-    Assertions.assertEquals("rpc_time_some_metrics",
+    assertEquals("rpc_time_some_metrics",
         sink.prometheusName("RpcTime", "SomeMetrics"));
 
-    Assertions.assertEquals("om_rpc_time_om_info_keys",
+    assertEquals("om_rpc_time_om_info_keys",
         sink.prometheusName("OMRpcTime", "OMInfoKeys"));
 
-    Assertions.assertEquals("rpc_time_small",
+    assertEquals("rpc_time_small",
         sink.prometheusName("RpcTime", "small"));
   }
 
@@ -198,7 +189,7 @@ public class TestPrometheusMetricsSink {
     String recordName = "SCMPipelineMetrics";
     String metricName = "NumBlocksAllocated-"
         + "RATIS-THREE-47659e3d-40c9-43b3-9792-4982fc279aba";
-    Assertions.assertEquals(
+    assertEquals(
         "scm_pipeline_metrics_"
             + "num_blocks_allocated_"
             + "ratis_three_47659e3d_40c9_43b3_9792_4982fc279aba",
@@ -211,7 +202,7 @@ public class TestPrometheusMetricsSink {
 
     String recordName = "org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl";
     String metricName = "DfsUsed";
-    Assertions.assertEquals(
+    assertEquals(
         "org_apache_hadoop_hdfs_server_datanode_fsdataset_impl_fs_dataset_impl_dfs_used",
         sink.prometheusName(recordName, metricName));
   }
@@ -222,7 +213,7 @@ public class TestPrometheusMetricsSink {
 
     String recordName = "JvmMetrics";
     String metricName = "GcCount" + "G1 Old Generation";
-    Assertions.assertEquals(
+    assertEquals(
         "jvm_metrics_gc_count_g1_old_generation",
         sink.prometheusName(recordName, metricName));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestPrometheusMetricsSink.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,10 +69,10 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assert.assertTrue(
-        "The expected metric line is missing from prometheus metrics output",
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\"")
+    Assertions.assertTrue(
+    
+       writtenMetrics.contains(
+            "test_metrics_num_bucket_create_fails{context=\"dfs\""), "The expected metric line is missing from prometheus metrics output"
     );
 
     metrics.unregisterSource("TestMetrics");
@@ -110,15 +110,15 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assert.assertTrue(
-        "The expected first metric line is missing from prometheus metrics output",
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\"")
+    Assertions.assertTrue(
+    
+       writtenMetrics.contains(
+            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""), "The expected first metric line is missing from prometheus metrics output"
     );
-    Assert.assertTrue(
-        "The expected second metric line is missing from prometheus metrics output",
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\"")
+    Assertions.assertTrue(
+    
+       writtenMetrics.contains(
+            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""), "The expected second metric line is missing from prometheus metrics output"
     );
 
     metrics.unregisterSource("TestMetrics1");
@@ -161,15 +161,15 @@ public class TestPrometheusMetricsSink {
     //THEN
     String writtenMetrics = stream.toString(UTF_8.name());
     System.out.println(writtenMetrics);
-    Assert.assertFalse(
-        "The first metric should not exist after flushing",
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\"")
+    Assertions.assertFalse(
+    
+       writtenMetrics.contains(
+            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue1\""), "The first metric should not exist after flushing"
     );
-    Assert.assertTrue(
-        "The expected metric line is missing from prometheus metrics output",
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\"")
+    Assertions.assertTrue(
+    
+       writtenMetrics.contains(
+            "test_metrics_num_bucket_create_fails{context=\"dfs\",testtag=\"testTagValue2\""), "The expected metric line is missing from prometheus metrics output"
     );
 
     metrics.unregisterSource("TestMetrics");
@@ -181,13 +181,13 @@ public class TestPrometheusMetricsSink {
   public void testNamingCamelCase() {
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
 
-    Assert.assertEquals("rpc_time_some_metrics",
+    Assertions.assertEquals("rpc_time_some_metrics",
         sink.prometheusName("RpcTime", "SomeMetrics"));
 
-    Assert.assertEquals("om_rpc_time_om_info_keys",
+    Assertions.assertEquals("om_rpc_time_om_info_keys",
         sink.prometheusName("OMRpcTime", "OMInfoKeys"));
 
-    Assert.assertEquals("rpc_time_small",
+    Assertions.assertEquals("rpc_time_small",
         sink.prometheusName("RpcTime", "small"));
   }
 
@@ -198,7 +198,7 @@ public class TestPrometheusMetricsSink {
     String recordName = "SCMPipelineMetrics";
     String metricName = "NumBlocksAllocated-"
         + "RATIS-THREE-47659e3d-40c9-43b3-9792-4982fc279aba";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "scm_pipeline_metrics_"
             + "num_blocks_allocated_"
             + "ratis_three_47659e3d_40c9_43b3_9792_4982fc279aba",
@@ -211,7 +211,7 @@ public class TestPrometheusMetricsSink {
 
     String recordName = "org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl";
     String metricName = "DfsUsed";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "org_apache_hadoop_hdfs_server_datanode_fsdataset_impl_fs_dataset_impl_dfs_used",
         sink.prometheusName(recordName, metricName));
   }
@@ -222,7 +222,7 @@ public class TestPrometheusMetricsSink {
 
     String recordName = "JvmMetrics";
     String metricName = "GcCount" + "G1 Old Generation";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "jvm_metrics_gc_count_g1_old_generation",
         sink.prometheusName(recordName, metricName));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
@@ -51,18 +51,15 @@ public class TestRollingFileSystemSink {
 
     sink.init(conf);
 
-    assertEquals(
-       sink.rollIntervalMillis, 600000, "The roll interval was not set correctly");
-    assertEquals(
-       sink.rollOffsetIntervalMillis, 1, "The roll offset interval was not set correctly");
-    assertEquals(
-       sink.basePath, new Path("path"), "The base path was not set correctly");
-    assertEquals(
-       sink.ignoreError, true, "ignore-error was not set correctly");
-    assertEquals(
-       sink.allowAppend, true, "allow-append was not set correctly");
-    assertEquals("The source was not set correctly",
-        sink.source, "src");
+    assertEquals(sink.rollIntervalMillis, 600000,
+        "The roll interval was not set correctly");
+    assertEquals(sink.rollOffsetIntervalMillis, 1,
+        "The roll offset interval was not set correctly");
+    assertEquals(sink.basePath, new Path("path"),
+        "The base path was not set correctly");
+    assertEquals(sink.ignoreError, true, "ignore-error was not set correctly");
+    assertEquals(sink.allowAppend, true, "allow-append was not set correctly");
+    assertEquals(sink.source, "src", "The source was not set correctly");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
@@ -24,11 +24,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.impl.ConfigBuilder;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test that the init() method picks up all the configuration settings
@@ -51,16 +51,16 @@ public class TestRollingFileSystemSink {
 
     sink.init(conf);
 
-    assertEquals("The roll interval was not set correctly",
-        sink.rollIntervalMillis, 600000);
-    assertEquals("The roll offset interval was not set correctly",
-        sink.rollOffsetIntervalMillis, 1);
-    assertEquals("The base path was not set correctly",
-        sink.basePath, new Path("path"));
-    assertEquals("ignore-error was not set correctly",
-        sink.ignoreError, true);
-    assertEquals("allow-append was not set correctly",
-        sink.allowAppend, true);
+    assertEquals(
+       sink.rollIntervalMillis, 600000, "The roll interval was not set correctly");
+    assertEquals(
+       sink.rollOffsetIntervalMillis, 1, "The roll offset interval was not set correctly");
+    assertEquals(
+       sink.basePath, new Path("path"), "The base path was not set correctly");
+    assertEquals(
+       sink.ignoreError, true, "ignore-error was not set correctly");
+    assertEquals(
+       sink.allowAppend, true, "allow-append was not set correctly");
     assertEquals("The source was not set correctly",
         sink.source, "src");
   }
@@ -80,36 +80,36 @@ public class TestRollingFileSystemSink {
     calendar.set(Calendar.DAY_OF_YEAR, 1);
     calendar.set(Calendar.YEAR, 2016);
 
-    assertNull("Last flush time should have been null prior to calling init()",
-        rfsSink.nextFlush);
+    assertNull(
+       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
 
     rfsSink.setInitialFlushTime(calendar.getTime());
 
     long diff =
         rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertEquals("The initial flush time was calculated incorrectly", 0L, diff);
+    assertEquals(0L, diff, "The initial flush time was calculated incorrectly");
 
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertEquals("The initial flush time was calculated incorrectly",
-        -10L, diff);
+    assertEquals(
+       -10L, diff, "The initial flush time was calculated incorrectly");
 
     calendar.set(Calendar.SECOND, 1);
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertEquals("The initial flush time was calculated incorrectly",
-        -10L, diff);
+    assertEquals(
+       -10L, diff, "The initial flush time was calculated incorrectly");
 
     // Try again with a random offset
     rfsSink = new RollingFileSystemSink(1000, 100);
 
-    assertNull("Last flush time should have been null prior to calling init()",
-        rfsSink.nextFlush);
+    assertNull(
+       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
 
     calendar.set(Calendar.MILLISECOND, 0);
     calendar.set(Calendar.SECOND, 0);
@@ -117,29 +117,29 @@ public class TestRollingFileSystemSink {
 
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue("The initial flush time was calculated incorrectly: " + diff,
-        (diff == 0L) || ((diff > -1000L) && (diff < -900L)));
+    assertTrue(
+       (diff == 0L) || ((diff > -1000L) && (diff < -900L)), "The initial flush time was calculated incorrectly: " + diff);
 
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue("The initial flush time was calculated incorrectly: " + diff,
-        (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)));
+    assertTrue(
+       (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)), "The initial flush time was calculated incorrectly: " + diff);
 
     calendar.set(Calendar.SECOND, 1);
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue("The initial flush time was calculated incorrectly: " + diff,
-        (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)));
+    assertTrue(
+       (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)), "The initial flush time was calculated incorrectly: " + diff);
 
     // Now try pathological settings
     rfsSink = new RollingFileSystemSink(1000, 1000000);
 
-    assertNull("Last flush time should have been null prior to calling init()",
-        rfsSink.nextFlush);
+    assertNull(
+       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
 
     calendar.set(Calendar.MILLISECOND, 1);
     calendar.set(Calendar.SECOND, 0);
@@ -147,8 +147,8 @@ public class TestRollingFileSystemSink {
 
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue("The initial flush time was calculated incorrectly: " + diff,
-        (diff > -1000L) && (diff <= 0L));
+    assertTrue(
+       (diff > -1000L) && (diff <= 0L), "The initial flush time was calculated incorrectly: " + diff);
   }
 
   /**
@@ -170,26 +170,26 @@ public class TestRollingFileSystemSink {
     rfsSink.nextFlush.setTime(calendar.getTime());
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals("The next roll time should have been 1 second in the future",
-        calendar.getTimeInMillis() + 1000,
-        rfsSink.nextFlush.getTimeInMillis());
+    assertEquals(
+       calendar.getTimeInMillis() + 1000
+,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 1 second in the future");
 
     rfsSink.nextFlush.setTime(calendar.getTime());
     calendar.add(Calendar.MILLISECOND, 10);
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals("The next roll time should have been 990 ms in the future",
-        calendar.getTimeInMillis() + 990,
-        rfsSink.nextFlush.getTimeInMillis());
+    assertEquals(
+       calendar.getTimeInMillis() + 990
+,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 990 ms in the future");
 
     rfsSink.nextFlush.setTime(calendar.getTime());
     calendar.add(Calendar.SECOND, 2);
     calendar.add(Calendar.MILLISECOND, 10);
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals("The next roll time should have been 990 ms in the future",
-        calendar.getTimeInMillis() + 990,
-        rfsSink.nextFlush.getTimeInMillis());
+    assertEquals(
+       calendar.getTimeInMillis() + 990
+,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 990 ms in the future");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
@@ -78,7 +78,7 @@ public class TestRollingFileSystemSink {
     calendar.set(Calendar.YEAR, 2016);
 
     assertNull(
-       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
+        rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
 
     rfsSink.setInitialFlushTime(calendar.getTime());
 
@@ -92,7 +92,7 @@ public class TestRollingFileSystemSink {
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
     assertEquals(
-       -10L, diff, "The initial flush time was calculated incorrectly");
+        -10L, diff, "The initial flush time was calculated incorrectly");
 
     calendar.set(Calendar.SECOND, 1);
     calendar.set(Calendar.MILLISECOND, 10);
@@ -100,13 +100,13 @@ public class TestRollingFileSystemSink {
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
     assertEquals(
-       -10L, diff, "The initial flush time was calculated incorrectly");
+        -10L, diff, "The initial flush time was calculated incorrectly");
 
     // Try again with a random offset
     rfsSink = new RollingFileSystemSink(1000, 100);
 
     assertNull(
-       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
+        rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
 
     calendar.set(Calendar.MILLISECOND, 0);
     calendar.set(Calendar.SECOND, 0);
@@ -114,29 +114,29 @@ public class TestRollingFileSystemSink {
 
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue(
-       (diff == 0L) || ((diff > -1000L) && (diff < -900L)), "The initial flush time was calculated incorrectly: " + diff);
+    assertTrue((diff == 0L) || ((diff > -1000L) && (diff < -900L)),
+        "The initial flush time was calculated incorrectly: " + diff);
 
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue(
-       (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)), "The initial flush time was calculated incorrectly: " + diff);
+    assertTrue((diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)),
+       "The initial flush time was calculated incorrectly: " + diff);
 
     calendar.set(Calendar.SECOND, 1);
     calendar.set(Calendar.MILLISECOND, 10);
     rfsSink.setInitialFlushTime(calendar.getTime());
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue(
-       (diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)), "The initial flush time was calculated incorrectly: " + diff);
+    assertTrue((diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)),
+        "The initial flush time was calculated incorrectly: " + diff);
 
     // Now try pathological settings
     rfsSink = new RollingFileSystemSink(1000, 1000000);
 
-    assertNull(
-       rfsSink.nextFlush, "Last flush time should have been null prior to calling init()");
+    assertNull(rfsSink.nextFlush,
+        "Last flush time should have been null prior to calling init()");
 
     calendar.set(Calendar.MILLISECOND, 1);
     calendar.set(Calendar.SECOND, 0);
@@ -144,8 +144,8 @@ public class TestRollingFileSystemSink {
 
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
-    assertTrue(
-       (diff > -1000L) && (diff <= 0L), "The initial flush time was calculated incorrectly: " + diff);
+    assertTrue((diff > -1000L) && (diff <= 0L),
+        "The initial flush time was calculated incorrectly: " + diff);
   }
 
   /**
@@ -167,26 +167,26 @@ public class TestRollingFileSystemSink {
     rfsSink.nextFlush.setTime(calendar.getTime());
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals(
-       calendar.getTimeInMillis() + 1000
-,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 1 second in the future");
+    assertEquals(calendar.getTimeInMillis() + 1000,
+        rfsSink.nextFlush.getTimeInMillis(),
+        "The next roll time should have been 1 second in the future");
 
     rfsSink.nextFlush.setTime(calendar.getTime());
     calendar.add(Calendar.MILLISECOND, 10);
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals(
-       calendar.getTimeInMillis() + 990
-,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 990 ms in the future");
+    assertEquals(calendar.getTimeInMillis() + 990,
+        rfsSink.nextFlush.getTimeInMillis(),
+        "The next roll time should have been 990 ms in the future");
 
     rfsSink.nextFlush.setTime(calendar.getTime());
     calendar.add(Calendar.SECOND, 2);
     calendar.add(Calendar.MILLISECOND, 10);
     rfsSink.updateFlushTime(calendar.getTime());
 
-    assertEquals(
-       calendar.getTimeInMillis() + 990
-,         rfsSink.nextFlush.getTimeInMillis(), "The next roll time should have been 990 ms in the future");
+    assertEquals(calendar.getTimeInMillis() + 990,
+        rfsSink.nextFlush.getTimeInMillis(),
+        "The next roll time should have been 990 ms in the future");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSink.java
@@ -122,7 +122,7 @@ public class TestRollingFileSystemSink {
     diff = rfsSink.nextFlush.getTimeInMillis() - calendar.getTimeInMillis();
 
     assertTrue((diff >= -10L) && (diff <= 0L) || ((diff > -1000L) && (diff < -910L)),
-       "The initial flush time was calculated incorrectly: " + diff);
+        "The initial flush time was calculated incorrectly: " + diff);
 
     calendar.set(Calendar.SECOND, 1);
     calendar.set(Calendar.MILLISECOND, 10);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSinkWithLocal.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSinkWithLocal.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.metrics2.sink;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.metrics2.MetricsSystem;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the {@link RollingFileSystemSink} class in the context of the local file
@@ -114,9 +114,9 @@ public class TestRollingFileSystemSinkWithLocal
       // publish the metrics
       ms.publishMetricsNow();
 
-      assertTrue(
-         MockSink.errored, "No exception was generated while writing metrics "
-          + "even though the target directory was not writable");
+      assertTrue("No exception was generated while writing metrics "
+          + "even though the target directory was not writable",
+          MockSink.errored);
 
       ms.stop();
       ms.shutdown();
@@ -143,10 +143,10 @@ public class TestRollingFileSystemSinkWithLocal
       // publish the metrics
       ms.publishMetricsNow();
 
-      assertFalse(
-         MockSink.errored, "An exception was generated while writing metrics "
+      assertFalse("An exception was generated while writing metrics "
           + "when the target directory was not writable, even though the "
-          + "sink is set to ignore errors");
+          + "sink is set to ignore errors",
+          MockSink.errored);
 
       ms.stop();
       ms.shutdown();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSinkWithLocal.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestRollingFileSystemSinkWithLocal.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.metrics2.sink;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.metrics2.MetricsSystem;
 
-import org.junit.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the {@link RollingFileSystemSink} class in the context of the local file
@@ -114,9 +114,9 @@ public class TestRollingFileSystemSinkWithLocal
       // publish the metrics
       ms.publishMetricsNow();
 
-      assertTrue("No exception was generated while writing metrics "
-          + "even though the target directory was not writable",
-          MockSink.errored);
+      assertTrue(
+         MockSink.errored, "No exception was generated while writing metrics "
+          + "even though the target directory was not writable");
 
       ms.stop();
       ms.shutdown();
@@ -143,10 +143,10 @@ public class TestRollingFileSystemSinkWithLocal
       // publish the metrics
       ms.publishMetricsNow();
 
-      assertFalse("An exception was generated while writing metrics "
+      assertFalse(
+         MockSink.errored, "An exception was generated while writing metrics "
           + "when the target directory was not writable, even though the "
-          + "sink is set to ignore errors",
-          MockSink.errored);
+          + "sink is set to ignore errors");
 
       ms.stop();
       ms.shutdown();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.metrics2.sink;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +38,8 @@ import org.apache.hadoop.metrics2.MetricsTag;
 import org.apache.hadoop.metrics2.impl.MetricsRecordImpl;
 import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.sink.StatsDSink.StatsD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestStatsDMetrics {
 
@@ -51,7 +52,8 @@ public class TestStatsDMetrics {
     return metric;
   }
 
-  @Test(timeout=3000)
+  @Test
+  @Timeout(value = 3)
   public void testPutMetrics() throws IOException, IllegalAccessException {
     final StatsDSink sink = new StatsDSink();
     List<MetricsTag> tags = new ArrayList<MetricsTag>();
@@ -77,16 +79,17 @@ public class TestStatsDMetrics {
       String result =new String(p.getData(), 0, p.getLength(),
           StandardCharsets.UTF_8);
       assertTrue(
-          "Received data did not match data sent",
-          result.equals("host.process.jvm.Context.foo1:1.25|c") ||
-          result.equals("host.process.jvm.Context.foo2:2.25|g"));
+      
+         result.equals("host.process.jvm.Context.foo1:1.25|c") ||
+          result.equals("host.process.jvm.Context.foo2:2.25|g"), "Received data did not match data sent");
 
     } finally {
       sink.close();
     }
   }
 
-  @Test(timeout=3000)
+  @Test
+  @Timeout(value = 3)
   public void testPutMetrics2() throws IOException, IllegalAccessException {
     StatsDSink sink = new StatsDSink();
     List<MetricsTag> tags = new ArrayList<MetricsTag>();
@@ -111,9 +114,9 @@ public class TestStatsDMetrics {
       String result =
           new String(p.getData(), 0, p.getLength(), StandardCharsets.UTF_8);
 
-      assertTrue("Received data did not match data sent",
-          result.equals("process.jvm.Context.foo1:1|c") ||
-          result.equals("process.jvm.Context.foo2:2|g"));
+      assertTrue(
+         result.equals("process.jvm.Context.foo1:1|c") ||
+          result.equals("process.jvm.Context.foo2:2|g"), "Received data did not match data sent");
     } finally {
       sink.close();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/TestStatsDMetrics.java
@@ -78,10 +78,9 @@ public class TestStatsDMetrics {
 
       String result =new String(p.getData(), 0, p.getLength(),
           StandardCharsets.UTF_8);
-      assertTrue(
-      
-         result.equals("host.process.jvm.Context.foo1:1.25|c") ||
-          result.equals("host.process.jvm.Context.foo2:2.25|g"), "Received data did not match data sent");
+      assertTrue(result.equals("host.process.jvm.Context.foo1:1.25|c") ||
+          result.equals("host.process.jvm.Context.foo2:2.25|g"),
+          "Received data did not match data sent");
 
     } finally {
       sink.close();
@@ -114,9 +113,9 @@ public class TestStatsDMetrics {
       String result =
           new String(p.getData(), 0, p.getLength(), StandardCharsets.UTF_8);
 
-      assertTrue(
-         result.equals("process.jvm.Context.foo1:1|c") ||
-          result.equals("process.jvm.Context.foo2:2|g"), "Received data did not match data sent");
+      assertTrue(result.equals("process.jvm.Context.foo1:1|c") ||
+          result.equals("process.jvm.Context.foo2:2|g"),
+          "Received data did not match data sent");
     } finally {
       sink.close();
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
@@ -21,14 +21,14 @@ package org.apache.hadoop.metrics2.sink.ganglia;
 import org.apache.commons.configuration2.SubsetConfiguration;
 import org.apache.hadoop.metrics2.impl.ConfigBuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.DatagramSocket;
 import java.net.MulticastSocket;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestGangliaSink {
   @Test
@@ -38,8 +38,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertFalse("Did not create DatagramSocket",
-        socket == null || socket instanceof MulticastSocket);
+    assertFalse(
+       socket == null || socket instanceof MulticastSocket, "Did not create DatagramSocket");
   }
 
   @Test
@@ -49,8 +49,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertFalse("Did not create DatagramSocket",
-        socket == null || socket instanceof MulticastSocket);
+    assertFalse(
+       socket == null || socket instanceof MulticastSocket, "Did not create DatagramSocket");
   }
 
   @Test
@@ -60,10 +60,10 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertTrue("Did not create MulticastSocket",
-        socket != null && socket instanceof MulticastSocket);
+    assertTrue(
+       socket != null && socket instanceof MulticastSocket, "Did not create MulticastSocket");
     int ttl = ((MulticastSocket) socket).getTimeToLive();
-    assertEquals("Did not set default TTL", 1, ttl);
+    assertEquals(1, ttl, "Did not set default TTL");
   }
 
   @Test
@@ -73,10 +73,10 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertTrue("Did not create MulticastSocket",
-        socket != null && socket instanceof MulticastSocket);
+    assertTrue(
+       socket != null && socket instanceof MulticastSocket, "Did not create MulticastSocket");
     int ttl = ((MulticastSocket) socket).getTimeToLive();
-    assertEquals("Did not set TTL", 3, ttl);
+    assertEquals(3, ttl, "Did not set TTL");
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/sink/ganglia/TestGangliaSink.java
@@ -38,8 +38,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertFalse(
-       socket == null || socket instanceof MulticastSocket, "Did not create DatagramSocket");
+    assertFalse(socket == null || socket instanceof MulticastSocket,
+        "Did not create DatagramSocket");
   }
 
   @Test
@@ -49,8 +49,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertFalse(
-       socket == null || socket instanceof MulticastSocket, "Did not create DatagramSocket");
+    assertFalse(socket == null || socket instanceof MulticastSocket,
+        "Did not create DatagramSocket");
   }
 
   @Test
@@ -60,8 +60,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertTrue(
-       socket != null && socket instanceof MulticastSocket, "Did not create MulticastSocket");
+    assertTrue(socket != null && socket instanceof MulticastSocket,
+        "Did not create MulticastSocket");
     int ttl = ((MulticastSocket) socket).getTimeToLive();
     assertEquals(1, ttl, "Did not set default TTL");
   }
@@ -73,8 +73,8 @@ public class TestGangliaSink {
     GangliaSink30 gangliaSink = new GangliaSink30();
     gangliaSink.init(conf);
     DatagramSocket socket = gangliaSink.getDatagramSocket();
-    assertTrue(
-       socket != null && socket instanceof MulticastSocket, "Did not create MulticastSocket");
+    assertTrue(socket != null && socket instanceof MulticastSocket,
+        "Did not create MulticastSocket");
     int ttl = ((MulticastSocket) socket).getTimeToLive();
     assertEquals(3, ttl, "Did not set TTL");
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
@@ -21,12 +21,15 @@ package org.apache.hadoop.metrics2.source;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.util.GcTimeMonitor;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyFloat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.apache.hadoop.test.MetricsAsserts.*;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,19 +39,18 @@ import org.apache.hadoop.service.ServiceOperations;
 import org.apache.hadoop.service.ServiceStateException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.JvmPauseMonitor;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.metrics2.source.JvmMetricsInfo.*;
 import static org.apache.hadoop.metrics2.impl.MsInfo.*;
 
+@Timeout(30)
 public class TestJvmMetrics {
 
-  @Rule
-  public Timeout timeout = new Timeout(30000, TimeUnit.MILLISECONDS);
   private JvmPauseMonitor pauseMonitor;
   private GcTimeMonitor gcTimeMonitor;
 
@@ -129,7 +131,7 @@ public class TestJvmMetrics {
       pauseMonitor.init(new Configuration());
       pauseMonitor.stop();
       pauseMonitor.start();
-      Assertions.fail("Expected an exception, got " + pauseMonitor);
+      fail("Expected an exception, got " + pauseMonitor);
     } catch (ServiceStateException e) {
       GenericTestUtils.assertExceptionContains("cannot enter state", e);
     }
@@ -141,7 +143,7 @@ public class TestJvmMetrics {
     try {
       pauseMonitor.stop();
       pauseMonitor.init(new Configuration());
-      Assertions.fail("Expected an exception, got " + pauseMonitor);
+      fail("Expected an exception, got " + pauseMonitor);
     } catch (ServiceStateException e) {
       GenericTestUtils.assertExceptionContains("cannot enter state", e);
     }
@@ -193,10 +195,10 @@ public class TestJvmMetrics {
       gcCount = gcData.getAccumulatedGcCount();
     }
 
-    Assertions.assertTrue(maxGcTimePercentage > 0);
-    Assertions.assertTrue(gcCount > 0);
-    Assertions.assertTrue(alerter.numAlerts > 0);
-    Assertions.assertTrue(alerter.maxGcTimePercentage >= alertGcPerc);
+    assertTrue(maxGcTimePercentage > 0);
+    assertTrue(gcCount > 0);
+    assertTrue(alerter.numAlerts > 0);
+    assertTrue(alerter.maxGcTimePercentage >= alertGcPerc);
   }
 
   @Test
@@ -205,7 +207,7 @@ public class TestJvmMetrics {
         .initSingleton("test", null);
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton("test", null);
-    Assertions.assertEquals(
+    assertEquals(
        jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
   }
 
@@ -217,11 +219,11 @@ public class TestJvmMetrics {
     final String process2Name = "process2";
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton(process2Name, null);
-    Assertions.assertEquals(
+    assertEquals(
        jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
-    Assertions.assertEquals(
+    assertEquals(
        process1Name, jvmMetrics1.processName, "unexpected process name of the singleton instance");
-    Assertions.assertEquals(
+    assertEquals(
        process1Name, jvmMetrics2.processName, "unexpected process name of the singleton instance");
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.metrics2.source;
 
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.util.GcTimeMonitor;
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 import static org.mockito.Mockito.*;
@@ -55,7 +55,7 @@ public class TestJvmMetrics {
   /**
    * Robust shutdown of the monitors if they haven't been stopped already.
    */
-  @After
+  @AfterEach
   public void teardown() {
     ServiceOperations.stop(pauseMonitor);
     if (gcTimeMonitor != null) {
@@ -129,7 +129,7 @@ public class TestJvmMetrics {
       pauseMonitor.init(new Configuration());
       pauseMonitor.stop();
       pauseMonitor.start();
-      Assert.fail("Expected an exception, got " + pauseMonitor);
+      Assertions.fail("Expected an exception, got " + pauseMonitor);
     } catch (ServiceStateException e) {
       GenericTestUtils.assertExceptionContains("cannot enter state", e);
     }
@@ -141,7 +141,7 @@ public class TestJvmMetrics {
     try {
       pauseMonitor.stop();
       pauseMonitor.init(new Configuration());
-      Assert.fail("Expected an exception, got " + pauseMonitor);
+      Assertions.fail("Expected an exception, got " + pauseMonitor);
     } catch (ServiceStateException e) {
       GenericTestUtils.assertExceptionContains("cannot enter state", e);
     }
@@ -193,10 +193,10 @@ public class TestJvmMetrics {
       gcCount = gcData.getAccumulatedGcCount();
     }
 
-    Assert.assertTrue(maxGcTimePercentage > 0);
-    Assert.assertTrue(gcCount > 0);
-    Assert.assertTrue(alerter.numAlerts > 0);
-    Assert.assertTrue(alerter.maxGcTimePercentage >= alertGcPerc);
+    Assertions.assertTrue(maxGcTimePercentage > 0);
+    Assertions.assertTrue(gcCount > 0);
+    Assertions.assertTrue(alerter.numAlerts > 0);
+    Assertions.assertTrue(alerter.maxGcTimePercentage >= alertGcPerc);
   }
 
   @Test
@@ -205,8 +205,8 @@ public class TestJvmMetrics {
         .initSingleton("test", null);
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton("test", null);
-    Assert.assertEquals("initSingleton should return the singleton instance",
-        jvmMetrics1, jvmMetrics2);
+    Assertions.assertEquals(
+       jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
   }
 
   @Test
@@ -217,12 +217,12 @@ public class TestJvmMetrics {
     final String process2Name = "process2";
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton(process2Name, null);
-    Assert.assertEquals("initSingleton should return the singleton instance",
-        jvmMetrics1, jvmMetrics2);
-    Assert.assertEquals("unexpected process name of the singleton instance",
-        process1Name, jvmMetrics1.processName);
-    Assert.assertEquals("unexpected process name of the singleton instance",
-        process1Name, jvmMetrics2.processName);
+    Assertions.assertEquals(
+       jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
+    Assertions.assertEquals(
+       process1Name, jvmMetrics1.processName, "unexpected process name of the singleton instance");
+    Assertions.assertEquals(
+       process1Name, jvmMetrics2.processName, "unexpected process name of the singleton instance");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/source/TestJvmMetrics.java
@@ -207,8 +207,8 @@ public class TestJvmMetrics {
         .initSingleton("test", null);
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton("test", null);
-    assertEquals(
-       jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
+    assertEquals(jvmMetrics1, jvmMetrics2,
+        "initSingleton should return the singleton instance");
   }
 
   @Test
@@ -219,12 +219,12 @@ public class TestJvmMetrics {
     final String process2Name = "process2";
     JvmMetrics jvmMetrics2 = org.apache.hadoop.metrics2.source.JvmMetrics
         .initSingleton(process2Name, null);
-    assertEquals(
-       jvmMetrics1, jvmMetrics2, "initSingleton should return the singleton instance");
-    assertEquals(
-       process1Name, jvmMetrics1.processName, "unexpected process name of the singleton instance");
-    assertEquals(
-       process1Name, jvmMetrics2.processName, "unexpected process name of the singleton instance");
+    assertEquals(jvmMetrics1, jvmMetrics2,
+        "initSingleton should return the singleton instance");
+    assertEquals(process1Name, jvmMetrics1.processName,
+        "unexpected process name of the singleton instance");
+    assertEquals(process1Name, jvmMetrics2.processName,
+        "unexpected process name of the singleton instance");
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMBeans.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMBeans.java
@@ -17,8 +17,8 @@
 
 package org.apache.hadoop.metrics2.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -46,7 +46,7 @@ public class TestMBeans implements DummyMXBean {
 
       int jmxCounter = (int) platformMBeanServer
           .getAttribute(objectName, "Counter");
-      Assert.assertEquals(counter, jmxCounter);
+      Assertions.assertEquals(counter, jmxCounter);
     } finally {
       if (objectName != null) {
         MBeans.unregister(objectName);
@@ -70,7 +70,7 @@ public class TestMBeans implements DummyMXBean {
           ManagementFactory.getPlatformMBeanServer();
       int jmxCounter =
           (int) platformMBeanServer.getAttribute(objectName, "Counter");
-      Assert.assertEquals(counter, jmxCounter);
+      Assertions.assertEquals(counter, jmxCounter);
     } finally {
       if (objectName != null) {
         MBeans.unregister(objectName);
@@ -85,7 +85,7 @@ public class TestMBeans implements DummyMXBean {
     ObjectName mBeanName = MBeans.getMBeanName("Service",
         "Name", properties);
 
-    Assert.assertEquals("Service",
+    Assertions.assertEquals("Service",
         MBeans.getMbeanNameService(mBeanName));
 
     properties.put("key", "value");
@@ -94,7 +94,7 @@ public class TestMBeans implements DummyMXBean {
         "Name",
         properties);
 
-    Assert.assertEquals("Service",
+    Assertions.assertEquals("Service",
         MBeans.getMbeanNameService(mBeanName));
 
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMBeans.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMBeans.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.metrics2.util;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
@@ -25,6 +24,8 @@ import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test MXBean addition of key/value pairs to registered MBeans.
@@ -46,7 +47,7 @@ public class TestMBeans implements DummyMXBean {
 
       int jmxCounter = (int) platformMBeanServer
           .getAttribute(objectName, "Counter");
-      Assertions.assertEquals(counter, jmxCounter);
+      assertEquals(counter, jmxCounter);
     } finally {
       if (objectName != null) {
         MBeans.unregister(objectName);
@@ -70,7 +71,7 @@ public class TestMBeans implements DummyMXBean {
           ManagementFactory.getPlatformMBeanServer();
       int jmxCounter =
           (int) platformMBeanServer.getAttribute(objectName, "Counter");
-      Assertions.assertEquals(counter, jmxCounter);
+      assertEquals(counter, jmxCounter);
     } finally {
       if (objectName != null) {
         MBeans.unregister(objectName);
@@ -85,7 +86,7 @@ public class TestMBeans implements DummyMXBean {
     ObjectName mBeanName = MBeans.getMBeanName("Service",
         "Name", properties);
 
-    Assertions.assertEquals("Service",
+    assertEquals("Service",
         MBeans.getMbeanNameService(mBeanName));
 
     properties.put("key", "value");
@@ -94,7 +95,7 @@ public class TestMBeans implements DummyMXBean {
         "Name",
         properties);
 
-    Assertions.assertEquals("Service",
+    assertEquals("Service",
         MBeans.getMbeanNameService(mBeanName));
 
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
@@ -53,8 +53,8 @@ public class TestMetricsCache {
     verify(mr).name();
     verify(mr).tags();
     verify(mr).metrics();
-    assertEquals(cr.metrics().size()
-,                  ((Collection<AbstractMetric>)mr.metrics()).size(), "same record size");
+    assertEquals(cr.metrics().size(), ((Collection<AbstractMetric>) mr.metrics()).size(),
+        "same record size");
     assertEquals(0, cr.getMetric("m"), "same metric value");
 
     MetricsRecord mr2 = makeRecord("r",

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
@@ -22,8 +22,13 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
@@ -72,7 +77,7 @@ public class TestMetricsCache {
     // until now
     cr = cache.update(mr3, true);
     assertEquals(1, cr.tags().size(), "Got 1 tag");
-    assertEquals("Tag value", "tv3", cr.getTag("t"));
+    assertEquals("tv3", cr.getTag("t"), "Tag value");
     checkMetricValue("Metric value", cr, "m3", 3);
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestMetricsCache.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.metrics2.util;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.hadoop.metrics2.AbstractMetric;
@@ -48,15 +48,15 @@ public class TestMetricsCache {
     verify(mr).name();
     verify(mr).tags();
     verify(mr).metrics();
-    assertEquals("same record size", cr.metrics().size(),
-                 ((Collection<AbstractMetric>)mr.metrics()).size());
-    assertEquals("same metric value", 0, cr.getMetric("m"));
+    assertEquals(cr.metrics().size()
+,                  ((Collection<AbstractMetric>)mr.metrics()).size(), "same record size");
+    assertEquals(0, cr.getMetric("m"), "same metric value");
 
     MetricsRecord mr2 = makeRecord("r",
         Arrays.asList(makeTag("t", "tv")),
         Arrays.asList(makeMetric("m", 2), makeMetric("m2", 42)));
     cr = cache.update(mr2);
-    assertEquals("contains 3 metric", 3, cr.metrics().size());
+    assertEquals(3, cr.metrics().size(), "contains 3 metric");
     checkMetricValue("updated metric value", cr, "m", 2);
     checkMetricValue("old metric value", cr, "m1", 1);
     checkMetricValue("new metric value", cr, "m2", 42);
@@ -65,13 +65,13 @@ public class TestMetricsCache {
         Arrays.asList(makeTag("t", "tv3")), // different tag value
         Arrays.asList(makeMetric("m3", 3)));
     cr = cache.update(mr3); // should get a new record
-    assertEquals("contains 1 metric", 1, cr.metrics().size());
+    assertEquals(1, cr.metrics().size(), "contains 1 metric");
     checkMetricValue("updated metric value", cr, "m3", 3);
     // tags cache should be empty so far
-    assertEquals("no tags", 0, cr.tags().size());
+    assertEquals(0, cr.tags().size(), "no tags");
     // until now
     cr = cache.update(mr3, true);
-    assertEquals("Got 1 tag", 1, cr.tags().size());
+    assertEquals(1, cr.tags().size(), "Got 1 tag");
     assertEquals("Tag value", "tv3", cr.getTag("t"));
     checkMetricValue("Metric value", cr, "m3", 3);
   }
@@ -79,7 +79,7 @@ public class TestMetricsCache {
   @SuppressWarnings("deprecation")
   @Test public void testGet() {
     MetricsCache cache = new MetricsCache();
-    assertNull("empty", cache.get("r", Arrays.asList(makeTag("t", "t"))));
+    assertNull(cache.get("r", Arrays.asList(makeTag("t", "t"))), "empty");
     MetricsRecord mr = makeRecord("r",
         Arrays.asList(makeTag("t", "t")),
         Arrays.asList(makeMetric("m", 1)));
@@ -87,8 +87,8 @@ public class TestMetricsCache {
     MetricsCache.Record cr = cache.get("r", mr.tags());
     LOG.debug("tags="+ mr.tags() +" cr="+ cr);
 
-    assertNotNull("Got record", cr);
-    assertEquals("contains 1 metric", 1, cr.metrics().size());
+    assertNotNull(cr, "Got record");
+    assertEquals(1, cr.metrics().size(), "contains 1 metric");
     checkMetricValue("new metric value", cr, "m", 1);
   }
 
@@ -102,7 +102,7 @@ public class TestMetricsCache {
         Arrays.asList(makeMetric("m", 0), makeMetric("m1", 1)));
 
     MetricsCache.Record cr = cache.update(mr);
-    assertTrue("t value should be null", null == cr.getTag("t"));
+    assertTrue(null == cr.getTag("t"), "t value should be null");
   }
 
   @Test public void testOverflow() {
@@ -115,17 +115,17 @@ public class TestMetricsCache {
           Arrays.asList(makeMetric("m", i))));
       checkMetricValue("new metric value", cr, "m", i);
       if (i < MetricsCache.MAX_RECS_PER_NAME_DEFAULT) {
-        assertNotNull("t0 is still there", cache.get("r", t0));
+        assertNotNull(cache.get("r", t0), "t0 is still there");
       }
     }
-    assertNull("t0 is gone", cache.get("r", t0));
+    assertNull(cache.get("r", t0), "t0 is gone");
   }
 
   private void checkMetricValue(String description, MetricsCache.Record cr,
       String key, Number val) {
-    assertEquals(description, val, cr.getMetric(key));
-    assertNotNull("metric not null", cr.getMetricInstance(key));
-    assertEquals(description, val, cr.getMetricInstance(key).value());
+    assertEquals(val, cr.getMetric(key), description);
+    assertNotNull(cr.getMetricInstance(key), "metric not null");
+    assertEquals(val, cr.getMetricInstance(key).value(), description);
   }
 
   private MetricsRecord makeRecord(String name, Collection<MetricsTag> tags,

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleQuantiles.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.Random;
 
 import org.apache.hadoop.metrics2.lib.MutableInverseQuantiles;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +39,7 @@ public class TestSampleQuantiles {
   SampleQuantiles estimator;
   final static int NUM_REPEATS = 10;
 
-  @Before
+  @BeforeEach
   public void init() {
     estimator = new SampleQuantiles(quantiles);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.metrics2.util;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test the running sample stat computation

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.metrics2.util;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test the running sample stat computation
@@ -32,36 +32,36 @@ public class TestSampleStat {
    */
   @Test public void testSimple() {
     SampleStat stat = new SampleStat();
-    assertEquals("num samples", 0, stat.numSamples());
-    assertEquals("mean", 0.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
-    assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
-    assertEquals("min", SampleStat.MinMax.DEFAULT_MIN_VALUE, stat.min(), EPSILON);
-    assertEquals("max", SampleStat.MinMax.DEFAULT_MAX_VALUE, stat.max(), EPSILON);
+    assertEquals(0, stat.numSamples(), "num samples");
+    assertEquals(0.0, stat.mean(), EPSILON, "mean");
+    assertEquals(0.0, stat.variance(), EPSILON, "variance");
+    assertEquals(0.0, stat.stddev(), EPSILON, "stddev");
+    assertEquals(SampleStat.MinMax.DEFAULT_MIN_VALUE, stat.min(), EPSILON, "min");
+    assertEquals(SampleStat.MinMax.DEFAULT_MAX_VALUE, stat.max(), EPSILON, "max");
 
     stat.add(3);
-    assertEquals("num samples", 1L, stat.numSamples());
-    assertEquals("mean", 3.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
-    assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
-    assertEquals("min", 3.0, stat.min(), EPSILON);
-    assertEquals("max", 3.0, stat.max(), EPSILON);
+    assertEquals(1L, stat.numSamples(), "num samples");
+    assertEquals(3.0, stat.mean(), EPSILON, "mean");
+    assertEquals(0.0, stat.variance(), EPSILON, "variance");
+    assertEquals(0.0, stat.stddev(), EPSILON, "stddev");
+    assertEquals(3.0, stat.min(), EPSILON, "min");
+    assertEquals(3.0, stat.max(), EPSILON, "max");
 
     stat.add(2).add(1);
-    assertEquals("num samples", 3L, stat.numSamples());
-    assertEquals("mean", 2.0, stat.mean(), EPSILON);
-    assertEquals("variance", 1.0, stat.variance(), EPSILON);
-    assertEquals("stddev", 1.0, stat.stddev(), EPSILON);
-    assertEquals("min", 1.0, stat.min(), EPSILON);
-    assertEquals("max", 3.0, stat.max(), EPSILON);
+    assertEquals(3L, stat.numSamples(), "num samples");
+    assertEquals(2.0, stat.mean(), EPSILON, "mean");
+    assertEquals(1.0, stat.variance(), EPSILON, "variance");
+    assertEquals(1.0, stat.stddev(), EPSILON, "stddev");
+    assertEquals(1.0, stat.min(), EPSILON, "min");
+    assertEquals(3.0, stat.max(), EPSILON, "max");
 
     stat.reset();
-    assertEquals("num samples", 0, stat.numSamples());
-    assertEquals("mean", 0.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
-    assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
-    assertEquals("min", SampleStat.MinMax.DEFAULT_MIN_VALUE, stat.min(), EPSILON);
-    assertEquals("max", SampleStat.MinMax.DEFAULT_MAX_VALUE, stat.max(), EPSILON);
+    assertEquals(0, stat.numSamples(), "num samples");
+    assertEquals(0.0, stat.mean(), EPSILON, "mean");
+    assertEquals(0.0, stat.variance(), EPSILON, "variance");
+    assertEquals(0.0, stat.stddev(), EPSILON, "stddev");
+    assertEquals(SampleStat.MinMax.DEFAULT_MIN_VALUE, stat.min(), EPSILON, "min");
+    assertEquals(SampleStat.MinMax.DEFAULT_MAX_VALUE, stat.max(), EPSILON, "max");
   }
 
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19415. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-common Part3.

### How was this patch tested?

Junit  Test & mvn clean test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

