### PR TITLE
HADOOP-19425. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-azure Part1.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestName.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestName.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class TestName implements BeforeEachCallback {
 
-    private volatile String name;
+  private volatile String name;
 
-    @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception {
-        name = extensionContext.getTestMethod().get().getName();
-    }
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    name = extensionContext.getTestMethod().get().getName();
+  }
 
-    public String getMethodName() {
-        return this.name;
-    }
+  public String getMethodName() {
+    return this.name;
+  }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestName.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestName.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.test;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This is a custom JUnit5 `RegisterExtension`
+ * we created to obtain the methond name of the executing function.
+ */
+public class TestName implements BeforeEachCallback {
+
+    private volatile String name;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        name = extensionContext.getTestMethod().get().getName();
+    }
+
+    public String getMethodName() {
+        return this.name;
+    }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -53,7 +53,7 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   @BeforeEach
   public void setUp(TestInfo testInfo) throws Exception {
     AzureBlobStorageTestAccount account = createTestAccount();
-    assumeTrue(account != null, "test account");
+    assumeNotNull(account, "test account");
     bindToTestAccount(account);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.io.IOUtils;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.*;
 
 /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -59,7 +59,7 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
 
   @AfterEach
   public void tearDown(TestInfo info) throws Exception {
-    describe(info,"closing test account and filesystem");
+    describe(info, "closing test account and filesystem");
     testAccount = cleanupTestAccount(testAccount);
     IOUtils.closeStream(fs);
     fs = null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.fs.azure;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,14 +49,14 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   protected NativeAzureFileSystem fs;
   protected AzureBlobStorageTestAccount testAccount;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     AzureBlobStorageTestAccount account = createTestAccount();
     assumeNotNull("test account", account);
     bindToTestAccount(account);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     describe("closing test account and filesystem");
     testAccount = cleanupTestAccount(testAccount);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,15 +49,15 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   protected AzureBlobStorageTestAccount testAccount;
 
   @BeforeEach
-  public void setUp(TestInfo testInfo) throws Exception {
+  public void setUp() throws Exception {
     AzureBlobStorageTestAccount account = createTestAccount();
     assumeNotNull(account, "test account");
     bindToTestAccount(account);
   }
 
   @AfterEach
-  public void tearDown(TestInfo info) throws Exception {
-    describe(info, "closing test account and filesystem");
+  public void tearDown() throws Exception {
+    describe("closing test account and filesystem");
     testAccount = cleanupTestAccount(testAccount);
     IOUtils.closeStream(fs);
     fs = null;
@@ -146,37 +145,31 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   /**
    * Return a path bonded to this method name, unique to this fork during
    * parallel execution.
-   * @param testInfo Provides information about the currently executing test method.
-   * This can include details such as the name of the test method, display name.
    * @return a method name unique to (fork, method).
    * @throws IOException IO problems
    */
-  protected Path methodPath(TestInfo testInfo) throws IOException {
-    return path(testInfo.getDisplayName());
+  protected Path methodPath() throws IOException {
+    return path(methodName.getMethodName());
   }
 
   /**
    * Return a blob path bonded to this method name, unique to this fork during
    * parallel execution.
-   * @param testInfo Provides information about the currently executing test method.
-   * This can include details such as the name of the test method, display name.
    * @return a method name unique to (fork, method).
    * @throws IOException IO problems
    */
-  protected Path methodBlobPath(TestInfo testInfo) throws IOException {
-    return blobPath(testInfo.getDisplayName());
+  protected Path methodBlobPath() throws IOException {
+    return blobPath(methodName.getMethodName());
   }
 
   /**
    * Describe a test in the logs.
-   * @param testInfo Provides information about the currently executing test method.
-   * This can include details such as the name of the test method, display name.
    * @param text text to print
    * @param args arguments to format in the printing
    */
-  protected void describe(TestInfo testInfo, String text, Object... args) {
+  protected void describe(String text, Object... args) {
     LOG.info("\n\n{}: {}\n",
-        testInfo.getDisplayName(),
+        methodName.getMethodName(),
         String.format(text, args));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -153,16 +153,6 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   }
 
   /**
-   * Return a blob path bonded to this method name, unique to this fork during
-   * parallel execution.
-   * @return a method name unique to (fork, method).
-   * @throws IOException IO problems
-   */
-  protected Path methodBlobPath() throws IOException {
-    return blobPath(methodName.getMethodName());
-  }
-
-  /**
    * Describe a test in the logs.
    * @param text text to print
    * @param args arguments to format in the printing

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -153,6 +153,16 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   }
 
   /**
+   * Return a blob path bonded to this method name, unique to this fork during
+   * parallel execution.
+   * @return a method name unique to (fork, method).
+   * @throws IOException IO problems
+   */
+  protected Path methodBlobPath() throws IOException {
+    return blobPath(methodName.getMethodName());
+  }
+
+  /**
    * Describe a test in the logs.
    * @param text text to print
    * @param args arguments to format in the printing

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,15 +51,15 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   protected AzureBlobStorageTestAccount testAccount;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp(TestInfo testInfo) throws Exception {
     AzureBlobStorageTestAccount account = createTestAccount();
     assumeNotNull("test account", account);
     bindToTestAccount(account);
   }
 
   @AfterEach
-  public void tearDown() throws Exception {
-    describe("closing test account and filesystem");
+  public void tearDown(TestInfo info) throws Exception {
+    describe(info,"closing test account and filesystem");
     testAccount = cleanupTestAccount(testAccount);
     IOUtils.closeStream(fs);
     fs = null;
@@ -146,31 +147,37 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   /**
    * Return a path bonded to this method name, unique to this fork during
    * parallel execution.
+   * @param testInfo Provides information about the currently executing test method.
+   * This can include details such as the name of the test method, display name.
    * @return a method name unique to (fork, method).
    * @throws IOException IO problems
    */
-  protected Path methodPath() throws IOException {
-    return path(methodName.getMethodName());
+  protected Path methodPath(TestInfo testInfo) throws IOException {
+    return path(testInfo.getDisplayName());
   }
 
   /**
    * Return a blob path bonded to this method name, unique to this fork during
    * parallel execution.
+   * @param testInfo Provides information about the currently executing test method.
+   * This can include details such as the name of the test method, display name.
    * @return a method name unique to (fork, method).
    * @throws IOException IO problems
    */
-  protected Path methodBlobPath() throws IOException {
-    return blobPath(methodName.getMethodName());
+  protected Path methodBlobPath(TestInfo testInfo) throws IOException {
+    return blobPath(testInfo.getDisplayName());
   }
 
   /**
    * Describe a test in the logs.
+   * @param testInfo Provides information about the currently executing test method.
+   * This can include details such as the name of the test method, display name.
    * @param text text to print
    * @param args arguments to format in the printing
    */
-  protected void describe(String text, Object... args) {
+  protected void describe(TestInfo testInfo, String text, Object... args) {
     LOG.info("\n\n{}: {}\n",
-        methodName.getMethodName(),
+        testInfo.getDisplayName(),
         String.format(text, args));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestBase.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.io.IOUtils;
 
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.*;
 
 /**
@@ -53,7 +53,7 @@ public abstract class AbstractWasbTestBase extends AbstractWasbTestWithTimeout
   @BeforeEach
   public void setUp(TestInfo testInfo) throws Exception {
     AzureBlobStorageTestAccount account = createTestAccount();
-    assumeNotNull("test account", account);
+    assumeTrue(account != null, "test account");
     bindToTestAccount(account);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -21,10 +21,10 @@ package org.apache.hadoop.fs.azure;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
-
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.apache.hadoop.test.TestName;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -34,6 +34,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 @Timeout(AzureTestConstants.AZURE_TEST_TIMEOUT)
 public class AbstractWasbTestWithTimeout extends Assertions {
+
+  /**
+   * The name of the current method.
+   */
+  @RegisterExtension
+  public TestName methodName = new TestName();
 
   /**
    * Name the junit thread for the class. This will overridden
@@ -48,8 +54,8 @@ public class AbstractWasbTestWithTimeout extends Assertions {
    * Name the thread to the current test method.
    */
   @BeforeEach
-  public void nameThread(TestInfo testInfo) {
-    Thread.currentThread().setName("JUnit-" + testInfo.getDisplayName());
+  public void nameThread() {
+    Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -39,7 +39,7 @@ public class AbstractWasbTestWithTimeout extends Assertions {
    * The name of the current method.
    */
   @RegisterExtension
-  public TestName methodName = new TestName();
+  private TestName methodName = new TestName();
 
   /**
    * Name the junit thread for the class. This will overridden

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -39,7 +39,7 @@ public class AbstractWasbTestWithTimeout extends Assertions {
    * The name of the current method.
    */
   @RegisterExtension
-  private TestName methodName = new TestName();
+  public TestName methodName = new TestName();
 
   /**
    * Name the junit thread for the class. This will overridden

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.fs.azure;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
  * Base class for any Wasb test with timeouts & named threads.
  * This class does not attempt to bind to Azure.
  */
-public class AbstractWasbTestWithTimeout extends Assert {
+public class AbstractWasbTestWithTimeout extends Assertions {
 
   /**
    * The name of the current method.
@@ -49,7 +49,7 @@ public class AbstractWasbTestWithTimeout extends Assert {
    * Name the junit thread for the class. This will overridden
    * before the individual test methods are run.
    */
-  @BeforeClass
+  @BeforeAll
   public static void nameTestThread() {
     Thread.currentThread().setName("JUnit");
   }
@@ -57,7 +57,7 @@ public class AbstractWasbTestWithTimeout extends Assert {
   /**
    * Name the thread to the current test method.
    */
-  @Before
+  @BeforeEach
   public void nameThread() {
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -19,11 +19,10 @@
 package org.apache.hadoop.fs.azure;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 
@@ -31,19 +30,8 @@ import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
  * Base class for any Wasb test with timeouts & named threads.
  * This class does not attempt to bind to Azure.
  */
+@Timeout(AzureTestConstants.AZURE_TEST_TIMEOUT)
 public class AbstractWasbTestWithTimeout extends Assertions {
-
-  /**
-   * The name of the current method.
-   */
-  @Rule
-  public TestName methodName = new TestName();
-  /**
-   * Set the timeout for every test.
-   * This is driven by the value returned by {@link #getTestTimeoutMillis()}.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(getTestTimeoutMillis());
 
   /**
    * Name the junit thread for the class. This will overridden
@@ -58,8 +46,8 @@ public class AbstractWasbTestWithTimeout extends Assertions {
    * Name the thread to the current test method.
    */
   @BeforeEach
-  public void nameThread() {
-    Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
+  public void nameThread(TestInfo testInfo) {
+    Thread.currentThread().setName("JUnit-" + testInfo.getDisplayName());
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AbstractWasbTestWithTimeout.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 /**
  * Base class for any Wasb test with timeouts & named threads.
  * This class does not attempt to bind to Azure.
@@ -58,4 +60,11 @@ public class AbstractWasbTestWithTimeout extends Assertions {
     return AzureTestConstants.AZURE_TEST_TIMEOUT;
   }
 
+  public static void assumeNotNull(Object objects) {
+    assumeTrue(objects != null);
+  }
+
+  public static void assumeNotNull(Object objects, String message) {
+    assumeTrue(objects != null, message);
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.azure;
 import com.microsoft.azure.storage.*;
 import com.microsoft.azure.storage.blob.*;
 import com.microsoft.azure.storage.core.Base64;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +49,7 @@ import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.DEFAULT_STOR
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_USE_LOCAL_SAS_KEY_MODE;
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_USE_SECURE_MODE;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.verifyWasbAccountNameInConfig;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Helper class to create WASB file systems backed by either a mock in-memory
@@ -212,9 +212,9 @@ public final class AzureBlobStorageTestAccount implements AutoCloseable,
    * @return
    */
   private boolean wasGeneratedByMe(MetricsRecord currentRecord) {
-    Assertions.assertNotNull(fs, "null filesystem");
-    Assertions.assertNotNull(
-       fs.getInstrumentation().getFileSystemInstanceId(), "null filesystemn instance ID");
+    assertNotNull(fs, "null filesystem");
+    assertNotNull(fs.getInstrumentation().getFileSystemInstanceId(),
+        "null filesystemn instance ID");
     String myFsId = fs.getInstrumentation().getFileSystemInstanceId().toString();
     for (MetricsTag currentTag : currentRecord.tags()) {
       if (currentTag.name().equalsIgnoreCase("wasbFileSystemId")) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/AzureBlobStorageTestAccount.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.azure;
 import com.microsoft.azure.storage.*;
 import com.microsoft.azure.storage.blob.*;
 import com.microsoft.azure.storage.core.Base64;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,9 +212,9 @@ public final class AzureBlobStorageTestAccount implements AutoCloseable,
    * @return
    */
   private boolean wasGeneratedByMe(MetricsRecord currentRecord) {
-    Assert.assertNotNull("null filesystem", fs);
-    Assert.assertNotNull("null filesystemn instance ID",
-        fs.getInstrumentation().getFileSystemInstanceId());
+    Assertions.assertNotNull(fs, "null filesystem");
+    Assertions.assertNotNull(
+       fs.getInstrumentation().getFileSystemInstanceId(), "null filesystemn instance ID");
     String myFsId = fs.getInstrumentation().getFileSystemInstanceId().toString();
     for (MetricsTag currentTag : currentRecord.tags()) {
       if (currentTag.name().equalsIgnoreCase("wasbFileSystemId")) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureConcurrentOutOfBandIo.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureConcurrentOutOfBandIo.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
@@ -157,7 +157,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       injectTransientError(fs, new ConnectionRecognizer() {
@@ -200,7 +200,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       injectTransientError(fs, new ConnectionRecognizer() {
@@ -224,7 +224,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       Path testFile = new Path("/a/b");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.NO_ACCESS_TO_CONTAINER_MSG;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Error handling.
@@ -157,7 +157,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       injectTransientError(fs, new ConnectionRecognizer() {
@@ -200,7 +200,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       injectTransientError(fs, new ConnectionRecognizer() {
@@ -224,7 +224,7 @@ public class ITestAzureFileSystemErrorConditions extends
     // Need to do this test against a live storage account
     AzureBlobStorageTestAccount testAccount =
         AzureBlobStorageTestAccount.create();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     try {
       NativeAzureFileSystem fs = testAccount.getFileSystem();
       Path testFile = new Path("/a/b");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.NO_ACCESS_TO_CONTAINER_MSG;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Error handling.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestAzureFileSystemErrorConditions.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Callable;
 import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.SendingRequestEvent;
 import com.microsoft.azure.storage.StorageEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -76,7 +76,7 @@ public class ITestAzureFileSystemErrorConditions extends
     try {
       FileSystem.get(noAccessPath.toUri(), new Configuration())
         .open(noAccessPath);
-      assertTrue("Should've thrown.", false);
+      assertTrue(false, "Should've thrown.");
     } catch (AzureException ex) {
       GenericTestUtils.assertExceptionContains(
           String.format(NO_ACCESS_TO_CONTAINER_MSG, account, container), ex);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.azure;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_CHECK_BLOCK_MD5;
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_STORE_BLOB_MD5;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azure;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_CHECK_BLOCK_MD5;
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_STORE_BLOB_MD5;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import com.microsoft.azure.storage.Constants;
 import com.microsoft.azure.storage.OperationContext;
@@ -65,9 +66,9 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
    * Test that by default we don't store the blob-level MD5.
    */
   @Test
-  public void testBlobMd5StoreOffByDefault() throws Exception {
+  public void testBlobMd5StoreOffByDefault(TestInfo testInfo) throws Exception {
     testAccount = AzureBlobStorageTestAccount.create();
-    testStoreBlobMd5(false);
+    testStoreBlobMd5(false, testInfo);
   }
 
   /**
@@ -75,11 +76,11 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
    * in the configuration.
    */
   @Test
-  public void testStoreBlobMd5() throws Exception {
+  public void testStoreBlobMd5(TestInfo testInfo) throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(KEY_STORE_BLOB_MD5, true);
     testAccount = AzureBlobStorageTestAccount.create(conf);
-    testStoreBlobMd5(true);
+    testStoreBlobMd5(true, testInfo);
   }
 
   /**
@@ -91,12 +92,12 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
         toTrim);
   }
 
-  private void testStoreBlobMd5(boolean expectMd5Stored) throws Exception {
-    assumeNotNull(testAccount);
+  private void testStoreBlobMd5(boolean expectMd5Stored, TestInfo testInfo) throws Exception {
+    assumeTrue(testAccount != null);
     // Write a test file.
     NativeAzureFileSystem fs = testAccount.getFileSystem();
     Path testFilePath = AzureTestUtils.pathForTests(fs,
-        methodName.getMethodName());
+        testInfo.getDisplayName());
     String testFileKey = trim(testFilePath.toUri().getPath(), "/");
     OutputStream outStream = fs.create(testFilePath);
     outStream.write(new byte[] { 5, 15 });
@@ -211,7 +212,7 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
 
   private void testCheckBlockMd5(final boolean expectMd5Checked)
       throws Exception {
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     Path testFilePath = new Path("/testFile");
 
     // Add a hook to check that for GET/PUT requests we set/don't set

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import com.microsoft.azure.storage.Constants;
 import com.microsoft.azure.storage.OperationContext;
@@ -65,9 +64,9 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
    * Test that by default we don't store the blob-level MD5.
    */
   @Test
-  public void testBlobMd5StoreOffByDefault(TestInfo testInfo) throws Exception {
+  public void testBlobMd5StoreOffByDefault() throws Exception {
     testAccount = AzureBlobStorageTestAccount.create();
-    testStoreBlobMd5(false, testInfo);
+    testStoreBlobMd5(false);
   }
 
   /**
@@ -75,11 +74,11 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
    * in the configuration.
    */
   @Test
-  public void testStoreBlobMd5(TestInfo testInfo) throws Exception {
+  public void testStoreBlobMd5() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(KEY_STORE_BLOB_MD5, true);
     testAccount = AzureBlobStorageTestAccount.create(conf);
-    testStoreBlobMd5(true, testInfo);
+    testStoreBlobMd5(true);
   }
 
   /**
@@ -91,12 +90,11 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
         toTrim);
   }
 
-  private void testStoreBlobMd5(boolean expectMd5Stored, TestInfo testInfo) throws Exception {
+  private void testStoreBlobMd5(boolean expectMd5Stored) throws Exception {
     assumeNotNull(testAccount);
     // Write a test file.
     NativeAzureFileSystem fs = testAccount.getFileSystem();
-    Path testFilePath = AzureTestUtils.pathForTests(fs,
-        testInfo.getDisplayName());
+    Path testFilePath = AzureTestUtils.pathForTests(fs, methodName.getMethodName());
     String testFileKey = trim(testFilePath.toUri().getPath(), "/");
     OutputStream outStream = fs.create(testFilePath);
     outStream.write(new byte[] { 5, 15 });

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -93,7 +93,7 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
   }
 
   private void testStoreBlobMd5(boolean expectMd5Stored, TestInfo testInfo) throws Exception {
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     // Write a test file.
     NativeAzureFileSystem fs = testAccount.getFileSystem();
     Path testFilePath = AzureTestUtils.pathForTests(fs,
@@ -212,7 +212,7 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
 
   private void testCheckBlockMd5(final boolean expectMd5Checked)
       throws Exception {
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     Path testFilePath = new Path("/testFile");
 
     // Add a hook to check that for GET/PUT requests we set/don't set

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.TestHookOperationContext;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.storage.Constants;
 import com.microsoft.azure.storage.OperationContext;
@@ -56,7 +56,7 @@ import com.microsoft.azure.storage.core.Base64;
 public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
   private AzureBlobStorageTestAccount testAccount;
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount = AzureTestUtils.cleanupTestAccount(testAccount);
   }
@@ -109,7 +109,7 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
     if (expectMd5Stored) {
       assertNotNull(obtainedMd5);
     } else {
-      assertNull("Expected no MD5, found: " + obtainedMd5, obtainedMd5);
+      assertNull(obtainedMd5, "Expected no MD5, found: " + obtainedMd5);
     }
 
     // Mess with the content so it doesn't match the MD5.
@@ -137,8 +137,8 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
       }
       StorageException cause = (StorageException)ex.getCause();
       assertNotNull(cause);
-      assertEquals("Unexpected cause: " + cause,
-          StorageErrorCodeStrings.INVALID_MD5, cause.getErrorCode());
+      assertEquals(
+         StorageErrorCodeStrings.INVALID_MD5, cause.getErrorCode(), "Unexpected cause: " + cause);
     }
   }
 
@@ -192,7 +192,7 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
       if (expectMd5) {
         assertNotNull(obtainedMd5);
       } else {
-        assertNull("Expected no MD5, found: " + obtainedMd5, obtainedMd5);
+        assertNull(obtainedMd5, "Expected no MD5, found: " + obtainedMd5);
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobDataValidation.java
@@ -138,8 +138,8 @@ public class ITestBlobDataValidation extends AbstractWasbTestWithTimeout {
       }
       StorageException cause = (StorageException)ex.getCause();
       assertNotNull(cause);
-      assertEquals(
-         StorageErrorCodeStrings.INVALID_MD5, cause.getErrorCode(), "Unexpected cause: " + cause);
+      assertEquals(StorageErrorCodeStrings.INVALID_MD5, cause.getErrorCode(),
+          "Unexpected cause: " + cause);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobTypeSpeedDifference.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlobTypeSpeedDifference.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
@@ -25,7 +25,11 @@ import java.util.EnumSet;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -354,8 +358,8 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
 
     int numBytesReadV2NoBuffer = inputStreamV2NoBuffer.read(pos,
         bufferV2NoBuffer, 0, size);
-    assertEquals(size
-,         numBytesReadV2NoBuffer, "Bytes read from V2 stream (buffered pread disabled)");
+    assertEquals(size, numBytesReadV2NoBuffer,
+        "Bytes read from V2 stream (buffered pread disabled)");
 
     assertArrayEquals(bufferV1, bufferV2, "Mismatch in read data");
     assertArrayEquals(bufferV2, bufferV2NoBuffer, "Mismatch in read data");
@@ -509,11 +513,9 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
           }
       );
       long elapsedTimeMs = timer.elapsedTimeMs();
-      assertTrue(
-      
-         elapsedTimeMs < 20, String.format(
-              "There should not be any network I/O (elapsedTimeMs=%1$d).",
-              elapsedTimeMs));
+      assertTrue(elapsedTimeMs < 20, String.format(
+          "There should not be any network I/O (elapsedTimeMs=%1$d).",
+          elapsedTimeMs));
     }
   }
 
@@ -575,10 +577,9 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
 
       long elapsedTimeMs = timer.elapsedTimeMs();
       assertTrue(
-      
-         elapsedTimeMs < 20, String.format(
-              "There should not be any network I/O (elapsedTimeMs=%1$d).",
-              elapsedTimeMs));
+          elapsedTimeMs < 20, String.format(
+          "There should not be any network I/O (elapsedTimeMs=%1$d).",
+          elapsedTimeMs));
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
@@ -25,9 +25,7 @@ import java.util.EnumSet;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
-import org.junit.FixMethodOrder;
-import org.junit.jupiter.api.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +51,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.*;
  * (KEY_INPUT_STREAM_VERSION=1) and the new
  * <code>BlockBlobInputStream</code> (KEY_INPUT_STREAM_VERSION=2).
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 
 public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -73,9 +71,10 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
   private FileStatus testFileStatus;
   private Path hugefile;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     Configuration conf = new Configuration();
     conf.setInt(AzureNativeFileSystemStore.KEY_INPUT_STREAM_VERSION, 1);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
@@ -46,8 +46,6 @@ import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.contract.ContractTestUtils.NanoTimer;
 
-import static org.junit.Assume.assumeNotNull;
-
 import static org.apache.hadoop.test.LambdaTestUtils.*;
 
 /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
@@ -26,7 +26,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 
 import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +172,7 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
     ContractTestUtils.assertPathExists(fs, "huge file not created", hugefile);
     FileStatus status = fs.getFileStatus(hugefile);
     ContractTestUtils.assertIsFile(hugefile, status);
-    assertTrue("File " + hugefile + " is empty", status.getLen() > 0);
+    assertTrue(status.getLen() > 0, "File " + hugefile + " is empty");
   }
 
   /**
@@ -299,12 +299,12 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
       byte[] bufferV2) throws IOException {
     int size = bufferV1.length;
     final int numBytesReadV1 = inputStreamV1.read(bufferV1, 0, size);
-    assertEquals("Bytes read from V1 stream", size, numBytesReadV1);
+    assertEquals(size, numBytesReadV1, "Bytes read from V1 stream");
 
     final int numBytesReadV2 = inputStreamV2.read(bufferV2, 0, size);
-    assertEquals("Bytes read from V2 stream", size, numBytesReadV2);
+    assertEquals(size, numBytesReadV2, "Bytes read from V2 stream");
 
-    assertArrayEquals("Mismatch in read data", bufferV1, bufferV2);
+    assertArrayEquals(bufferV1, bufferV2, "Mismatch in read data");
   }
 
   @Test
@@ -348,18 +348,18 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
       throws IOException {
     int size = bufferV1.length;
     int numBytesReadV1 = inputStreamV1.read(pos, bufferV1, 0, size);
-    assertEquals("Bytes read from V1 stream", size, numBytesReadV1);
+    assertEquals(size, numBytesReadV1, "Bytes read from V1 stream");
 
     int numBytesReadV2 = inputStreamV2.read(pos, bufferV2, 0, size);
-    assertEquals("Bytes read from V2 stream", size, numBytesReadV2);
+    assertEquals(size, numBytesReadV2, "Bytes read from V2 stream");
 
     int numBytesReadV2NoBuffer = inputStreamV2NoBuffer.read(pos,
         bufferV2NoBuffer, 0, size);
-    assertEquals("Bytes read from V2 stream (buffered pread disabled)", size,
-        numBytesReadV2NoBuffer);
+    assertEquals(size
+,         numBytesReadV2NoBuffer, "Bytes read from V2 stream (buffered pread disabled)");
 
-    assertArrayEquals("Mismatch in read data", bufferV1, bufferV2);
-    assertArrayEquals("Mismatch in read data", bufferV2, bufferV2NoBuffer);
+    assertArrayEquals(bufferV1, bufferV2, "Mismatch in read data");
+    assertArrayEquals(bufferV2, bufferV2NoBuffer, "Mismatch in read data");
   }
 
   /**
@@ -383,7 +383,7 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
   private void validateMarkSupported(FileSystem fs) throws IOException {
     assumeHugeFileExists();
     try (FSDataInputStream inputStream = fs.open(TEST_FILE_PATH)) {
-      assertTrue("mark is not supported", inputStream.markSupported());
+      assertTrue(inputStream.markSupported(), "mark is not supported");
     }
   }
 
@@ -417,7 +417,7 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
       assertEquals(buffer.length, bytesRead);
 
       inputStream.reset();
-      assertEquals("rest -> pos 0", 0, inputStream.getPos());
+      assertEquals(0, inputStream.getPos(), "rest -> pos 0");
 
       inputStream.mark(8 * KILOBYTE - 1);
 
@@ -511,10 +511,10 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
       );
       long elapsedTimeMs = timer.elapsedTimeMs();
       assertTrue(
-          String.format(
+      
+         elapsedTimeMs < 20, String.format(
               "There should not be any network I/O (elapsedTimeMs=%1$d).",
-              elapsedTimeMs),
-          elapsedTimeMs < 20);
+              elapsedTimeMs));
     }
   }
 
@@ -559,7 +559,7 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
           }
       );
 
-      assertTrue("Test file length only " + testFileLength, testFileLength > 0);
+      assertTrue(testFileLength > 0, "Test file length only " + testFileLength);
       inputStream.seek(testFileLength);
       assertEquals(testFileLength, inputStream.getPos());
 
@@ -576,10 +576,10 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
 
       long elapsedTimeMs = timer.elapsedTimeMs();
       assertTrue(
-          String.format(
+      
+         elapsedTimeMs < 20, String.format(
               "There should not be any network I/O (elapsedTimeMs=%1$d).",
-              elapsedTimeMs),
-          elapsedTimeMs < 20);
+              elapsedTimeMs));
     }
   }
 
@@ -770,13 +770,13 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
           (long) v2ElapsedMs,
           ratio));
     }
-    assertTrue(String.format(
+    assertTrue(
+       ratio < maxAcceptableRatio, String.format(
         "Performance of version 2 is not acceptable: v1ElapsedMs=%1$d,"
             + " v2ElapsedMs=%2$d, ratio=%3$.2f",
         (long) v1ElapsedMs,
         (long) v2ElapsedMs,
-        ratio),
-        ratio < maxAcceptableRatio);
+        ratio));
   }
 
   /**
@@ -804,14 +804,14 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
           (long) afterSeekElapsedMs,
           ratio));
     }
-    assertTrue(String.format(
+    assertTrue(
+       ratio < maxAcceptableRatio, String.format(
         "Performance of version 2 after reverse seek is not acceptable:"
             + " beforeSeekElapsedMs=%1$d, afterSeekElapsedMs=%2$d,"
             + " ratio=%3$.2f",
         (long) beforeSeekElapsedMs,
         (long) afterSeekElapsedMs,
-        ratio),
-        ratio < maxAcceptableRatio);
+        ratio));
   }
 
   private long sequentialRead(int version,
@@ -871,13 +871,13 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
           (long) v2ElapsedMs,
           ratio));
     }
-    assertTrue(String.format(
+    assertTrue(
+       ratio < maxAcceptableRatio, String.format(
         "Performance of version 2 is not acceptable: v1ElapsedMs=%1$d,"
             + " v2ElapsedMs=%2$d, ratio=%3$.2f",
         (long) v1ElapsedMs,
         (long) v2ElapsedMs,
-        ratio),
-        ratio < maxAcceptableRatio);
+        ratio));
   }
 
   private long randomRead(int version, FileSystem fs) throws IOException {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestBlockBlobInputStream.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,8 +74,8 @@ public class ITestBlockBlobInputStream extends AbstractAzureScaleTest {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     Configuration conf = new Configuration();
     conf.setInt(AzureNativeFileSystemStore.KEY_INPUT_STREAM_VERSION, 1);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
@@ -61,7 +61,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerExistAfterDoesNotExist() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -74,8 +74,8 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
       fs.listStatus(new Path("/"));
       assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue(
-         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
+      assertTrue(ex.getMessage().contains("is not found"),
+          "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -101,7 +101,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerCreateAfterDoesNotExist() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -114,8 +114,8 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
       assertNull(fs.listStatus(new Path("/")));
       assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue(
-         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
+      assertTrue(ex.getMessage().contains("is not found"),
+          "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -127,7 +127,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerCreateOnWrite() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -139,8 +139,8 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
       fs.listStatus(new Path("/"));
       assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue(
-         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
+      assertTrue(ex.getMessage().contains("is not found"),
+          "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -173,7 +173,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
     assumeFalse(runningInSASMode);
     testAccount = AzureBlobStorageTestAccount.create("",
         EnumSet.of(CreateOptions.UseSas));
-    assumeTrue(testAccount != null);
+    assumeNotNull(testAccount);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.fs.azure;
 
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.FileNotFoundException;
 import java.util.EnumSet;
@@ -32,7 +33,6 @@ import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +61,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerExistAfterDoesNotExist() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -101,7 +101,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerCreateAfterDoesNotExist() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -127,7 +127,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerCreateOnWrite() throws Exception {
     testAccount = blobStorageTestAccount();
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 
@@ -170,10 +170,10 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   @Test
   public void testContainerChecksWithSas() throws Exception {
 
-    Assume.assumeFalse(runningInSASMode);
+    assumeFalse(runningInSASMode);
     testAccount = AzureBlobStorageTestAccount.create("",
         EnumSet.of(CreateOptions.UseSas));
-    assumeNotNull(testAccount);
+    assumeTrue(testAccount != null);
     CloudBlobContainer container = testAccount.getRealContainer();
     FileSystem fs = testAccount.getFileSystem();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.CreateOptions;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.storage.blob.BlobOutputStream;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
@@ -47,12 +47,12 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
   private AzureBlobStorageTestAccount testAccount;
   private boolean runningInSASMode = false;
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount = AzureTestUtils.cleanup(testAccount);
   }
 
-  @Before
+  @BeforeEach
   public void setMode() {
     runningInSASMode = AzureBlobStorageTestAccount.createTestConfiguration().
         getBoolean(AzureNativeFileSystemStore.KEY_USE_SECURE_MODE, false);
@@ -72,10 +72,10 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
     // state to DoesNotExist
     try {
       fs.listStatus(new Path("/"));
-      assertTrue("Should've thrown.", false);
+      assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue("Unexpected exception: " + ex,
-          ex.getMessage().contains("is not found"));
+      assertTrue(
+         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -112,10 +112,10 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
     // state to DoesNotExist
     try {
       assertNull(fs.listStatus(new Path("/")));
-      assertTrue("Should've thrown.", false);
+      assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue("Unexpected exception: " + ex,
-          ex.getMessage().contains("is not found"));
+      assertTrue(
+         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -137,10 +137,10 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
     // A list shouldn't create the container.
     try {
       fs.listStatus(new Path("/"));
-      assertTrue("Should've thrown.", false);
+      assertTrue(false, "Should've thrown.");
     } catch (FileNotFoundException ex) {
-      assertTrue("Unexpected exception: " + ex,
-          ex.getMessage().contains("is not found"));
+      assertTrue(
+         ex.getMessage().contains("is not found"), "Unexpected exception: " + ex);
     }
     assertFalse(container.exists());
 
@@ -183,7 +183,7 @@ public class ITestContainerChecks extends AbstractWasbTestWithTimeout {
     // A write should just fail
     try {
       fs.createNewFile(new Path("/testContainerChecksWithSas-foo"));
-      assertFalse("Should've thrown.", true);
+      assertFalse(true, "Should've thrown.");
     } catch (AzureException ex) {
     }
     assertFalse(container.exists());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestContainerChecks.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.fs.azure;
 
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.FileNotFoundException;
 import java.util.EnumSet;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.FSExceptionMessages.STREAM_IS_CLOSED;
 import static org.apache.hadoop.fs.azure.ExceptionHandlingTestHelper.*;
@@ -81,113 +81,127 @@ public class ITestFileSystemOperationExceptionHandling
   /**
    * Tests a basic single threaded read scenario for Page blobs.
    */
-  @Test(expected=FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobReadScenario() throws Throwable {
-    AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-    setupInputStreamToTest(testAccount);
-    byte[] readBuffer = new byte[512];
-    inputStream.read(readBuffer);
+    assertThrows(FileNotFoundException.class, () -> {
+      AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
+      setupInputStreamToTest(testAccount);
+      byte[] readBuffer = new byte[512];
+      inputStream.read(readBuffer);
+    });
   }
 
   /**
    * Tests a basic single threaded seek scenario for Page blobs.
    */
-  @Test(expected=FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobSeekScenario() throws Throwable {
-    AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-    setupInputStreamToTest(testAccount);
-    inputStream.seek(5);
+    assertThrows(FileNotFoundException.class, () -> {
+      AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
+      setupInputStreamToTest(testAccount);
+      inputStream.seek(5);
+    });
   }
 
   /**
    * Test a basic single thread seek scenario for Block blobs.
    */
-  @Test(expected=FileNotFoundException.class)
+  @Test
   public void testSingleThreadBlockBlobSeekScenario() throws Throwable {
-
-    AzureBlobStorageTestAccount testAccount = createTestAccount();
-    setupInputStreamToTest(testAccount);
-    inputStream.seek(5);
-    inputStream.read();
+    assertThrows(FileNotFoundException.class, ()->{
+      AzureBlobStorageTestAccount testAccount = createTestAccount();
+      setupInputStreamToTest(testAccount);
+      inputStream.seek(5);
+      inputStream.read();
+    });
   }
 
   /**
    * Tests a basic single threaded read scenario for Block blobs.
    */
-  @Test(expected=FileNotFoundException.class)
-  public void testSingledThreadBlockBlobReadScenario() throws Throwable{
-    AzureBlobStorageTestAccount testAccount = createTestAccount();
-    setupInputStreamToTest(testAccount);
-    byte[] readBuffer = new byte[512];
-    inputStream.read(readBuffer);
+  @Test
+  public void testSingledThreadBlockBlobReadScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, ()->{
+      AzureBlobStorageTestAccount testAccount = createTestAccount();
+      setupInputStreamToTest(testAccount);
+      byte[] readBuffer = new byte[512];
+      inputStream.read(readBuffer);
+    });
   }
 
   /**
    * Tests basic single threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedBlockBlobSetPermissionScenario() throws Throwable {
-
-    createEmptyFile(createTestAccount(), testPath);
-    fs.delete(testPath, true);
-    fs.setPermission(testPath,
-        new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      fs.delete(testPath, true);
+      fs.setPermission(testPath,
+         new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    });
   }
 
   /**
    * Tests basic single threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobSetPermissionScenario()
       throws Throwable {
-    createEmptyFile(getPageBlobTestStorageAccount(), testPath);
-    fs.delete(testPath, true);
-    fs.setOwner(testPath, "testowner", "testgroup");
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(getPageBlobTestStorageAccount(), testPath);
+      fs.delete(testPath, true);
+      fs.setOwner(testPath, "testowner", "testgroup");
+    });
   }
 
   /**
    * Tests basic single threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedBlockBlobSetOwnerScenario() throws Throwable {
-
-    createEmptyFile(createTestAccount(), testPath);
-    fs.delete(testPath, true);
-    fs.setOwner(testPath, "testowner", "testgroup");
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      fs.delete(testPath, true);
+      fs.setOwner(testPath, "testowner", "testgroup");
+    });
   }
 
   /**
    * Tests basic single threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobSetOwnerScenario() throws Throwable {
-    createEmptyFile(getPageBlobTestStorageAccount(),
-        testPath);
-    fs.delete(testPath, true);
-    fs.setPermission(testPath,
-        new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    assertThrows(FileNotFoundException.class, ()->{
+      createEmptyFile(getPageBlobTestStorageAccount(), testPath);
+      fs.delete(testPath, true);
+      fs.setPermission(testPath,
+          new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    });
   }
 
   /**
    * Test basic single threaded listStatus scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedBlockBlobListStatusScenario() throws Throwable {
-    createTestFolder(createTestAccount(),
-        testFolderPath);
-    fs.delete(testFolderPath, true);
-    fs.listStatus(testFolderPath);
+    assertThrows(FileNotFoundException.class, () -> {
+      createTestFolder(createTestAccount(), testFolderPath);
+      fs.delete(testFolderPath, true);
+      fs.listStatus(testFolderPath);
+    });
   }
 
   /**
    * Test basic single threaded listStatus scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobListStatusScenario() throws Throwable {
-    createTestFolder(getPageBlobTestStorageAccount(),
-        testFolderPath);
-    fs.delete(testFolderPath, true);
-    fs.listStatus(testFolderPath);
+    assertThrows(FileNotFoundException.class, () -> {
+      createTestFolder(getPageBlobTestStorageAccount(), testFolderPath);
+      fs.delete(testFolderPath, true);
+      fs.listStatus(testFolderPath);
+    });
   }
 
   /**
@@ -247,25 +261,25 @@ public class ITestFileSystemOperationExceptionHandling
   /**
    * Test basic single threaded listStatus scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedBlockBlobOpenScenario() throws Throwable {
-
-    createEmptyFile(createTestAccount(),
-        testPath);
-    fs.delete(testPath, true);
-    inputStream = fs.open(testPath);
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      fs.delete(testPath, true);
+      inputStream = fs.open(testPath);
+    });
   }
 
   /**
    * Test delete then open a file.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testSingleThreadedPageBlobOpenScenario() throws Throwable {
-
-    createEmptyFile(getPageBlobTestStorageAccount(),
-        testPath);
-    fs.delete(testPath, true);
-    inputStream = fs.open(testPath);
+    assertThrows(FileNotFoundException.class, ()->{
+      createEmptyFile(getPageBlobTestStorageAccount(), testPath);
+      fs.delete(testPath, true);
+      inputStream = fs.open(testPath);
+    });
   }
 
   /**
@@ -285,7 +299,7 @@ public class ITestFileSystemOperationExceptionHandling
     out.close();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (inputStream != null) {
       inputStream.close();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
@@ -29,7 +29,9 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import static org.apache.hadoop.fs.FSExceptionMessages.STREAM_IS_CLOSED;
 import static org.apache.hadoop.fs.azure.ExceptionHandlingTestHelper.*;
@@ -46,9 +48,10 @@ public class ITestFileSystemOperationExceptionHandling
   private Path testPath;
   private Path testFolderPath;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     testPath = path("testfile.dat");
     testFolderPath = path("testfolder");
   }
@@ -57,13 +60,13 @@ public class ITestFileSystemOperationExceptionHandling
    * Helper method that creates a InputStream to validate exceptions
    * for various scenarios.
    */
-  private void setupInputStreamToTest(AzureBlobStorageTestAccount testAccount)
+  private void setupInputStreamToTest(AzureBlobStorageTestAccount testAccount, TestInfo testInfo)
       throws Exception {
 
     FileSystem fs = testAccount.getFileSystem();
 
     // Step 1: Create a file and write dummy data.
-    Path base = methodPath();
+    Path base = methodPath(testInfo);
     Path testFilePath1 = new Path(base, "test1.dat");
     Path testFilePath2 = new Path(base, "test2.dat");
     FSDataOutputStream outputStream = fs.create(testFilePath1);
@@ -82,10 +85,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded read scenario for Page blobs.
    */
   @Test
-  public void testSingleThreadedPageBlobReadScenario() throws Throwable {
+  public void testSingleThreadedPageBlobReadScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-      setupInputStreamToTest(testAccount);
+      setupInputStreamToTest(testAccount, testInfo);
       byte[] readBuffer = new byte[512];
       inputStream.read(readBuffer);
     });
@@ -95,10 +98,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded seek scenario for Page blobs.
    */
   @Test
-  public void testSingleThreadedPageBlobSeekScenario() throws Throwable {
+  public void testSingleThreadedPageBlobSeekScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-      setupInputStreamToTest(testAccount);
+      setupInputStreamToTest(testAccount, testInfo);
       inputStream.seek(5);
     });
   }
@@ -107,10 +110,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Test a basic single thread seek scenario for Block blobs.
    */
   @Test
-  public void testSingleThreadBlockBlobSeekScenario() throws Throwable {
-    assertThrows(FileNotFoundException.class, ()->{
+  public void testSingleThreadBlockBlobSeekScenario(TestInfo testInfo) throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
-      setupInputStreamToTest(testAccount);
+      setupInputStreamToTest(testAccount, testInfo);
       inputStream.seek(5);
       inputStream.read();
     });
@@ -120,10 +123,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded read scenario for Block blobs.
    */
   @Test
-  public void testSingledThreadBlockBlobReadScenario() throws Throwable {
-    assertThrows(FileNotFoundException.class, ()->{
+  public void testSingledThreadBlockBlobReadScenario(TestInfo testInfo) throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
-      setupInputStreamToTest(testAccount);
+      setupInputStreamToTest(testAccount, testInfo);
       byte[] readBuffer = new byte[512];
       inputStream.read(readBuffer);
     });
@@ -300,13 +303,13 @@ public class ITestFileSystemOperationExceptionHandling
   }
 
   @AfterEach
-  public void tearDown() throws Exception {
+  public void tearDown(TestInfo testInfo) throws Exception {
     if (inputStream != null) {
       inputStream.close();
     }
 
     ContractTestUtils.rm(fs, testPath, true, true);
-    super.tearDown();
+    super.tearDown(testInfo);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionHandling.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import static org.apache.hadoop.fs.FSExceptionMessages.STREAM_IS_CLOSED;
 import static org.apache.hadoop.fs.azure.ExceptionHandlingTestHelper.*;
@@ -50,8 +49,8 @@ public class ITestFileSystemOperationExceptionHandling
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     testPath = path("testfile.dat");
     testFolderPath = path("testfolder");
   }
@@ -60,13 +59,13 @@ public class ITestFileSystemOperationExceptionHandling
    * Helper method that creates a InputStream to validate exceptions
    * for various scenarios.
    */
-  private void setupInputStreamToTest(AzureBlobStorageTestAccount testAccount, TestInfo testInfo)
+  private void setupInputStreamToTest(AzureBlobStorageTestAccount testAccount)
       throws Exception {
 
     FileSystem fs = testAccount.getFileSystem();
 
     // Step 1: Create a file and write dummy data.
-    Path base = methodPath(testInfo);
+    Path base = methodPath();
     Path testFilePath1 = new Path(base, "test1.dat");
     Path testFilePath2 = new Path(base, "test2.dat");
     FSDataOutputStream outputStream = fs.create(testFilePath1);
@@ -85,10 +84,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded read scenario for Page blobs.
    */
   @Test
-  public void testSingleThreadedPageBlobReadScenario(TestInfo testInfo) throws Throwable {
+  public void testSingleThreadedPageBlobReadScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-      setupInputStreamToTest(testAccount, testInfo);
+      setupInputStreamToTest(testAccount);
       byte[] readBuffer = new byte[512];
       inputStream.read(readBuffer);
     });
@@ -98,10 +97,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded seek scenario for Page blobs.
    */
   @Test
-  public void testSingleThreadedPageBlobSeekScenario(TestInfo testInfo) throws Throwable {
+  public void testSingleThreadedPageBlobSeekScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = getPageBlobTestStorageAccount();
-      setupInputStreamToTest(testAccount, testInfo);
+      setupInputStreamToTest(testAccount);
       inputStream.seek(5);
     });
   }
@@ -110,10 +109,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Test a basic single thread seek scenario for Block blobs.
    */
   @Test
-  public void testSingleThreadBlockBlobSeekScenario(TestInfo testInfo) throws Throwable {
+  public void testSingleThreadBlockBlobSeekScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
-      setupInputStreamToTest(testAccount, testInfo);
+      setupInputStreamToTest(testAccount);
       inputStream.seek(5);
       inputStream.read();
     });
@@ -123,10 +122,10 @@ public class ITestFileSystemOperationExceptionHandling
    * Tests a basic single threaded read scenario for Block blobs.
    */
   @Test
-  public void testSingledThreadBlockBlobReadScenario(TestInfo testInfo) throws Throwable {
+  public void testSingledThreadBlockBlobReadScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
-      setupInputStreamToTest(testAccount, testInfo);
+      setupInputStreamToTest(testAccount);
       byte[] readBuffer = new byte[512];
       inputStream.read(readBuffer);
     });
@@ -303,13 +302,13 @@ public class ITestFileSystemOperationExceptionHandling
   }
 
   @AfterEach
-  public void tearDown(TestInfo testInfo) throws Exception {
+  public void tearDown() throws Exception {
     if (inputStream != null) {
       inputStream.close();
     }
 
     ContractTestUtils.rm(fs, testPath, true, true);
-    super.tearDown(testInfo);
+    super.tearDown();
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionMessage.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationExceptionMessage.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.NO_ACCESS_TO_CONTAINER_MSG;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.verifyWasbAccountNameInConfig;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
@@ -22,7 +22,6 @@ import java.io.FileNotFoundException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -48,8 +47,8 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     testPath = path("testfile.dat");
     testFolderPath = path("testfolder");
   }
@@ -60,12 +59,12 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
   }
 
   @Override
-  public void tearDown(TestInfo info) throws Exception {
+  public void tearDown() throws Exception {
 
     IOUtils.closeStream(inputStream);
     ContractTestUtils.rm(fs, testPath, true, false);
     ContractTestUtils.rm(fs, testFolderPath, true, false);
-    super.tearDown(info);
+    super.tearDown();
   }
 
   /**
@@ -87,11 +86,11 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for block blobs.
    */
   @Test
-  public void testMultiThreadedBlockBlobReadScenario(TestInfo testInfo) throws Throwable {
+  public void testMultiThreadedBlockBlobReadScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
       NativeAzureFileSystem fs = testAccount.getFileSystem();
-      Path base = methodPath(testInfo);
+      Path base = methodPath();
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
       getInputStreamToTest(fs, testFilePath1);
@@ -111,13 +110,13 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for block blobs.
    */
   @Test
-  public void testMultiThreadBlockBlobSeekScenario(TestInfo testInfo) throws Throwable {
+  public void testMultiThreadBlockBlobSeekScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       /*
        * AzureBlobStorageTestAccount testAccount = createTestAccount();
        * fs = testAccount.getFileSystem();
        */
-      Path base = methodPath(testInfo);
+      Path base = methodPath();
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 
@@ -286,10 +285,10 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for page blobs.
    */
   @Test
-  public void testMultiThreadedPageBlobReadScenario(TestInfo testInfo) throws Throwable {
+  public void testMultiThreadedPageBlobReadScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       bindToTestAccount(getPageBlobTestStorageAccount());
-      Path base = methodPath(testInfo);
+      Path base = methodPath();
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 
@@ -310,11 +309,11 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    */
 
   @Test
-  public void testMultiThreadedPageBlobSeekScenario(TestInfo testInfo) throws Throwable {
+  public void testMultiThreadedPageBlobSeekScenario() throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       bindToTestAccount(getPageBlobTestStorageAccount());
 
-      Path base = methodPath(testInfo);
+      Path base = methodPath();
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azure;
 
 import java.io.FileNotFoundException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -83,211 +83,222 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * Test to validate correct exception is thrown for Multithreaded read
    * scenario for block blobs.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedBlockBlobReadScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
+      AzureBlobStorageTestAccount testAccount = createTestAccount();
+      NativeAzureFileSystem fs = testAccount.getFileSystem();
+      Path base = methodPath();
+      Path testFilePath1 = new Path(base, "test1.dat");
+      Path renamePath = new Path(base, "test2.dat");
+      getInputStreamToTest(fs, testFilePath1);
+      Thread renameThread = new Thread(
+          new RenameThread(fs, testFilePath1, renamePath));
+      renameThread.start();
 
-    AzureBlobStorageTestAccount testAccount = createTestAccount();
-    NativeAzureFileSystem fs = testAccount.getFileSystem();
-    Path base = methodPath();
-    Path testFilePath1 = new Path(base, "test1.dat");
-    Path renamePath = new Path(base, "test2.dat");
-    getInputStreamToTest(fs, testFilePath1);
-    Thread renameThread = new Thread(
-        new RenameThread(fs, testFilePath1, renamePath));
-    renameThread.start();
+      renameThread.join();
 
-    renameThread.join();
-
-    byte[] readBuffer = new byte[512];
-    inputStream.read(readBuffer);
+      byte[] readBuffer = new byte[512];
+      inputStream.read(readBuffer);
+    });
   }
 
   /**
    * Test to validate correct exception is thrown for Multithreaded seek
    * scenario for block blobs.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadBlockBlobSeekScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
+      /*
+       * AzureBlobStorageTestAccount testAccount = createTestAccount();
+       * fs = testAccount.getFileSystem();
+       */
+      Path base = methodPath();
+      Path testFilePath1 = new Path(base, "test1.dat");
+      Path renamePath = new Path(base, "test2.dat");
 
-/*
-    AzureBlobStorageTestAccount testAccount = createTestAccount();
-    fs = testAccount.getFileSystem();
-*/
-    Path base = methodPath();
-    Path testFilePath1 = new Path(base, "test1.dat");
-    Path renamePath = new Path(base, "test2.dat");
+      getInputStreamToTest(fs, testFilePath1);
+      Thread renameThread = new Thread(
+              new RenameThread(fs, testFilePath1, renamePath));
+      renameThread.start();
 
-    getInputStreamToTest(fs, testFilePath1);
-    Thread renameThread = new Thread(
-        new RenameThread(fs, testFilePath1, renamePath));
-    renameThread.start();
+      renameThread.join();
 
-    renameThread.join();
-
-    inputStream.seek(5);
-    inputStream.read();
+      inputStream.seek(5);
+      inputStream.read();
+    });
   }
 
   /**
    * Tests basic multi threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobSetPermissionScenario()
       throws Throwable {
-    createEmptyFile(
-        getPageBlobTestStorageAccount(),
-        testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(
+          getPageBlobTestStorageAccount(),
+          testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.setPermission(testPath,
+            new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+      }
       fs.setPermission(testPath,
           new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
-    }
-    fs.setPermission(testPath,
-        new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    });
   }
 
   /**
    * Tests basic multi threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedBlockBlobSetPermissionScenario()
       throws Throwable {
-    createEmptyFile(createTestAccount(),
-        testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.setPermission(testPath,
+            new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+      }
       fs.setPermission(testPath,
           new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
-    }
-    fs.setPermission(testPath,
-        new FsPermission(FsAction.EXECUTE, FsAction.READ, FsAction.READ));
+    });
   }
 
   /**
    * Tests basic multi threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobOpenScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
+      while (t.isAlive()) {
+        inputStream = fs.open(testPath);
+        inputStream.close();
+      }
 
-    createEmptyFile(createTestAccount(),
-        testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-    while (t.isAlive()) {
       inputStream = fs.open(testPath);
       inputStream.close();
-    }
-
-    inputStream = fs.open(testPath);
-    inputStream.close();
+    });
   }
 
   /**
    * Tests basic multi threaded setPermission scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedBlockBlobOpenScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(
+          getPageBlobTestStorageAccount(),
+          testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
 
-    createEmptyFile(
-        getPageBlobTestStorageAccount(),
-        testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-
-    while (t.isAlive()) {
+      while (t.isAlive()) {
+        inputStream = fs.open(testPath);
+        inputStream.close();
+      }
       inputStream = fs.open(testPath);
       inputStream.close();
-    }
-    inputStream = fs.open(testPath);
-    inputStream.close();
+    });
   }
 
   /**
    * Tests basic multi threaded setOwner scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedBlockBlobSetOwnerScenario() throws Throwable {
-
-    createEmptyFile(createTestAccount(), testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(createTestAccount(), testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.setOwner(testPath, "testowner", "testgroup");
+      }
       fs.setOwner(testPath, "testowner", "testgroup");
-    }
-    fs.setOwner(testPath, "testowner", "testgroup");
+    });
   }
 
   /**
    * Tests basic multi threaded setOwner scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobSetOwnerScenario() throws Throwable {
-    createEmptyFile(
-        getPageBlobTestStorageAccount(),
-        testPath);
-    Thread t = new Thread(new DeleteThread(fs, testPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createEmptyFile(
+          getPageBlobTestStorageAccount(),
+          testPath);
+      Thread t = new Thread(new DeleteThread(fs, testPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.setOwner(testPath, "testowner", "testgroup");
+      }
       fs.setOwner(testPath, "testowner", "testgroup");
-    }
-    fs.setOwner(testPath, "testowner", "testgroup");
+    });
   }
 
   /**
    * Tests basic multi threaded listStatus scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedBlockBlobListStatusScenario() throws Throwable {
-
-    createTestFolder(createTestAccount(),
-        testFolderPath);
-    Thread t = new Thread(new DeleteThread(fs, testFolderPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createTestFolder(createTestAccount(), testFolderPath);
+      Thread t = new Thread(new DeleteThread(fs, testFolderPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.listStatus(testFolderPath);
+      }
       fs.listStatus(testFolderPath);
-    }
-    fs.listStatus(testFolderPath);
+    });
   }
 
   /**
    * Tests basic multi threaded listStatus scenario.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobListStatusScenario() throws Throwable {
-
-    createTestFolder(
-        getPageBlobTestStorageAccount(),
-        testFolderPath);
-    Thread t = new Thread(new DeleteThread(fs, testFolderPath));
-    t.start();
-    while (t.isAlive()) {
+    assertThrows(FileNotFoundException.class, () -> {
+      createTestFolder(
+          getPageBlobTestStorageAccount(),
+          testFolderPath);
+      Thread t = new Thread(new DeleteThread(fs, testFolderPath));
+      t.start();
+      while (t.isAlive()) {
+        fs.listStatus(testFolderPath);
+      }
       fs.listStatus(testFolderPath);
-    }
-    fs.listStatus(testFolderPath);
+    });
   }
 
   /**
    * Test to validate correct exception is thrown for Multithreaded read
    * scenario for page blobs.
    */
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobReadScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, () -> {
+      bindToTestAccount(getPageBlobTestStorageAccount());
+      Path base = methodPath();
+      Path testFilePath1 = new Path(base, "test1.dat");
+      Path renamePath = new Path(base, "test2.dat");
 
-    bindToTestAccount(getPageBlobTestStorageAccount());
-    Path base = methodPath();
-    Path testFilePath1 = new Path(base, "test1.dat");
-    Path renamePath = new Path(base, "test2.dat");
+      getInputStreamToTest(fs, testFilePath1);
+      Thread renameThread = new Thread(
+              new RenameThread(fs, testFilePath1, renamePath));
+      renameThread.start();
 
-    getInputStreamToTest(fs, testFilePath1);
-    Thread renameThread = new Thread(
-        new RenameThread(fs, testFilePath1, renamePath));
-    renameThread.start();
-
-    renameThread.join();
-    byte[] readBuffer = new byte[512];
-    inputStream.read(readBuffer);
+      renameThread.join();
+      byte[] readBuffer = new byte[512];
+      inputStream.read(readBuffer);
+    });
   }
 
   /**
@@ -295,22 +306,23 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for page blobs.
    */
 
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testMultiThreadedPageBlobSeekScenario() throws Throwable {
+    assertThrows(FileNotFoundException.class, ()->{
+      bindToTestAccount(getPageBlobTestStorageAccount());
 
-    bindToTestAccount(getPageBlobTestStorageAccount());
+      Path base = methodPath();
+      Path testFilePath1 = new Path(base, "test1.dat");
+      Path renamePath = new Path(base, "test2.dat");
 
-    Path base = methodPath();
-    Path testFilePath1 = new Path(base, "test1.dat");
-    Path renamePath = new Path(base, "test2.dat");
+      getInputStreamToTest(fs, testFilePath1);
+      Thread renameThread = new Thread(
+              new RenameThread(fs, testFilePath1, renamePath));
+      renameThread.start();
 
-    getInputStreamToTest(fs, testFilePath1);
-    Thread renameThread = new Thread(
-        new RenameThread(fs, testFilePath1, renamePath));
-    renameThread.start();
-
-    renameThread.join();
-    inputStream.seek(5);
+      renameThread.join();
+      inputStream.seek(5);
+    });
   }
 
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.fs.azure;
 
 import java.io.FileNotFoundException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -44,9 +46,10 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
   private Path testPath;
   private Path testFolderPath;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     testPath = path("testfile.dat");
     testFolderPath = path("testfolder");
   }
@@ -57,12 +60,12 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
   }
 
   @Override
-  public void tearDown() throws Exception {
+  public void tearDown(TestInfo info) throws Exception {
 
     IOUtils.closeStream(inputStream);
     ContractTestUtils.rm(fs, testPath, true, false);
     ContractTestUtils.rm(fs, testFolderPath, true, false);
-    super.tearDown();
+    super.tearDown(info);
   }
 
   /**
@@ -84,11 +87,11 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for block blobs.
    */
   @Test
-  public void testMultiThreadedBlockBlobReadScenario() throws Throwable {
+  public void testMultiThreadedBlockBlobReadScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       AzureBlobStorageTestAccount testAccount = createTestAccount();
       NativeAzureFileSystem fs = testAccount.getFileSystem();
-      Path base = methodPath();
+      Path base = methodPath(testInfo);
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
       getInputStreamToTest(fs, testFilePath1);
@@ -108,13 +111,13 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for block blobs.
    */
   @Test
-  public void testMultiThreadBlockBlobSeekScenario() throws Throwable {
+  public void testMultiThreadBlockBlobSeekScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       /*
        * AzureBlobStorageTestAccount testAccount = createTestAccount();
        * fs = testAccount.getFileSystem();
        */
-      Path base = methodPath();
+      Path base = methodPath(testInfo);
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 
@@ -283,10 +286,10 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    * scenario for page blobs.
    */
   @Test
-  public void testMultiThreadedPageBlobReadScenario() throws Throwable {
+  public void testMultiThreadedPageBlobReadScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, () -> {
       bindToTestAccount(getPageBlobTestStorageAccount());
-      Path base = methodPath();
+      Path base = methodPath(testInfo);
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 
@@ -307,11 +310,11 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
    */
 
   @Test
-  public void testMultiThreadedPageBlobSeekScenario() throws Throwable {
+  public void testMultiThreadedPageBlobSeekScenario(TestInfo testInfo) throws Throwable {
     assertThrows(FileNotFoundException.class, ()->{
       bindToTestAccount(getPageBlobTestStorageAccount());
 
-      Path base = methodPath();
+      Path base = methodPath(testInfo);
       Path testFilePath1 = new Path(base, "test1.dat");
       Path renamePath = new Path(base, "test2.dat");
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsExceptionHandlingMultiThreaded.java
@@ -311,7 +311,7 @@ public class ITestFileSystemOperationsExceptionHandlingMultiThreaded
 
   @Test
   public void testMultiThreadedPageBlobSeekScenario(TestInfo testInfo) throws Throwable {
-    assertThrows(FileNotFoundException.class, ()->{
+    assertThrows(FileNotFoundException.class, () -> {
       bindToTestAccount(getPageBlobTestStorageAccount());
 
       Path base = methodPath(testInfo);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.fs.azure;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.RejectedExecutionException;
@@ -34,9 +30,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -53,12 +48,9 @@ public class ITestFileSystemOperationsWithThreads extends AbstractWasbTestBase {
   private int iterations = 1;
   private LogCapturer logs = null;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     Configuration conf = fs.getConf();
 
     // By default enable parallel threads for rename and delete operations.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.fs.azure;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URI;
@@ -33,9 +33,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -56,7 +56,7 @@ public class ITestFileSystemOperationsWithThreads extends AbstractWasbTestBase {
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     Configuration conf = fs.getConf();
@@ -207,7 +207,7 @@ public class ITestFileSystemOperationsWithThreads extends AbstractWasbTestBase {
    * @param term search term
    */
   protected void assertInLog(String content, String term) {
-    assertTrue("Empty log", !content.isEmpty());
+    assertTrue(!content.isEmpty(), "Empty log");
     if (!content.contains(term)) {
       String message = "No " + term + " found in logs";
       LOG.error(message);
@@ -222,7 +222,7 @@ public class ITestFileSystemOperationsWithThreads extends AbstractWasbTestBase {
    * @param term search term
    */
   protected void assertNotInLog(String content, String term) {
-    assertTrue("Empty log", !content.isEmpty());
+    assertTrue(!content.isEmpty(), "Empty log");
     if (content.contains(term)) {
       String message = term + " found in logs";
       LOG.error(message);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestFileSystemOperationsWithThreads.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -49,8 +48,8 @@ public class ITestFileSystemOperationsWithThreads extends AbstractWasbTestBase {
   private LogCapturer logs = null;
 
   @BeforeEach
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     Configuration conf = fs.getConf();
 
     // By default enable parallel threads for rename and delete operations.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
@@ -34,7 +34,7 @@ import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.junit.Assume;
 import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,9 +137,9 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
     LOG.info("time to create files: {} millis", elapsedMs);
 
     for (Future<Integer> future : futures) {
-      assertTrue("Future timed out", future.isDone());
-      assertEquals("Future did not write all files timed out",
-          filesPerThread, future.get().intValue());
+      assertTrue(future.isDone(), "Future timed out");
+      assertEquals(
+         filesPerThread, future.get().intValue(), "Future did not write all files timed out");
     }
   }
 
@@ -159,8 +159,8 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
       LOG.info("{}: {}", fileStatus.getPath(),
           fileStatus.isDirectory() ? "dir" : "file");
     }
-    assertEquals("Mismatch between expected files and actual",
-        expectedFileCount, fileList.length);
+    assertEquals(
+       expectedFileCount, fileList.length, "Mismatch between expected files and actual");
 
 
     // now do a listFiles() recursive
@@ -174,14 +174,14 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
       FileStatus fileStatus = listing.next();
       Path path = fileStatus.getPath();
       FileStatus removed = foundInList.remove(path);
-      assertNotNull("Did not find "  + path + "{} in the previous listing",
-          removed);
+      assertNotNull(
+         removed, "Did not find "  + path + "{} in the previous listing");
     }
     elapsedMs = timer.elapsedTimeMs();
     LOG.info("time for listFiles() initial call: {} millis;"
         + " time to iterate: {} millis", initialListTime, elapsedMs);
-    assertEquals("Not all files from listStatus() were found in listFiles()",
-        0, foundInList.size());
+    assertEquals(
+       0, foundInList.size(), "Not all files from listStatus() were found in listFiles()");
 
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
@@ -32,10 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.Assume;
-import org.junit.FixMethodOrder;
-import org.junit.jupiter.api.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,11 +45,12 @@ import org.apache.hadoop.fs.azure.integration.AbstractAzureScaleTest;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 /**
  * Test list performance.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 public class ITestListPerformance extends AbstractAzureScaleTest {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestListPerformance.class);
@@ -69,9 +67,10 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
 
   private int expectedFileCount;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     Configuration conf = getConfiguration();
     // fail fast
     threads = AzureTestUtils.getTestPropertyInt(conf,
@@ -97,7 +96,7 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
 
   @Test
   public void test_0101_CreateDirectoryWithFiles() throws Exception {
-    Assume.assumeFalse("Test path exists; skipping", fs.exists(TEST_DIR_PATH));
+    assumeFalse(fs.exists(TEST_DIR_PATH), "Test path exists; skipping");
 
     ExecutorService executorService = Executors.newFixedThreadPool(threads);
     CloudBlobContainer container = testAccount.getRealContainer();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
@@ -73,8 +73,8 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     Configuration conf = getConfiguration();
     // fail fast
     threads = AzureTestUtils.getTestPropertyInt(conf,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestListPerformance.java
@@ -32,7 +32,11 @@ import java.util.concurrent.TimeUnit;
 
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,8 +141,8 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
 
     for (Future<Integer> future : futures) {
       assertTrue(future.isDone(), "Future timed out");
-      assertEquals(
-         filesPerThread, future.get().intValue(), "Future did not write all files timed out");
+      assertEquals(filesPerThread, future.get().intValue(),
+          "Future did not write all files timed out");
     }
   }
 
@@ -158,8 +162,8 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
       LOG.info("{}: {}", fileStatus.getPath(),
           fileStatus.isDirectory() ? "dir" : "file");
     }
-    assertEquals(
-       expectedFileCount, fileList.length, "Mismatch between expected files and actual");
+    assertEquals(expectedFileCount, fileList.length,
+        "Mismatch between expected files and actual");
 
 
     // now do a listFiles() recursive
@@ -173,14 +177,14 @@ public class ITestListPerformance extends AbstractAzureScaleTest {
       FileStatus fileStatus = listing.next();
       Path path = fileStatus.getPath();
       FileStatus removed = foundInList.remove(path);
-      assertNotNull(
-         removed, "Did not find "  + path + "{} in the previous listing");
+      assertNotNull(removed,
+          "Did not find "  + path + "{} in the previous listing");
     }
     elapsedMs = timer.elapsedTimeMs();
     LOG.info("time for listFiles() initial call: {} millis;"
         + " time to iterate: {} millis", initialListTime, elapsedMs);
-    assertEquals(
-       0, foundInList.size(), "Not all files from listStatus() were found in listFiles()");
+    assertEquals(0, foundInList.size(),
+        "Not all files from listStatus() were found in listFiles()");
 
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFSAuthorizationCaching.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFSAuthorizationCaching.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.azure;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.azure.CachingAuthorizer.KEY_AUTH_SERVICE_CACHING_ENABLE;
 
@@ -48,6 +48,6 @@ public class ITestNativeAzureFSAuthorizationCaching
     cache.put("TEST", 1);
     cache.put("TEST", 3);
     int result = cache.get("TEST");
-    assertEquals("Cache returned unexpected result", 3, result);
+    assertEquals(3, result, "Cache returned unexpected result");
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
@@ -29,7 +29,9 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Test append operations.
@@ -46,10 +48,11 @@ public class ITestNativeAzureFileSystemAppend extends AbstractWasbTestBase {
     return conf;
   }
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    testPath = methodPath();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
+    testPath = methodPath(testInfo);
   }
 
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test append operations.
@@ -323,28 +323,30 @@ public class ITestNativeAzureFileSystemAppend extends AbstractWasbTestBase {
     }
   }
 
-  @Test(expected=UnsupportedOperationException.class)
+  @Test
   /*
    * Test to verify the behavior when Append Support configuration flag is set to false
    */
   public void testFalseConfigurationFlagBehavior() throws Throwable {
+    assertThrows(UnsupportedOperationException.class, ()->{
+      fs = testAccount.getFileSystem();
+      Configuration conf = fs.getConf();
+      conf.setBoolean(NativeAzureFileSystem.APPEND_SUPPORT_ENABLE_PROPERTY_NAME, false);
+      URI uri = fs.getUri();
+      fs.initialize(uri, conf);
 
-    fs = testAccount.getFileSystem();
-    Configuration conf = fs.getConf();
-    conf.setBoolean(NativeAzureFileSystem.APPEND_SUPPORT_ENABLE_PROPERTY_NAME, false);
-    URI uri = fs.getUri();
-    fs.initialize(uri, conf);
+      FSDataOutputStream appendStream = null;
 
-    FSDataOutputStream appendStream = null;
-
-    try {
-      createBaseFileWithData(0, testPath);
-      appendStream = fs.append(testPath, 10);
-    } finally {
-      if (appendStream != null) {
-        appendStream.close();
+      try {
+        createBaseFileWithData(0, testPath);
+        appendStream = fs.append(testPath, 10);
+      } finally {
+        if (appendStream != null) {
+          appendStream.close();
+        }
       }
-    }
+
+    });
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAppend.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * Test append operations.
@@ -50,9 +49,9 @@ public class ITestNativeAzureFileSystemAppend extends AbstractWasbTestBase {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
-    testPath = methodPath(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
+    testPath = methodPath();
   }
 
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAtomicRenameDirList.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemAtomicRenameDirList.java
@@ -23,7 +23,7 @@ import java.net.URI;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test atomic renaming.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemClientLogging.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemClientLogging.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,13 +104,13 @@ public class ITestNativeAzureFileSystemClientLogging
     performWASBOperations();
 
     String output = getLogOutput(logs);
-    assertTrue("Log entry " + TEMP_DIR + " not found  in " + output,
-        verifyStorageClientLogs(output, TEMP_DIR));
+    assertTrue(
+       verifyStorageClientLogs(output, TEMP_DIR), "Log entry " + TEMP_DIR + " not found  in " + output);
   }
 
   protected String getLogOutput(LogCapturer logs) {
     String output = logs.getOutput();
-    assertTrue("No log created/captured", !output.isEmpty());
+    assertTrue(!output.isEmpty(), "No log created/captured");
     return output;
   }
 
@@ -125,8 +125,8 @@ public class ITestNativeAzureFileSystemClientLogging
     performWASBOperations();
     String output = getLogOutput(logs);
 
-    assertFalse("Log entry " + TEMP_DIR + " found  in " + output,
-        verifyStorageClientLogs(output, TEMP_DIR));
+    assertFalse(
+       verifyStorageClientLogs(output, TEMP_DIR), "Log entry " + TEMP_DIR + " found  in " + output);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemClientLogging.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemClientLogging.java
@@ -104,8 +104,8 @@ public class ITestNativeAzureFileSystemClientLogging
     performWASBOperations();
 
     String output = getLogOutput(logs);
-    assertTrue(
-       verifyStorageClientLogs(output, TEMP_DIR), "Log entry " + TEMP_DIR + " not found  in " + output);
+    assertTrue(verifyStorageClientLogs(output, TEMP_DIR),
+        "Log entry " + TEMP_DIR + " not found  in " + output);
   }
 
   protected String getLogOutput(LogCapturer logs) {
@@ -125,8 +125,8 @@ public class ITestNativeAzureFileSystemClientLogging
     performWASBOperations();
     String output = getLogOutput(logs);
 
-    assertFalse(
-       verifyStorageClientLogs(output, TEMP_DIR), "Log entry " + TEMP_DIR + " found  in " + output);
+    assertFalse(verifyStorageClientLogs(output, TEMP_DIR),
+        "Log entry " + TEMP_DIR + " found  in " + output);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
@@ -56,8 +56,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
    */
   @Test
   @Timeout(TEST_EXECUTION_TIMEOUT)
-  public void testConcurrentCreateDeleteFile() throws Exception {
-    Path testFile = methodPath();
+  public void testConcurrentCreateDeleteFile(TestInfo testInfo) throws Exception {
+    Path testFile = methodPath(testInfo);
 
     List<CreateFileTask> tasks = new ArrayList<>(THREAD_COUNT);
 
@@ -73,12 +73,12 @@ public class ITestNativeAzureFileSystemConcurrencyLive
       List<Future<Void>> futures = es.invokeAll(tasks);
 
       for (Future<Void> future : futures) {
-        Assertions.assertTrue(future.isDone());
+        assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown
         // when we call get
-        Assertions.assertEquals(null, future.get());
+        assertEquals(null, future.get());
       }
     } finally {
       if (es != null) {
@@ -112,7 +112,7 @@ public class ITestNativeAzureFileSystemConcurrencyLive
 
       int successCount = 0;
       for (Future<Boolean> future : futures) {
-        Assertions.assertTrue(future.isDone());
+        assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown
@@ -123,7 +123,7 @@ public class ITestNativeAzureFileSystemConcurrencyLive
         }
       }
 
-      Assertions.assertEquals(
+      assertEquals(
       
          1
 ,           successCount, "Exactly one delete operation should return true.");
@@ -161,7 +161,7 @@ public class ITestNativeAzureFileSystemConcurrencyLive
       List<Future<Integer>> futures = es.invokeAll(tasks);
 
       for (Future<Integer> future : futures) {
-        Assertions.assertTrue(future.isDone());
+        assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
@@ -56,8 +56,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
    */
   @Test
   @Timeout(TEST_EXECUTION_TIMEOUT)
-  public void testConcurrentCreateDeleteFile(TestInfo testInfo) throws Exception {
-    Path testFile = methodPath(testInfo);
+  public void testConcurrentCreateDeleteFile() throws Exception {
+    Path testFile = methodPath();
 
     List<CreateFileTask> tasks = new ArrayList<>(THREAD_COUNT);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
@@ -23,8 +23,9 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,7 @@ public class ITestNativeAzureFileSystemConcurrencyLive
     extends AbstractWasbTestBase {
 
   private static final int THREAD_COUNT = 102;
-  private static final int TEST_EXECUTION_TIMEOUT = 30000;
+  private static final int TEST_EXECUTION_TIMEOUT = 30;
 
   @Override
   protected AzureBlobStorageTestAccount createTestAccount() throws Exception {
@@ -53,7 +54,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
    * overwritten, even if the original destination exists but is deleted by an
    * external agent during the create operation.
    */
-  @Test(timeout = TEST_EXECUTION_TIMEOUT)
+  @Test
+  @Timeout(TEST_EXECUTION_TIMEOUT)
   public void testConcurrentCreateDeleteFile() throws Exception {
     Path testFile = methodPath();
 
@@ -71,12 +73,12 @@ public class ITestNativeAzureFileSystemConcurrencyLive
       List<Future<Void>> futures = es.invokeAll(tasks);
 
       for (Future<Void> future : futures) {
-        Assert.assertTrue(future.isDone());
+        Assertions.assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown
         // when we call get
-        Assert.assertEquals(null, future.get());
+        Assertions.assertEquals(null, future.get());
       }
     } finally {
       if (es != null) {
@@ -90,7 +92,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
    * One of the threads should successfully delete the file and return true;
    * all other threads should return false.
    */
-  @Test(timeout = TEST_EXECUTION_TIMEOUT)
+  @Test
+  @Timeout(TEST_EXECUTION_TIMEOUT)
   public void testConcurrentDeleteFile() throws Exception {
     Path testFile = new Path("test.dat");
     fs.create(testFile).close();
@@ -109,7 +112,7 @@ public class ITestNativeAzureFileSystemConcurrencyLive
 
       int successCount = 0;
       for (Future<Boolean> future : futures) {
-        Assert.assertTrue(future.isDone());
+        Assertions.assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown
@@ -120,10 +123,10 @@ public class ITestNativeAzureFileSystemConcurrencyLive
         }
       }
 
-      Assert.assertEquals(
-          "Exactly one delete operation should return true.",
-          1,
-          successCount);
+      Assertions.assertEquals(
+      
+         1
+,           successCount, "Exactly one delete operation should return true.");
     } finally {
       if (es != null) {
         es.shutdownNow();
@@ -139,7 +142,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
    *
    * @see <a href="https://github.com/Azure/azure-storage-java/pull/546">https://github.com/Azure/azure-storage-java/pull/546</a>
    */
-  @Test(timeout = TEST_EXECUTION_TIMEOUT)
+  @Test
+  @Timeout(TEST_EXECUTION_TIMEOUT)
   public void testConcurrentList() throws Exception {
     final Path testDir = new Path("/tmp/data-loss/11230174258112/_temporary/0/_temporary/attempt_20200624190514_0006_m_0");
     final Path testFile = new Path(testDir, "part-00004-15ea87b1-312c-4fdf-1820-95afb3dfc1c3-a010.snappy.parquet");
@@ -157,13 +161,13 @@ public class ITestNativeAzureFileSystemConcurrencyLive
       List<Future<Integer>> futures = es.invokeAll(tasks);
 
       for (Future<Integer> future : futures) {
-        Assert.assertTrue(future.isDone());
+        Assertions.assertTrue(future.isDone());
 
         // we are using Callable<V>, so if an exception
         // occurred during the operation, it will be thrown
         // when we call get
         long fileCount = future.get();
-        assertEquals("The list should always contain 1 file.", 1, fileCount);
+        assertEquals(1, fileCount, "The list should always contain 1 file.");
       }
     } finally {
       if (es != null) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemConcurrencyLive.java
@@ -123,10 +123,8 @@ public class ITestNativeAzureFileSystemConcurrencyLive
         }
       }
 
-      assertEquals(
-      
-         1
-,           successCount, "Exactly one delete operation should return true.");
+      assertEquals(1, successCount,
+          "Exactly one delete operation should return true.");
     } finally {
       if (es != null) {
         es.shutdownNow();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractEmulator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractEmulator.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
@@ -43,7 +43,7 @@ public class ITestNativeAzureFileSystemContractEmulator extends
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }
 
-  @BeforeEach
+  @Before
   public void setUp() throws Exception {
     nameThread();
     testAccount = AzureBlobStorageTestAccount.createForEmulator();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractEmulator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractEmulator.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
@@ -43,7 +43,7 @@ public class ITestNativeAzureFileSystemContractEmulator extends
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     nameThread();
     testAccount = AzureBlobStorageTestAccount.createForEmulator();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractLive.java
@@ -25,11 +25,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 
 /**
@@ -47,7 +47,7 @@ public class ITestNativeAzureFileSystemContractLive extends
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     nameThread();
     testAccount = AzureBlobStorageTestAccount.create();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractLive.java
@@ -25,11 +25,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.rules.TestName;
 
 /**
@@ -47,7 +47,7 @@ public class ITestNativeAzureFileSystemContractLive extends
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }
 
-  @BeforeEach
+  @Before
   public void setUp() throws Exception {
     nameThread();
     testAccount = AzureBlobStorageTestAccount.create();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractPageBlobLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractPageBlobLive.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
 import static org.junit.Assume.assumeNotNull;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 
 /**
@@ -59,7 +59,7 @@ public class ITestNativeAzureFileSystemContractPageBlobLive extends
     return AzureBlobStorageTestAccount.create(conf);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testAccount = createTestAccount();
     assumeNotNull(testAccount);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractPageBlobLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemContractPageBlobLive.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.fs.azure.integration.AzureTestConstants;
 import org.apache.hadoop.fs.azure.integration.AzureTestUtils;
 
 import static org.junit.Assume.assumeNotNull;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.rules.TestName;
 
 /**
@@ -59,7 +59,7 @@ public class ITestNativeAzureFileSystemContractPageBlobLive extends
     return AzureBlobStorageTestAccount.create(conf);
   }
 
-  @BeforeEach
+  @Before
   public void setUp() throws Exception {
     testAccount = createTestAccount();
     assumeNotNull(testAccount);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.storage.StorageException;
 
@@ -299,7 +299,7 @@ public class ITestNativeAzureFileSystemLive extends
     AzureNativeFileSystemStore store = nfs.getStore();
     // Acquire the lease on the folder
     lease = store.acquireLease(fullKey);
-    assertNotNull("lease ID", lease.getLeaseID() != null);
+    assertNotNull(lease.getLeaseID() != null, "lease ID");
     // Try to create the same folder
     store.storeEmptyFolder(fullKey,
       nfs.createPermissionStatus(FsPermission.getDirDefault()));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import com.microsoft.azure.storage.StorageException;
 
@@ -141,11 +142,11 @@ public class ITestNativeAzureFileSystemLive extends
    * held lease on the blob when doing some DDL operation
    */
   @Test
-  public void testDeleteThrowsExceptionWithLeaseExistsErrorMessage()
+  public void testDeleteThrowsExceptionWithLeaseExistsErrorMessage(TestInfo testInfo)
       throws Exception {
     LOG.info("Starting test");
     // Create the file
-    Path path = methodPath();
+    Path path = methodPath(testInfo);
     fs.create(path);
     assertPathExists("test file", path);
     NativeAzureFileSystem nfs = fs;
@@ -289,10 +290,10 @@ public class ITestNativeAzureFileSystemLive extends
    * under the same path.
    */
   @Test
-  public void testMkdirOnExistingFolderWithLease() throws Exception {
+  public void testMkdirOnExistingFolderWithLease(TestInfo testInfo) throws Exception {
     SelfRenewingLease lease;
     // Create the folder
-    Path path = methodPath();
+    Path path = methodPath(testInfo);
     fs.mkdirs(path);
     NativeAzureFileSystem nfs = fs;
     String fullKey = nfs.pathToKey(nfs.makeAbsolute(path));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
@@ -142,11 +142,11 @@ public class ITestNativeAzureFileSystemLive extends
    * held lease on the blob when doing some DDL operation
    */
   @Test
-  public void testDeleteThrowsExceptionWithLeaseExistsErrorMessage(TestInfo testInfo)
+  public void testDeleteThrowsExceptionWithLeaseExistsErrorMessage()
       throws Exception {
     LOG.info("Starting test");
     // Create the file
-    Path path = methodPath(testInfo);
+    Path path = methodPath();
     fs.create(path);
     assertPathExists("test file", path);
     NativeAzureFileSystem nfs = fs;
@@ -290,10 +290,10 @@ public class ITestNativeAzureFileSystemLive extends
    * under the same path.
    */
   @Test
-  public void testMkdirOnExistingFolderWithLease(TestInfo testInfo) throws Exception {
+  public void testMkdirOnExistingFolderWithLease() throws Exception {
     SelfRenewingLease lease;
     // Create the folder
-    Path path = methodPath(testInfo);
+    Path path = methodPath();
     fs.mkdirs(path);
     NativeAzureFileSystem nfs = fs;
     String fullKey = nfs.pathToKey(nfs.makeAbsolute(path));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeAzureFileSystemLive.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import com.microsoft.azure.storage.StorageException;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.fs.azure;
 
-import org.junit.FixMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -31,7 +31,7 @@ import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.cleanupTestA
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.readStringFromFile;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.writeStringToFile;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 /**
  * Because FileSystem.Statistics is per FileSystem, so statistics can not be ran in
  * parallel, hence in this test file, force them to run in sequential.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import static org.junit.Assume.assumeNotNull;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.cleanupTestAccount;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.readStringFromFile;
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.writeStringToFile;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestNativeFileSystemStatistics.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.azure;
 
 import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.MethodSorters;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutOfBandAzureBlobOperationsLive.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutOfBandAzureBlobOperationsLive.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.azure;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.storage.blob.BlobOutputStream;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasStreamCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertLacksStreamCapabilities;
@@ -57,8 +58,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
     return buffer;
   }
 
-  private Path getBlobPathWithTestName(String parentDir) {
-    return new Path(parentDir + "/" + methodName.getMethodName());
+  private Path getBlobPathWithTestName(String parentDir, String name) {
+    return new Path(parentDir + "/" + name);
   }
 
   private void validate(Path path, byte[] writeBuffer, boolean isEqual)
@@ -70,11 +71,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
       int numBytesRead = inputStream.read(readBuffer, 0, readBuffer.length);
 
       if (isEqual) {
-        assertArrayEquals(
-        
-           writeBuffer
-,             readBuffer, String.format("Bytes read do not match bytes written to %1$s",
-                blobPath));
+        assertArrayEquals(writeBuffer, readBuffer,
+            String.format("Bytes read do not match bytes written to %1$s", blobPath));
       } else {
         assertThat(readBuffer).isNotEqualTo(writeBuffer).as(
             String.format("Bytes read unexpectedly match bytes written to %1$s", blobPath));
@@ -118,8 +116,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush writes data to storage for Page Blobs
   @Test
-  public void testPageBlobFlush() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobFlush(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
@@ -141,8 +139,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush writes data to storage for Page Blobs
   @Test
-  public void testPageBlobHFlush() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobHFlush(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -155,8 +153,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // HSync must write data to storage for Page Blobs
   @Test
-  public void testPageBlobHSync() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobHSync(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -169,8 +167,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Page Blobs
   @Test
-  public void testPageBlobClose() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobClose(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -183,8 +181,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Page Blobs have StreamCapabilities.HFLUSH and StreamCapabilities.HSYNC.
   @Test
-  public void testPageBlobCapabilities() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobCapabilities(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -199,8 +197,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobFlush() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobFlush(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -221,8 +219,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobHFlush() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobHFlush(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -243,8 +241,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hsync does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobHSync() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobHSync(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -265,8 +263,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Block Blobs
   @Test
-  public void testBlockBlobClose() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobClose(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
@@ -278,8 +276,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Block Blobs do not have any StreamCapabilities.
   @Test
-  public void testBlockBlobCapabilities() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobCapabilities(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertLacksStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -293,8 +291,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush writes data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionFlush() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionFlush(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -316,8 +314,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush writes data to storage for Block Blobs with Compaction
   @Test
-  public void testBlockBlobCompactionHFlush() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionHFlush(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -339,8 +337,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hsync writes data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionHSync() throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionHSync(TestInfo testInfo) throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -362,8 +360,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionClose() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionClose(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isBlockBlobAppendStreamWrapper(stream));
       byte[] buffer = getRandomBytes();
@@ -375,8 +373,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Block Blobs with Compaction have StreamCapabilities.HFLUSH and HSYNC.
   @Test
-  public void testBlockBlobCompactionCapabilities() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionCapabilities(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -391,8 +389,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // A small write does not write data to storage for Page Blobs
   @Test
-  public void testPageBlobSmallWrite() throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR);
+  public void testPageBlobSmallWrite(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
       byte[] buffer = getRandomBytes();
@@ -403,8 +401,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // A small write does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobSmallWrite() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR);
+  public void testBlockBlobSmallWrite(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
       stream.write(buffer);
@@ -415,8 +413,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
   // A small write does not write data to storage for Block Blobs
   // with Compaction
   @Test
-  public void testBlockBlobCompactionSmallWrite() throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR);
+  public void testBlockBlobCompactionSmallWrite(TestInfo testInfo) throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isBlockBlobAppendStreamWrapper(stream));
       byte[] buffer = getRandomBytes();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
@@ -33,12 +33,11 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.fs.StreamCapabilities;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasStreamCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertLacksStreamCapabilities;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test semantics of functions flush, hflush, hsync, and close for block blobs,
@@ -72,16 +71,13 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
       if (isEqual) {
         assertArrayEquals(
-            String.format("Bytes read do not match bytes written to %1$s",
-                blobPath),
-            writeBuffer,
-            readBuffer);
+        
+           writeBuffer
+,             readBuffer, String.format("Bytes read do not match bytes written to %1$s",
+                blobPath));
       } else {
-        assertThat(
-            String.format("Bytes read unexpectedly match bytes written to %1$s",
-                blobPath),
-            readBuffer,
-            IsNot.not(IsEqual.equalTo(writeBuffer)));
+        assertThat(readBuffer).isNotEqualTo(writeBuffer).as(
+            String.format("Bytes read unexpectedly match bytes written to %1$s", blobPath));
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestOutputStreamSemantics.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasStreamCapabilities;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertLacksStreamCapabilities;
@@ -116,8 +115,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush writes data to storage for Page Blobs
   @Test
-  public void testPageBlobFlush(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobFlush() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
@@ -139,8 +138,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush writes data to storage for Page Blobs
   @Test
-  public void testPageBlobHFlush(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobHFlush() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -153,8 +152,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // HSync must write data to storage for Page Blobs
   @Test
-  public void testPageBlobHSync(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobHSync() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -167,8 +166,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Page Blobs
   @Test
-  public void testPageBlobClose(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobClose() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
@@ -181,8 +180,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Page Blobs have StreamCapabilities.HFLUSH and StreamCapabilities.HSYNC.
   @Test
-  public void testPageBlobCapabilities(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobCapabilities() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -197,8 +196,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobFlush(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobFlush() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -219,8 +218,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobHFlush(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobHFlush() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -241,8 +240,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hsync does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobHSync(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobHSync() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -263,8 +262,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Block Blobs
   @Test
-  public void testBlockBlobClose(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobClose() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
 
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
@@ -276,8 +275,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Block Blobs do not have any StreamCapabilities.
   @Test
-  public void testBlockBlobCapabilities(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCapabilities() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertLacksStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -291,8 +290,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify flush writes data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionFlush(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionFlush() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -314,8 +313,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hflush writes data to storage for Block Blobs with Compaction
   @Test
-  public void testBlockBlobCompactionHFlush(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionHFlush() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -337,8 +336,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Verify hsync writes data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionHSync(TestInfo testInfo) throws Exception {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionHSync() throws Exception {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     byte[] buffer = getRandomBytes();
 
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -360,8 +359,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Close must write data to storage for Block Blobs with compaction
   @Test
-  public void testBlockBlobCompactionClose(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionClose() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isBlockBlobAppendStreamWrapper(stream));
       byte[] buffer = getRandomBytes();
@@ -373,8 +372,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // Block Blobs with Compaction have StreamCapabilities.HFLUSH and HSYNC.
   @Test
-  public void testBlockBlobCompactionCapabilities(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionCapabilities() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertHasStreamCapabilities(stream,
           StreamCapabilities.HFLUSH,
@@ -389,8 +388,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // A small write does not write data to storage for Page Blobs
   @Test
-  public void testPageBlobSmallWrite(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, testInfo.getDisplayName());
+  public void testPageBlobSmallWrite() throws IOException {
+    Path path = getBlobPathWithTestName(PAGE_BLOB_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isPageBlobStreamWrapper(stream));
       byte[] buffer = getRandomBytes();
@@ -401,8 +400,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
 
   // A small write does not write data to storage for Block Blobs
   @Test
-  public void testBlockBlobSmallWrite(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, testInfo.getDisplayName());
+  public void testBlockBlobSmallWrite() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       byte[] buffer = getRandomBytes();
       stream.write(buffer);
@@ -413,8 +412,8 @@ public class ITestOutputStreamSemantics extends AbstractWasbTestBase {
   // A small write does not write data to storage for Block Blobs
   // with Compaction
   @Test
-  public void testBlockBlobCompactionSmallWrite(TestInfo testInfo) throws IOException {
-    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, testInfo.getDisplayName());
+  public void testBlockBlobCompactionSmallWrite() throws IOException {
+    Path path = getBlobPathWithTestName(BLOCK_BLOB_COMPACTION_DIR, methodName.getMethodName());
     try (FSDataOutputStream stream = fs.create(path)) {
       assertTrue(isBlockBlobAppendStreamWrapper(stream));
       byte[] buffer = getRandomBytes();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
@@ -24,11 +24,12 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.concurrent.Callable;
 
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +46,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * Test semantics of the page blob input stream
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
-
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@Timeout(600)
 public class ITestPageBlobInputStream extends AbstractWasbTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestPageBlobInputStream.class);
@@ -58,17 +59,13 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
 
   private long testFileLength;
 
-  /**
-   * Long test timeout.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(10 * 60 * 1000);
   private FileStatus testFileStatus;
   private Path hugefile;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     createTestAccount();
 
     hugefile = fs.makeQualified(TEST_FILE_PATH);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
 
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
@@ -132,7 +132,7 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
     ContractTestUtils.assertPathExists(fs, "huge file not created", hugefile);
     FileStatus status = fs.getFileStatus(hugefile);
     ContractTestUtils.assertIsFile(hugefile, status);
-    assertTrue("File " + hugefile + " is empty", status.getLen() > 0);
+    assertTrue(status.getLen() > 0, "File " + hugefile + " is empty");
   }
 
   @Test
@@ -246,14 +246,14 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
                                      long position) throws IOException {
     int size = buffer.length;
     final int numBytesRead = inputStream.read(buffer, 0, size);
-    assertEquals("Bytes read from stream", size, numBytesRead);
+    assertEquals(size, numBytesRead, "Bytes read from stream");
 
     byte[] expected = new byte[size];
     for (int i = 0; i < expected.length; i++) {
       expected[i] = (byte) ((position + i) % 256);
     }
 
-    assertArrayEquals("Mismatch", expected, buffer);
+    assertArrayEquals(expected, buffer, "Mismatch");
   }
 
   /**
@@ -264,7 +264,7 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
   public void test_0301_MarkSupported() throws IOException {
     assumeHugeFileExists();
     try (FSDataInputStream inputStream = fs.open(TEST_FILE_PATH)) {
-      assertTrue("mark is not supported", inputStream.markSupported());
+      assertTrue(inputStream.markSupported(), "mark is not supported");
     }
   }
 
@@ -284,7 +284,7 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
       assertEquals(buffer.length, bytesRead);
 
       inputStream.reset();
-      assertEquals("rest -> pos 0", 0, inputStream.getPos());
+      assertEquals(0, inputStream.getPos(), "rest -> pos 0");
 
       inputStream.mark(8 * KILOBYTE - 1);
 
@@ -374,7 +374,7 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
           }
       );
 
-      assertTrue("Test file length only " + testFileLength, testFileLength > 0);
+      assertTrue(testFileLength > 0, "Test file length only " + testFileLength);
       inputStream.seek(testFileLength);
       assertEquals(testFileLength, inputStream.getPos());
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
@@ -64,8 +64,8 @@ public class ITestPageBlobInputStream extends AbstractWasbTestBase {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     createTestAccount();
 
     hugefile = fs.makeQualified(TEST_FILE_PATH);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobInputStream.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestPageBlobOutputStream.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azure;
 import java.io.IOException;
 import java.util.EnumSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.fs.azure.integration.AbstractAzureScaleTest;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,8 +66,8 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     fs = getTestAccount().getFileSystem();
     // Make sure we are using an integral number of pages.
     assertEquals(0, MAX_BYTES % PAGE_SIZE);
@@ -81,9 +80,9 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
   }
 
   @Override
-  public void tearDown(TestInfo testInfo) throws Exception {
+  public void tearDown() throws Exception {
     deleteQuietly(fs, blobPath, true);
-    super.tearDown(testInfo);
+    super.tearDown();
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
@@ -277,8 +277,7 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
       long end = Time.monotonicNow();
       LOG.debug("close duration = " + (end - start) + " msec.");
       if (writesSinceHFlush > 0) {
-        assertTrue(
-           end - start >= MINIMUM_EXPECTED_TIME, String.format(
+        assertTrue(end - start >= MINIMUM_EXPECTED_TIME, String.format(
             "close duration with >= 1 pending write is %d, less than minimum expected of %d",
             end - start, MINIMUM_EXPECTED_TIME));
         }
@@ -335,8 +334,8 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
 
     // Verify we can list the new size. That will prove we expanded the file.
     FileStatus[] status = fs.listStatus(blobPath);
-    assertEquals(
-       numWrites * writeSize, status[0].getLen(), "File size hasn't changed " + status);
+    assertEquals(numWrites * writeSize, status[0].getLen(),
+        "File size hasn't changed " + status);
     LOG.debug("Total bytes written to " + blobPath + " = " + status[0].getLen());
     fs.delete(blobPath, false);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AbstractAzureScaleTest;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +92,7 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
     AzureNativeFileSystemStore store = ((NativeAzureFileSystem) fs).getStore();
     String[] a = blobPath.toUri().getPath().split("/");
     String key2 = a[1] + "/";
-    assertTrue("Not a page blob: " + blobPath, store.isPageBlobKey(key2));
+    assertTrue(store.isPageBlobKey(key2), "Not a page blob: " + blobPath);
   }
 
   /**
@@ -274,10 +274,10 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
       long end = Time.monotonicNow();
       LOG.debug("close duration = " + (end - start) + " msec.");
       if (writesSinceHFlush > 0) {
-        assertTrue(String.format(
+        assertTrue(
+           end - start >= MINIMUM_EXPECTED_TIME, String.format(
             "close duration with >= 1 pending write is %d, less than minimum expected of %d",
-            end - start, MINIMUM_EXPECTED_TIME),
-            end - start >= MINIMUM_EXPECTED_TIME);
+            end - start, MINIMUM_EXPECTED_TIME));
         }
     }
 
@@ -332,8 +332,8 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
 
     // Verify we can list the new size. That will prove we expanded the file.
     FileStatus[] status = fs.listStatus(blobPath);
-    assertEquals("File size hasn't changed " + status,
-        numWrites * writeSize, status[0].getLen());
+    assertEquals(
+       numWrites * writeSize, status[0].getLen(), "File size hasn't changed " + status);
     LOG.debug("Total bytes written to " + blobPath + " = " + status[0].getLen());
     fs.delete(blobPath, false);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestReadAndSeekPageBlobAfterWrite.java
@@ -30,7 +30,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.integration.AbstractAzureScaleTest;
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,9 +65,10 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
   // path of page blob file to read and write
   private Path blobPath;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     fs = getTestAccount().getFileSystem();
     // Make sure we are using an integral number of pages.
     assertEquals(0, MAX_BYTES % PAGE_SIZE);
@@ -78,9 +81,9 @@ public class ITestReadAndSeekPageBlobAfterWrite extends AbstractAzureScaleTest {
   }
 
   @Override
-  public void tearDown() throws Exception {
+  public void tearDown(TestInfo testInfo) throws Exception {
     deleteQuietly(fs, blobPath, true);
-    super.tearDown();
+    super.tearDown(testInfo);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -32,8 +32,6 @@ import org.apache.http.ParseException;
 import org.apache.http.HeaderElement;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -68,8 +68,8 @@ public class ITestWasbRemoteCallHelper
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     boolean useSecureMode = fs.getConf().getBoolean(KEY_USE_SECURE_MODE, false);
     boolean useAuthorization = fs.getConf()
         .getBoolean(NativeAzureFileSystem.KEY_AZURE_AUTHORIZATION, false);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -36,7 +36,7 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Assume;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -34,10 +34,9 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Assume;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
@@ -50,6 +49,8 @@ import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_USE_SECU
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test class to hold all WasbRemoteCallHelper tests.
@@ -67,18 +68,16 @@ public class ITestWasbRemoteCallHelper
     return AzureBlobStorageTestAccount.create(conf);
   }
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     boolean useSecureMode = fs.getConf().getBoolean(KEY_USE_SECURE_MODE, false);
     boolean useAuthorization = fs.getConf()
         .getBoolean(NativeAzureFileSystem.KEY_AZURE_AUTHORIZATION, false);
-    Assume.assumeTrue("Test valid when both SecureMode and Authorization are enabled .. skipping",
-        useSecureMode && useAuthorization);
+    assumeTrue(useSecureMode && useAuthorization,
+        "Test valid when both SecureMode and Authorization are enabled .. skipping");
   }
-
-  @Rule
-  public ExpectedException expectedEx = ExpectedException.none();
 
   /**
    * Test invalid status-code.
@@ -87,18 +86,18 @@ public class ITestWasbRemoteCallHelper
   @Test // (expected = WasbAuthorizationException.class)
   public void testInvalidStatusCode() throws Throwable {
 
-    setupExpectations();
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any()))
+          .thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine())
+          .thenReturn(newStatusLine(INVALID_HTTP_STATUS_CODE_999));
+      // finished setting up mocks
 
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any()))
-        .thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine())
-        .thenReturn(newStatusLine(INVALID_HTTP_STATUS_CODE_999));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+      performop(mockHttpClient);
+    });
   }
 
   /**
@@ -107,19 +106,17 @@ public class ITestWasbRemoteCallHelper
    */
   @Test // (expected = WasbAuthorizationException.class)
   public void testInvalidContentType() throws Throwable {
-
-    setupExpectations();
-
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "text/plain"));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "text/plain"));
+      // finished setting up mocks
+      performop(mockHttpClient);
+    });
   }
 
   /**
@@ -129,18 +126,18 @@ public class ITestWasbRemoteCallHelper
   @Test // (expected = WasbAuthorizationException.class)
   public void testMissingContentLength() throws Throwable {
 
-    setupExpectations();
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "application/json"));
+      // finished setting up mocks
 
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "application/json"));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+      performop(mockHttpClient);
+    });
   }
 
   /**
@@ -150,20 +147,19 @@ public class ITestWasbRemoteCallHelper
   @Test // (expected = WasbAuthorizationException.class)
   public void testContentLengthExceedsMax() throws Throwable {
 
-    setupExpectations();
-
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "application/json"));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
-        .thenReturn(newHeader("Content-Length", "2048"));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "application/json"));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
+          .thenReturn(newHeader("Content-Length", "2048"));
+      // finished setting up mocks
+      performop(mockHttpClient);
+    });
   }
 
   /**
@@ -173,20 +169,20 @@ public class ITestWasbRemoteCallHelper
   @Test // (expected = WasbAuthorizationException.class)
   public void testInvalidContentLengthValue() throws Throwable {
 
-    setupExpectations();
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "application/json"));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
+          .thenReturn(newHeader("Content-Length", "20abc48"));
+      // finished setting up mocks
 
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "application/json"));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
-        .thenReturn(newHeader("Content-Length", "20abc48"));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+      performop(mockHttpClient);
+    });
   }
 
   /**
@@ -225,27 +221,29 @@ public class ITestWasbRemoteCallHelper
   @Test // (expected = WasbAuthorizationException.class)
   public void testMalFormedJSONResponse() throws Throwable {
 
-    expectedEx.expect(WasbAuthorizationException.class);
-    expectedEx.expectMessage("com.fasterxml.jackson.core.JsonParseException: Unexpected end-of-input in FIELD_NAME");
+    String errorMsg =
+        "com.fasterxml.jackson.core.JsonParseException: Unexpected end-of-input in FIELD_NAME";
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
 
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      HttpEntity mockHttpEntity = Mockito.mock(HttpEntity.class);
 
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    HttpEntity mockHttpEntity = Mockito.mock(HttpEntity.class);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "application/json"));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
+          .thenReturn(newHeader("Content-Length", "1024"));
+      Mockito.when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+      Mockito.when(mockHttpEntity.getContent())
+          .thenReturn(new ByteArrayInputStream(malformedJsonResponse().getBytes(StandardCharsets.UTF_8)));
+      // finished setting up mocks
 
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "application/json"));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
-        .thenReturn(newHeader("Content-Length", "1024"));
-    Mockito.when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
-    Mockito.when(mockHttpEntity.getContent())
-        .thenReturn(new ByteArrayInputStream(malformedJsonResponse().getBytes(StandardCharsets.UTF_8)));
-    // finished setting up mocks
+      performop(mockHttpClient);
+    }, errorMsg);
 
-    performop(mockHttpClient);
   }
 
   /**
@@ -254,28 +252,28 @@ public class ITestWasbRemoteCallHelper
    */
   @Test // (expected = WasbAuthorizationException.class)
   public void testFailureCodeJSONResponse() throws Throwable {
+    String errorMsg = "Remote authorization service encountered an error Unauthorized";
 
-    expectedEx.expect(WasbAuthorizationException.class);
-    expectedEx.expectMessage("Remote authorization service encountered an error Unauthorized");
+    assertThrows(WasbAuthorizationException.class, () -> {
+      // set up mocks
+      HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
 
-    // set up mocks
-    HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+      HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
+      HttpEntity mockHttpEntity = Mockito.mock(HttpEntity.class);
 
-    HttpResponse mockHttpResponse = Mockito.mock(HttpResponse.class);
-    HttpEntity mockHttpEntity = Mockito.mock(HttpEntity.class);
-
-    Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
-    Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
-        .thenReturn(newHeader("Content-Type", "application/json"));
-    Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
-        .thenReturn(newHeader("Content-Length", "1024"));
-    Mockito.when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
-    Mockito.when(mockHttpEntity.getContent())
-        .thenReturn(new ByteArrayInputStream(failureCodeJsonResponse().getBytes(StandardCharsets.UTF_8)));
-    // finished setting up mocks
-
-    performop(mockHttpClient);
+      Mockito.when(mockHttpClient.execute(Mockito.<HttpGet>any())).thenReturn(mockHttpResponse);
+      Mockito.when(mockHttpResponse.getStatusLine()).thenReturn(newStatusLine(HttpStatus.SC_OK));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Type"))
+          .thenReturn(newHeader("Content-Type", "application/json"));
+      Mockito.when(mockHttpResponse.getFirstHeader("Content-Length"))
+          .thenReturn(newHeader("Content-Length", "1024"));
+      Mockito.when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+      Mockito.when(mockHttpEntity.getContent())
+          .thenReturn(new ByteArrayInputStream(failureCodeJsonResponse()
+          .getBytes(StandardCharsets.UTF_8)));
+      // finished setting up mocks
+      performop(mockHttpClient);
+    }, errorMsg);
   }
 
   @Test
@@ -411,7 +409,6 @@ public class ITestWasbRemoteCallHelper
   }
 
   private void setupExpectations() {
-    expectedEx.expect(WasbAuthorizationException.class);
 
     class MatchesPattern extends TypeSafeMatcher<String> {
       private String pattern;
@@ -434,10 +431,6 @@ public class ITestWasbRemoteCallHelper
       }
     }
 
-    expectedEx.expectMessage(new MatchesPattern(
-        "org\\.apache\\.hadoop\\.fs\\.azure\\.WasbRemoteCallException: "
-            + "Encountered error while making remote call to "
-            + "http:\\/\\/localhost1\\/,http:\\/\\/localhost2\\/,http:\\/\\/localhost:8080 retried 6 time\\(s\\)\\."));
   }
 
   private void performop(HttpClient mockHttpClient) throws Throwable {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -408,31 +408,6 @@ public class ITestWasbRemoteCallHelper
     }
   }
 
-  private void setupExpectations() {
-
-    class MatchesPattern extends TypeSafeMatcher<String> {
-      private String pattern;
-
-      MatchesPattern(String pattern) {
-        this.pattern = pattern;
-      }
-
-      @Override protected boolean matchesSafely(String item) {
-        return item.matches(pattern);
-      }
-
-      @Override public void describeTo(Description description) {
-        description.appendText("matches pattern ").appendValue(pattern);
-      }
-
-      @Override protected void describeMismatchSafely(String item,
-          Description mismatchDescription) {
-        mismatchDescription.appendText("does not match");
-      }
-    }
-
-  }
-
   private void performop(HttpClient mockHttpClient) throws Throwable {
 
     Path testPath = new Path("/", "test.dat");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbRemoteCallHelper.java
@@ -34,7 +34,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -50,11 +50,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
@@ -70,8 +68,6 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   protected String accountKey;
   protected static Configuration conf = null;
   private boolean runningInSASMode = false;
-  @Rule
-  public final TemporaryFolder tempDir = new TemporaryFolder();
 
   private AzureBlobStorageTestAccount testAccount;
 
@@ -138,7 +134,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   @Test
   public void testConnectUsingSAS() throws Exception {
 
-    Assume.assumeFalse(runningInSASMode);
+    assumeFalse(runningInSASMode);
     // Create the test account with SAS credentials.
     testAccount = AzureBlobStorageTestAccount.create("",
         EnumSet.of(CreateOptions.UseSas, CreateOptions.CreateContainer));
@@ -154,7 +150,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   @Test
   public void testConnectUsingSASReadonly() throws Exception {
 
-    Assume.assumeFalse(runningInSASMode);
+    assumeFalse(runningInSASMode);
     // Create the test account with SAS credentials.
     testAccount = AzureBlobStorageTestAccount.create("", EnumSet.of(
         CreateOptions.UseSas, CreateOptions.CreateContainer,
@@ -381,14 +377,15 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
   }
 
   @Test
-  public void testCredsFromCredentialProvider() throws Exception {
+  public void testCredsFromCredentialProvider(@TempDir java.nio.file.Path tempDir)
+      throws Exception {
 
     assumeFalse(runningInSASMode);
     String account = "testacct";
     String key = "testkey";
     // set up conf to have a cred provider
     final Configuration conf = new Configuration();
-    final File file = tempDir.newFile("test.jks");
+    final File file = new File(tempDir.toFile(), "myfile.txt");
     final URI jks = ProviderUtils.nestURIForLocalJavaKeyStoreProvider(
         file.toURI());
     conf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -436,7 +436,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
         "org.apache.Nonexistant.Class");
     try {
       AzureNativeFileSystemStore.getAccountKeyFromConfiguration(account, conf);
-      Assertions.fail("Nonexistant key provider class should have thrown a "
+      fail("Nonexistant key provider class should have thrown a "
           + "KeyProviderException");
     } catch (KeyProviderException e) {
     }
@@ -450,7 +450,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
     conf.set("fs.azure.account.keyprovider." + account, "java.lang.String");
     try {
       AzureNativeFileSystemStore.getAccountKeyFromConfiguration(account, conf);
-      Assertions.fail("Key provider class that doesn't implement KeyProvider "
+      fail("Key provider class that doesn't implement KeyProvider "
           + "should have thrown a KeyProviderException");
     } catch (KeyProviderException e) {
     }
@@ -656,7 +656,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
 
       conf.setBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, true);
       FileSystem fs1 = FileSystem.newInstance(defaultUri, conf);
-      Assertions.assertEquals("getCanonicalServiceName() should return URI",
+      assertEquals("getCanonicalServiceName() should return URI",
               fs1.getUri().toString(), fs1.getCanonicalServiceName());
     } finally {
       testAccount.cleanup();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -48,12 +48,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.CreateOptions;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.microsoft.azure.storage.StorageException;
@@ -75,12 +75,12 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
 
   private AzureBlobStorageTestAccount testAccount;
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount = AzureTestUtils.cleanupTestAccount(testAccount);
   }
 
-  @Before
+  @BeforeEach
   public void setMode() {
     runningInSASMode = AzureBlobStorageTestAccount.createTestConfiguration().
         getBoolean(AzureNativeFileSystemStore.KEY_USE_SECURE_MODE, false);
@@ -303,7 +303,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
     } catch (Exception e) {
       String errMsg = String.format(
           "Expected AzureException but got %s instead.", e);
-      assertTrue(errMsg, false);
+      assertTrue(false, errMsg);
     }
   }
 
@@ -336,11 +336,11 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
       int expectedValue) throws Exception {
     InputStream inputStream = fs.open(testFile);
     int byteRead = inputStream.read();
-    assertTrue("File unexpectedly empty: " + testFile, byteRead >= 0);
-    assertTrue("File has more than a single byte: " + testFile,
-        inputStream.read() < 0);
+    assertTrue(byteRead >= 0, "File unexpectedly empty: " + testFile);
+    assertTrue(
+       inputStream.read() < 0, "File has more than a single byte: " + testFile);
     inputStream.close();
-    assertEquals("Unxpected content in: " + testFile, expectedValue, byteRead);
+    assertEquals(expectedValue, byteRead, "Unxpected content in: " + testFile);
   }
 
   @Test
@@ -403,7 +403,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
     String result = AzureNativeFileSystemStore.getAccountKeyFromConfiguration(
         account, conf);
     // result should contain the credential provider key not the config key
-    assertEquals("AccountKey incorrect.", key, result);
+    assertEquals(key, result, "AccountKey incorrect.");
   }
 
   void provisionAccountKey(
@@ -439,7 +439,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
         "org.apache.Nonexistant.Class");
     try {
       AzureNativeFileSystemStore.getAccountKeyFromConfiguration(account, conf);
-      Assert.fail("Nonexistant key provider class should have thrown a "
+      Assertions.fail("Nonexistant key provider class should have thrown a "
           + "KeyProviderException");
     } catch (KeyProviderException e) {
     }
@@ -453,7 +453,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
     conf.set("fs.azure.account.keyprovider." + account, "java.lang.String");
     try {
       AzureNativeFileSystemStore.getAccountKeyFromConfiguration(account, conf);
-      Assert.fail("Key provider class that doesn't implement KeyProvider "
+      Assertions.fail("Key provider class that doesn't implement KeyProvider "
           + "should have thrown a KeyProviderException");
     } catch (KeyProviderException e) {
     }
@@ -659,7 +659,7 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
 
       conf.setBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, true);
       FileSystem fs1 = FileSystem.newInstance(defaultUri, conf);
-      Assert.assertEquals("getCanonicalServiceName() should return URI",
+      Assertions.assertEquals("getCanonicalServiceName() should return URI",
               fs1.getUri().toString(), fs1.getCanonicalServiceName());
     } finally {
       testAccount.cleanup();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.CreateOptions;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/ITestWasbUriAndConfiguration.java
@@ -21,8 +21,7 @@ package org.apache.hadoop.fs.azure;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.azure.NativeAzureFileSystem.RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -655,8 +654,8 @@ public class ITestWasbUriAndConfiguration extends AbstractWasbTestWithTimeout {
 
       conf.setBoolean(RETURN_URI_AS_CANONICAL_SERVICE_NAME_PROPERTY_NAME, true);
       FileSystem fs1 = FileSystem.newInstance(defaultUri, conf);
-      assertEquals("getCanonicalServiceName() should return URI",
-              fs1.getUri().toString(), fs1.getCanonicalServiceName());
+      assertEquals(fs1.getUri().toString(), fs1.getCanonicalServiceName(),
+          "getCanonicalServiceName() should return URI");
     } finally {
       testAccount.cleanup();
       FileSystem.closeAll();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -41,12 +41,14 @@ import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 
 import com.microsoft.azure.storage.AccessCondition;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlob;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +78,10 @@ public abstract class NativeAzureFileSystemBaseTest
   public static final Logger LOG = LoggerFactory.getLogger(NativeAzureFileSystemBaseTest.class);
   protected NativeAzureFileSystem fs;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     fs = getFileSystem();
   }
 
@@ -112,8 +115,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testStoreRetrieveFile() throws Exception {
-    Path testFile = methodPath();
+  public void testStoreRetrieveFile(TestInfo testInfo) throws Exception {
+    Path testFile = methodPath(testInfo);
     writeString(testFile, "Testing");
     assertTrue(fs.exists(testFile));
     FileStatus status = fs.getFileStatus(testFile);
@@ -126,12 +129,12 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttr() throws Exception {
+  public void testSetGetXAttr(TestInfo testInfo) throws Exception {
     byte[] attributeValue1 = "hi".getBytes(StandardCharsets.UTF_8);
     byte[] attributeValue2 = "你好".getBytes(StandardCharsets.UTF_8);
     String attributeName1 = "user.asciiAttribute";
     String attributeName2 = "user.unicodeAttribute";
-    Path testFile = methodPath();
+    Path testFile = methodPath(testInfo);
 
     // after creating a file, the xAttr should not be present
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -148,10 +151,10 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttrCreateReplace() throws Exception {
+  public void testSetGetXAttrCreateReplace(TestInfo testInfo) throws Exception {
     byte[] attributeValue = "one".getBytes(StandardCharsets.UTF_8);
     String attributeName = "user.someAttribute";
-    Path testFile = methodPath();
+    Path testFile = methodPath(testInfo);
 
     // after creating a file, it must be possible to create a new xAttr
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -163,11 +166,11 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttrReplace() throws Exception {
+  public void testSetGetXAttrReplace(TestInfo testInfo) throws Exception {
     byte[] attributeValue1 = "one".getBytes(StandardCharsets.UTF_8);
     byte[] attributeValue2 = "two".getBytes(StandardCharsets.UTF_8);
     String attributeName = "user.someAttribute";
-    Path testFile = methodPath();
+    Path testFile = methodPath(testInfo);
 
     // after creating a file, it must not be possible to replace an xAttr
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -180,8 +183,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testStoreDeleteFolder() throws Exception {
-    Path testFolder = methodPath();
+  public void testStoreDeleteFolder(TestInfo testInfo) throws Exception {
+    Path testFolder = methodPath(testInfo);
     assertFalse(fs.exists(testFolder));
     assertTrue(fs.mkdirs(testFolder));
     assertTrue(fs.exists(testFolder));
@@ -200,15 +203,15 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFileOwnership() throws Exception {
-    Path testFile = methodPath();
+  public void testFileOwnership(TestInfo testInfo) throws Exception {
+    Path testFile = methodPath(testInfo);
     writeString(testFile, "Testing");
     testOwnership(testFile);
   }
 
   @Test
-  public void testFolderOwnership() throws Exception {
-    Path testFolder = methodPath();
+  public void testFolderOwnership(TestInfo testInfo) throws Exception {
+    Path testFolder = methodPath(testInfo);
     fs.mkdirs(testFolder);
     testOwnership(testFolder);
   }
@@ -234,8 +237,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFilePermissions() throws Exception {
-    Path testFile = methodPath();
+  public void testFilePermissions(TestInfo testInfo) throws Exception {
+    Path testFile = methodPath(testInfo);
     FsPermission permission = FsPermission.createImmutable((short) 644);
     createEmptyFile(testFile, permission);
     FileStatus ret = fs.getFileStatus(testFile);
@@ -244,8 +247,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFolderPermissions() throws Exception {
-    Path testFolder = methodPath();
+  public void testFolderPermissions(TestInfo testInfo) throws Exception {
+    Path testFolder = methodPath(testInfo);
     FsPermission permission = FsPermission.createImmutable((short) 644);
     fs.mkdirs(testFolder, permission);
     FileStatus ret = fs.getFileStatus(testFolder);
@@ -384,14 +387,14 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testCopyFromLocalFileSystem() throws Exception {
+  public void testCopyFromLocalFileSystem(TestInfo testInfo) throws Exception {
     Path localFilePath = new Path(System.getProperty("test.build.data",
         "azure_test"));
     FileSystem localFs = FileSystem.get(new Configuration());
     localFs.delete(localFilePath, true);
     try {
       writeStringToFile(localFs, localFilePath, "Testing");
-      Path dstPath = methodPath();
+      Path dstPath = methodPath(testInfo);
       assertTrue(FileUtil.copy(localFs, localFilePath, fs, dstPath, false,
           fs.getConf()));
       assertPathExists("coied from local", dstPath);
@@ -490,8 +493,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testReadingDirectoryAsFile() throws Exception {
-    Path dir = methodPath();
+  public void testReadingDirectoryAsFile(TestInfo testInfo) throws Exception {
+    Path dir = methodPath(testInfo);
     assertTrue(fs.mkdirs(dir));
     try {
       fs.open(dir).close();
@@ -502,8 +505,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testCreatingFileOverDirectory() throws Exception {
-    Path dir = methodPath();
+  public void testCreatingFileOverDirectory(TestInfo testInfo) throws Exception {
+    Path dir = methodPath(testInfo);
     assertTrue(fs.mkdirs(dir));
     try {
       fs.create(dir).close();
@@ -515,8 +518,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithZeroSizeBuffer() throws Exception {
-    Path newFile = methodPath();
+  public void testInputStreamReadWithZeroSizeBuffer(TestInfo testInfo) throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -527,8 +530,9 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithBufferReturnsMinusOneOnEof() throws Exception {
-    Path newFile = methodPath();
+  public void testInputStreamReadWithBufferReturnsMinusOneOnEof(TestInfo testInfo)
+      throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -549,8 +553,9 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithBufferReturnsMinusOneOnEofForLargeBuffer() throws Exception {
-    Path newFile = methodPath();
+  public void testInputStreamReadWithBufferReturnsMinusOneOnEofForLargeBuffer(TestInfo testInfo)
+      throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     byte[] outputBuff = new byte[97331];
     for(int i = 0; i < outputBuff.length; ++i) {
@@ -575,8 +580,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadIntReturnsMinusOneOnEof() throws Exception {
-    Path newFile = methodPath();
+  public void testInputStreamReadIntReturnsMinusOneOnEof(TestInfo testInfo) throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -592,8 +597,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetPermissionOnFile() throws Exception {
-    Path newFile = methodPath();
+  public void testSetPermissionOnFile(TestInfo testInfo) throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     output.write(13);
     output.close();
@@ -614,8 +619,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetPermissionOnFolder() throws Exception {
-    Path newFolder = methodPath();
+  public void testSetPermissionOnFolder(TestInfo testInfo) throws Exception {
+    Path newFolder = methodPath(testInfo);
     assertTrue(fs.mkdirs(newFolder));
     FsPermission newPermission = new FsPermission((short) 0600);
     fs.setPermission(newFolder, newPermission);
@@ -626,8 +631,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetOwnerOnFile() throws Exception {
-    Path newFile = methodPath();
+  public void testSetOwnerOnFile(TestInfo testInfo) throws Exception {
+    Path newFile = methodPath(testInfo);
     OutputStream output = fs.create(newFile);
     output.write(13);
     output.close();
@@ -650,8 +655,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetOwnerOnFolder() throws Exception {
-    Path newFolder = methodPath();
+  public void testSetOwnerOnFolder(TestInfo testInfo) throws Exception {
+    Path newFolder = methodPath(testInfo);
     assertTrue(fs.mkdirs(newFolder));
     fs.setOwner(newFolder, "newUser", null);
     FileStatus newStatus = fs.getFileStatus(newFolder);
@@ -661,22 +666,22 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testModifiedTimeForFile() throws Exception {
-    Path testFile = methodPath();
+  public void testModifiedTimeForFile(TestInfo testInfo) throws Exception {
+    Path testFile = methodPath(testInfo);
     fs.create(testFile).close();
     testModifiedTime(testFile);
   }
 
   @Test
-  public void testModifiedTimeForFolder() throws Exception {
-    Path testFolder = methodPath();
+  public void testModifiedTimeForFolder(TestInfo testInfo) throws Exception {
+    Path testFolder = methodPath(testInfo);
     assertTrue(fs.mkdirs(testFolder));
     testModifiedTime(testFolder);
   }
 
   @Test
-  public void testFolderLastModifiedTime() throws Exception {
-    Path parentFolder = methodPath();
+  public void testFolderLastModifiedTime(TestInfo testInfo) throws Exception {
+    Path parentFolder = methodPath(testInfo);
     Path innerFile = new Path(parentFolder, "innerfile");
     assertTrue(fs.mkdirs(parentFolder));
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -1537,9 +1537,9 @@ public abstract class NativeAzureFileSystemBaseTest
     final long errorMargin = 60 * 1000; // Give it +/-60 seconds
     assertTrue(
         fileStatus.getModificationTime() > (currentUtcTime - errorMargin) &&
-        fileStatus.getModificationTime() < (currentUtcTime + errorMargin), "Modification time " +
-        new Date(fileStatus.getModificationTime()) + " is not close to now: " +
-        utc.getTime());
+        fileStatus.getModificationTime() < (currentUtcTime + errorMargin),
+        "Modification time " + new Date(fileStatus.getModificationTime())
+        + " is not close to now: " + utc.getTime());
   }
 
   private void createEmptyFile(Path testFile, FsPermission permission)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -1536,7 +1536,7 @@ public abstract class NativeAzureFileSystemBaseTest
     FileStatus fileStatus = fs.getFileStatus(testPath);
     final long errorMargin = 60 * 1000; // Give it +/-60 seconds
     assertTrue(
-       fileStatus.getModificationTime() > (currentUtcTime - errorMargin) &&
+        fileStatus.getModificationTime() > (currentUtcTime - errorMargin) &&
         fileStatus.getModificationTime() < (currentUtcTime + errorMargin), "Modification time " +
         new Date(fileStatus.getModificationTime()) + " is not close to now: " +
         utc.getTime());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 
 import com.microsoft.azure.storage.AccessCondition;
@@ -495,7 +495,7 @@ public abstract class NativeAzureFileSystemBaseTest
     assertTrue(fs.mkdirs(dir));
     try {
       fs.open(dir).close();
-      assertTrue("Should've thrown", false);
+      assertTrue(false, "Should've thrown");
     } catch (FileNotFoundException ex) {
       assertExceptionContains("a directory not a file.", ex);
     }
@@ -507,7 +507,7 @@ public abstract class NativeAzureFileSystemBaseTest
     assertTrue(fs.mkdirs(dir));
     try {
       fs.create(dir).close();
-      assertTrue("Should've thrown", false);
+      assertTrue(false, "Should've thrown");
     } catch (IOException ex) {
       assertExceptionContains("Cannot create file", ex);
       assertExceptionContains("already exists as a directory", ex);
@@ -1051,7 +1051,7 @@ public abstract class NativeAzureFileSystemBaseTest
 
     // Make sure rename pending file is gone.
     FileStatus[] listed = fs.listStatus(new Path("/"));
-    assertEquals("Pending directory still found", 1, listed.length);
+    assertEquals(1, listed.length, "Pending directory still found");
     assertTrue(listed[0].isDirectory());
   }
 
@@ -1348,7 +1348,7 @@ public abstract class NativeAzureFileSystemBaseTest
           assertTrue(fs.createNewFile(makePath(prefix, name)));
         }
       } else {
-        assertTrue("The object must be a (leaf) file or a folder.", false);
+        assertTrue(false, "The object must be a (leaf) file or a folder.");
       }
     }
 
@@ -1506,7 +1506,7 @@ public abstract class NativeAzureFileSystemBaseTest
     Path testFile = new Path(testFolder, "testFile");
     try {
       fs.createNonRecursive(testFile, true, 1024, (short)1, 1024, null);
-      assertTrue("Should've thrown", false);
+      assertTrue(false, "Should've thrown");
     } catch (FileNotFoundException e) {
     }
     fs.mkdirs(testFolder);
@@ -1530,11 +1530,11 @@ public abstract class NativeAzureFileSystemBaseTest
     long currentUtcTime = utc.getTime().getTime();
     FileStatus fileStatus = fs.getFileStatus(testPath);
     final long errorMargin = 60 * 1000; // Give it +/-60 seconds
-    assertTrue("Modification time " +
+    assertTrue(
+       fileStatus.getModificationTime() > (currentUtcTime - errorMargin) &&
+        fileStatus.getModificationTime() < (currentUtcTime + errorMargin), "Modification time " +
         new Date(fileStatus.getModificationTime()) + " is not close to now: " +
-        utc.getTime(),
-        fileStatus.getModificationTime() > (currentUtcTime - errorMargin) &&
-        fileStatus.getModificationTime() < (currentUtcTime + errorMargin));
+        utc.getTime());
   }
 
   private void createEmptyFile(Path testFile, FsPermission permission)
@@ -1675,7 +1675,7 @@ public abstract class NativeAzureFileSystemBaseTest
           lease = nfs.getStore().acquireLease(key);
           LOG.info(name + " acquired lease " + lease.getLeaseID());
         } catch (AzureException e) {
-          assertTrue("Unanticipated exception", false);
+          assertTrue(false, "Unanticipated exception");
         }
         assertTrue(lease != null);
         try {
@@ -1706,14 +1706,14 @@ public abstract class NativeAzureFileSystemBaseTest
           secondStartTime = System.currentTimeMillis();
           LOG.info(name + " acquired lease " + lease.getLeaseID());
         } catch (AzureException e) {
-          assertTrue("Unanticipated exception", false);
+          assertTrue(false, "Unanticipated exception");
         }
         assertTrue(lease != null);
         try {
           lease.free();
           LOG.info(name + " freed lease " + lease.getLeaseID());
         } catch (StorageException e) {
-          assertTrue("Unanticipated exception", false);
+          assertTrue(false, "Unanticipated exception");
         }
       } else {
         fail("Unknown thread name");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/NativeAzureFileSystemBaseTest.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.fs.azure.NativeAzureFileSystem.FolderRenamePending;
 import com.microsoft.azure.storage.AccessCondition;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlob;
-import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,8 +79,8 @@ public abstract class NativeAzureFileSystemBaseTest
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     fs = getFileSystem();
   }
 
@@ -115,8 +114,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testStoreRetrieveFile(TestInfo testInfo) throws Exception {
-    Path testFile = methodPath(testInfo);
+  public void testStoreRetrieveFile() throws Exception {
+    Path testFile = methodPath();
     writeString(testFile, "Testing");
     assertTrue(fs.exists(testFile));
     FileStatus status = fs.getFileStatus(testFile);
@@ -129,12 +128,12 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttr(TestInfo testInfo) throws Exception {
+  public void testSetGetXAttr() throws Exception {
     byte[] attributeValue1 = "hi".getBytes(StandardCharsets.UTF_8);
     byte[] attributeValue2 = "你好".getBytes(StandardCharsets.UTF_8);
     String attributeName1 = "user.asciiAttribute";
     String attributeName2 = "user.unicodeAttribute";
-    Path testFile = methodPath(testInfo);
+    Path testFile = methodPath();
 
     // after creating a file, the xAttr should not be present
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -151,10 +150,10 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttrCreateReplace(TestInfo testInfo) throws Exception {
+  public void testSetGetXAttrCreateReplace() throws Exception {
     byte[] attributeValue = "one".getBytes(StandardCharsets.UTF_8);
     String attributeName = "user.someAttribute";
-    Path testFile = methodPath(testInfo);
+    Path testFile = methodPath();
 
     // after creating a file, it must be possible to create a new xAttr
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -166,11 +165,11 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetGetXAttrReplace(TestInfo testInfo) throws Exception {
+  public void testSetGetXAttrReplace() throws Exception {
     byte[] attributeValue1 = "one".getBytes(StandardCharsets.UTF_8);
     byte[] attributeValue2 = "two".getBytes(StandardCharsets.UTF_8);
     String attributeName = "user.someAttribute";
-    Path testFile = methodPath(testInfo);
+    Path testFile = methodPath();
 
     // after creating a file, it must not be possible to replace an xAttr
     createEmptyFile(testFile, FsPermission.createImmutable(READ_WRITE_PERMISSIONS));
@@ -183,8 +182,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testStoreDeleteFolder(TestInfo testInfo) throws Exception {
-    Path testFolder = methodPath(testInfo);
+  public void testStoreDeleteFolder() throws Exception {
+    Path testFolder = methodPath();
     assertFalse(fs.exists(testFolder));
     assertTrue(fs.mkdirs(testFolder));
     assertTrue(fs.exists(testFolder));
@@ -203,15 +202,15 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFileOwnership(TestInfo testInfo) throws Exception {
-    Path testFile = methodPath(testInfo);
+  public void testFileOwnership() throws Exception {
+    Path testFile = methodPath();
     writeString(testFile, "Testing");
     testOwnership(testFile);
   }
 
   @Test
-  public void testFolderOwnership(TestInfo testInfo) throws Exception {
-    Path testFolder = methodPath(testInfo);
+  public void testFolderOwnership() throws Exception {
+    Path testFolder = methodPath();
     fs.mkdirs(testFolder);
     testOwnership(testFolder);
   }
@@ -237,8 +236,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFilePermissions(TestInfo testInfo) throws Exception {
-    Path testFile = methodPath(testInfo);
+  public void testFilePermissions() throws Exception {
+    Path testFile = methodPath();
     FsPermission permission = FsPermission.createImmutable((short) 644);
     createEmptyFile(testFile, permission);
     FileStatus ret = fs.getFileStatus(testFile);
@@ -247,8 +246,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testFolderPermissions(TestInfo testInfo) throws Exception {
-    Path testFolder = methodPath(testInfo);
+  public void testFolderPermissions() throws Exception {
+    Path testFolder = methodPath();
     FsPermission permission = FsPermission.createImmutable((short) 644);
     fs.mkdirs(testFolder, permission);
     FileStatus ret = fs.getFileStatus(testFolder);
@@ -387,14 +386,14 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testCopyFromLocalFileSystem(TestInfo testInfo) throws Exception {
+  public void testCopyFromLocalFileSystem() throws Exception {
     Path localFilePath = new Path(System.getProperty("test.build.data",
         "azure_test"));
     FileSystem localFs = FileSystem.get(new Configuration());
     localFs.delete(localFilePath, true);
     try {
       writeStringToFile(localFs, localFilePath, "Testing");
-      Path dstPath = methodPath(testInfo);
+      Path dstPath = methodPath();
       assertTrue(FileUtil.copy(localFs, localFilePath, fs, dstPath, false,
           fs.getConf()));
       assertPathExists("coied from local", dstPath);
@@ -493,8 +492,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testReadingDirectoryAsFile(TestInfo testInfo) throws Exception {
-    Path dir = methodPath(testInfo);
+  public void testReadingDirectoryAsFile() throws Exception {
+    Path dir = methodPath();
     assertTrue(fs.mkdirs(dir));
     try {
       fs.open(dir).close();
@@ -505,8 +504,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testCreatingFileOverDirectory(TestInfo testInfo) throws Exception {
-    Path dir = methodPath(testInfo);
+  public void testCreatingFileOverDirectory() throws Exception {
+    Path dir = methodPath();
     assertTrue(fs.mkdirs(dir));
     try {
       fs.create(dir).close();
@@ -518,8 +517,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithZeroSizeBuffer(TestInfo testInfo) throws Exception {
-    Path newFile = methodPath(testInfo);
+  public void testInputStreamReadWithZeroSizeBuffer() throws Exception {
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -530,9 +529,9 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithBufferReturnsMinusOneOnEof(TestInfo testInfo)
+  public void testInputStreamReadWithBufferReturnsMinusOneOnEof()
       throws Exception {
-    Path newFile = methodPath(testInfo);
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -553,9 +552,9 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadWithBufferReturnsMinusOneOnEofForLargeBuffer(TestInfo testInfo)
+  public void testInputStreamReadWithBufferReturnsMinusOneOnEofForLargeBuffer()
       throws Exception {
-    Path newFile = methodPath(testInfo);
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     byte[] outputBuff = new byte[97331];
     for(int i = 0; i < outputBuff.length; ++i) {
@@ -580,8 +579,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testInputStreamReadIntReturnsMinusOneOnEof(TestInfo testInfo) throws Exception {
-    Path newFile = methodPath(testInfo);
+  public void testInputStreamReadIntReturnsMinusOneOnEof() throws Exception {
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     output.write(10);
     output.close();
@@ -597,8 +596,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetPermissionOnFile(TestInfo testInfo) throws Exception {
-    Path newFile = methodPath(testInfo);
+  public void testSetPermissionOnFile() throws Exception {
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     output.write(13);
     output.close();
@@ -619,8 +618,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetPermissionOnFolder(TestInfo testInfo) throws Exception {
-    Path newFolder = methodPath(testInfo);
+  public void testSetPermissionOnFolder() throws Exception {
+    Path newFolder = methodPath();
     assertTrue(fs.mkdirs(newFolder));
     FsPermission newPermission = new FsPermission((short) 0600);
     fs.setPermission(newFolder, newPermission);
@@ -631,8 +630,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetOwnerOnFile(TestInfo testInfo) throws Exception {
-    Path newFile = methodPath(testInfo);
+  public void testSetOwnerOnFile() throws Exception {
+    Path newFile = methodPath();
     OutputStream output = fs.create(newFile);
     output.write(13);
     output.close();
@@ -655,8 +654,8 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testSetOwnerOnFolder(TestInfo testInfo) throws Exception {
-    Path newFolder = methodPath(testInfo);
+  public void testSetOwnerOnFolder() throws Exception {
+    Path newFolder = methodPath();
     assertTrue(fs.mkdirs(newFolder));
     fs.setOwner(newFolder, "newUser", null);
     FileStatus newStatus = fs.getFileStatus(newFolder);
@@ -666,22 +665,22 @@ public abstract class NativeAzureFileSystemBaseTest
   }
 
   @Test
-  public void testModifiedTimeForFile(TestInfo testInfo) throws Exception {
-    Path testFile = methodPath(testInfo);
+  public void testModifiedTimeForFile() throws Exception {
+    Path testFile = methodPath();
     fs.create(testFile).close();
     testModifiedTime(testFile);
   }
 
   @Test
-  public void testModifiedTimeForFolder(TestInfo testInfo) throws Exception {
-    Path testFolder = methodPath(testInfo);
+  public void testModifiedTimeForFolder() throws Exception {
+    Path testFolder = methodPath();
     assertTrue(fs.mkdirs(testFolder));
     testModifiedTime(testFolder);
   }
 
   @Test
-  public void testFolderLastModifiedTime(TestInfo testInfo) throws Exception {
-    Path parentFolder = methodPath(testInfo);
+  public void testFolderLastModifiedTime() throws Exception {
+    Path parentFolder = methodPath();
     Path innerFile = new Path(parentFolder, "innerfile");
     assertTrue(fs.mkdirs(parentFolder));
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobMetadata.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobMetadata.java
@@ -30,9 +30,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that we put the correct metadata on blobs created through WASB.
@@ -42,14 +42,14 @@ public class TestBlobMetadata extends AbstractWasbTestWithTimeout {
   private FileSystem fs;
   private InMemoryBlockBlobStore backingStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testAccount = AzureBlobStorageTestAccount.createMock();
     fs = testAccount.getFileSystem();
     backingStore = testAccount.getMockStorage().getBackingStore();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount.cleanup();
     fs = null;
@@ -203,7 +203,7 @@ public class TestBlobMetadata extends AbstractWasbTestWithTimeout {
     fs.create(selfishFile, justMe, true, 4096, fs.getDefaultReplication(),
         fs.getDefaultBlockSize(), null).close();
     String mockUri = AzureBlobStorageTestAccount.toMockUri(selfishFile);
-    assertNotNull("converted URI", mockUri);
+    assertNotNull(mockUri, "converted URI");
     HashMap<String, String> metadata = backingStore
         .getMetadata(mockUri);
     assertNotNull(metadata);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobOperationDescriptor.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestBlobOperationDescriptor.java
@@ -29,7 +29,7 @@ import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.CloudPageBlob;
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.azure;
 
 import org.apache.hadoop.fs.contract.ContractTestUtils.NanoTimer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>ClientThrottlingAnalyzer</code>.
@@ -44,31 +44,31 @@ public class TestClientThrottlingAnalyzer extends AbstractWasbTestWithTimeout {
     final double upperBound = expected + percentage / 100 * expected;
 
     assertTrue(
-        String.format(
+    
+       actual >= lowerBound && actual <= upperBound, String.format(
             "The actual value %1$d is not within the expected range: "
                 + "[%2$.2f, %3$.2f].",
             actual,
             lowerBound,
-            upperBound),
-        actual >= lowerBound && actual <= upperBound);
+            upperBound));
   }
 
   private void validate(long expected, long actual) {
     assertEquals(
-        String.format("The actual value %1$d is not the expected value %2$d.",
+    
+       expected, actual, String.format("The actual value %1$d is not the expected value %2$d.",
             actual,
-            expected),
-        expected, actual);
+            expected));
   }
 
   private void validateLessThanOrEqual(long maxExpected, long actual) {
     assertTrue(
-        String.format(
+    
+       actual < maxExpected, String.format(
             "The actual value %1$d is not less than or equal to the maximum"
             + " expected value %2$d.",
             actual,
-            maxExpected),
-        actual < maxExpected);
+            maxExpected));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
@@ -44,8 +44,8 @@ public class TestClientThrottlingAnalyzer extends AbstractWasbTestWithTimeout {
     final double upperBound = expected + percentage / 100 * expected;
 
     assertTrue(actual >= lowerBound && actual <= upperBound, String.format(
-        "The actual value %1$d is not within the expected range: " +
-        "[%2$.2f, %3$.2f].",
+        "The actual value %1$d is not within the expected range: "
+        + "[%2$.2f, %3$.2f].",
         actual,
         lowerBound,
         upperBound));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
@@ -43,22 +43,17 @@ public class TestClientThrottlingAnalyzer extends AbstractWasbTestWithTimeout {
     final double lowerBound = Math.max(expected - percentage / 100 * expected, 0);
     final double upperBound = expected + percentage / 100 * expected;
 
-    assertTrue(
-    
-       actual >= lowerBound && actual <= upperBound, String.format(
-            "The actual value %1$d is not within the expected range: "
-                + "[%2$.2f, %3$.2f].",
-            actual,
-            lowerBound,
-            upperBound));
+    assertTrue(actual >= lowerBound && actual <= upperBound, String.format(
+        "The actual value %1$d is not within the expected range: " +
+        "[%2$.2f, %3$.2f].",
+        actual,
+        lowerBound,
+        upperBound));
   }
 
   private void validate(long expected, long actual) {
-    assertEquals(
-    
-       expected, actual, String.format("The actual value %1$d is not the expected value %2$d.",
-            actual,
-            expected));
+    assertEquals(expected, actual,
+       String.format("The actual value %1$d is not the expected value %2$d.", actual, expected));
   }
 
   private void validateLessThanOrEqual(long maxExpected, long actual) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestClientThrottlingAnalyzer.java
@@ -57,13 +57,11 @@ public class TestClientThrottlingAnalyzer extends AbstractWasbTestWithTimeout {
   }
 
   private void validateLessThanOrEqual(long maxExpected, long actual) {
-    assertTrue(
-    
-       actual < maxExpected, String.format(
-            "The actual value %1$d is not less than or equal to the maximum"
-            + " expected value %2$d.",
-            actual,
-            maxExpected));
+    assertTrue(actual < maxExpected, String.format(
+        "The actual value %1$d is not less than or equal to the maximum"
+        + " expected value %2$d.",
+        actual,
+        maxExpected));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestKeyPageBlobDirectories.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestKeyPageBlobDirectories.java
@@ -36,9 +36,8 @@ public class TestKeyPageBlobDirectories extends AbstractWasbTestBase{
   }
 
   public void expectPageBlobKey(boolean expectedOutcome, AzureNativeFileSystemStore store, String path) {
-    assertEquals(
-           expectedOutcome, store.isPageBlobKey(path), "Unexpected result for isPageBlobKey(" + path + ")");
-
+    assertEquals(expectedOutcome, store.isPageBlobKey(path),
+        "Unexpected result for isPageBlobKey(" + path + ")");
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestKeyPageBlobDirectories.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestKeyPageBlobDirectories.java
@@ -23,7 +23,7 @@ import java.net.URI;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test config property KEY_PAGE_BLOB_DIRECTORIES.
@@ -36,8 +36,8 @@ public class TestKeyPageBlobDirectories extends AbstractWasbTestBase{
   }
 
   public void expectPageBlobKey(boolean expectedOutcome, AzureNativeFileSystemStore store, String path) {
-    assertEquals("Unexpected result for isPageBlobKey(" + path + ")",
-            expectedOutcome, store.isPageBlobKey(path));
+    assertEquals(
+           expectedOutcome, store.isPageBlobKey(path), "Unexpected result for isPageBlobKey(" + path + ")");
 
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
@@ -40,17 +40,16 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 
-import org.junit.Assume;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-import org.junit.rules.ExpectedException;
 import org.apache.hadoop.classification.VisibleForTesting;
 
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_USE_SECURE_MODE;
 import static org.apache.hadoop.fs.azure.CachingAuthorizer.KEY_AUTH_SERVICE_CACHING_ENABLE;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test class to hold all WASB authorization tests.
@@ -89,20 +88,18 @@ public class TestNativeAzureFileSystemAuthorization
   }
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  @BeforeEach
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     boolean useSecureMode = fs.getConf().getBoolean(KEY_USE_SECURE_MODE, false);
     boolean useAuthorization = fs.getConf().getBoolean(NativeAzureFileSystem.KEY_AZURE_AUTHORIZATION, false);
-    Assume.assumeTrue("Test valid when both SecureMode and Authorization are enabled .. skipping",
-        useSecureMode && useAuthorization);
+    assumeTrue((useSecureMode && useAuthorization),
+        "Test valid when both SecureMode and Authorization are enabled .. skipping");
 
     authorizer = new MockWasbAuthorizerImpl(fs);
     authorizer.init(fs.getConf());
     fs.updateWasbAuthorizer(authorizer);
   }
-
-  @Rule
-  public ExpectedException expectedEx = ExpectedException.none();
 
   /**
    * Setup up permissions to allow a recursive delete for cleanup purposes.
@@ -123,10 +120,9 @@ public class TestNativeAzureFileSystemAuthorization
   /**
    * Setup the expected exception class, and exception message that the test is supposed to fail with.
    */
-  protected void setExpectedFailureMessage(String operation, Path path) {
-    expectedEx.expect(WasbAuthorizationException.class);
-    expectedEx.expectMessage(String.format("%s operation for Path : %s not allowed",
-        operation, path.makeQualified(fs.getUri(), fs.getWorkingDirectory())));
+  protected String setExpectedFailureMessage(String operation, Path path) {
+    return String.format("%s operation for Path : %s not allowed",
+        operation, path.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
   }
 
   /**
@@ -198,19 +194,19 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/");
     Path testPath = new Path(parentDir, "test.dat");
 
-    setExpectedFailureMessage("create", testPath);
+    String errorMsg = setExpectedFailureMessage("create", testPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    fs.updateWasbAuthorizer(authorizer);
-
-    try {
-      fs.create(testPath);
-      ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
-      fs.create(testPath, true);
-    }
-    finally {
-      fs.delete(testPath, false);
-    }
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      fs.updateWasbAuthorizer(authorizer);
+      try {
+        fs.create(testPath);
+        ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
+        fs.create(testPath, true);
+      } finally {
+        fs.delete(testPath, false);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -249,19 +245,21 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/testCreateAccessCheckNegative");
     Path testPath = new Path(parentDir, "test.dat");
 
-    setExpectedFailureMessage("create", testPath);
+    String errorMsg = setExpectedFailureMessage("create", testPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, false);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, false);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      fs.create(testPath);
-    }
-    finally {
-      /* Provide permissions to cleanup in case the file got created */
-      allowRecursiveDelete(fs, parentDir.toString());
-      fs.delete(parentDir, true);
-    }
+      try {
+        fs.create(testPath);
+      }
+      finally {
+        /* Provide permissions to cleanup in case the file got created */
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -300,20 +298,19 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/testListAccessCheckNegative");
     Path testPath = new Path(parentDir, "test.dat");
 
-    setExpectedFailureMessage("liststatus", testPath);
-
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(testPath.toString(), READ, false);
-    fs.updateWasbAuthorizer(authorizer);
-
-    try {
-      fs.create(testPath);
-      fs.listStatus(testPath);
-    }
-    finally {
-      allowRecursiveDelete(fs, parentDir.toString());
-      fs.delete(parentDir, true);
-    }
+    String errorMsg = setExpectedFailureMessage("liststatus", testPath);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(testPath.toString(), READ, false);
+      fs.updateWasbAuthorizer(authorizer);
+      try {
+        fs.create(testPath);
+        fs.listStatus(testPath);
+      } finally {
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -356,24 +353,26 @@ public class TestNativeAzureFileSystemAuthorization
     Path srcPath = new Path(parentDir, "test1.dat");
     Path dstPath = new Path(parentDir, "test2.dat");
 
-    setExpectedFailureMessage("rename", srcPath);
+    String errorMsg = setExpectedFailureMessage("rename", srcPath);
 
-    /* to create parent dir */
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, false);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      /* to create parent dir */
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, false);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      fs.create(srcPath);
-      ContractTestUtils.assertPathExists(fs, "sourcePath does not exist", srcPath);
-      fs.rename(srcPath, dstPath);
-      ContractTestUtils.assertPathExists(fs, "destPath does not exist", dstPath);
-    } finally {
-      ContractTestUtils.assertPathExists(fs, "sourcePath does not exist after rename failure!", srcPath);
-
-      allowRecursiveDelete(fs, parentDir.toString());
-      fs.delete(parentDir, true);
-    }
+      try {
+        fs.create(srcPath);
+        ContractTestUtils.assertPathExists(fs, "sourcePath does not exist", srcPath);
+        fs.rename(srcPath, dstPath);
+        ContractTestUtils.assertPathExists(fs, "destPath does not exist", dstPath);
+      } finally {
+        ContractTestUtils.assertPathExists(fs,
+            "sourcePath does not exist after rename failure!", srcPath);
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -388,23 +387,26 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDstDir = new Path("/testRenameAccessCheckNegativeDst");
     Path dstPath = new Path(parentDstDir, "test2.dat");
 
-    setExpectedFailureMessage("rename", dstPath);
+    String errorMsg = setExpectedFailureMessage("rename", dstPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true); /* to create parent dir */
-    authorizer.addAuthRuleForOwner(parentSrcDir.toString(), WRITE, true);
-    authorizer.addAuthRuleForOwner(parentDstDir.toString(), WRITE, false);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true); /* to create parent dir */
+      authorizer.addAuthRuleForOwner(parentSrcDir.toString(), WRITE, true);
+      authorizer.addAuthRuleForOwner(parentDstDir.toString(), WRITE, false);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      touch(fs, srcPath);
-      ContractTestUtils.assertPathExists(fs, "sourcePath does not exist", srcPath);
-      fs.mkdirs(parentDstDir);
-      fs.rename(srcPath, dstPath);
-      ContractTestUtils.assertPathDoesNotExist(fs, "destPath does not exist", dstPath);
-    } finally {
-      ContractTestUtils.assertPathExists(fs, "sourcePath does not exist after rename !", srcPath);
-      recursiveDelete(parentSrcDir);
-    }
+      try {
+        touch(fs, srcPath);
+        ContractTestUtils.assertPathExists(fs, "sourcePath does not exist", srcPath);
+        fs.mkdirs(parentDstDir);
+        fs.rename(srcPath, dstPath);
+        ContractTestUtils.assertPathDoesNotExist(fs, "destPath does not exist", dstPath);
+      } finally {
+        ContractTestUtils.assertPathExists(fs,
+            "sourcePath does not exist after rename !", srcPath);
+        recursiveDelete(parentSrcDir);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -630,52 +632,53 @@ public class TestNativeAzureFileSystemAuthorization
     final Path parentDstDir = new Path("/testRenameWithStickyBitNegativeDst");
     final Path dstPath = new Path(parentDstDir, "test2.dat");
 
-    expectedEx.expect(WasbAuthorizationException.class);
-    expectedEx.expectMessage(String.format("Rename operation for %s is not permitted."
-      + " Details : Stickybit check failed.", srcPath.toString()));
+    String errorMsg = String.format("Rename operation for %s is not permitted."
+        + " Details : Stickybit check failed.", srcPath.toString());
 
-    /* to create parent dirs */
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(parentSrcDir.toString(),
-        WRITE, true);
-    /* Required for asserPathExists calls */
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      /* to create parent dirs */
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(parentSrcDir.toString(),
+          WRITE, true);
+      /* Required for asserPathExists calls */
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      touch(fs, srcPath);
-      assertPathExists(fs, "sourcePath does not exist", srcPath);
-      fs.mkdirs(parentDstDir);
-      assertIsDirectory(fs, parentDstDir);
-      // set stickybit on parent of source folder
-      fs.setPermission(parentSrcDir, new FsPermission(STICKYBIT_PERMISSION_CONSTANT));
+      try {
+        touch(fs, srcPath);
+        assertPathExists(fs, "sourcePath does not exist", srcPath);
+        fs.mkdirs(parentDstDir);
+        assertIsDirectory(fs, parentDstDir);
+        // set stickybit on parent of source folder
+        fs.setPermission(parentSrcDir, new FsPermission(STICKYBIT_PERMISSION_CONSTANT));
 
-      UserGroupInformation dummyUser = UserGroupInformation.createUserForTesting(
-          "dummyUser", new String[] {"dummygroup"});
+        UserGroupInformation dummyUser = UserGroupInformation.createUserForTesting(
+            "dummyUser", new String[] {"dummygroup"});
 
-      dummyUser.doAs(new PrivilegedExceptionAction<Void>() {
-        @Override
-        public Void run() throws Exception {
-          // Add auth rules for dummyuser
-          authorizer.addAuthRule(parentSrcDir.toString(),
-            WRITE, getCurrentUserShortName(), true);
-          authorizer.addAuthRule(parentDstDir.toString(),
-            WRITE, getCurrentUserShortName(), true);
+        dummyUser.doAs(new PrivilegedExceptionAction<Void>() {
+          @Override
+          public Void run() throws Exception {
+            // Add auth rules for dummyuser
+            authorizer.addAuthRule(parentSrcDir.toString(),
+                WRITE, getCurrentUserShortName(), true);
+            authorizer.addAuthRule(parentDstDir.toString(),
+                WRITE, getCurrentUserShortName(), true);
 
-          try {
-            fs.rename(srcPath, dstPath);
-          } catch (WasbAuthorizationException wae) {
-            assertPathExists(fs, "sourcePath does not exist", srcPath);
-            assertPathDoesNotExist(fs, "destPath exists", dstPath);
-            throw wae;
+            try {
+              fs.rename(srcPath, dstPath);
+            } catch (WasbAuthorizationException wae) {
+              assertPathExists(fs, "sourcePath does not exist", srcPath);
+              assertPathDoesNotExist(fs, "destPath exists", dstPath);
+              throw wae;
+            }
+
+            return null;
           }
-
-          return null;
-        }
-      });
-    } finally {
-      recursiveDelete(parentSrcDir);
-      recursiveDelete(parentDstDir);
-    }
+        });
+      } finally {
+        recursiveDelete(parentSrcDir);
+        recursiveDelete(parentDstDir);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -777,33 +780,35 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/testReadAccessCheckNegative");
     Path testPath = new Path(parentDir, "test.dat");
 
-    setExpectedFailureMessage("read", testPath);
+    String errorMsg = setExpectedFailureMessage("read", testPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(testPath.toString(), READ, false);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(testPath.toString(), READ, false);
+      fs.updateWasbAuthorizer(authorizer);
 
-    FSDataInputStream inputStream = null;
-    FSDataOutputStream fso = null;
+      FSDataInputStream inputStream = null;
+      FSDataOutputStream fso = null;
 
-    try {
-      fso = fs.create(testPath);
-      String data = "Hello World";
-      fso.writeBytes(data);
-      fso.close();
-
-      inputStream = fs.open(testPath);
-      ContractTestUtils.verifyRead(inputStream, data.getBytes(), 0, data.length());
-    } finally {
-      if (fso != null) {
+      try {
+        fso = fs.create(testPath);
+        String data = "Hello World";
+        fso.writeBytes(data);
         fso.close();
+
+        inputStream = fs.open(testPath);
+        ContractTestUtils.verifyRead(inputStream, data.getBytes(), 0, data.length());
+      } finally {
+        if (fso != null) {
+          fso.close();
+        }
+        if (inputStream != null) {
+          inputStream.close();
+        }
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
       }
-      if (inputStream != null) {
-        inputStream.close();
-      }
-      allowRecursiveDelete(fs, parentDir.toString());
-      fs.delete(parentDir, true);
-    }
+    }, errorMsg);
   }
 
   /**
@@ -838,31 +843,33 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/");
     Path testPath = new Path(parentDir, "test.dat");
 
-    setExpectedFailureMessage("delete", testPath);
+    String errorMsg = setExpectedFailureMessage("delete", testPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    fs.updateWasbAuthorizer(authorizer);
-    try {
-      fs.create(testPath);
-      ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
-
-
-      /* Remove permissions for delete to force failure */
-      authorizer.deleteAllAuthRules();
-      authorizer.addAuthRuleForOwner("/", WRITE, false);
-      fs.updateWasbAuthorizer(authorizer);
-
-      fs.delete(testPath, false);
-    }
-    finally {
-      /* Restore permissions to force a successful delete */
-      authorizer.deleteAllAuthRules();
+    assertThrows(WasbAuthorizationException.class, () -> {
       authorizer.addAuthRuleForOwner("/", WRITE, true);
       fs.updateWasbAuthorizer(authorizer);
+      try {
+        fs.create(testPath);
+        ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
 
-      fs.delete(testPath, false);
-      ContractTestUtils.assertPathDoesNotExist(fs, "testPath exists after deletion!", testPath);
-    }
+
+        /* Remove permissions for delete to force failure */
+        authorizer.deleteAllAuthRules();
+        authorizer.addAuthRuleForOwner("/", WRITE, false);
+        fs.updateWasbAuthorizer(authorizer);
+
+        fs.delete(testPath, false);
+      }
+      finally {
+        /* Restore permissions to force a successful delete */
+        authorizer.deleteAllAuthRules();
+        authorizer.addAuthRuleForOwner("/", WRITE, true);
+        fs.updateWasbAuthorizer(authorizer);
+
+        fs.delete(testPath, false);
+        ContractTestUtils.assertPathDoesNotExist(fs, "testPath exists after deletion!", testPath);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -982,43 +989,44 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/testSingleFileDeleteWithStickyBitNegative");
     Path testPath = new Path(parentDir, "test.dat");
 
-    expectedEx.expect(WasbAuthorizationException.class);
-    expectedEx.expectMessage(String.format("%s has sticky bit set. File %s cannot be deleted.",
-        parentDir.toString(), testPath.toString()));
+    String errorMsg = String.format("%s has sticky bit set. File %s cannot be deleted.",
+        parentDir.toString(), testPath.toString());
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, true);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, true);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      fs.create(testPath);
-      ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
-      // set stickybit on parent directory
-      fs.setPermission(parentDir, new FsPermission(STICKYBIT_PERMISSION_CONSTANT));
+      try {
+        fs.create(testPath);
+        ContractTestUtils.assertPathExists(fs, "testPath was not created", testPath);
+        // set stickybit on parent directory
+        fs.setPermission(parentDir, new FsPermission(STICKYBIT_PERMISSION_CONSTANT));
 
-      UserGroupInformation dummyUser = UserGroupInformation.createUserForTesting(
-          "dummyUser", new String[] {"dummygroup"});
+        UserGroupInformation dummyUser = UserGroupInformation.createUserForTesting(
+           "dummyUser", new String[] {"dummygroup"});
 
-      dummyUser.doAs(new PrivilegedExceptionAction<Void>() {
-        @Override
-        public Void run() throws Exception {
-          try {
-            authorizer.addAuthRule(parentDir.toString(), WRITE,
-                getCurrentUserShortName(), true);
-            fs.delete(testPath, true);
-            return null;
+        dummyUser.doAs(new PrivilegedExceptionAction<Void>() {
+          @Override
+          public Void run() throws Exception {
+            try {
+              authorizer.addAuthRule(parentDir.toString(), WRITE,
+                  getCurrentUserShortName(), true);
+              fs.delete(testPath, true);
+              return null;
+            }
+            catch (WasbAuthorizationException wae) {
+              ContractTestUtils.assertPathExists(fs, "testPath should not be deleted!", testPath);
+              throw wae;
+            }
           }
-          catch (WasbAuthorizationException wae) {
-            ContractTestUtils.assertPathExists(fs, "testPath should not be deleted!", testPath);
-            throw wae;
-          }
-        }
-      });
-    }
-    finally {
-      allowRecursiveDelete(fs, parentDir.toString());
-      fs.delete(parentDir, true);
-    }
+        });
+      }
+      finally {
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -1362,19 +1370,21 @@ public class TestNativeAzureFileSystemAuthorization
 
     Path testPath = new Path("/testMkdirsAccessCheckNegative/1/2/3");
 
-    setExpectedFailureMessage("mkdirs", testPath);
+    String errorMsg = setExpectedFailureMessage("mkdirs", testPath);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, false);
-    fs.updateWasbAuthorizer(authorizer);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, false);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try {
-      fs.mkdirs(testPath);
-      ContractTestUtils.assertPathDoesNotExist(fs, "testPath was not created", testPath);
-    }
-    finally {
-      allowRecursiveDelete(fs, "/testMkdirsAccessCheckNegative");
-      fs.delete(new Path("/testMkdirsAccessCheckNegative"), true);
-    }
+      try {
+        fs.mkdirs(testPath);
+        ContractTestUtils.assertPathDoesNotExist(fs, "testPath was not created", testPath);
+      }
+      finally {
+        allowRecursiveDelete(fs, "/testMkdirsAccessCheckNegative");
+        fs.delete(new Path("/testMkdirsAccessCheckNegative"), true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -1434,30 +1444,32 @@ public class TestNativeAzureFileSystemAuthorization
     Path parentDir = new Path("/testOwnerPermissionNegative");
     Path childDir = new Path(parentDir, "childDir");
 
-    setExpectedFailureMessage("mkdirs", childDir);
+    String errorMsg = setExpectedFailureMessage("mkdirs", childDir);
 
-    authorizer.addAuthRuleForOwner("/", WRITE, true);
-    authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, true);
+    assertThrows(WasbAuthorizationException.class, () -> {
+      authorizer.addAuthRuleForOwner("/", WRITE, true);
+      authorizer.addAuthRuleForOwner(parentDir.toString(), WRITE, true);
 
-    fs.updateWasbAuthorizer(authorizer);
+      fs.updateWasbAuthorizer(authorizer);
 
-    try{
-      fs.mkdirs(parentDir);
-      UserGroupInformation ugiSuperUser = UserGroupInformation.createUserForTesting(
-          "testuser", new String[] {});
+      try {
+        fs.mkdirs(parentDir);
+        UserGroupInformation ugiSuperUser = UserGroupInformation.createUserForTesting(
+            "testuser", new String[] {});
 
-      ugiSuperUser.doAs(new PrivilegedExceptionAction<Void>() {
-      @Override
-      public Void run() throws Exception {
-          fs.mkdirs(childDir);
-          return null;
-        }
-      });
+        ugiSuperUser.doAs(new PrivilegedExceptionAction<Void>() {
+          @Override
+          public Void run() throws Exception {
+            fs.mkdirs(childDir);
+            return null;
+          }
+        });
 
-    } finally {
-       allowRecursiveDelete(fs, parentDir.toString());
-       fs.delete(parentDir, true);
-    }
+      } finally {
+        allowRecursiveDelete(fs, parentDir.toString());
+        fs.delete(parentDir, true);
+      }
+    }, errorMsg);
   }
 
   /**
@@ -1533,8 +1545,8 @@ public class TestNativeAzureFileSystemAuthorization
       ContractTestUtils.assertPathExists(fs, "test path does not exist", testPath);
 
       String owner = fs.getFileStatus(testPath).getOwner();
-      Assume.assumeTrue("changing owner requires original and new owner to be different",
-        !StringUtils.equalsIgnoreCase(owner, newOwner));
+      assumeTrue(!StringUtils.equalsIgnoreCase(owner, newOwner),
+          "changing owner requires original and new owner to be different");
 
       authorisedUser.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
@@ -1576,8 +1588,8 @@ public class TestNativeAzureFileSystemAuthorization
       ContractTestUtils.assertPathExists(fs, "test path does not exist", testPath);
 
       String owner = fs.getFileStatus(testPath).getOwner();
-      Assume.assumeTrue("changing owner requires original and new owner to be different",
-        !StringUtils.equalsIgnoreCase(owner, newOwner));
+      assumeTrue(!StringUtils.equalsIgnoreCase(owner, newOwner),
+          "changing owner requires original and new owner to be different");
 
       user.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
@@ -1892,17 +1904,18 @@ public class TestNativeAzureFileSystemAuthorization
    */
   @Test
   public void testAccessFileDoesNotExist() throws Throwable{
-    expectedEx.expect(FileNotFoundException.class);
-    Configuration conf = fs.getConf();
-    fs.setConf(conf);
-    final Path testPath = new Path("/testAccessFileDoesNotExist");
+    assertThrows(FileNotFoundException.class, () -> {
+      Configuration conf = fs.getConf();
+      fs.setConf(conf);
+      final Path testPath = new Path("/testAccessFileDoesNotExist");
 
-    authorizer.init(conf);
-    authorizer.addAuthRuleForOwner(testPath.toString(), READ,  true);
-    authorizer.addAuthRuleForOwner(testPath.toString(), WRITE,  true);
-    fs.updateWasbAuthorizer(authorizer);
-    assertPathDoesNotExist(fs, "test path exists", testPath);
-    fs.access(testPath, FsAction.ALL);
+      authorizer.init(conf);
+      authorizer.addAuthRuleForOwner(testPath.toString(), READ, true);
+      authorizer.addAuthRuleForOwner(testPath.toString(), WRITE, true);
+      fs.updateWasbAuthorizer(authorizer);
+      assertPathDoesNotExist(fs, "test path exists", testPath);
+      fs.access(testPath, FsAction.ALL);
+    });
   }
 
   /**
@@ -1910,15 +1923,16 @@ public class TestNativeAzureFileSystemAuthorization
    */
   @Test
   public void testAccessFileDoesNotExistWhenNoAccessPermission() throws Throwable {
-    expectedEx.expect(FileNotFoundException.class);
-    Configuration conf = fs.getConf();
-    fs.setConf(conf);
-    final Path testPath = new Path("/testAccessFileDoesNotExistWhenNoAccessPermission");
+    assertThrows(FileNotFoundException.class, () -> {
+      Configuration conf = fs.getConf();
+      fs.setConf(conf);
+      final Path testPath = new Path("/testAccessFileDoesNotExistWhenNoAccessPermission");
 
-    authorizer.init(conf);
-    fs.updateWasbAuthorizer(authorizer);
-    assertPathDoesNotExist(fs, "test path exists", testPath);
-    fs.access(testPath, FsAction.ALL);
+      authorizer.init(conf);
+      fs.updateWasbAuthorizer(authorizer);
+      assertPathDoesNotExist(fs, "test path exists", testPath);
+      fs.access(testPath, FsAction.ALL);
+    });
   }
 
   /**
@@ -2074,8 +2088,8 @@ public class TestNativeAzureFileSystemAuthorization
   private void assertPermissionEquals(Path path, FsPermission newPermission)
       throws IOException {
     FileStatus status = fs.getFileStatus(path);
-    assertEquals(
-       newPermission, status.getPermission(), "Wrong permissions in " + status);
+    assertEquals(newPermission, status.getPermission(),
+        "Wrong permissions in " + status);
   }
 
   private void assertOwnerEquals(Path path, String owner) throws IOException {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.util.StringUtils;
 
 import org.junit.Assume;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.junit.rules.ExpectedException;
 import org.apache.hadoop.classification.VisibleForTesting;
@@ -50,7 +50,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import static org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.KEY_USE_SECURE_MODE;
 import static org.apache.hadoop.fs.azure.CachingAuthorizer.KEY_AUTH_SERVICE_CACHING_ENABLE;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class to hold all WASB authorization tests.
@@ -2074,13 +2074,13 @@ public class TestNativeAzureFileSystemAuthorization
   private void assertPermissionEquals(Path path, FsPermission newPermission)
       throws IOException {
     FileStatus status = fs.getFileStatus(path);
-    assertEquals("Wrong permissions in " + status,
-        newPermission, status.getPermission());
+    assertEquals(
+       newPermission, status.getPermission(), "Wrong permissions in " + status);
   }
 
   private void assertOwnerEquals(Path path, String owner) throws IOException {
     FileStatus status = fs.getFileStatus(path);
-    assertEquals("Wrong owner in " + status, owner, status.getOwner());
+    assertEquals(owner, status.getOwner(), "Wrong owner in " + status);
   }
 
   private void assertNoAccess(final Path path, final FsAction action)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemAuthorization.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.util.StringUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
@@ -89,8 +88,8 @@ public class TestNativeAzureFileSystemAuthorization
 
   @Override
   @BeforeEach
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     boolean useSecureMode = fs.getConf().getBoolean(KEY_USE_SECURE_MODE, false);
     boolean useAuthorization = fs.getConf().getBoolean(NativeAzureFileSystem.KEY_AZURE_AUTHORIZATION, false);
     assumeTrue((useSecureMode && useAuthorization),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -47,7 +47,7 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
 
   private AzureBlobStorageTestAccount testAccount = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     testAccount = createTestAccount();
@@ -88,8 +88,8 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
       dataOutputStream = (SyncableDataOutputStream) appendStream.getWrappedStream();
     }
 
-    Assert.assertNotNull("Did not recognize " + dataOutputStream,
-        dataOutputStream);
+    Assertions.assertNotNull(
+       dataOutputStream, "Did not recognize " + dataOutputStream);
 
     return (BlockBlobAppendStream) dataOutputStream.getOutStream();
   }
@@ -97,11 +97,11 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
   private void verifyBlockList(BlockBlobAppendStream blockBlobStream,
                                int[] testData) throws Throwable {
     List<BlockEntry> blockList = blockBlobStream.getBlockList();
-    Assert.assertEquals("Block list length", testData.length, blockList.size());
+    Assertions.assertEquals(testData.length, blockList.size(), "Block list length");
 
     int i = 0;
     for (BlockEntry block: blockList) {
-      Assert.assertTrue(block.getSize() == testData[i++]);
+      Assertions.assertTrue(block.getSize() == testData[i++]);
     }
   }
 
@@ -135,13 +135,13 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
       } else if (wrappedStream instanceof SyncableDataOutputStream) {
         dataOutputStream = (SyncableDataOutputStream) wrappedStream;
       } else {
-        Assert.fail("Unable to determine type of " + wrappedStream
+        Assertions.fail("Unable to determine type of " + wrappedStream
             + " class of " + wrappedStream.getClass());
       }
 
-      Assert.assertFalse("Data output stream is a BlockBlobAppendStream: "
-          + dataOutputStream,
-          dataOutputStream.getOutStream() instanceof BlockBlobAppendStream);
+      Assertions.assertFalse(
+         dataOutputStream.getOutStream() instanceof BlockBlobAppendStream, "Data output stream is a BlockBlobAppendStream: "
+          + dataOutputStream);
 
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -47,7 +47,7 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
   private AzureBlobStorageTestAccount testAccount = null;
 
   @BeforeEach
-  public void setUp( ) throws Exception {
+  public void setUp() throws Exception {
     super.setUp();
     testAccount = createTestAccount();
     fs = testAccount.getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -48,8 +47,8 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
   private AzureBlobStorageTestAccount testAccount = null;
 
   @BeforeEach
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp( ) throws Exception {
+    super.setUp();
     testAccount = createTestAccount();
     fs = testAccount.getFileSystem();
     Configuration conf = fs.getConf();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -48,8 +49,8 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
   private AzureBlobStorageTestAccount testAccount = null;
 
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     testAccount = createTestAccount();
     fs = testAccount.getFileSystem();
     Configuration conf = fs.getConf();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -89,7 +89,7 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
       dataOutputStream = (SyncableDataOutputStream) appendStream.getWrappedStream();
     }
 
-    Assertions.assertNotNull(
+    assertNotNull(
        dataOutputStream, "Did not recognize " + dataOutputStream);
 
     return (BlockBlobAppendStream) dataOutputStream.getOutStream();
@@ -98,11 +98,11 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
   private void verifyBlockList(BlockBlobAppendStream blockBlobStream,
                                int[] testData) throws Throwable {
     List<BlockEntry> blockList = blockBlobStream.getBlockList();
-    Assertions.assertEquals(testData.length, blockList.size(), "Block list length");
+    assertEquals(testData.length, blockList.size(), "Block list length");
 
     int i = 0;
     for (BlockEntry block: blockList) {
-      Assertions.assertTrue(block.getSize() == testData[i++]);
+      assertTrue(block.getSize() == testData[i++]);
     }
   }
 
@@ -136,12 +136,12 @@ public class TestNativeAzureFileSystemBlockCompaction extends AbstractWasbTestBa
       } else if (wrappedStream instanceof SyncableDataOutputStream) {
         dataOutputStream = (SyncableDataOutputStream) wrappedStream;
       } else {
-        Assertions.fail("Unable to determine type of " + wrappedStream
+        fail("Unable to determine type of " + wrappedStream
             + " class of " + wrappedStream.getClass());
       }
 
-      Assertions.assertFalse(
-         dataOutputStream.getOutStream() instanceof BlockBlobAppendStream, "Data output stream is a BlockBlobAppendStream: "
+      assertFalse(dataOutputStream.getOutStream() instanceof BlockBlobAppendStream,
+          "Data output stream is a BlockBlobAppendStream: "
           + dataOutputStream);
 
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemBlockCompaction.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
@@ -32,21 +32,20 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
   private InMemoryBlockBlobStore backingStore;
 
   @Override
   @BeforeEach
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     backingStore = getTestAccount().getMockStorage().getBackingStore();
   }
 
   @Override
-  public void tearDown(TestInfo testInfo) throws Exception {
-    super.tearDown(testInfo);
+  public void tearDown() throws Exception {
+    super.tearDown();
     backingStore = null;
   }
 
@@ -143,7 +142,7 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
    * operations against the same FS.
    */
   @Test
-  public void testMultiThreadedOperation(TestInfo info) throws Exception {
+  public void testMultiThreadedOperation() throws Exception {
     for (int iter = 0; iter < 10; iter++) {
       final int numThreads = 20;
       Thread[] threads = new Thread[numThreads];
@@ -174,8 +173,8 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
       }
       assertTrue(exceptionsEncountered.isEmpty(), "Encountered exceptions: "
           + StringUtils.join("\r\n", selectToString(exceptionsEncountered)));
-      tearDown(info);
-      setUp(info);
+      tearDown();
+      setUp();
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
@@ -30,20 +30,23 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
   private InMemoryBlockBlobStore backingStore;
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  @BeforeEach
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     backingStore = getTestAccount().getMockStorage().getBackingStore();
   }
 
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void tearDown(TestInfo testInfo) throws Exception {
+    super.tearDown(testInfo);
     backingStore = null;
   }
 
@@ -140,7 +143,7 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
    * operations against the same FS.
    */
   @Test
-  public void testMultiThreadedOperation() throws Exception {
+  public void testMultiThreadedOperation(TestInfo info) throws Exception {
     for (int iter = 0; iter < 10; iter++) {
       final int numThreads = 20;
       Thread[] threads = new Thread[numThreads];
@@ -169,12 +172,10 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
       for (Thread t : threads) {
         t.join();
       }
-      assertTrue(
-      
-         exceptionsEncountered.isEmpty(), "Encountered exceptions: "
-              + StringUtils.join("\r\n", selectToString(exceptionsEncountered)));
-      tearDown();
-      setUp();
+      assertTrue(exceptionsEncountered.isEmpty(), "Encountered exceptions: "
+          + StringUtils.join("\r\n", selectToString(exceptionsEncountered)));
+      tearDown(info);
+      setUp(info);
     }
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemConcurrency.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
   private InMemoryBlockBlobStore backingStore;
@@ -95,8 +95,8 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
     FSDataOutputStream outputStream = fs.create(filePath);
     // Make sure I can't see the temporary blob if I ask for a listing
     FileStatus[] listOfRoot = fs.listStatus(new Path("/"));
-    assertEquals("Expected one file listed, instead got: "
-        + toString(listOfRoot), 1, listOfRoot.length);
+    assertEquals(1, listOfRoot.length, "Expected one file listed, instead got: "
+        + toString(listOfRoot));
     assertEquals(fs.makeQualified(filePath), listOfRoot[0].getPath());
     outputStream.close();
   }
@@ -170,9 +170,9 @@ public class TestNativeAzureFileSystemConcurrency extends AbstractWasbTestBase {
         t.join();
       }
       assertTrue(
-          "Encountered exceptions: "
-              + StringUtils.join("\r\n", selectToString(exceptionsEncountered)),
-          exceptionsEncountered.isEmpty());
+      
+         exceptionsEncountered.isEmpty(), "Encountered exceptions: "
+              + StringUtils.join("\r\n", selectToString(exceptionsEncountered)));
       tearDown();
       setUp();
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemContractMocked.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemContractMocked.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.fs.azure;
 
 import org.apache.hadoop.fs.FileSystemContractBaseTest;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Mocked testing of FileSystemContractBaseTest.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 public class TestNativeAzureFileSystemContractMocked extends
     FileSystemContractBaseTest {
 
-  @BeforeEach
+  @Before
   public void setUp() throws Exception {
     fs = AzureBlobStorageTestAccount.createMock().getFileSystem();
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemContractMocked.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemContractMocked.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.fs.azure;
 
 import org.apache.hadoop.fs.FileSystemContractBaseTest;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Mocked testing of FileSystemContractBaseTest.
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class TestNativeAzureFileSystemContractMocked extends
     FileSystemContractBaseTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fs = AzureBlobStorageTestAccount.createMock().getFileSystem();
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.Path;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * Tests the scenario where a colon is included in the file/directory name.
@@ -39,8 +38,8 @@ public class TestNativeAzureFileSystemFileNameCheck extends AbstractWasbTestBase
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     root = fs.getUri().toString();
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
@@ -23,7 +23,9 @@ import java.util.HashMap;
 
 import org.apache.hadoop.fs.Path;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Tests the scenario where a colon is included in the file/directory name.
@@ -35,9 +37,10 @@ import org.junit.jupiter.api.Test;
 public class TestNativeAzureFileSystemFileNameCheck extends AbstractWasbTestBase {
   private String root = null;
 
+  @BeforeEach
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     root = fs.getUri().toString();
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemFileNameCheck.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the scenario where a colon is included in the file/directory name.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemMocked.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemMocked.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.fs.azure;
 
+import org.junit.jupiter.api.Disabled;
 import java.io.IOException;
-import org.junit.Ignore;
 
 /**
  * Run {@link NativeAzureFileSystemBaseTest} tests against a mocked store,
@@ -36,32 +36,32 @@ public class TestNativeAzureFileSystemMocked extends
   // Ignore the following tests because taking a lease requires a real
   // (not mock) file system store. These tests don't work on the mock.
   @Override
-  @Ignore
+  @Disabled
   public void testLeaseAsDistributedLock() {
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testSelfRenewingLease() {
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testRedoFolderRenameAll() {
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testCreateNonRecursive() {
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testSelfRenewingLeaseFileDelete() {
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testRenameRedoFolderAlreadyDone() throws IOException{
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 import org.apache.hadoop.fs.Path;
 
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the upload, buffering and flush logic in WASB.

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.Path;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * Tests for the upload, buffering and flush logic in WASB.
@@ -68,8 +67,8 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
   @Test
   @Disabled
   /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterSmallFlushes(TestInfo testInfo) throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.BeforeSingleBufferFull, testInfo);
+  public void testConsistencyAfterSmallFlushes() throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.BeforeSingleBufferFull);
   }
 
   /**
@@ -79,8 +78,8 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
   @Test
   @Disabled
   /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterMediumFlushes(TestInfo testInfo) throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterSingleBufferFull, testInfo);
+  public void testConsistencyAfterMediumFlushes() throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterSingleBufferFull);
   }
 
   /**
@@ -90,8 +89,8 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
   @Test
   @Disabled
   /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterLargeFlushes(TestInfo testInfo) throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterAllRingBufferFull, testInfo);
+  public void testConsistencyAfterLargeFlushes() throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterAllRingBufferFull);
   }
 
   /**
@@ -151,9 +150,9 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
    * with what I'd expect.
    * @param variation The variation/scenario to test.
    */
-  private void testConsistencyAfterManyFlushes(FlushFrequencyVariation variation,
-      TestInfo testInfo) throws Exception {
-    Path uploadedFile = methodPath(testInfo);
+  private void testConsistencyAfterManyFlushes(FlushFrequencyVariation variation)
+      throws Exception {
+    Path uploadedFile = methodPath();
     try {
       OutputStream outStream = getFileSystem().create(uploadedFile);
       final int totalSize = 9123;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestNativeAzureFileSystemUploadLogic.java
@@ -24,8 +24,9 @@ import java.io.OutputStream;
 
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Tests for the upload, buffering and flush logic in WASB.
@@ -65,9 +66,10 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
    * bit of data.
    */
   @Test
-  @Ignore /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterSmallFlushes() throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.BeforeSingleBufferFull);
+  @Disabled
+  /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
+  public void testConsistencyAfterSmallFlushes(TestInfo testInfo) throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.BeforeSingleBufferFull, testInfo);
   }
 
   /**
@@ -75,9 +77,10 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
    * bit of data.
    */
   @Test
-  @Ignore /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterMediumFlushes() throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterSingleBufferFull);
+  @Disabled
+  /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
+  public void testConsistencyAfterMediumFlushes(TestInfo testInfo) throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterSingleBufferFull, testInfo);
   }
 
   /**
@@ -85,9 +88,10 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
    * of data.
    */
   @Test
-  @Ignore /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
-  public void testConsistencyAfterLargeFlushes() throws Exception {
-    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterAllRingBufferFull);
+  @Disabled
+  /* flush() no longer does anything. @@TODO: implement a force-flush and reinstate this test */
+  public void testConsistencyAfterLargeFlushes(TestInfo testInfo) throws Exception {
+    testConsistencyAfterManyFlushes(FlushFrequencyVariation.AfterAllRingBufferFull, testInfo);
   }
 
   /**
@@ -147,9 +151,9 @@ public class TestNativeAzureFileSystemUploadLogic extends AbstractWasbTestBase {
    * with what I'd expect.
    * @param variation The variation/scenario to test.
    */
-  private void testConsistencyAfterManyFlushes(FlushFrequencyVariation variation)
-      throws Exception {
-    Path uploadedFile = methodPath();
+  private void testConsistencyAfterManyFlushes(FlushFrequencyVariation variation,
+      TestInfo testInfo) throws Exception {
+    Path uploadedFile = methodPath(testInfo);
     try {
       OutputStream outStream = getFileSystem().create(uploadedFile);
       final int totalSize = 9123;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestOutOfBandAzureBlobOperations.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestOutOfBandAzureBlobOperations.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that WASB handles things gracefully when users add blobs to the Azure
@@ -38,14 +38,14 @@ public class TestOutOfBandAzureBlobOperations
   private FileSystem fs;
   private InMemoryBlockBlobStore backingStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testAccount = AzureBlobStorageTestAccount.createMock();
     fs = testAccount.getFileSystem();
     backingStore = testAccount.getMockStorage().getBackingStore();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount.cleanup();
     fs = null;
@@ -115,7 +115,7 @@ public class TestOutOfBandAzureBlobOperations
       // Trying to delete root/b/c would cause a dilemma for WASB, so
       // it should throw.
       fs.delete(new Path("/root/b/c"), true);
-      assertTrue("Should've thrown.", false);
+      assertTrue(false, "Should've thrown.");
     } catch (AzureException e) {
       assertEquals("File /root/b/c has a parent directory /root/b"
           + " which is also a file. Can't resolve.", e.getMessage());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestShellDecryptionKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestShellDecryptionKeyProvider.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestShellDecryptionKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestShellDecryptionKeyProvider.java
@@ -25,8 +25,8 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +51,7 @@ public class TestShellDecryptionKeyProvider
     conf.set(SimpleKeyProvider.KEY_ACCOUNT_KEY_PREFIX + account, key);
     try {
       provider.getStorageAccountKey(account, conf);
-      Assert
-          .fail("fs.azure.shellkeyprovider.script is not specified, we should throw");
+      fail("fs.azure.shellkeyprovider.script is not specified, we should throw");
     } catch (KeyProviderException e) {
       LOG.info("Received an expected exception: " + e.getMessage());
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestSyncableDataOutputStream.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azure;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.test.LambdaTestUtils;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestWasbFsck.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestWasbFsck.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -67,7 +67,8 @@ public class TestWasbFsck extends AbstractWasbTestWithTimeout {
    * Tests that we recover files properly
    */
   @Test
-  @Ignore  /* flush() no longer does anything  @@TODO: reinstate an appropriate test of fsck recovery*/
+  @Disabled
+  /* flush() no longer does anything  @@TODO: reinstate an appropriate test of fsck recovery*/
   public void testRecover() throws Exception {
     Path danglingFile = new Path("/crashedInTheMiddle");
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestWasbFsck.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/TestWasbFsck.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests which look at fsck recovery.
@@ -36,14 +36,14 @@ public class TestWasbFsck extends AbstractWasbTestWithTimeout {
   private FileSystem fs;
   private InMemoryBlockBlobStore backingStore;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testAccount = AzureBlobStorageTestAccount.createMock();
     fs = testAccount.getFileSystem();
     backingStore = testAccount.getMockStorage().getBackingStore();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     testAccount.cleanup();
     fs = null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AbstractAzureScaleTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AbstractAzureScaleTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.azure.integration;
 
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,9 +45,10 @@ public abstract class AbstractAzureScaleTest
     return AzureTestConstants.SCALE_TEST_TIMEOUT_MILLIS;
   }
 
+  @BeforeEach
   @Override
-  public void setUp(TestInfo info) throws Exception {
-    super.setUp(info);
+  public void setUp() throws Exception {
+    super.setUp();
     LOG.debug("Scale test operation count = {}", getOperationCount());
     assumeScaleTestsEnabled(getConfiguration());
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AbstractAzureScaleTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AbstractAzureScaleTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.azure.integration;
 
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,20 +34,20 @@ import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.*;
  * tests if not.
  *
  */
+@Timeout(AzureTestConstants.SCALE_TEST_TIMEOUT_MILLIS)
 public abstract class AbstractAzureScaleTest
     extends AbstractWasbTestBase implements Sizes {
 
   protected static final Logger LOG =
       LoggerFactory.getLogger(AbstractAzureScaleTest.class);
 
-  @Override
   protected int getTestTimeoutMillis() {
     return AzureTestConstants.SCALE_TEST_TIMEOUT_MILLIS;
   }
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo info) throws Exception {
+    super.setUp(info);
     LOG.debug("Scale test operation count = {}", getOperationCount());
     assumeScaleTestsEnabled(getConfiguration());
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
@@ -26,7 +26,7 @@ import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
 import org.junit.internal.AssumptionViolatedException;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
  * Utilities for the Azure tests. Based on {@code S3ATestUtils}, so
  * (initially) has unused method.
  */
-public final class AzureTestUtils extends Assert {
+public final class AzureTestUtils extends Assertions {
   private static final Logger LOG = LoggerFactory.getLogger(
       AzureTestUtils.class);
 
@@ -343,10 +343,10 @@ public final class AzureTestUtils extends Assert {
    * @param expectedClass class
    * @param obj object to check
    */
-  public static void assertInstanceOf(Class<?> expectedClass, Object obj) {
-    Assert.assertTrue(String.format("Expected instance of class %s, but is %s.",
-        expectedClass, obj.getClass()),
-        expectedClass.isAssignableFrom(obj.getClass()));
+  public static void assertInstanceOf2(Class<?> expectedClass, Object obj) {
+    Assertions.assertTrue(
+       expectedClass.isAssignableFrom(obj.getClass()), String.format("Expected instance of class %s, but is %s.",
+        expectedClass, obj.getClass()));
   }
 
   /**
@@ -381,7 +381,7 @@ public final class AzureTestUtils extends Assert {
   public static void assertOptionEquals(Configuration conf,
       String key,
       String expected) {
-    assertEquals("Value of " + key, expected, conf.get(key));
+    assertEquals(expected, conf.get(key), "Value of " + key);
   }
 
   /**
@@ -445,7 +445,6 @@ public final class AzureTestUtils extends Assert {
    * field.
    * @param testAccount test account to clean up
    * @return null
-   * @throws Execption cleanup problems
    */
   public static AzureBlobStorageTestAccount cleanup(
       AzureBlobStorageTestAccount testAccount) throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX;
 import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_TEST_ACCOUNT_NAME_WITH_DOMAIN;
@@ -495,8 +495,9 @@ public final class AzureTestUtils extends Assertions {
     if (accountName == null) {
       accountName = conf.get(WASB_TEST_ACCOUNT_NAME_WITH_DOMAIN);
     }
-    assumeTrue("Account for WASB is missing or it is not in correct format",
-            accountName != null && !accountName.endsWith(WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX));
+    assumeTrue(accountName != null &&
+        !accountName.endsWith(WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX),
+        "Account for WASB is missing or it is not in correct format");
     return accountName;
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/AzureTestUtils.java
@@ -495,8 +495,7 @@ public final class AzureTestUtils extends Assertions {
     if (accountName == null) {
       accountName = conf.get(WASB_TEST_ACCOUNT_NAME_WITH_DOMAIN);
     }
-    assumeTrue(accountName != null &&
-        !accountName.endsWith(WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX),
+    assumeTrue(accountName != null && !accountName.endsWith(WASB_ACCOUNT_NAME_DOMAIN_SUFFIX_REGEX),
         "Account for WASB is missing or it is not in correct format");
     return accountName;
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
@@ -23,7 +23,7 @@ import java.util.EnumSet;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.azure.AbstractWasbTestBase;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.azure.AbstractWasbTestBase;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * This looks like a test, but it is really a command to invoke to
@@ -47,8 +48,8 @@ public class CleanupTestContainers extends AbstractWasbTestBase {
   }
 
   @Test
-  public void testEnumContainers() throws Throwable {
-    describe("Enumerating all the WASB test containers");
+  public void testEnumContainers(TestInfo testInfo) throws Throwable {
+    describe(testInfo, "Enumerating all the WASB test containers");
 
     int count = 0;
     CloudStorageAccount storageAccount = getTestAccount().getRealAccount();
@@ -65,8 +66,8 @@ public class CleanupTestContainers extends AbstractWasbTestBase {
   }
 
   @Test
-  public void testDeleteContainers() throws Throwable {
-    describe("Delete all the WASB test containers");
+  public void testDeleteContainers(TestInfo testInfo) throws Throwable {
+    describe(testInfo, "Delete all the WASB test containers");
     int count = 0;
     CloudStorageAccount storageAccount = getTestAccount().getRealAccount();
     CloudBlobClient blobClient = storageAccount.createCloudBlobClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/CleanupTestContainers.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.azure.AbstractWasbTestBase;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * This looks like a test, but it is really a command to invoke to
@@ -48,8 +47,8 @@ public class CleanupTestContainers extends AbstractWasbTestBase {
   }
 
   @Test
-  public void testEnumContainers(TestInfo testInfo) throws Throwable {
-    describe(testInfo, "Enumerating all the WASB test containers");
+  public void testEnumContainers() throws Throwable {
+    describe("Enumerating all the WASB test containers");
 
     int count = 0;
     CloudStorageAccount storageAccount = getTestAccount().getRealAccount();
@@ -66,8 +65,8 @@ public class CleanupTestContainers extends AbstractWasbTestBase {
   }
 
   @Test
-  public void testDeleteContainers(TestInfo testInfo) throws Throwable {
-    describe(testInfo, "Delete all the WASB test containers");
+  public void testDeleteContainers() throws Throwable {
+    describe("Delete all the WASB test containers");
     int count = 0;
     CloudStorageAccount storageAccount = getTestAccount().getRealAccount();
     CloudBlobClient blobClient = storageAccount.createCloudBlobClient();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -23,7 +23,11 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +186,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     // clean up from any previous attempts
     deleteHugeFile(testInfo);
 
-    describe(testInfo,"Creating file %s of size %d MB", hugefile, filesizeMB);
+    describe(testInfo, "Creating file %s of size %d MB", hugefile, filesizeMB);
 
     // now do a check of available upload time, with a pessimistic bandwidth
     // (that of remote upload tests). If the test times out then not only is

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -201,9 +201,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
         timeout, uploadTime, KEY_TEST_TIMEOUT, uploadTime * 2),
         uploadTime < timeout);
 */
-    assertEquals(
-       0, filesize % UPLOAD_BLOCKSIZE, "File size set in " + KEY_HUGE_FILESIZE + " = " + filesize
-            + " is not a multiple of " + UPLOAD_BLOCKSIZE);
+    assertEquals(0, filesize % UPLOAD_BLOCKSIZE,
+        "File size set in " + KEY_HUGE_FILESIZE + " = " + filesize
+        + " is not a multiple of " + UPLOAD_BLOCKSIZE);
 
     byte[] data = SOURCE_DATA;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -83,8 +83,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
 
   @BeforeEach
   @Override
-  public void setUp(TestInfo testInfo) throws Exception {
-    super.setUp(testInfo);
+  public void setUp() throws Exception {
+    super.setUp();
     testPath = path("ITestAzureHugeFiles");
     scaleTestDir = new Path(testPath, "scale");
     hugefile = new Path(scaleTestDir, "hugefile");
@@ -97,9 +97,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
    * @throws Exception
    */
   @Override
-  public void tearDown(TestInfo testInfo) throws Exception {
+  public void tearDown() throws Exception {
     testAccount = null;
-    super.tearDown(testInfo);
+    super.tearDown();
     if (testAccountForCleanup != null) {
       cleanupTestAccount(testAccount);
     }
@@ -123,8 +123,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     // the last test in the suite does the teardown
   }
 
-  protected void deleteHugeFile(TestInfo info) throws IOException {
-    describe(info, "Deleting %s", hugefile);
+  protected void deleteHugeFile() throws IOException {
+    describe("Deleting %s", hugefile);
     ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
     getFileSystem().delete(hugefile, false);
     timer.end("time to delete %s", hugefile);
@@ -184,9 +184,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     long filesizeMB = filesize / S_1M;
 
     // clean up from any previous attempts
-    deleteHugeFile(testInfo);
+    deleteHugeFile();
 
-    describe(testInfo, "Creating file %s of size %d MB", hugefile, filesizeMB);
+    describe("Creating file %s of size %d MB", hugefile, filesizeMB);
 
     // now do a check of available upload time, with a pessimistic bandwidth
     // (that of remote upload tests). If the test times out then not only is
@@ -260,9 +260,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_040_PositionedReadHugeFile(TestInfo testInfo) throws Throwable {
+  public void test_040_PositionedReadHugeFile() throws Throwable {
     assumeHugeFileExists();
-    describe(testInfo, "Positioned reads of file %s", hugefile);
+    describe("Positioned reads of file %s", hugefile);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -318,9 +318,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_050_readHugeFile(TestInfo testInfo) throws Throwable {
+  public void test_050_readHugeFile() throws Throwable {
     assumeHugeFileExists();
-    describe(testInfo, "Reading %s", hugefile);
+    describe("Reading %s", hugefile);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -344,10 +344,10 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_060_openAndReadWholeFileBlocks(TestInfo testInfo) throws Throwable {
+  public void test_060_openAndReadWholeFileBlocks() throws Throwable {
     FileStatus status = assumeHugeFileExists();
     int blockSize = S_1M;
-    describe(testInfo, "Open the test file and read it in blocks of size %d", blockSize);
+    describe("Open the test file and read it in blocks of size %d", blockSize);
     long len =  status.getLen();
     FSDataInputStream in = openDataFile();
     NanoTimer timer2 = null;
@@ -414,9 +414,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_100_renameHugeFile(TestInfo testInfo) throws Throwable {
+  public void test_100_renameHugeFile() throws Throwable {
     assumeHugeFileExists();
-    describe(testInfo, "renaming %s to %s", hugefile, hugefileRenamed);
+    describe("renaming %s to %s", hugefile, hugefileRenamed);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -442,10 +442,10 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_999_deleteHugeFiles(TestInfo testInfo) throws IOException {
+  public void test_999_deleteHugeFiles() throws IOException {
     // mark the test account for cleanup after this test
     testAccountForCleanup = testAccount;
-    deleteHugeFile(testInfo);
+    deleteHugeFile();
     ContractTestUtils.NanoTimer timer2 = new ContractTestUtils.NanoTimer();
     NativeAzureFileSystem fs = getFileSystem();
     fs.delete(hugefileRenamed, false);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -23,11 +23,10 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
-import org.junit.FixMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +42,7 @@ import org.apache.hadoop.io.IOUtils;
 
 import static org.apache.hadoop.fs.azure.integration.AzureTestUtils.*;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
 /**
@@ -60,7 +60,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
  * ordering.</b>
  */
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -81,8 +81,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   private Path testPath;
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setUp(TestInfo testInfo) throws Exception {
+    super.setUp(testInfo);
     testPath = path("ITestAzureHugeFiles");
     scaleTestDir = new Path(testPath, "scale");
     hugefile = new Path(scaleTestDir, "hugefile");
@@ -95,9 +95,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
    * @throws Exception
    */
   @Override
-  public void tearDown() throws Exception {
+  public void tearDown(TestInfo testInfo) throws Exception {
     testAccount = null;
-    super.tearDown();
+    super.tearDown(testInfo);
     if (testAccountForCleanup != null) {
       cleanupTestAccount(testAccount);
     }
@@ -121,8 +121,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     // the last test in the suite does the teardown
   }
 
-  protected void deleteHugeFile() throws IOException {
-    describe("Deleting %s", hugefile);
+  protected void deleteHugeFile(TestInfo info) throws IOException {
+    describe(info,"Deleting %s", hugefile);
     ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
     getFileSystem().delete(hugefile, false);
     timer.end("time to delete %s", hugefile);
@@ -151,8 +151,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     assertPathExists(getFileSystem(), "huge file not created", hugefile);
     try {
       FileStatus status = getFileSystem().getFileStatus(hugefile);
-      Assume.assumeTrue("Not a file: " + status, status.isFile());
-      Assume.assumeTrue("File " + hugefile + " is empty", status.getLen() > 0);
+      assumeTrue(status.isFile(), "Not a file: " + status);
+      assumeTrue(status.getLen() > 0, "File " + hugefile + " is empty");
       return status;
     } catch (FileNotFoundException e) {
       skip("huge file not created: " + hugefile);
@@ -175,16 +175,16 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_010_CreateHugeFile() throws IOException {
+  public void test_010_CreateHugeFile(TestInfo testInfo) throws IOException {
     long filesize = getTestPropertyBytes(getConfiguration(),
         KEY_HUGE_FILESIZE,
         DEFAULT_HUGE_FILESIZE);
     long filesizeMB = filesize / S_1M;
 
     // clean up from any previous attempts
-    deleteHugeFile();
+    deleteHugeFile(testInfo);
 
-    describe("Creating file %s of size %d MB", hugefile, filesizeMB);
+    describe(testInfo,"Creating file %s of size %d MB", hugefile, filesizeMB);
 
     // now do a check of available upload time, with a pessimistic bandwidth
     // (that of remote upload tests). If the test times out then not only is
@@ -258,9 +258,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_040_PositionedReadHugeFile() throws Throwable {
+  public void test_040_PositionedReadHugeFile(TestInfo testInfo) throws Throwable {
     assumeHugeFileExists();
-    describe("Positioned reads of file %s", hugefile);
+    describe(testInfo, "Positioned reads of file %s", hugefile);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -316,9 +316,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_050_readHugeFile() throws Throwable {
+  public void test_050_readHugeFile(TestInfo testInfo) throws Throwable {
     assumeHugeFileExists();
-    describe("Reading %s", hugefile);
+    describe(testInfo, "Reading %s", hugefile);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -342,11 +342,10 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_060_openAndReadWholeFileBlocks() throws Throwable {
+  public void test_060_openAndReadWholeFileBlocks(TestInfo testInfo) throws Throwable {
     FileStatus status = assumeHugeFileExists();
     int blockSize = S_1M;
-    describe("Open the test file and read it in blocks of size %d",
-        blockSize);
+    describe(testInfo, "Open the test file and read it in blocks of size %d", blockSize);
     long len =  status.getLen();
     FSDataInputStream in = openDataFile();
     NanoTimer timer2 = null;
@@ -398,7 +397,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
         if (bandwidthInBytes(blockTimer, blockSize) < minimumBandwidth) {
           LOG.warn("Bandwidth {} too low on block {}: resetting connection",
               bw, blockId);
-          Assertions.assertTrue(resetCount <= maxResetCount, "Bandwidth of " + bw + " too low after "
+          assertTrue(resetCount <= maxResetCount, "Bandwidth of " + bw + " too low after "
               + resetCount + " attempts");
           resetCount++;
           // reset the connection
@@ -413,9 +412,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_100_renameHugeFile() throws Throwable {
+  public void test_100_renameHugeFile(TestInfo testInfo) throws Throwable {
     assumeHugeFileExists();
-    describe("renaming %s to %s", hugefile, hugefileRenamed);
+    describe(testInfo, "renaming %s to %s", hugefile, hugefileRenamed);
     NativeAzureFileSystem fs = getFileSystem();
     FileStatus status = fs.getFileStatus(hugefile);
     long filesize = status.getLen();
@@ -441,10 +440,10 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_999_deleteHugeFiles() throws IOException {
+  public void test_999_deleteHugeFiles(TestInfo testInfo) throws IOException {
     // mark the test account for cleanup after this test
     testAccountForCleanup = testAccount;
-    deleteHugeFile();
+    deleteHugeFile(testInfo);
     ContractTestUtils.NanoTimer timer2 = new ContractTestUtils.NanoTimer();
     NativeAzureFileSystem fs = getFileSystem();
     fs.delete(hugefileRenamed, false);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -177,7 +177,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   @Test
-  public void test_010_CreateHugeFile(TestInfo testInfo) throws IOException {
+  public void test_010_CreateHugeFile() throws IOException {
     long filesize = getTestPropertyBytes(getConfiguration(),
         KEY_HUGE_FILESIZE,
         DEFAULT_HUGE_FILESIZE);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -122,7 +122,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
   }
 
   protected void deleteHugeFile(TestInfo info) throws IOException {
-    describe(info,"Deleting %s", hugefile);
+    describe(info, "Deleting %s", hugefile);
     ContractTestUtils.NanoTimer timer = new ContractTestUtils.NanoTimer();
     getFileSystem().delete(hugefile, false);
     timer.end("time to delete %s", hugefile);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -23,10 +23,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +77,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
 
   private Path testPath;
 
+  @BeforeEach
   @Override
   public void setUp(TestInfo testInfo) throws Exception {
     super.setUp(testInfo);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/integration/ITestAzureHugeFiles.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
 import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,9 +201,9 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
         timeout, uploadTime, KEY_TEST_TIMEOUT, uploadTime * 2),
         uploadTime < timeout);
 */
-    assertEquals("File size set in " + KEY_HUGE_FILESIZE + " = " + filesize
-            + " is not a multiple of " + UPLOAD_BLOCKSIZE,
-        0, filesize % UPLOAD_BLOCKSIZE);
+    assertEquals(
+       0, filesize % UPLOAD_BLOCKSIZE, "File size set in " + KEY_HUGE_FILESIZE + " = " + filesize
+            + " is not a multiple of " + UPLOAD_BLOCKSIZE);
 
     byte[] data = SOURCE_DATA;
 
@@ -254,7 +254,7 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
     ContractTestUtils.assertPathExists(fs, "Huge file", hugefile);
     FileStatus status = fs.getFileStatus(hugefile);
     ContractTestUtils.assertIsFile(hugefile, status);
-    assertEquals("File size in " + status, filesize, status.getLen());
+    assertEquals(filesize, status.getLen(), "File size in " + status);
   }
 
   @Test
@@ -398,8 +398,8 @@ public class ITestAzureHugeFiles extends AbstractAzureScaleTest {
         if (bandwidthInBytes(blockTimer, blockSize) < minimumBandwidth) {
           LOG.warn("Bandwidth {} too low on block {}: resetting connection",
               bw, blockId);
-          Assert.assertTrue("Bandwidth of " + bw + " too low after "
-              + resetCount + " attempts", resetCount <= maxResetCount);
+          Assertions.assertTrue(resetCount <= maxResetCount, "Bandwidth of " + bw + " too low after "
+              + resetCount + " attempts");
           resetCount++;
           // reset the connection
         }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsTag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,37 +155,37 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     base = assertWebResponsesInRange(base, 2, 15);
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long bytesWritten = AzureMetricsTestUtil.getCurrentBytesWritten(getInstrumentation());
-    assertTrue("The bytes written in the last second " + bytesWritten +
+    assertTrue(
+       bytesWritten > (FILE_SIZE / 2) && bytesWritten < (FILE_SIZE * 2), "The bytes written in the last second " + bytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.",
-        bytesWritten > (FILE_SIZE / 2) && bytesWritten < (FILE_SIZE * 2));
+        " bytes plus a little overhead.");
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
-    assertTrue("The total bytes written  " + totalBytesWritten +
+    assertTrue(
+       totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2), "The total bytes written  " + totalBytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.",
-        totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2));
+        " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
     LOG.info("Upload rate: " + uploadRate + " bytes/second.");
     long expectedRate = (FILE_SIZE * 1000L) / uploadDurationMs;
-    assertTrue("The upload rate " + uploadRate +
+    assertTrue(
+       uploadRate >= expectedRate, "The upload rate " + uploadRate +
         " is below the expected range of around " + expectedRate +
         " bytes/second that the unit test observed. This should never be" +
         " the case since the test underestimates the rate by looking at " +
-        " end-to-end time instead of just block upload time.",
-        uploadRate >= expectedRate);
+        " end-to-end time instead of just block upload time.");
     long uploadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: {}", uploadLatency);
     long expectedLatency = uploadDurationMs; // We're uploading less than a block.
-    assertTrue("The upload latency " + uploadLatency +
-        " should be greater than zero now that I've just uploaded a file.",
-        uploadLatency > 0);
-    assertTrue("The upload latency " + uploadLatency +
+    assertTrue(
+       uploadLatency > 0, "The upload latency " + uploadLatency +
+        " should be greater than zero now that I've just uploaded a file.");
+    assertTrue(
+       uploadLatency <= expectedLatency, "The upload latency " + uploadLatency +
         " is more than the expected range of around " + expectedLatency +
         " milliseconds that the unit test observed. This should never be" +
         " the case since the test overestimates the latency by looking at " +
-        " end-to-end time instead of just block upload time.",
-        uploadLatency <= expectedLatency);
+        " end-to-end time instead of just block upload time.");
 
     // Read the file
     start = new Date();
@@ -207,32 +207,32 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     long totalBytesRead = AzureMetricsTestUtil.getCurrentTotalBytesRead(getInstrumentation());
     assertEquals(FILE_SIZE, totalBytesRead);
     long bytesRead = AzureMetricsTestUtil.getCurrentBytesRead(getInstrumentation());
-    assertTrue("The bytes read in the last second " + bytesRead +
+    assertTrue(
+       bytesRead > (FILE_SIZE / 2) && bytesRead < (FILE_SIZE * 2), "The bytes read in the last second " + bytesRead +
         " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.",
-        bytesRead > (FILE_SIZE / 2) && bytesRead < (FILE_SIZE * 2));
+        " bytes plus a little overhead.");
     long downloadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_DOWNLOAD_RATE);
     LOG.info("Download rate: " + downloadRate + " bytes/second.");
     expectedRate = (FILE_SIZE * 1000L) / downloadDurationMs;
-    assertTrue("The download rate " + downloadRate +
+    assertTrue(
+       downloadRate >= expectedRate, "The download rate " + downloadRate +
         " is below the expected range of around " + expectedRate +
         " bytes/second that the unit test observed. This should never be" +
         " the case since the test underestimates the rate by looking at " +
-        " end-to-end time instead of just block download time.",
-        downloadRate >= expectedRate);
+        " end-to-end time instead of just block download time.");
     long downloadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
     expectedLatency = downloadDurationMs; // We're downloading less than a block.
-    assertTrue("The download latency " + downloadLatency +
-        " should be greater than zero now that I've just downloaded a file.",
-        downloadLatency > 0);
-    assertTrue("The download latency " + downloadLatency +
+    assertTrue(
+       downloadLatency > 0, "The download latency " + downloadLatency +
+        " should be greater than zero now that I've just downloaded a file.");
+    assertTrue(
+       downloadLatency <= expectedLatency, "The download latency " + downloadLatency +
         " is more than the expected range of around " + expectedLatency +
         " milliseconds that the unit test observed. This should never be" +
         " the case since the test overestimates the latency by looking at " +
-        " end-to-end time instead of just block download time.",
-        downloadLatency <= expectedLatency);
+        " end-to-end time instead of just block download time.");
 
     assertNoErrors();
   }
@@ -265,18 +265,18 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     base = assertWebResponsesInRange(base, 20, 50);
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
-    assertTrue("The total bytes written  " + totalBytesWritten +
+    assertTrue(
+       totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2), "The total bytes written  " + totalBytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.",
-        totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2));
+        " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
     LOG.info("Upload rate: " + uploadRate + " bytes/second.");
     long uploadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: " + uploadLatency);
-    assertTrue("The upload latency " + uploadLatency +
-        " should be greater than zero now that I've just uploaded a file.",
-        uploadLatency > 0);
+    assertTrue(
+       uploadLatency > 0, "The upload latency " + uploadLatency +
+        " should be greater than zero now that I've just uploaded a file.");
 
     // Read the file
     InputStream inputStream = getFileSystem().open(filePath);
@@ -300,9 +300,9 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     long downloadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
-    assertTrue("The download latency " + downloadLatency +
-        " should be greater than zero now that I've just downloaded a file.",
-        downloadLatency > 0);
+    assertTrue(
+       downloadLatency > 0, "The download latency " + downloadLatency +
+        " should be greater than zero now that I've just downloaded a file.");
   }
 
   @Test
@@ -418,10 +418,10 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
       try {
         outputStream.write(new byte[FILE_SIZE]);
         outputStream.close();
-        assertTrue("Should've thrown", false);
+        assertTrue(false, "Should've thrown");
       } catch (AzureException ex) {
-        assertTrue("Unexpected exception: " + ex,
-          ex.getMessage().contains("lease"));
+        assertTrue(
+         ex.getMessage().contains("lease"), "Unexpected exception: " + ex);
       }
       assertEquals(1, AzureMetricsTestUtil.getLongCounterValue(getInstrumentation(), WASB_CLIENT_ERRORS));
       assertEquals(0, AzureMetricsTestUtil.getLongCounterValue(getInstrumentation(), WASB_SERVER_ERRORS));
@@ -482,11 +482,11 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
       long inclusiveUpperLimit) {
     long currentResponses = getCurrentWebResponses();
     long justOperation = currentResponses - base;
-    assertTrue(String.format(
+    assertTrue(
+       justOperation >= inclusiveLowerLimit &&
+        justOperation <= inclusiveUpperLimit, String.format(
         "Web responses expected in range [%d, %d], but was %d.",
-        inclusiveLowerLimit, inclusiveUpperLimit, justOperation),
-        justOperation >= inclusiveLowerLimit &&
-        justOperation <= inclusiveUpperLimit);
+        inclusiveLowerLimit, inclusiveUpperLimit, justOperation));
     return currentResponses;
   }  
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
@@ -155,20 +155,19 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     base = assertWebResponsesInRange(base, 2, 15);
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long bytesWritten = AzureMetricsTestUtil.getCurrentBytesWritten(getInstrumentation());
-    assertTrue(
-       bytesWritten > (FILE_SIZE / 2) && bytesWritten < (FILE_SIZE * 2), "The bytes written in the last second " + bytesWritten +
+    assertTrue(bytesWritten > (FILE_SIZE / 2) && bytesWritten < (FILE_SIZE * 2),
+        "The bytes written in the last second " + bytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
         " bytes plus a little overhead.");
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
-    assertTrue(
-       totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2), "The total bytes written  " + totalBytesWritten +
+    assertTrue(totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2),
+        "The total bytes written  " + totalBytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
         " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
     LOG.info("Upload rate: " + uploadRate + " bytes/second.");
     long expectedRate = (FILE_SIZE * 1000L) / uploadDurationMs;
-    assertTrue(
-       uploadRate >= expectedRate, "The upload rate " + uploadRate +
+    assertTrue(uploadRate >= expectedRate, "The upload rate " + uploadRate +
         " is below the expected range of around " + expectedRate +
         " bytes/second that the unit test observed. This should never be" +
         " the case since the test underestimates the rate by looking at " +
@@ -177,11 +176,11 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: {}", uploadLatency);
     long expectedLatency = uploadDurationMs; // We're uploading less than a block.
-    assertTrue(
-       uploadLatency > 0, "The upload latency " + uploadLatency +
+    assertTrue(uploadLatency > 0,
+        "The upload latency " + uploadLatency +
         " should be greater than zero now that I've just uploaded a file.");
-    assertTrue(
-       uploadLatency <= expectedLatency, "The upload latency " + uploadLatency +
+    assertTrue(uploadLatency <= expectedLatency,
+        "The upload latency " + uploadLatency +
         " is more than the expected range of around " + expectedLatency +
         " milliseconds that the unit test observed. This should never be" +
         " the case since the test overestimates the latency by looking at " +
@@ -207,15 +206,15 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     long totalBytesRead = AzureMetricsTestUtil.getCurrentTotalBytesRead(getInstrumentation());
     assertEquals(FILE_SIZE, totalBytesRead);
     long bytesRead = AzureMetricsTestUtil.getCurrentBytesRead(getInstrumentation());
-    assertTrue(
-       bytesRead > (FILE_SIZE / 2) && bytesRead < (FILE_SIZE * 2), "The bytes read in the last second " + bytesRead +
+    assertTrue(bytesRead > (FILE_SIZE / 2) && bytesRead < (FILE_SIZE * 2),
+        "The bytes read in the last second " + bytesRead +
         " is pretty far from the expected range of around " + FILE_SIZE +
         " bytes plus a little overhead.");
     long downloadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_DOWNLOAD_RATE);
     LOG.info("Download rate: " + downloadRate + " bytes/second.");
     expectedRate = (FILE_SIZE * 1000L) / downloadDurationMs;
-    assertTrue(
-       downloadRate >= expectedRate, "The download rate " + downloadRate +
+    assertTrue(downloadRate >= expectedRate,
+        "The download rate " + downloadRate +
         " is below the expected range of around " + expectedRate +
         " bytes/second that the unit test observed. This should never be" +
         " the case since the test underestimates the rate by looking at " +
@@ -224,11 +223,11 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
     expectedLatency = downloadDurationMs; // We're downloading less than a block.
-    assertTrue(
-       downloadLatency > 0, "The download latency " + downloadLatency +
+    assertTrue(downloadLatency > 0,
+        "The download latency " + downloadLatency +
         " should be greater than zero now that I've just downloaded a file.");
-    assertTrue(
-       downloadLatency <= expectedLatency, "The download latency " + downloadLatency +
+    assertTrue(downloadLatency <= expectedLatency,
+        "The download latency " + downloadLatency +
         " is more than the expected range of around " + expectedLatency +
         " milliseconds that the unit test observed. This should never be" +
         " the case since the test overestimates the latency by looking at " +
@@ -265,8 +264,8 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     base = assertWebResponsesInRange(base, 20, 50);
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
-    assertTrue(
-       totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2), "The total bytes written  " + totalBytesWritten +
+    assertTrue(totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2),
+        "The total bytes written  " + totalBytesWritten +
         " is pretty far from the expected range of around " + FILE_SIZE +
         " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
@@ -274,8 +273,8 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     long uploadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: " + uploadLatency);
-    assertTrue(
-       uploadLatency > 0, "The upload latency " + uploadLatency +
+    assertTrue(uploadLatency > 0,
+        "The upload latency " + uploadLatency +
         " should be greater than zero now that I've just uploaded a file.");
 
     // Read the file
@@ -300,8 +299,8 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     long downloadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
-    assertTrue(
-       downloadLatency > 0, "The download latency " + downloadLatency +
+    assertTrue(downloadLatency > 0,
+        "The download latency " + downloadLatency +
         " should be greater than zero now that I've just downloaded a file.");
   }
 
@@ -482,8 +481,7 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
       long inclusiveUpperLimit) {
     long currentResponses = getCurrentWebResponses();
     long justOperation = currentResponses - base;
-    assertTrue(
-       justOperation >= inclusiveLowerLimit &&
+    assertTrue(justOperation >= inclusiveLowerLimit &&
         justOperation <= inclusiveUpperLimit, String.format(
         "Web responses expected in range [%d, %d], but was %d.",
         inclusiveLowerLimit, inclusiveUpperLimit, justOperation));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/ITestAzureFileSystemInstrumentation.java
@@ -156,35 +156,35 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long bytesWritten = AzureMetricsTestUtil.getCurrentBytesWritten(getInstrumentation());
     assertTrue(bytesWritten > (FILE_SIZE / 2) && bytesWritten < (FILE_SIZE * 2),
-        "The bytes written in the last second " + bytesWritten +
-        " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.");
+        "The bytes written in the last second " + bytesWritten
+        + " is pretty far from the expected range of around " + FILE_SIZE
+        + " bytes plus a little overhead.");
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
     assertTrue(totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2),
-        "The total bytes written  " + totalBytesWritten +
-        " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.");
+        "The total bytes written  " + totalBytesWritten
+         + " is pretty far from the expected range of around " + FILE_SIZE
+         + " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
     LOG.info("Upload rate: " + uploadRate + " bytes/second.");
     long expectedRate = (FILE_SIZE * 1000L) / uploadDurationMs;
-    assertTrue(uploadRate >= expectedRate, "The upload rate " + uploadRate +
-        " is below the expected range of around " + expectedRate +
-        " bytes/second that the unit test observed. This should never be" +
-        " the case since the test underestimates the rate by looking at " +
-        " end-to-end time instead of just block upload time.");
+    assertTrue(uploadRate >= expectedRate, "The upload rate " + uploadRate
+        + " is below the expected range of around " + expectedRate
+        + " bytes/second that the unit test observed. This should never be"
+        + " the case since the test underestimates the rate by looking at "
+        + " end-to-end time instead of just block upload time.");
     long uploadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: {}", uploadLatency);
     long expectedLatency = uploadDurationMs; // We're uploading less than a block.
     assertTrue(uploadLatency > 0,
-        "The upload latency " + uploadLatency +
-        " should be greater than zero now that I've just uploaded a file.");
+        "The upload latency " + uploadLatency
+        + " should be greater than zero now that I've just uploaded a file.");
     assertTrue(uploadLatency <= expectedLatency,
-        "The upload latency " + uploadLatency +
-        " is more than the expected range of around " + expectedLatency +
-        " milliseconds that the unit test observed. This should never be" +
-        " the case since the test overestimates the latency by looking at " +
-        " end-to-end time instead of just block upload time.");
+        "The upload latency " + uploadLatency
+        + " is more than the expected range of around " + expectedLatency
+        + " milliseconds that the unit test observed. This should never be"
+        + " the case since the test overestimates the latency by looking at "
+        + " end-to-end time instead of just block upload time.");
 
     // Read the file
     start = new Date();
@@ -207,31 +207,31 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     assertEquals(FILE_SIZE, totalBytesRead);
     long bytesRead = AzureMetricsTestUtil.getCurrentBytesRead(getInstrumentation());
     assertTrue(bytesRead > (FILE_SIZE / 2) && bytesRead < (FILE_SIZE * 2),
-        "The bytes read in the last second " + bytesRead +
-        " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.");
+        "The bytes read in the last second " + bytesRead
+        + " is pretty far from the expected range of around " + FILE_SIZE
+        + " bytes plus a little overhead.");
     long downloadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_DOWNLOAD_RATE);
     LOG.info("Download rate: " + downloadRate + " bytes/second.");
     expectedRate = (FILE_SIZE * 1000L) / downloadDurationMs;
     assertTrue(downloadRate >= expectedRate,
-        "The download rate " + downloadRate +
-        " is below the expected range of around " + expectedRate +
-        " bytes/second that the unit test observed. This should never be" +
-        " the case since the test underestimates the rate by looking at " +
-        " end-to-end time instead of just block download time.");
+        "The download rate " + downloadRate
+        + " is below the expected range of around " + expectedRate
+        + " bytes/second that the unit test observed. This should never be"
+        + " the case since the test underestimates the rate by looking at "
+        + " end-to-end time instead of just block download time.");
     long downloadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
     expectedLatency = downloadDurationMs; // We're downloading less than a block.
     assertTrue(downloadLatency > 0,
-        "The download latency " + downloadLatency +
-        " should be greater than zero now that I've just downloaded a file.");
+        "The download latency " + downloadLatency
+         + " should be greater than zero now that I've just downloaded a file.");
     assertTrue(downloadLatency <= expectedLatency,
-        "The download latency " + downloadLatency +
-        " is more than the expected range of around " + expectedLatency +
-        " milliseconds that the unit test observed. This should never be" +
-        " the case since the test overestimates the latency by looking at " +
-        " end-to-end time instead of just block download time.");
+        "The download latency " + downloadLatency
+         + " is more than the expected range of around " + expectedLatency
+         + " milliseconds that the unit test observed. This should never be"
+         + " the case since the test overestimates the latency by looking at "
+         + " end-to-end time instead of just block download time.");
 
     assertNoErrors();
   }
@@ -265,17 +265,17 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
     getBandwidthGaugeUpdater().triggerUpdate(true);
     long totalBytesWritten = AzureMetricsTestUtil.getCurrentTotalBytesWritten(getInstrumentation());
     assertTrue(totalBytesWritten >= FILE_SIZE && totalBytesWritten < (FILE_SIZE * 2),
-        "The total bytes written  " + totalBytesWritten +
-        " is pretty far from the expected range of around " + FILE_SIZE +
-        " bytes plus a little overhead.");
+        "The total bytes written  " + totalBytesWritten
+        + " is pretty far from the expected range of around " + FILE_SIZE
+        + " bytes plus a little overhead.");
     long uploadRate = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(), WASB_UPLOAD_RATE);
     LOG.info("Upload rate: " + uploadRate + " bytes/second.");
     long uploadLatency = AzureMetricsTestUtil.getLongGaugeValue(getInstrumentation(),
         WASB_UPLOAD_LATENCY);
     LOG.info("Upload latency: " + uploadLatency);
     assertTrue(uploadLatency > 0,
-        "The upload latency " + uploadLatency +
-        " should be greater than zero now that I've just uploaded a file.");
+        "The upload latency " + uploadLatency
+         + " should be greater than zero now that I've just uploaded a file.");
 
     // Read the file
     InputStream inputStream = getFileSystem().open(filePath);
@@ -300,8 +300,8 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
         WASB_DOWNLOAD_LATENCY);
     LOG.info("Download latency: " + downloadLatency);
     assertTrue(downloadLatency > 0,
-        "The download latency " + downloadLatency +
-        " should be greater than zero now that I've just downloaded a file.");
+        "The download latency " + downloadLatency
+        + " should be greater than zero now that I've just downloaded a file.");
   }
 
   @Test
@@ -481,9 +481,8 @@ public class ITestAzureFileSystemInstrumentation extends AbstractWasbTestBase {
       long inclusiveUpperLimit) {
     long currentResponses = getCurrentWebResponses();
     long justOperation = currentResponses - base;
-    assertTrue(justOperation >= inclusiveLowerLimit &&
-        justOperation <= inclusiveUpperLimit, String.format(
-        "Web responses expected in range [%d, %d], but was %d.",
+    assertTrue(justOperation >= inclusiveLowerLimit && justOperation <= inclusiveUpperLimit,
+        String.format("Web responses expected in range [%d, %d], but was %d.",
         inclusiveLowerLimit, inclusiveUpperLimit, justOperation));
     return currentResponses;
   }  

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestBandwidthGaugeUpdater.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestBandwidthGaugeUpdater.java
@@ -18,13 +18,13 @@
 
 package org.apache.hadoop.fs.azure.metrics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBandwidthGaugeUpdater {
   @Test
@@ -43,9 +43,9 @@ public class TestBandwidthGaugeUpdater {
     updater.triggerUpdate(true);
     long currentBytes = AzureMetricsTestUtil.getCurrentBytesWritten(instrumentation);
     assertTrue(
-        "We expect around (200/10 = 20) bytes written as the gauge value." +
-        "Got " + currentBytes,
-        currentBytes > 18 && currentBytes < 22);
+    
+       currentBytes > 18 && currentBytes < 22, "We expect around (200/10 = 20) bytes written as the gauge value." +
+        "Got " + currentBytes);
     updater.close();
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestBandwidthGaugeUpdater.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestBandwidthGaugeUpdater.java
@@ -42,9 +42,8 @@ public class TestBandwidthGaugeUpdater {
         new Date(), 200);
     updater.triggerUpdate(true);
     long currentBytes = AzureMetricsTestUtil.getCurrentBytesWritten(instrumentation);
-    assertTrue(
-    
-       currentBytes > 18 && currentBytes < 22, "We expect around (200/10 = 20) bytes written as the gauge value." +
+    assertTrue(currentBytes > 18 && currentBytes < 22,
+        "We expect around (200/10 = 20) bytes written as the gauge value." +
         "Got " + currentBytes);
     updater.close();
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestNativeAzureFileSystemMetricsSystem.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestNativeAzureFileSystemMetricsSystem.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.azure.metrics;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;
@@ -73,8 +73,8 @@ public class TestNativeAzureFileSystemMetricsSystem {
    */
   private void assertFilesCreated(AzureBlobStorageTestAccount account,
       String name, int expected) {
-    assertEquals("Files created in account " + name,
-        expected, getFilesCreated(account));
+    assertEquals(
+       expected, getFilesCreated(account), "Files created in account " + name);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestNativeAzureFileSystemMetricsSystem.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestNativeAzureFileSystemMetricsSystem.java
@@ -18,12 +18,13 @@
 
 package org.apache.hadoop.fs.azure.metrics;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount;
 import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that the WASB-specific metrics system is working correctly.
@@ -73,8 +74,8 @@ public class TestNativeAzureFileSystemMetricsSystem {
    */
   private void assertFilesCreated(AzureBlobStorageTestAccount account,
       String name, int expected) {
-    assertEquals(
-       expected, getFilesCreated(account), "Files created in account " + name);
+    assertEquals(expected, getFilesCreated(account),
+        "Files created in account " + name);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestRollingWindowAverage.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azure/metrics/TestRollingWindowAverage.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.fs.azure.metrics;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestRollingWindowAverage {
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19425. Upgrade JUnit from 4 to 5 in hadoop-azure Part1.

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

