### PR TITLE
YARN-11766. Implement DELAYED_OR operator in the scheduling process for Rich Placement Constraint.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/constraint/PlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/util/constraint/PlacementConstraintParser.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -61,7 +62,9 @@ public final class PlacementConstraintParser {
   private static final String NOT_IN = "notin";
   private static final String AND = "and";
   private static final String OR = "or";
+  private static final String DELAYED_OR = "delayed_or";
   private static final String CARDINALITY = "cardinality";
+  private static final String TIMED = "timed";
   private static final String SCOPE_NODE = PlacementConstraints.NODE;
   private static final String SCOPE_RACK = PlacementConstraints.RACK;
 
@@ -195,7 +198,7 @@ public final class PlacementConstraintParser {
 
   /**
    * Tokenizer used to parse conjunction form of a constraint expression,
-   * [AND|OR](C1:C2:...:Cn). Each Cn is a constraint expression.
+   * [AND|OR|DELAYED_OR](C1:C2:...:Cn). Each Cn is a constraint expression.
    */
   public static final class ConjunctionTokenizer
       implements ConstraintTokenizer {
@@ -220,17 +223,20 @@ public final class PlacementConstraintParser {
       } else if(expression.startsWith(OR) ||
           expression.startsWith(OR.toUpperCase())) {
         op = OR;
+      } else if(expression.startsWith(DELAYED_OR) ||
+          expression.startsWith(DELAYED_OR.toUpperCase())) {
+        op = DELAYED_OR;
       } else {
         throw new PlacementConstraintParseException(
-            "Excepting starting with \"" + AND + "\" or \"" + OR + "\","
-                + " but met " + expression);
+            "Excepting starting with \"" + AND + "\" or \"" + OR + "\" or \""
+                + DELAYED_OR + "\"," + " but met " + expression);
       }
       parsedElements.add(op);
       Pattern p = Pattern.compile("\\((.*)\\)");
       Matcher m = p.matcher(expression);
       if (!m.find()) {
         throw new PlacementConstraintParseException("Unexpected format,"
-            + " expecting [AND|OR](A:B...) "
+            + " expecting [AND|OR|DELAYED_OR](A:B...) "
             + "but current expression is " + expression);
       }
       String childStrs = m.group(1);
@@ -568,6 +574,63 @@ public final class PlacementConstraintParser {
   }
 
   /**
+   * Timed Constraint parser used to parse a given timed constraint format:
+   *    "timed, [SCHEDULING_DELAY], [DELAY_UNIT: OPPORTUNITIES|MILLISECONDS],
+   *      [CONSTRAINT_EXPRESSION]", such as
+   *    "timed, 5, OPPORTUNITIES, NOTIN, NODE, foo, bar"
+   */
+  public static class TimedConstraintParser extends ConstraintParser {
+
+    public TimedConstraintParser(String expression) {
+      super(new BaseStringTokenizer(expression,
+          String.valueOf(EXPRESSION_VAL_DELIM)));
+    }
+
+    @Override
+    public AbstractConstraint parse()
+        throws PlacementConstraintParseException {
+      String op = nextToken();
+      if (!op.equalsIgnoreCase(TIMED)) {
+        throw new PlacementConstraintParseException("expecting " + TIMED
+            + " , but met " + op);
+      }
+
+      shouldHaveNext();
+      int schedulingDelay = toInt(nextToken());
+      shouldHaveNext();
+      String delayUnitStr = nextToken();
+      PlacementConstraint.TimedPlacementConstraint.DelayUnit delayUnit;
+      try {
+        delayUnit =
+            PlacementConstraint.TimedPlacementConstraint.DelayUnit.valueOf(
+                delayUnitStr.toUpperCase());
+      } catch (IllegalArgumentException e) {
+        throw new PlacementConstraintParseException(
+            "Invalid delay unit: " + delayUnitStr);
+      }
+      List<String> restElements = new ArrayList<>();
+      while(hasMoreTokens()) {
+        restElements.add(nextToken());
+      }
+      String constraintStr = String.join(",", restElements);
+      AbstractConstraint abstractConstraint = parseExpression(constraintStr);
+      switch (delayUnit) {
+      case OPPORTUNITIES:
+        return PlacementConstraints.delayedOr(
+            PlacementConstraints.timedOpportunitiesConstraint(
+                abstractConstraint, schedulingDelay));
+      case MILLISECONDS:
+        return PlacementConstraints.delayedOr(
+            PlacementConstraints.timedClockConstraint(abstractConstraint,
+                schedulingDelay, TimeUnit.MILLISECONDS));
+      default:
+        throw new PlacementConstraintParseException(
+            "Invalid delay unit: " + delayUnit);
+      }
+    }
+  }
+
+  /**
    * Parser used to parse conjunction form of constraints, such as
    * AND(A, ..., B), OR(A, ..., B).
    */
@@ -599,6 +662,20 @@ public final class PlacementConstraintParser {
         return PlacementConstraints.or(
             constraints.toArray(
                 new AbstractConstraint[constraints.size()]));
+      } else if (DELAYED_OR.equalsIgnoreCase(op)) {
+        List<PlacementConstraint.TimedPlacementConstraint> timedConstraints =
+            new ArrayList<>();
+        for (AbstractConstraint c : constraints) {
+          if (!(c instanceof PlacementConstraint.DelayedOr)) {
+            throw new PlacementConstraintParseException(
+                "Expecting delayed_or constraint, but met " + c);
+          }
+          timedConstraints.addAll(
+              ((PlacementConstraint.DelayedOr) c).getChildren());
+        }
+        return PlacementConstraints.delayedOr(timedConstraints.toArray(
+            new PlacementConstraint.TimedPlacementConstraint[
+                timedConstraints.size()]));
       } else {
         throw new PlacementConstraintParseException(
             "Unexpected conjunction operator : " + op
@@ -684,6 +761,11 @@ public final class PlacementConstraintParser {
         NodeConstraintParser np =
             new NodeConstraintParser(constraintStr);
         constraintOptional = Optional.ofNullable(np.tryParse());
+      }
+      if (!constraintOptional.isPresent()) {
+        TimedConstraintParser tcp =
+            new TimedConstraintParser(constraintStr);
+        constraintOptional = Optional.ofNullable(tcp.tryParse());
       }
       if (!constraintOptional.isPresent()) {
         throw new PlacementConstraintParseException(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/api/resource/TestPlacementConstraintParser.java
@@ -27,12 +27,16 @@ import org.apache.hadoop.yarn.api.records.NodeAttributeOpCode;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.AbstractConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.And;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.Or;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint.DelayedOr;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.SingleConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TargetExpression;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TimedPlacementConstraint;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TimedPlacementConstraint.DelayUnit;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParseException;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.SourceTags;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.TargetConstraintParser;
+import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.TimedConstraintParser;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.ConstraintParser;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.CardinalityConstraintParser;
 import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser.ConjunctionConstraintParser;
@@ -49,6 +53,7 @@ import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetNod
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetNotIn;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -197,6 +202,61 @@ class TestPlacementConstraintParser {
   }
 
   @Test
+  void testTimedConstraintParser() throws PlacementConstraintParseException {
+    String expressionExpr;
+    ConstraintParser parser;
+    AbstractConstraint constraint;
+    DelayedOr delayedOr;
+    TimedPlacementConstraint timedConstraint;
+
+    // timed,5,milliseconds,NODE,foo,0,1
+    expressionExpr = "timed,5,milliseconds,in,node,foo";
+    parser =
+        new PlacementConstraintParser.TimedConstraintParser(expressionExpr);
+    constraint = parser.parse();
+    assertInstanceOf(DelayedOr.class, constraint);
+    delayedOr = (DelayedOr) constraint;
+    assertEquals(1, delayedOr.getChildren().size());
+    timedConstraint = delayedOr.getChildren().get(0);
+    assertEquals(5, timedConstraint.getSchedulingDelay());
+    assertEquals(DelayUnit.MILLISECONDS, timedConstraint.getDelayUnit());
+    assertInstanceOf(SingleConstraint.class, timedConstraint.getConstraint());
+    SingleConstraint singleConstraint =
+        (SingleConstraint) timedConstraint.getConstraint();
+    assertEquals("node", singleConstraint.getScope());
+    assertEquals(1, singleConstraint.getMinCardinality());
+    assertEquals(Integer.MAX_VALUE, singleConstraint.getMaxCardinality());
+    assertEquals("in,node,foo", singleConstraint.toString());
+
+    // Invalid key word
+    try {
+      parser = new TimedConstraintParser("invalid,5,milliseconds,in,node");
+      parser.parse();
+      fail("Expecting a parsing failure!");
+    } catch (PlacementConstraintParseException e) {
+      assertTrue(e.getMessage().contains("expecting timed , but met invalid"));
+    }
+
+    // Invalid scheduling delay
+    try {
+      parser = new TimedConstraintParser("timed,a,milliseconds,in,node");
+      parser.parse();
+      fail("Expecting a parsing failure!");
+    } catch (PlacementConstraintParseException e) {
+      assertTrue(e.getMessage().contains("Expecting an Integer, but get a"));
+    }
+
+    // Invalid delay unit
+    try {
+      parser = new TimedConstraintParser("timed,5,invalid,in,node");
+      parser.parse();
+      fail("Expecting a parsing failure!");
+    } catch (PlacementConstraintParseException e) {
+      assertTrue(e.getMessage().contains("Invalid delay unit: invalid"));
+    }
+  }
+
+  @Test
   void testAndConstraintParser()
       throws PlacementConstraintParseException {
     String expressionExpr;
@@ -266,6 +326,41 @@ class TestPlacementConstraintParser {
     or = (Or) or.getChildren().get(1);
     assertEquals(2, or.getChildren().size());
     verifyConstraintToString(expressionExpr, constraint);
+  }
+
+  @Test
+  void testDelayedOrConstraintParser()
+      throws PlacementConstraintParseException {
+    String expressionExpr;
+    ConstraintParser parser;
+    AbstractConstraint constraint;
+    DelayedOr delayedOr;
+
+    expressionExpr = "DELAYED_OR(timed,5,OPPORTUNITIES,NOTIN,NODE,foo)";
+    parser = new ConjunctionConstraintParser(expressionExpr);
+    constraint = parser.parse();
+    assertInstanceOf(DelayedOr.class, constraint);
+    delayedOr = (DelayedOr) constraint;
+    assertEquals(1, delayedOr.getChildren().size());
+    TimedPlacementConstraint timedConstraint = delayedOr.getChildren().get(0);
+    assertEquals(5, timedConstraint.getSchedulingDelay());
+    assertEquals(DelayUnit.OPPORTUNITIES, timedConstraint.getDelayUnit());
+    assertEquals("notin,node,foo", timedConstraint.getConstraint().toString());
+
+    expressionExpr = "delayed_or(timed,5,opportunities,notin,node,foo:timed,60000,milliseconds,in,node,test)";
+    parser = new ConjunctionConstraintParser(expressionExpr);
+    constraint = parser.parse();
+    assertInstanceOf(DelayedOr.class, constraint);
+    delayedOr = (DelayedOr) constraint;
+    assertEquals(2, delayedOr.getChildren().size());
+    TimedPlacementConstraint firstConstraint = delayedOr.getChildren().get(0);
+    assertEquals(5, firstConstraint.getSchedulingDelay());
+    assertEquals(DelayUnit.OPPORTUNITIES, firstConstraint.getDelayUnit());
+    assertEquals("notin,node,foo", firstConstraint.getConstraint().toString());
+    TimedPlacementConstraint secondConstraint = delayedOr.getChildren().get(1);
+    assertEquals(60000, secondConstraint.getSchedulingDelay());
+    assertEquals(DelayUnit.MILLISECONDS, secondConstraint.getDelayUnit());
+    assertEquals("in,node,test", secondConstraint.getConstraint().toString());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/PlacementConstraintsRuntimeInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/PlacementConstraintsRuntimeInfo.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PlacementConstraintsRuntimeInfo {
+    private final AtomicLong lastAskUpdateTime;
+    private final AtomicLong missedOpportunities;
+
+    public PlacementConstraintsRuntimeInfo(long lastUpdateTime, long failedCount) {
+        this.lastAskUpdateTime = new AtomicLong(lastUpdateTime);
+        this.missedOpportunities = new AtomicLong(failedCount);
+    }
+
+    public void addMissedOpportunities() {
+        missedOpportunities.incrementAndGet();
+    }
+
+    public void resetMissedOpportunities() {
+        missedOpportunities.set(0);
+    }
+
+    public void askUpdated() {
+        lastAskUpdateTime.set(System.currentTimeMillis());
+    }
+
+    public long getLastAskUpdateTime() {
+        return lastAskUpdateTime.get();
+    }
+
+    public long getMissedOpportunities() {
+        return missedOpportunities.get();
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/PlacementConstraintsUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/PlacementConstraintsUtil.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.yarn.api.resource.PlacementConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.AbstractConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.And;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.Or;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint.DelayedOr;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TimedPlacementConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.SingleConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TargetExpression;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraint.TargetExpression.TargetType;
@@ -261,12 +263,12 @@ public final class PlacementConstraintsUtil {
    */
   private static boolean canSatisfyAndConstraint(ApplicationId appId,
       And constraint, SchedulerNode node, AllocationTagsManager atm,
-      Optional<DiagnosticsCollector> dcOpt)
+      Optional<DiagnosticsCollector> dcOpt, Optional<PlacementConstraintsRuntimeInfo> riOpt)
       throws InvalidAllocationTagsQueryException {
     // Iterate over the constraints tree, if found any child constraint
     // isn't satisfied, return false.
     for (AbstractConstraint child : constraint.getChildren()) {
-      if(!canSatisfyConstraints(appId, child.build(), node, atm, dcOpt)) {
+      if(!canSatisfyConstraints(appId, child.build(), node, atm, dcOpt, riOpt)) {
         return false;
       }
     }
@@ -284,20 +286,86 @@ public final class PlacementConstraintsUtil {
    */
   private static boolean canSatisfyOrConstraint(ApplicationId appId,
       Or constraint, SchedulerNode node, AllocationTagsManager atm,
-      Optional<DiagnosticsCollector> dcOpt)
+      Optional<DiagnosticsCollector> dcOpt, Optional<PlacementConstraintsRuntimeInfo> riOpt)
       throws InvalidAllocationTagsQueryException {
     for (AbstractConstraint child : constraint.getChildren()) {
-      if (canSatisfyConstraints(appId, child.build(), node, atm, dcOpt)) {
+      if (canSatisfyConstraints(appId, child.build(), node, atm, dcOpt, riOpt)) {
         return true;
       }
     }
     return false;
   }
 
+  /**
+   * Returns true as long as any of child constraint is satisfied.
+   * @param appId application id
+   * @param constraint Or constraint
+   * @param node node
+   * @param atm allocation tags manager
+   * @return true if any child constraint is satisfied, false otherwise
+   * @throws InvalidAllocationTagsQueryException
+   */
+  private static boolean canSatisfyDelayedOrConstraint(
+          ApplicationId appId,
+          DelayedOr constraint, SchedulerNode node, AllocationTagsManager atm,
+          Optional<DiagnosticsCollector> dcOpt,
+          Optional<PlacementConstraintsRuntimeInfo> riOpt)
+          throws InvalidAllocationTagsQueryException {
+    for (TimedPlacementConstraint child: constraint.getChildren()) {
+      boolean satisfied = canSatisfyConstraints(appId, child.getConstraint().build(), node, atm, dcOpt, riOpt);
+      if (satisfied) {
+        return true;
+      }
+      // can't pass if not satisfied and not reached the delay condition
+      boolean canPass = true;
+      String delayedInfo = "";
+      if (riOpt.isPresent()) {
+        PlacementConstraintsRuntimeInfo ri = riOpt.get();
+        long schedulingDelay = child.getSchedulingDelay();
+        TimedPlacementConstraint.DelayUnit delayUnit = child.getDelayUnit();
+        if (delayUnit == TimedPlacementConstraint.DelayUnit.MILLISECONDS) {
+          long elapsedMs = System.currentTimeMillis() - ri.getLastAskUpdateTime();
+          if (elapsedMs < schedulingDelay) {
+            canPass = false;
+            delayedInfo = new StringBuilder("schedulingDelay=").append(schedulingDelay)
+                    .append(", elapsedMs=").append(elapsedMs).toString();
+          }
+        } else if (delayUnit == TimedPlacementConstraint.DelayUnit.OPPORTUNITIES &&
+                ri.getMissedOpportunities() < schedulingDelay) {
+          canPass = false;
+          delayedInfo = new StringBuilder("schedulingDelay=").append(schedulingDelay)
+                  .append(", missedOpportunities=").append(ri.getMissedOpportunities()).toString();
+        }
+      } else {
+        canPass = false;
+        delayedInfo = "runtime info not found";
+      }
+      if (!canPass) {
+        if (dcOpt.isPresent()) {
+          DiagnosticsCollector dc = dcOpt.get();
+          StringBuilder sb;
+          if (dc.getDetails() != null) {
+              sb = new StringBuilder(dc.getDetails()).append(", delayInfo: ");
+          } else {
+              sb = new StringBuilder("delayInfo: ");
+          }
+          String details = sb.append(delayedInfo).toString();
+          dc.collect(dc.getDiagnostics(), details);
+        } else if (LOG.isDebugEnabled()) {
+          LOG.debug("can't pass the delayed constraint: {}, delayedInfo: {}", constraint, delayedInfo);
+        }
+        return false;
+      }
+    }
+    // all passed
+    return true;
+  }
+
   private static boolean canSatisfyConstraints(ApplicationId appId,
       PlacementConstraint constraint, SchedulerNode node,
       AllocationTagsManager atm,
-      Optional<DiagnosticsCollector> dcOpt)
+      Optional<DiagnosticsCollector> dcOpt,
+      Optional<PlacementConstraintsRuntimeInfo> riOpt)
       throws InvalidAllocationTagsQueryException {
     if (constraint == null) {
       LOG.debug("Constraint is found empty during constraint validation for"
@@ -317,10 +385,13 @@ public final class PlacementConstraintsUtil {
       return canSatisfySingleConstraint(appId, single, node, atm, dcOpt);
     } else if (sConstraintExpr instanceof And) {
       And and = (And) sConstraintExpr;
-      return canSatisfyAndConstraint(appId, and, node, atm, dcOpt);
+      return canSatisfyAndConstraint(appId, and, node, atm, dcOpt, riOpt);
     } else if (sConstraintExpr instanceof Or) {
       Or or = (Or) sConstraintExpr;
-      return canSatisfyOrConstraint(appId, or, node, atm, dcOpt);
+      return canSatisfyOrConstraint(appId, or, node, atm, dcOpt, riOpt);
+    } else if (sConstraintExpr instanceof DelayedOr) {
+      DelayedOr delayedOr = (DelayedOr) sConstraintExpr;
+      return canSatisfyDelayedOrConstraint(appId, delayedOr, node, atm, dcOpt, riOpt);
     } else {
       throw new InvalidAllocationTagsQueryException(
           "Unsupported type of constraint: "
@@ -346,13 +417,15 @@ public final class PlacementConstraintsUtil {
    * @param pcm placement constraint manager
    * @param atm allocation tags manager
    * @param dcOpt optional diagnostics collector
+   * @param riOpt optional placement constraints runtime info
    * @return true if the given node satisfies the constraint of the request
    * @throws InvalidAllocationTagsQueryException if given string is not in valid format.
    */
   public static boolean canSatisfyConstraints(ApplicationId applicationId,
       SchedulingRequest request, SchedulerNode schedulerNode,
       PlacementConstraintManager pcm, AllocationTagsManager atm,
-      Optional<DiagnosticsCollector> dcOpt)
+      Optional<DiagnosticsCollector> dcOpt,
+      Optional<PlacementConstraintsRuntimeInfo> riOpt)
       throws InvalidAllocationTagsQueryException {
     Set<String> sourceTags = null;
     PlacementConstraint pc = null;
@@ -362,7 +435,7 @@ public final class PlacementConstraintsUtil {
     }
     return canSatisfyConstraints(applicationId,
         pcm.getMultilevelConstraint(applicationId, sourceTags, pc),
-        schedulerNode, atm, dcOpt);
+        schedulerNode, atm, dcOpt, riOpt);
   }
 
   public static boolean canSatisfyConstraints(ApplicationId applicationId,
@@ -370,7 +443,7 @@ public final class PlacementConstraintsUtil {
       PlacementConstraintManager pcm, AllocationTagsManager atm)
       throws InvalidAllocationTagsQueryException {
     return canSatisfyConstraints(applicationId, request, schedulerNode, pcm,
-        atm, Optional.empty());
+        atm, Optional.empty(), Optional.empty());
   }
 
   private static NodeAttribute getNodeConstraintFromRequest(String attrKey,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/SingleConstraintAppPlacementAllocator.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.PendingAsk
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.AllocationTagsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.InvalidAllocationTagsQueryException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.PlacementConstraintManager;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.PlacementConstraintsRuntimeInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.PlacementConstraintsUtil;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 
@@ -69,6 +70,7 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
   private String targetNodePartition;
   private AllocationTagsManager allocationTagsManager;
   private PlacementConstraintManager placementConstraintManager;
+  private PlacementConstraintsRuntimeInfo runtimeInfo;
 
   public SingleConstraintAppPlacementAllocator() {
     ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -164,6 +166,7 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
       LOG.info(
           "Update numAllocation from old=" + existingNumAllocations + " to new="
               + newNumAllocations);
+      runtimeInfo.askUpdated();
 
       return updateResult;
     }
@@ -172,6 +175,9 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
     // This will update internal partitions, etc. after the SchedulingRequest is
     // valid.
     validateAndSetSchedulingRequest(newSchedulingRequest);
+
+    // update runtimeInfo
+    runtimeInfo.askUpdated();
 
     return new PendingAskUpdateResult(null,
         new PendingAsk(newSchedulingRequest.getResourceSizing()), null,
@@ -327,6 +333,9 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
       // Deduct sizing
       decreasePendingNumAllocation();
 
+      // Reset missed opportunities
+      runtimeInfo.resetMissedOpportunities();
+
       return new ContainerRequest(containerSchedulingRequest);
     } finally {
       writeLock.unlock();
@@ -334,29 +343,36 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
   }
 
   private boolean checkCardinalityAndPending(SchedulerNode node,
-      Optional<DiagnosticsCollector> dcOpt) {
+      Optional<DiagnosticsCollector> dcOpt, boolean isPreCheck) {
     // Do we still have pending resource?
     if (schedulingRequest.getResourceSizing().getNumAllocations() <= 0) {
       return false;
     }
 
     // node type will be ignored.
+    boolean satisfied;
     try {
-      return PlacementConstraintsUtil.canSatisfyConstraints(
+      satisfied = PlacementConstraintsUtil.canSatisfyConstraints(
           appSchedulingInfo.getApplicationId(), schedulingRequest, node,
-          placementConstraintManager, allocationTagsManager, dcOpt);
+          placementConstraintManager, allocationTagsManager, dcOpt,
+              Optional.of(runtimeInfo));
     } catch (InvalidAllocationTagsQueryException e) {
       LOG.warn("Failed to query node cardinality:", e);
       this.incrementPlacementAttempt();
-      return false;
+      satisfied = false;
     }
+    // add missed opportunities if not satisfied and in pre-check stage
+    if (isPreCheck && !satisfied) {
+      runtimeInfo.addMissedOpportunities();
+    }
+    return satisfied;
   }
 
   @Override
   public boolean canAllocate(NodeType type, SchedulerNode node) {
     readLock.lock();
     try {
-      return checkCardinalityAndPending(node, Optional.empty());
+      return checkCardinalityAndPending(node, Optional.empty(), false);
     } finally {
       readLock.unlock();
     }
@@ -397,7 +413,7 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
         }
         return rst;
       }
-      return checkCardinalityAndPending(schedulerNode, dcOpt);
+      return checkCardinalityAndPending(schedulerNode, dcOpt, true);
     } finally {
       readLock.unlock();
     }
@@ -442,5 +458,6 @@ public class SingleConstraintAppPlacementAllocator<N extends SchedulerNode>
     super.initialize(appSchedulingInfo, schedulerRequestKey, rmContext);
     this.allocationTagsManager = rmContext.getAllocationTagsManager();
     this.placementConstraintManager = rmContext.getPlacementConstraintManager();
+    this.runtimeInfo = new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerPlacementConstraintsHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerPlacementConstraintsHandler.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
+
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.yarn.api.records.ExecutionType;
+import org.apache.hadoop.yarn.api.records.ExecutionTypeRequest;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.ResourceSizing;
+import org.apache.hadoop.yarn.api.records.SchedulingRequest;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.resourcemanager.MockAM;
+import org.apache.hadoop.yarn.server.resourcemanager.MockNM;
+import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
+import org.apache.hadoop.yarn.server.resourcemanager.MockRMAppSubmissionData;
+import org.apache.hadoop.yarn.server.resourcemanager.MockRMAppSubmitter;
+import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
+import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.PlacementTargets.allocationTagWithNamespace;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.delayedOr;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetIn;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.timedOpportunitiesConstraint;
+
+public class TestCapacitySchedulerPlacementConstraintsHandler {
+
+  private final int GB = 1024;
+  private CapacitySchedulerConfiguration conf;
+
+  @Before
+  public void setUp() {
+    CapacitySchedulerConfiguration config =
+        new CapacitySchedulerConfiguration();
+    config.set(CapacitySchedulerConfiguration.RESOURCE_CALCULATOR_CLASS,
+        DominantResourceCalculator.class.getName());
+    conf = new CapacitySchedulerConfiguration(config);
+    conf.setClass(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class,
+        ResourceScheduler.class);
+    conf.set(YarnConfiguration.RM_PLACEMENT_CONSTRAINTS_HANDLER,
+        YarnConfiguration.SCHEDULER_RM_PLACEMENT_CONSTRAINTS_HANDLER);
+  }
+
+  @Test(timeout = 30000L)
+  public void testDelayedOrPlacementConstraint() throws Exception {
+    MockRM rm1 = new MockRM(conf);
+    rm1.start();
+
+    MockNM nm1 = rm1.registerNode("h1:1234", 20 * GB);
+
+    // submit 2 apps
+    MockRMAppSubmissionData submissionData1 =
+        MockRMAppSubmissionData.Builder.createWithMemory(GB, rm1)
+            .withAppName("app1")
+            .withUser("root")
+            .withAcls(null)
+            .withQueue("default")
+            .build();
+    RMApp app1 = MockRMAppSubmitter.submit(rm1, submissionData1);
+    MockAM am1 = MockRM.launchAndRegisterAM(app1, rm1, nm1);
+    MockRMAppSubmissionData submissionData2 =
+        MockRMAppSubmissionData.Builder.createWithMemory(GB, rm1)
+            .withAppName("app2")
+            .withUser("root")
+            .withAcls(null)
+            .withQueue("default")
+            .build();
+    RMApp app2 = MockRMAppSubmitter.submit(rm1, submissionData2);
+    MockAM am2 = MockRM.launchAndRegisterAM(app2, rm1, nm1);
+
+    CapacityScheduler cs = (CapacityScheduler) rm1.getResourceScheduler();
+    FiCaSchedulerApp schedulerApp1 =
+        cs.getApplicationAttempt(am1.getApplicationAttemptId());
+    FiCaSchedulerApp schedulerApp2 =
+        cs.getApplicationAttempt(am2.getApplicationAttemptId());
+    Assert.assertEquals(1, schedulerApp1.getLiveContainers().size());
+    Assert.assertEquals(1, schedulerApp2.getLiveContainers().size());
+
+    // Init scheduling-request with delayed_or placement-constraint
+    // which will try to allocate on node with specified allocation-tag
+    // in the first 3 scheduling attempts.
+    PlacementConstraint constraint = delayedOr(timedOpportunitiesConstraint(
+        targetIn("node", allocationTagWithNamespace("self", "test")),
+        3)).build();
+    SchedulingRequest sc = SchedulingRequest.newInstance(1,
+        Priority.newInstance(1),
+        ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED),
+        ImmutableSet.of("AM"),
+        ResourceSizing.newInstance(1, Resource.newInstance(GB, 1)),
+        constraint);
+
+    // test for app1
+    am1.addSchedulingRequest(ImmutableList.of(sc));
+    am1.doHeartbeat();
+    for (int i = 0; i < 3; i++) {
+      nm1.nodeHeartbeat(true);
+      rm1.drainEvents();
+      Assert.assertEquals(1, schedulerApp1.getLiveContainers().size());
+    }
+    nm1.nodeHeartbeat(true);
+    rm1.drainEvents();
+    Assert.assertEquals(2, schedulerApp1.getLiveContainers().size());
+
+    // test for app2
+    am2.addSchedulingRequest(ImmutableList.of(sc));
+    am2.doHeartbeat();
+    for (int i = 0; i < 3; i++) {
+      nm1.nodeHeartbeat(true);
+      rm1.drainEvents();
+      Assert.assertEquals(1, schedulerApp2.getLiveContainers().size());
+    }
+    nm1.nodeHeartbeat(true);
+    rm1.drainEvents();
+    Assert.assertEquals(2, schedulerApp2.getLiveContainers().size());
+
+    rm1.stop();
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintsUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/constraint/TestPlacementConstraintsUtil.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.NODE;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.PlacementTargets.allocationTagWithNamespace;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.RACK;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.delayedOr;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetIn;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetNodeAttribute;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.targetNotIn;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.maxCardinality;
 import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.and;
@@ -31,12 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.timedClockConstraint;
+import static org.apache.hadoop.yarn.api.resource.PlacementConstraints.timedOpportunitiesConstraint;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,11 +51,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 
+import org.apache.hadoop.yarn.api.records.NodeAttributeOpCode;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -244,7 +252,7 @@ public class TestPlacementConstraintsUtil {
         new GenericDiagnosticsCollector();
     assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
         createSchedulingRequest(sourceTag1), schedulerNode1, pcm, tm,
-        Optional.of(collector)));
+        Optional.of(collector), Optional.empty()));
     assertNotNull(collector.getDiagnostics());
     assertTrue(collector.getDiagnostics().contains("ALLOCATION_TAG"));
   }
@@ -1104,5 +1112,169 @@ public class TestPlacementConstraintsUtil {
       assertTrue(e.getMessage()
           .contains("Invalid namespace prefix: unknown_namespace"));
     }
+  }
+
+  @Test
+  public void testDelayOrConstraintAssignment()
+          throws InvalidAllocationTagsQueryException {
+    AllocationTagsManager tm = new AllocationTagsManager(rmContext);
+    PlacementConstraintManagerService pcm =
+            new MemoryPlacementConstraintManager();
+    DiagnosticsCollector dc = new GenericDiagnosticsCollector();
+    // Register App1 with delayedOr constraint: node partition p1 or p2
+    HashSet<String> delayedOrTag1 = new HashSet<>(Collections.singletonList("delayedOrTag1"));
+    HashSet<String> delayedOrTag2 = new HashSet<>(Collections.singletonList("delayedOrTag2"));
+    PlacementConstraint constraint1 = PlacementConstraints.build(delayedOr(
+            timedOpportunitiesConstraint(
+                    targetNodeAttribute(NODE, NodeAttributeOpCode.EQ,
+                            PlacementConstraints.PlacementTargets.nodePartition("p1")),
+                    3),
+            timedOpportunitiesConstraint(
+                    targetNodeAttribute(NODE, NodeAttributeOpCode.EQ,
+                            PlacementConstraints.PlacementTargets.nodePartition("p2")),
+                    6)));
+    PlacementConstraint constraint2 = PlacementConstraints.build(delayedOr(
+            timedClockConstraint(
+                    targetNodeAttribute(NODE, NodeAttributeOpCode.EQ,
+                            PlacementConstraints.PlacementTargets.nodePartition("p1")),
+                    1, TimeUnit.SECONDS)));
+    Map<Set<String>, PlacementConstraint> constraintMap = Stream
+            .of(new AbstractMap.SimpleEntry<>(delayedOrTag1, constraint1),
+                    new AbstractMap.SimpleEntry<>(delayedOrTag2, constraint2))
+            .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey,
+                    AbstractMap.SimpleEntry::getValue));
+    pcm.registerApplication(appId1, constraintMap);
+    RMNode n0r1 = rmNodes.get(0);
+    RMNode n1r1 = rmNodes.get(1);
+    RMNode n2r2 = rmNodes.get(2);
+
+    // init nodes: n0 (partition=p1), n1 (partition=p2), n2 (partition="")
+    SchedulerNode schedulerNode0 =newSchedulerNode(n0r1.getHostName(),
+            n0r1.getRackName(), n0r1.getNodeID());
+    SchedulerNode schedulerNode1 =newSchedulerNode(n1r1.getHostName(),
+            n1r1.getRackName(), n1r1.getNodeID());
+    SchedulerNode schedulerNode2 =newSchedulerNode(n2r2.getHostName(),
+            n2r2.getRackName(), n2r2.getNodeID());
+    when(schedulerNode0.getPartition()).thenReturn("p1");
+    when(schedulerNode1.getPartition()).thenReturn("p2");
+    when(schedulerNode2.getPartition()).thenReturn("");
+
+    BiFunction<DiagnosticsCollector, String, Boolean> checkParitionUnsatisfied =
+            (collector, partition) -> collector.getDiagnostics().startsWith(
+                    "unsatisfied PC expression=\"node,EQ,yarn_node_partition/=["+partition+"]\"");
+    BiFunction<DiagnosticsCollector, String, Boolean> checkDetails =
+            (collector, delayInfo) -> collector.getDetails().startsWith(
+                    "delayInfo: "+delayInfo);
+    SchedulingRequest requestWithTag1 = createSchedulingRequest(delayedOrTag1);
+    SchedulingRequest requestWithTag2 = createSchedulingRequest(delayedOrTag2);
+
+    /*
+     * test cases for delayUnit OPPORTUNITIES
+     */
+    /*
+     * n0 (partition=p1) should always be accepted
+     */
+    // satisfied even if no runtime info
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode0, pcm, tm, Optional.of(dc),
+            Optional.empty()));
+
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode0, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0))));
+
+    /*
+     * n1 should be accepted until reached the second delayOr condition
+     */
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.empty()));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "runtime info not found"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=3, missedOpportunities=0"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 2))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=3, missedOpportunities=2"));
+
+    // satisfied when placement attempt >= 3
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 3))));
+
+    /*
+     * n2 should be accepted until reached all delay conditions
+     */
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode2, pcm, tm, Optional.of(dc),
+            Optional.empty()));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "runtime info not found"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode2, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=3, missedOpportunities=0"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode2, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 2))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=3, missedOpportunities=2"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode2, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 5))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p2"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=6, missedOpportunities=5"));
+
+    // satisfied when placement attempt >= 6
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag1, schedulerNode2, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 6))));
+
+
+    /*
+     * test cases for delayUnit MILLISECONDS
+     */
+    /*
+     * n0 (partition=p1) should always be accepted
+     */
+    // satisfied even if no runtime info
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag2, schedulerNode0, pcm, tm, Optional.of(dc),
+            Optional.empty()));
+
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag2, schedulerNode0, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0))));
+
+    /*
+     * n1 should be accepted until reached the delayOr condition
+     */
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag2, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.empty()));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "runtime info not found"));
+
+    assertFalse(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag2, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis(), 0))));
+    assertTrue(checkParitionUnsatisfied.apply(dc, "p1"));
+    assertTrue(checkDetails.apply(dc, "schedulingDelay=1000, elapsedMs="));
+
+    // satisfied when elapsedMs >= 1000
+    assertTrue(PlacementConstraintsUtil.canSatisfyConstraints(appId1,
+            requestWithTag2, schedulerNode1, pcm, tm, Optional.of(dc),
+            Optional.of(new PlacementConstraintsRuntimeInfo(System.currentTimeMillis()-1000, 0))));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/TestSingleConstraintAppPlacementAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/placement/TestSingleConstraintAppPlacementAllocator.java
@@ -18,8 +18,9 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement;
 
+import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.api.records.*;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.AllocationTags;
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraints;
 import org.apache.hadoop.yarn.exceptions.SchedulerInvalidResourceRequestException;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
@@ -28,13 +29,18 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.NodeType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.SchedulingMode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.TestUtils;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.AllocationTags;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.AllocationTagsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.InvalidAllocationTagsQueryException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.MemoryPlacementConstraintManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.constraint.PlacementConstraintManager;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.Assert;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -515,5 +521,71 @@ public class TestSingleConstraintAppPlacementAllocator {
             attributes));
     assertFalse(result,
         "Allocation should fail as java=1.8 doesnt exist in node");
+  }
+
+  @Test
+  public void testDelayedOrOperator() {
+    LogManager.getRootLogger().setLevel(Level.DEBUG);
+    // placement constraints expression: partition=p1 and (java=1.9, delay=1 || java=1.8, delay=3)
+    PlacementConstraint.AbstractConstraint constraint = PlacementConstraints.and(
+            PlacementConstraints.targetIn(
+                    PlacementConstraints.NODE,
+                    PlacementConstraints.PlacementTargets.nodePartition("p1")),
+            PlacementConstraints.delayedOr(
+                    PlacementConstraints.timedOpportunitiesConstraint(
+                            PlacementConstraints.targetNodeAttribute(PlacementConstraints.NODE,
+                                    NodeAttributeOpCode.EQ,
+                                    PlacementConstraints.PlacementTargets.nodeAttribute("java", "1.9")),
+                            3),
+                    PlacementConstraints.timedOpportunitiesConstraint(
+                            PlacementConstraints.targetNodeAttribute(PlacementConstraints.NODE,
+                                    NodeAttributeOpCode.EQ,
+                                    PlacementConstraints.PlacementTargets.nodeAttribute("java", "1.8")),
+                            6)));
+    SchedulingRequest schedulingRequest1 =
+            SchedulingRequest.newBuilder().executionType(ExecutionTypeRequest.newInstance(ExecutionType.GUARANTEED))
+                    .allocationRequestId(10L).priority(Priority.newInstance(1))
+                    .placementConstraintExpression(constraint.build())
+                    .resourceSizing(ResourceSizing.newInstance(1, Resource.newInstance(1024, 1)))
+                    .build();
+    allocator = new SingleConstraintAppPlacementAllocator();
+    allocator.initialize(appSchedulingInfo, schedulerRequestKey, rmContext);
+    allocator.updatePendingAsk(schedulerRequestKey, schedulingRequest1, false);
+    FiCaSchedulerNode testNode = TestUtils.getMockNode("host1", "/rack1", 123, 1024, 1);
+
+    // 1. test node: partition="p1", attributes={"java":"1.9"}
+    when(testNode.getPartition()).thenReturn("p1");
+    when(testNode.getNodeAttributes()).thenReturn(
+            Sets.newHashSet(NodeAttribute.newInstance("java", NodeAttributeType.STRING, "1.9")));
+    Assert.assertTrue("can allocate in node with required partition and attributes",
+            allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+
+    // 2. test node: partition="p1", attributes={"java":"1.8"}
+    when(testNode.getPartition()).thenReturn("p1");
+    when(testNode.getNodeAttributes()).thenReturn(
+            Sets.newHashSet(NodeAttribute.newInstance("java", NodeAttributeType.STRING, "1.8")));
+    for (int i = 0; i < 3; i++) {
+      Assert.assertFalse("can't allocate in node since delayed condition is not met",
+              allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+    }
+    Assert.assertTrue("can allocate in node when delayed condition is met",
+            allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+
+    // missed opportunities should be reset to 0 after satisfied
+    for (int i = 0; i < 3; i++) {
+      Assert.assertFalse("can't allocate in node since delayed condition is not met",
+              allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+    }
+    Assert.assertTrue("can allocate in node when delayed condition is met",
+            allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+
+    // 3. test node: partition="", attributes={"java":"1.9"}
+    when(testNode.getPartition()).thenReturn("");
+    when(testNode.getNodeAttributes()).thenReturn(
+            Sets.newHashSet(NodeAttribute.newInstance("java", NodeAttributeType.STRING, "1.9")));
+    for (int i = 0; i < 10; i++) {
+      Assert.assertFalse("can't allocate in node without required partition",
+              allocator.canAllocate(NodeType.NODE_LOCAL, testNode));
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Please refer to YARN-11766

### How was this patch tested?

UT

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

