### PR TITLE
YARN-11768. add timeout config for container-launch.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -1362,6 +1362,11 @@ public class YarnConfiguration extends Configuration {
   public static final String NM_CONTAINER_EXECUTOR =
     NM_PREFIX + "container-executor.class";
 
+  /** launch container shell exec time out period.*/
+  public static final String NM_CONTAINER_LAUNCH_TIMEOUT_MS =
+    NM_PREFIX + "container-launch.shell.timeout-ms";
+  public static final long DEFAULT_NM_CONTAINER_LAUNCH_TIMEOUT_MS = 2 * 60 * 1000;
+
   /** List of container state transition listeners.*/
   public static final String NM_CONTAINER_STATE_TRANSITION_LISTENERS =
       NM_PREFIX + "container-state-transition-listener.classes";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/DefaultContainerExecutor.java
@@ -429,12 +429,14 @@ public class DefaultContainerExecutor extends ContainerExecutor {
       command = concatStringCommands(numaCommands, command);
     }
 
-    LOG.info("launchContainer: {}", Arrays.toString(command));
+    long timeout = getConf().getLong(YarnConfiguration.NM_CONTAINER_LAUNCH_TIMEOUT_MS, 
+        YarnConfiguration.DEFAULT_NM_CONTAINER_LAUNCH_TIMEOUT_MS);
+    LOG.info("launchContainer: " + Arrays.toString(command) + ", timeout: " + timeout + " ms");
     return new ShellCommandExecutor(
         command,
         workDir,
         environment,
-        0L,
+        timeout,
         false);
   }
 


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/YARN-11768

To prevent yarn-nodemanager from blocked forever(see [YARN-10272](https://issues.apache.org/jira/browse/YARN-10272)), add a timeout parameter  “yarn.nodemanager.container-launch.shell.timeout-ms”


