### PR TITLE
HADOOP-19400: Expand specification and contract test coverage for InputStream reads.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/filesystem/fsdatainputstream.md
@@ -129,10 +129,11 @@ as implicitly set in `pos`.
 #### Preconditions
 
     isOpen(FSDIS)
-    buffer != null else raise NullPointerException
-    length >= 0
-    offset < len(buffer)
-    length <= len(buffer) - offset
+    buffer != null else raise NullPointerException, IllegalArgumentException
+    offset >= 0 else raise IndexOutOfBoundsException
+    length >= 0 else raise IndexOutOfBoundsException, IllegalArgumentException
+    offset < len(buffer) else raise IndexOutOfBoundsException
+    length <= len(buffer) - offset else raise IndexOutOfBoundsException
     pos >= 0 else raise EOFException, IOException
 
 Exceptions that may be raised on precondition failure are
@@ -174,6 +175,19 @@ What is critical is that unless the destination buffer size is 0, the call
 must block until at least one byte is returned. Thus, for any data source
 of length greater than zero, repeated invocations of this `read()` operation
 will eventually read all the data.
+
+#### Implementation Notes
+
+1. If the caller passes a `null` buffer, then an unchecked exception MUST be thrown. The base JDK
+`InputStream` implementation throws `NullPointerException`. HDFS historically used
+`IllegalArgumentException`. Implementations MAY use either of these.
+1. If the caller passes a negative value for `length`, then an unchecked exception MUST be thrown.
+The base JDK `InputStream` implementation throws `IndexOutOfBoundsException`. HDFS historically used
+`IllegalArgumentException`. Implementations MAY use either of these.
+1. Reads through any method MUST return the same data.
+1. Callers MAY interleave calls to different read methods (single-byte and multi-byte) on the same
+stream. The stream MUST return the same underlying data, regardless of the specific read calls or
+their ordering.
 
 ### <a name="Seekable.seek"></a>`Seekable.seek(s)`
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractOpenTest.java
@@ -38,6 +38,9 @@ import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_LE
 import static org.apache.hadoop.fs.contract.ContractTestUtils.compareByteArrays;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.readDataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.readDatasetSingleByteReads;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.readNBytes;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.test.LambdaTestUtils.interceptFuture;
@@ -408,4 +411,137 @@ public abstract class AbstractContractOpenTest
         .isEqualTo(len);
   }
 
+  @Test
+  public void testInputStreamReadNullBuffer() throws Throwable {
+    // The JDK base InputStream (and by extension LocalFSFileInputStream) throws
+    // NullPointerException. Historically, DFSInputStream has thrown IllegalArgumentException
+    // instead. Allow either behavior.
+    describe("Attempting to read into a null buffer should throw IllegalArgumentException or " +
+        "NullPointerException");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      Assertions.assertThatThrownBy(() -> is.read(null, 0, 10))
+          .isInstanceOfAny(IllegalArgumentException.class, NullPointerException.class);
+    }
+  }
+
+  @Test
+  public void testInputStreamReadNegativePosition() throws Throwable {
+    describe("Attempting to read into a negative position should throw IndexOutOfBoundsException");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      Assertions.assertThatThrownBy(() -> is.read(new byte[10], -1, 10))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+  }
+
+  @Test
+  public void testInputStreamReadNegativeLength() throws Throwable {
+    // The JDK base InputStream (and by extension LocalFSFileInputStream) throws
+    // IndexOutOfBoundsException. Historically, DFSInputStream has thrown IllegalArgumentException
+    // instead. Allow either behavior.
+    describe("Attempting to read into a null buffer should throw IllegalArgumentException or " +
+        "IndexOutOfBoundsException");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      Assertions.assertThatThrownBy(() -> is.read(new byte[10], 0, -1))
+          .isInstanceOfAny(IllegalArgumentException.class, IndexOutOfBoundsException.class);
+    }
+  }
+
+  @Test
+  public void testInputStreamReadTooLong() throws Throwable {
+    describe("Attempting a read longer than the buffer should throw IndexOutOfBoundsException");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      Assertions.assertThatThrownBy(() -> is.read(new byte[10], 0, 11))
+          .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+  }
+
+  @Test
+  public void testInputStreamReadZeroLengthRead() throws Throwable {
+    describe("Reading 0 bytes is a no-op");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      Assertions.assertThat(is.read(new byte[10], 0, 0)).describedAs("bytes read").isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void testInputStreamConsistentEOF() throws Throwable {
+    describe("Both single-byte and multi-byte read should report EOF after consuming stream");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      IOUtils.skipFully(is, len);
+      Assertions.assertThat(is.read()).describedAs("single byte EOF").isEqualTo(-1);
+      Assertions.assertThat(is.read(new byte[10], 0, 10)).describedAs("multi byte EOF")
+              .isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void testInputStreamSingleAndMultiByteReadsEqual() throws Throwable {
+    describe("Single-byte and multi-byte read should return the same bytes");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    byte[] multiByteReads = readDataset(fs, path, len);
+    byte[] singleByteReads = readDatasetSingleByteReads(fs, path, len);
+    compareByteArrays(multiByteReads, singleByteReads, len);
+  }
+
+  @Test
+  public void testInputStreamMixedSingleAndMultiByteReadsEqual() throws Throwable {
+    describe("Mixed single and multi-byte reads on the same stream should return the same bytes");
+    Path path = methodPath();
+    FileSystem fs = getFileSystem();
+    int len = 4096;
+    createFile(fs, path, true,
+        dataset(len, 0x40, 0x80));
+    byte[] expected = readDataset(fs, path, len);
+    byte[] actual = new byte[len];
+    int readSize = 128;
+    try (FSDataInputStream is = fs.openFile(path).build().get()) {
+      for (int offset = 0; offset < len; offset = offset + readSize + readSize) {
+        if (readNBytes(is, actual, offset, readSize) != readSize) {
+          fail("End of file reached before reading fully.");
+        }
+        for (int i = 0; i < readSize; ++i) {
+          int nextByte = is.read();
+          if (-1 == nextByte) {
+            fail("End of file reached before reading fully.");
+          }
+          actual[offset + readSize + i] = (byte)nextByte;
+        }
+      }
+    }
+    compareByteArrays(expected, actual, len);
+  }
 }


### PR DESCRIPTION
### Description of PR

Enhance the FS specification and contract tests to cover expected semantics of the InputStream single-byte and multi-byte read methods:

* Multi-byte read should validate the arguments passed to it, according to the patterns established in the JDK base `InputStream` class and HDFS `DFSInputStream`.
* You should get the same bytes whether going through single-byte or multi-byte read.
* It is legal to mix calls to single-byte and multi-byte read, and this should also yield the same bytes.

### How was this patch tested?

I ran all subclasses of `AbstractContractOpenTest` for local, HDFS and S3A (connecting to GCS's S3-compatible XML API).

```
mvn -o \
    -pl hadoop-common-project/hadoop-common,hadoop-hdfs-project/hadoop-hdfs,hadoop-hdfs-project/hadoop-hdfs-rbf,hadoop-tools/hadoop-aws test \
    -Dtest=TestFTPContractOpen,TestHDFSContractOpen,TestRouterHDFSContractOpenSecure,TestRouterWebHDFSContractOpen,TestRouterHDFSContractOpen,ITestS3AContractOpen,TestLocalFSContractOpen,TestRawlocalContractOpen
```

These new tests also pass for `GoogleHadoopFileSystem`.

```
./mvnw -o test \
    -Dtest=TestGoogleContractOpen,TestInMemoryGoogleContractOpen -Dsurefire.failIfNoSpecifiedTests=false
```

I generated the site locally and confirmed the new specification content.

```
mvn -o site site:stage -Preleasedocs,docs -DstagingDirectory=/tmp/hadoop-site
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

