### PR TITLE
HDFS-17719. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs-httpfs Part1.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -210,6 +210,26 @@
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -1195,8 +1195,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         "Storage policy returned from the DFS and HttpFS should be equals");
     // unset policy
     httpfs.unsetStoragePolicy(path);
-     assertEquals(defaultdfsPolicy, httpfs.getStoragePolicy(path),
-         "After unset storage policy, the get API shoudld return the default policy");
+    assertEquals(defaultdfsPolicy, httpfs.getStoragePolicy(path),
+        "After unset storage policy, the get API shoudld return the default policy");
     fs.close();
   }
 
@@ -1435,9 +1435,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           "Should have exactly one snapshot.");
       String resultingSnapName = snapshotItems[0].getPath().getName();
       if (snapshotName == null) {
-        assertTrue(
-           Pattern.matches("(s)(\\d{8})(-)(\\d{6})(\\.)(\\d{3})",
-                resultingSnapName), "Snapshot auto generated name not matching pattern");
+        assertTrue(Pattern.matches("(s)(\\d{8})(-)(\\d{6})(\\.)(\\d{3})",
+            resultingSnapName), "Snapshot auto generated name not matching pattern");
       } else {
         assertTrue(snapshotName.equals(resultingSnapName),
             "Snapshot name is not same as passed name.");

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -251,7 +251,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     try {
       testCreate(path, false);
       fail("the create should have failed because the file exists " +
-                  "and override is FALSE");
+          "and override is FALSE");
     } catch (IOException ex) {
       System.out.println("#");
     } catch (Exception ex) {
@@ -311,8 +311,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
   private void assertPathCapabilityForTruncate(Path file) throws Exception {
     FileSystem fs = this.getHttpFSFileSystem();
-    assertTrue(
-       fs.hasPathCapability(file, CommonPathCapabilities.FS_TRUNCATE), "HttpFS/WebHdfs/SWebHdfs support truncate");
+    assertTrue(fs.hasPathCapability(file, CommonPathCapabilities.FS_TRUNCATE),
+        "HttpFS/WebHdfs/SWebHdfs support truncate");
     fs.close();
   }
 
@@ -482,18 +482,18 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertFalse(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be disallowed by default");
+      assertFalse(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot should be disallowed by default");
       // Allow snapshot
       distributedFs.allowSnapshot(path);
       // Check FileStatus
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot enabled bit is not set in FileStatus");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot enabled bit is not set in FileStatus");
       // Disallow snapshot
       distributedFs.disallowSnapshot(path);
       // Check FileStatus
-      assertFalse(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot enabled bit is not cleared in FileStatus");
+      assertFalse(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot enabled bit is not cleared in FileStatus");
       // Cleanup
       fs.delete(path, true);
       fs.close();
@@ -1174,9 +1174,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     Path path = new Path(getProxiedFSTestDir(), "policy.txt");
     FileSystem httpfs = getHttpFSFileSystem();
     // test getAllStoragePolicies
-    assertArrayEquals(
-    
-       fs.getAllStoragePolicies().toArray(), httpfs.getAllStoragePolicies().toArray(), "Policy array returned from the DFS and HttpFS should be equals");
+    assertArrayEquals(fs.getAllStoragePolicies().toArray(),
+        httpfs.getAllStoragePolicies().toArray(),
+        "Policy array returned from the DFS and HttpFS should be equals");
 
     // test get/set/unset policies
     DFSTestUtil.createFile(fs, path, 0, (short) 1, 0L);
@@ -1191,14 +1191,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     assertEquals(HdfsConstants.COLD_STORAGE_POLICY_NAME.toString(),
         httpFsPolicy.getName(), "Storage policy returned from the get API should" +
         " be same as set policy");
-    assertEquals(
-    
-       httpFsPolicy, dfsPolicy, "Storage policy returned from the DFS and HttpFS should be equals");
+    assertEquals(httpFsPolicy, dfsPolicy,
+        "Storage policy returned from the DFS and HttpFS should be equals");
     // unset policy
     httpfs.unsetStoragePolicy(path);
-     assertEquals(
-           defaultdfsPolicy, httpfs.getStoragePolicy(path), "After unset storage policy, the get API shoudld"
-            + " return the default policy");
+     assertEquals(defaultdfsPolicy, httpfs.getStoragePolicy(path),
+         "After unset storage policy, the get API shoudld return the default policy");
     fs.close();
   }
 
@@ -1433,16 +1431,16 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       }
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue(
-         snapshotItems.length == 1, "Should have exactly one snapshot.");
+      assertTrue(snapshotItems.length == 1,
+          "Should have exactly one snapshot.");
       String resultingSnapName = snapshotItems[0].getPath().getName();
       if (snapshotName == null) {
         assertTrue(
            Pattern.matches("(s)(\\d{8})(-)(\\d{6})(\\.)(\\d{3})",
                 resultingSnapName), "Snapshot auto generated name not matching pattern");
       } else {
-        assertTrue(
-           snapshotName.equals(resultingSnapName), "Snapshot name is not same as passed name.");
+        assertTrue(snapshotName.equals(resultingSnapName),
+            "Snapshot name is not same as passed name.");
       }
       cleanSnapshotTests(snapshottablePath, resultingSnapName);
     }
@@ -1492,11 +1490,11 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           "snap-new-name");
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue(
-         snapshotItems.length == 1, "Should have exactly one snapshot.");
+      assertTrue(snapshotItems.length == 1,
+          "Should have exactly one snapshot.");
       String resultingSnapName = snapshotItems[0].getPath().getName();
-      assertTrue(
-         "snap-new-name".equals(resultingSnapName), "Snapshot name is not same as passed name.");
+      assertTrue("snap-new-name".equals(resultingSnapName),
+          "Snapshot name is not same as passed name.");
       cleanSnapshotTests(snapshottablePath, resultingSnapName);
     }
   }
@@ -1510,12 +1508,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.createSnapshot(snapshottablePath, "snap-to-delete");
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue(
-         snapshotItems.length == 1, "Should have exactly one snapshot.");
+      assertTrue(snapshotItems.length == 1,
+          "Should have exactly one snapshot.");
       fs.deleteSnapshot(snapshottablePath, "snap-to-delete");
       snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue(
-         snapshotItems.length == 0, "There should be no snapshot anymore.");
+      assertTrue(snapshotItems.length == 0,
+          "There should be no snapshot anymore.");
       fs.delete(snapshottablePath, true);
     }
   }
@@ -1528,8 +1526,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertFalse(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be disallowed by default");
+      assertFalse(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot should be disallowed by default");
       // Allow snapshot
       if (fs instanceof HttpFSFileSystem) {
         HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
@@ -1542,8 +1540,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
             " doesn't support allowSnapshot");
       }
       // Check FileStatus
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "allowSnapshot failed");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "allowSnapshot failed");
       // Cleanup
       fs.delete(path, true);
     }
@@ -1557,8 +1555,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot should be allowed by DFS");
       // Disallow snapshot
       if (fs instanceof HttpFSFileSystem) {
         HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
@@ -1571,8 +1569,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
             " doesn't support disallowSnapshot");
       }
       // Check FileStatus
-      assertFalse(
-         fs.getFileStatus(path).isSnapshotEnabled(), "disallowSnapshot failed");
+      assertFalse(fs.getFileStatus(path).isSnapshotEnabled(),
+          "disallowSnapshot failed");
       // Cleanup
       fs.delete(path, true);
     }
@@ -1586,8 +1584,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot should be allowed by DFS");
       // Create some snapshots
       fs.createSnapshot(path, "snap-01");
       fs.createSnapshot(path, "snap-02");
@@ -1619,8 +1617,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       }
       // Check FileStatus, should still be enabled since
       // disallow snapshot should fail
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "disallowSnapshot should not have succeeded");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "disallowSnapshot should not have succeeded");
       // Cleanup
       fs.deleteSnapshot(path, "snap-02");
       fs.deleteSnapshot(path, "snap-01");
@@ -1707,8 +1705,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue(
-         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled(),
+          "Snapshot should be allowed by DFS");
       assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Get snapshot diff
       testGetSnapshotDiffIllegalParamCase(fs, path, "", "");
@@ -1870,8 +1868,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       sds = webHdfsFileSystem.getServerDefaults();
     } else {
-      fail(
-          fs.getClass().getSimpleName() + " doesn't support getServerDefaults");
+      fail(fs.getClass().getSimpleName() + " doesn't support getServerDefaults");
     }
     // Verify result with DFS
     FsServerDefaults dfssds = dfs.getServerDefaults();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -81,9 +81,9 @@ import org.apache.hadoop.util.Lists;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ContainerFactory;
 import org.json.simple.parser.JSONParser;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.eclipse.jetty.server.Server;
@@ -107,11 +107,11 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(value = Parameterized.class)
 public abstract class BaseTestHttpFSWith extends HFSTestCase {
@@ -251,12 +251,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     testCreate(path, true);
     try {
       testCreate(path, false);
-      Assert.fail("the create should have failed because the file exists " +
+      Assertions.fail("the create should have failed because the file exists " +
                   "and override is FALSE");
     } catch (IOException ex) {
       System.out.println("#");
     } catch (Exception ex) {
-      Assert.fail(ex.toString());
+      Assertions.fail(ex.toString());
     }
   }
 
@@ -299,7 +299,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       final int newLength = blockSize;
 
       boolean isReady = fs.truncate(file, newLength);
-      assertTrue("Recovery is not expected.", isReady);
+      assertTrue(isReady, "Recovery is not expected.");
 
       FileStatus fileStatus = fs.getFileStatus(file);
       assertEquals(fileStatus.getLen(), newLength);
@@ -312,8 +312,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
   private void assertPathCapabilityForTruncate(Path file) throws Exception {
     FileSystem fs = this.getHttpFSFileSystem();
-    assertTrue("HttpFS/WebHdfs/SWebHdfs support truncate",
-        fs.hasPathCapability(file, CommonPathCapabilities.FS_TRUNCATE));
+    assertTrue(
+       fs.hasPathCapability(file, CommonPathCapabilities.FS_TRUNCATE), "HttpFS/WebHdfs/SWebHdfs support truncate");
     fs.close();
   }
 
@@ -371,10 +371,10 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     assertFalse(fs.exists(foo));
     try {
       hoopFs.delete(new Path(bar.toUri().getPath()), false);
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
     assertTrue(fs.exists(bar));
     assertTrue(hoopFs.delete(new Path(bar.toUri().getPath()), true));
@@ -467,10 +467,10 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
     // The full path should be the path to the file. See HDFS-12139
     FileStatus[] statl = fs.listStatus(path);
-    Assert.assertEquals(1, statl.length);
-    Assert.assertEquals(status2.getPath(), statl[0].getPath());
-    Assert.assertEquals(statl[0].getPath().getName(), path.getName());
-    Assert.assertEquals(stati[0].getPath(), statl[0].getPath());
+    Assertions.assertEquals(1, statl.length);
+    Assertions.assertEquals(status2.getPath(), statl[0].getPath());
+    Assertions.assertEquals(statl[0].getPath().getName(), path.getName());
+    Assertions.assertEquals(stati[0].getPath(), statl[0].getPath());
   }
 
   private void testFileStatusAttr() throws Exception {
@@ -483,18 +483,18 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertFalse("Snapshot should be disallowed by default",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertFalse(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be disallowed by default");
       // Allow snapshot
       distributedFs.allowSnapshot(path);
       // Check FileStatus
-      assertTrue("Snapshot enabled bit is not set in FileStatus",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot enabled bit is not set in FileStatus");
       // Disallow snapshot
       distributedFs.disallowSnapshot(path);
       // Check FileStatus
-      assertFalse("Snapshot enabled bit is not cleared in FileStatus",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertFalse(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot enabled bit is not cleared in FileStatus");
       // Cleanup
       fs.delete(path, true);
       fs.close();
@@ -555,13 +555,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     RemoteIterator<FileStatus> si = proxyFs.listStatusIterator(dir1);
     FileStatus statusl = si.next();
     FileStatus status = proxyFs.getFileStatus(file1);
-    Assert.assertEquals(file1.getName(), statusl.getPath().getName());
-    Assert.assertEquals(status.getPath(), statusl.getPath());
+    Assertions.assertEquals(file1.getName(), statusl.getPath().getName());
+    Assertions.assertEquals(status.getPath(), statusl.getPath());
 
     si = proxyFs.listStatusIterator(file1);
     statusl = si.next();
-    Assert.assertEquals(file1.getName(), statusl.getPath().getName());
-    Assert.assertEquals(status.getPath(), statusl.getPath());
+    Assertions.assertEquals(file1.getName(), statusl.getPath().getName());
+    Assertions.assertEquals(status.getPath(), statusl.getPath());
   }
 
   private void testWorkingdirectory() throws Exception {
@@ -845,7 +845,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.setXAttr(path, name4, value4);
       try {
         fs.setXAttr(path, name5, value1);
-        Assert.fail("Set xAttr with incorrect name format should fail.");
+        Assertions.fail("Set xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -910,7 +910,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       final String name5 = "a1";
       try {
         value = fs.getXAttr(path, name5);
-        Assert.fail("Get xAttr with incorrect name format should fail.");
+        Assertions.fail("Get xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -961,7 +961,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.removeXAttr(path, name4);
       try {
         fs.removeXAttr(path, name5);
-        Assert.fail("Remove xAttr with incorrect name format should fail.");
+        Assertions.fail("Remove xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -1175,9 +1175,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     Path path = new Path(getProxiedFSTestDir(), "policy.txt");
     FileSystem httpfs = getHttpFSFileSystem();
     // test getAllStoragePolicies
-    Assert.assertArrayEquals(
-        "Policy array returned from the DFS and HttpFS should be equals",
-        fs.getAllStoragePolicies().toArray(), httpfs.getAllStoragePolicies().toArray());
+    Assertions.assertArrayEquals(
+    
+       fs.getAllStoragePolicies().toArray(), httpfs.getAllStoragePolicies().toArray(), "Policy array returned from the DFS and HttpFS should be equals");
 
     // test get/set/unset policies
     DFSTestUtil.createFile(fs, path, 0, (short) 1, 0L);
@@ -1189,22 +1189,19 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     BlockStoragePolicySpi dfsPolicy = fs.getStoragePolicy(path);
     // get policy from webhdfs
     BlockStoragePolicySpi httpFsPolicy = httpfs.getStoragePolicy(path);
-    Assert
-       .assertEquals(
-            "Storage policy returned from the get API should"
+    assertEquals(
+        "Storage policy returned from the get API should"
             + " be same as set policy",
             HdfsConstants.COLD_STORAGE_POLICY_NAME.toString(),
             httpFsPolicy.getName());
-    Assert.assertEquals(
-        "Storage policy returned from the DFS and HttpFS should be equals",
-        httpFsPolicy, dfsPolicy);
+    Assertions.assertEquals(
+    
+       httpFsPolicy, dfsPolicy, "Storage policy returned from the DFS and HttpFS should be equals");
     // unset policy
     httpfs.unsetStoragePolicy(path);
-    Assert
-       .assertEquals(
-            "After unset storage policy, the get API shoudld"
-            + " return the default policy",
-            defaultdfsPolicy, httpfs.getStoragePolicy(path));
+     assertEquals(
+           defaultdfsPolicy, httpfs.getStoragePolicy(path), "After unset storage policy, the get API shoudld"
+            + " return the default policy");
     fs.close();
   }
 
@@ -1436,16 +1433,16 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       }
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue("Should have exactly one snapshot.",
-          snapshotItems.length == 1);
+      assertTrue(
+         snapshotItems.length == 1, "Should have exactly one snapshot.");
       String resultingSnapName = snapshotItems[0].getPath().getName();
       if (snapshotName == null) {
-        assertTrue("Snapshot auto generated name not matching pattern",
-            Pattern.matches("(s)(\\d{8})(-)(\\d{6})(\\.)(\\d{3})",
-                resultingSnapName));
+        assertTrue(
+           Pattern.matches("(s)(\\d{8})(-)(\\d{6})(\\.)(\\d{3})",
+                resultingSnapName), "Snapshot auto generated name not matching pattern");
       } else {
-        assertTrue("Snapshot name is not same as passed name.",
-            snapshotName.equals(resultingSnapName));
+        assertTrue(
+           snapshotName.equals(resultingSnapName), "Snapshot name is not same as passed name.");
       }
       cleanSnapshotTests(snapshottablePath, resultingSnapName);
     }
@@ -1495,11 +1492,11 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           "snap-new-name");
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue("Should have exactly one snapshot.",
-          snapshotItems.length == 1);
+      assertTrue(
+         snapshotItems.length == 1, "Should have exactly one snapshot.");
       String resultingSnapName = snapshotItems[0].getPath().getName();
-      assertTrue("Snapshot name is not same as passed name.",
-          "snap-new-name".equals(resultingSnapName));
+      assertTrue(
+         "snap-new-name".equals(resultingSnapName), "Snapshot name is not same as passed name.");
       cleanSnapshotTests(snapshottablePath, resultingSnapName);
     }
   }
@@ -1513,12 +1510,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.createSnapshot(snapshottablePath, "snap-to-delete");
       Path snapshotsDir = new Path("/tmp/tmp-snap-test/.snapshot");
       FileStatus[] snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue("Should have exactly one snapshot.",
-          snapshotItems.length == 1);
+      assertTrue(
+         snapshotItems.length == 1, "Should have exactly one snapshot.");
       fs.deleteSnapshot(snapshottablePath, "snap-to-delete");
       snapshotItems = fs.listStatus(snapshotsDir);
-      assertTrue("There should be no snapshot anymore.",
-          snapshotItems.length == 0);
+      assertTrue(
+         snapshotItems.length == 0, "There should be no snapshot anymore.");
       fs.delete(snapshottablePath, true);
     }
   }
@@ -1531,8 +1528,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertFalse("Snapshot should be disallowed by default",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertFalse(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be disallowed by default");
       // Allow snapshot
       if (fs instanceof HttpFSFileSystem) {
         HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
@@ -1541,12 +1538,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.allowSnapshot(path);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " doesn't support allowSnapshot");
       }
       // Check FileStatus
-      assertTrue("allowSnapshot failed",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "allowSnapshot failed");
       // Cleanup
       fs.delete(path, true);
     }
@@ -1560,8 +1557,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue("Snapshot should be allowed by DFS",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
       // Disallow snapshot
       if (fs instanceof HttpFSFileSystem) {
         HttpFSFileSystem httpFS = (HttpFSFileSystem) fs;
@@ -1570,12 +1567,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.disallowSnapshot(path);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " doesn't support disallowSnapshot");
       }
       // Check FileStatus
-      assertFalse("disallowSnapshot failed",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertFalse(
+         fs.getFileStatus(path).isSnapshotEnabled(), "disallowSnapshot failed");
       // Cleanup
       fs.delete(path, true);
     }
@@ -1589,8 +1586,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue("Snapshot should be allowed by DFS",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
       // Create some snapshots
       fs.createSnapshot(path, "snap-01");
       fs.createSnapshot(path, "snap-02");
@@ -1613,17 +1610,17 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           // Expect SnapshotException
         }
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " doesn't support disallowSnapshot");
       }
       if (disallowSuccess) {
-        Assert.fail("disallowSnapshot doesn't throw SnapshotException when "
+        Assertions.fail("disallowSnapshot doesn't throw SnapshotException when "
             + "disallowing snapshot on a directory with at least one snapshot");
       }
       // Check FileStatus, should still be enabled since
       // disallow snapshot should fail
-      assertTrue("disallowSnapshot should not have succeeded",
-          fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "disallowSnapshot should not have succeeded");
       // Cleanup
       fs.deleteSnapshot(path, "snap-02");
       fs.deleteSnapshot(path, "snap-01");
@@ -1639,7 +1636,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assert.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -1659,13 +1656,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
           diffReport = webHdfsFileSystem.getSnapshotDiffReport(path, "snap1", "snap2");
         } else {
-          Assert.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
+          Assertions.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
         }
         // Verify result with DFS
         DistributedFileSystem dfs =
             (DistributedFileSystem) FileSystem.get(path.toUri(), this.getProxiedFSConf());
         SnapshotDiffReport dfsDiffReport = dfs.getSnapshotDiffReport(path, "snap1", "snap2");
-        Assert.assertEquals(diffReport.toString(), dfsDiffReport.toString());
+        Assertions.assertEquals(diffReport.toString(), dfsDiffReport.toString());
       } finally {
         // Cleanup
         fs.deleteSnapshot(path, "snap2");
@@ -1686,7 +1683,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         webHdfsFileSystem.getSnapshotDiffReport(path, oldsnapshotname,
             snapshotname);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " doesn't support getSnapshotDiff");
       }
     } catch (SnapshotException|IllegalArgumentException|RemoteException e) {
@@ -1694,12 +1691,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // or RemoteException(IllegalArgumentException)
       if (e instanceof RemoteException) {
         // Check RemoteException class name, should be IllegalArgumentException
-        Assert.assertEquals(((RemoteException) e).getClassName()
+        Assertions.assertEquals(((RemoteException) e).getClassName()
             .compareTo(java.lang.IllegalArgumentException.class.getName()), 0);
       }
       return;
     }
-    Assert.fail("getSnapshotDiff illegal param didn't throw Exception");
+    Assertions.fail("getSnapshotDiff illegal param didn't throw Exception");
   }
 
   private void testGetSnapshotDiffIllegalParam() throws Exception {
@@ -1710,9 +1707,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      assertTrue("Snapshot should be allowed by DFS",
-          fs.getFileStatus(path).isSnapshotEnabled());
-      Assert.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(
+         fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
+      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Get snapshot diff
       testGetSnapshotDiffIllegalParamCase(fs, path, "", "");
       testGetSnapshotDiffIllegalParamCase(fs, path, "snap1", "");
@@ -1734,12 +1731,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       sds = webHdfsFileSystem.getSnapshottableDirectoryList();
     } else {
-      Assert.fail(fs.getClass().getSimpleName() +
+      Assertions.fail(fs.getClass().getSimpleName() +
           " doesn't support getSnapshottableDirListing");
     }
     // Verify result with DFS
     SnapshottableDirectoryStatus[] dfssds = dfs.getSnapshottableDirListing();
-    Assert.assertEquals(JsonUtil.toJsonString(sds),
+    Assertions.assertEquals(JsonUtil.toJsonString(sds),
         JsonUtil.toJsonString(dfssds));
   }
 
@@ -1751,7 +1748,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assert.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -1769,7 +1766,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         snapshotStatus = webHdfsFileSystem.getSnapshotListing(path);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " doesn't support getSnapshotDiff");
       }
       // Verify result with DFS
@@ -1777,7 +1774,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           FileSystem.get(path.toUri(), this.getProxiedFSConf());
       SnapshotStatus[] dfsStatus =
           dfs.getSnapshotListing(path);
-      Assert.assertEquals(JsonUtil.toJsonString(snapshotStatus),
+      Assertions.assertEquals(JsonUtil.toJsonString(snapshotStatus),
           JsonUtil.toJsonString(dfsStatus));
       // Cleanup
       fs.deleteSnapshot(path, "snap2");
@@ -1797,12 +1794,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Verify response when there is no snapshottable directory
       verifyGetSnapshottableDirListing(fs, dfs);
       createSnapshotTestsPreconditions(path1);
-      Assert.assertTrue(fs.getFileStatus(path1).isSnapshotEnabled());
+      Assertions.assertTrue(fs.getFileStatus(path1).isSnapshotEnabled());
       // Verify response when there is one snapshottable directory
       verifyGetSnapshottableDirListing(fs, dfs);
       Path path2 = new Path("/tmp/tmp-snap-dirlist-test-2");
       createSnapshotTestsPreconditions(path2);
-      Assert.assertTrue(fs.getFileStatus(path2).isSnapshotEnabled());
+      Assertions.assertTrue(fs.getFileStatus(path2).isSnapshotEnabled());
       // Verify response when there are two snapshottable directories
       verifyGetSnapshottableDirListing(fs, dfs);
 
@@ -1829,7 +1826,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     FileSystem httpfs = getHttpFSFileSystem(conf);
     if (!(httpfs instanceof WebHdfsFileSystem)
         && !(httpfs instanceof HttpFSFileSystem)) {
-      Assert.fail(httpfs.getClass().getSimpleName() +
+      Assertions.fail(httpfs.getClass().getSimpleName() +
           " doesn't support custom user and group name pattern. "
           + "Only WebHdfsFileSystem and HttpFSFileSystem support it.");
     }
@@ -1857,8 +1854,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     for (AclEntry aclEntry : httpfsAclStat.getEntries()) {
       strEntries.add(aclEntry.toStringStable());
     }
-    Assert.assertTrue(strEntries.contains(aclUser));
-    Assert.assertTrue(strEntries.contains(aclGroup));
+    Assertions.assertTrue(strEntries.contains(aclUser));
+    Assertions.assertTrue(strEntries.contains(aclGroup));
     // Clean up
     proxyFs.delete(new Path(dir), true);
   }
@@ -1873,12 +1870,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       sds = webHdfsFileSystem.getServerDefaults();
     } else {
-      Assert.fail(
+      Assertions.fail(
           fs.getClass().getSimpleName() + " doesn't support getServerDefaults");
     }
     // Verify result with DFS
     FsServerDefaults dfssds = dfs.getServerDefaults();
-    Assert.assertEquals(JsonUtil.toJsonString(sds),
+    Assertions.assertEquals(JsonUtil.toJsonString(sds),
         JsonUtil.toJsonString(dfssds));
   }
 
@@ -1916,7 +1913,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       webHdfsFileSystem.access(p1, FsAction.READ);
     } else {
-      Assert.fail(fs.getClass().getSimpleName() + " doesn't support access");
+      Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
     }
   }
 
@@ -1942,7 +1939,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertEquals(ecPolicy, ecPolicy1);
         httpFS.unsetErasureCodingPolicy(p1);
         ecPolicy1 = httpFS.getErasureCodingPolicy(p1);
-        Assert.assertNull(ecPolicy1);
+        Assertions.assertNull(ecPolicy1);
       } else if (fs instanceof WebHdfsFileSystem) {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.setErasureCodingPolicy(p1, ecPolicyName);
@@ -1951,9 +1948,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertEquals(ecPolicy, ecPolicy1);
         webHdfsFileSystem.unsetErasureCodingPolicy(p1);
         ecPolicy1 = dfs.getErasureCodingPolicy(p1);
-        Assert.assertNull(ecPolicy1);
+        Assertions.assertNull(ecPolicy1);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
     }
   }
@@ -1988,7 +1985,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertTrue(xAttrs
             .containsKey(HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY));
       } else {
-        Assert.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
       dfs.delete(path1, true);
     }
@@ -2020,7 +2017,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         blockLocations = webHdfsFileSystem.getFileBlockLocations(testFile, 0, 1);
         assertNotNull(blockLocations);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
     }
   }
@@ -2033,7 +2030,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assert.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -2056,7 +2053,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
               .getSnapshotDiffReportListing(path.toUri().getPath(), "snap1", "snap2", emptyBytes,
                   -1);
         } else {
-          Assert.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
+          Assertions.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
         }
         // Verify result with DFS
         DistributedFileSystem dfs =
@@ -2117,7 +2114,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       httpFs.close();
       dfs.close();
     } else {
-      Assert.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
@@ -2144,7 +2141,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) httpFs;
         diffErasureCodingPolicies = webHdfsFileSystem.getAllErasureCodingPolicies();
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " is not of type HttpFSFileSystem or WebHdfsFileSystem");
       }
 
@@ -2152,7 +2149,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       assertEquals(dfsAllErasureCodingPolicies.size(), diffErasureCodingPolicies.size());
       assertTrue(dfsAllErasureCodingPolicies.containsAll(diffErasureCodingPolicies));
     } else {
-      Assert.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
@@ -2194,13 +2191,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     Map<String, String> diffErasureCodingCodecs = diffErasureCodingCodecsRef.get();
 
     //Validate testGetECCodecs are the same as DistributedFileSystem
-    Assert.assertEquals(dfsErasureCodingCodecs.size(), diffErasureCodingCodecs.size());
+    Assertions.assertEquals(dfsErasureCodingCodecs.size(), diffErasureCodingCodecs.size());
 
     for (Map.Entry<String, String> entry : dfsErasureCodingCodecs.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
-      Assert.assertTrue(diffErasureCodingCodecs.containsKey(key));
-      Assert.assertEquals(value, diffErasureCodingCodecs.get(key));
+      Assertions.assertTrue(diffErasureCodingCodecs.containsKey(key));
+      Assertions.assertEquals(value, diffErasureCodingCodecs.get(key));
     }
   }
 
@@ -2232,38 +2229,38 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) httpFs;
         diffTrashRoots = webHdfsFileSystem.getTrashRoots(true);
       } else {
-        Assert.fail(fs.getClass().getSimpleName() +
+        Assertions.fail(fs.getClass().getSimpleName() +
             " is not of type HttpFSFileSystem or WebHdfsFileSystem");
       }
 
       // Validate getTrashRoots are the same as DistributedFileSystem
       assertEquals(dfsTrashRoots.size(), diffTrashRoots.size());
     } else {
-      Assert.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
   private void assertHttpFsReportListingWithDfsClient(SnapshotDiffReportListing diffReportListing,
       SnapshotDiffReportListing dfsDiffReportListing) {
-    Assert.assertEquals(diffReportListing.getCreateList().size(),
+    Assertions.assertEquals(diffReportListing.getCreateList().size(),
         dfsDiffReportListing.getCreateList().size());
-    Assert.assertEquals(diffReportListing.getDeleteList().size(),
+    Assertions.assertEquals(diffReportListing.getDeleteList().size(),
         dfsDiffReportListing.getDeleteList().size());
-    Assert.assertEquals(diffReportListing.getModifyList().size(),
+    Assertions.assertEquals(diffReportListing.getModifyList().size(),
         dfsDiffReportListing.getModifyList().size());
-    Assert.assertEquals(diffReportListing.getIsFromEarlier(),
+    Assertions.assertEquals(diffReportListing.getIsFromEarlier(),
         dfsDiffReportListing.getIsFromEarlier());
-    Assert.assertEquals(diffReportListing.getLastIndex(), dfsDiffReportListing.getLastIndex());
-    Assert.assertEquals(DFSUtil.bytes2String(diffReportListing.getLastPath()),
+    Assertions.assertEquals(diffReportListing.getLastIndex(), dfsDiffReportListing.getLastIndex());
+    Assertions.assertEquals(DFSUtil.bytes2String(diffReportListing.getLastPath()),
         DFSUtil.bytes2String(dfsDiffReportListing.getLastPath()));
     int i = 0;
     for (SnapshotDiffReportListing.DiffReportListingEntry entry : diffReportListing
         .getCreateList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getCreateList().get(i);
-      Assert.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assert.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assert.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }
@@ -2272,9 +2269,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         .getDeleteList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getDeleteList().get(i);
-      Assert.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assert.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assert.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }
@@ -2283,9 +2280,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         .getModifyList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getModifyList().get(i);
-      Assert.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assert.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assert.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/BaseTestHttpFSWith.java
@@ -81,13 +81,10 @@ import org.apache.hadoop.util.Lists;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ContainerFactory;
 import org.json.simple.parser.JSONParser;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -111,9 +108,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-@RunWith(value = Parameterized.class)
 public abstract class BaseTestHttpFSWith extends HFSTestCase {
   protected abstract Path getProxiedFSTestDir();
 
@@ -251,12 +250,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     testCreate(path, true);
     try {
       testCreate(path, false);
-      Assertions.fail("the create should have failed because the file exists " +
+      fail("the create should have failed because the file exists " +
                   "and override is FALSE");
     } catch (IOException ex) {
       System.out.println("#");
     } catch (Exception ex) {
-      Assertions.fail(ex.toString());
+      fail(ex.toString());
     }
   }
 
@@ -371,10 +370,10 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     assertFalse(fs.exists(foo));
     try {
       hoopFs.delete(new Path(bar.toUri().getPath()), false);
-      Assertions.fail();
+      fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
     assertTrue(fs.exists(bar));
     assertTrue(hoopFs.delete(new Path(bar.toUri().getPath()), true));
@@ -467,10 +466,10 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
     // The full path should be the path to the file. See HDFS-12139
     FileStatus[] statl = fs.listStatus(path);
-    Assertions.assertEquals(1, statl.length);
-    Assertions.assertEquals(status2.getPath(), statl[0].getPath());
-    Assertions.assertEquals(statl[0].getPath().getName(), path.getName());
-    Assertions.assertEquals(stati[0].getPath(), statl[0].getPath());
+    assertEquals(1, statl.length);
+    assertEquals(status2.getPath(), statl[0].getPath());
+    assertEquals(statl[0].getPath().getName(), path.getName());
+    assertEquals(stati[0].getPath(), statl[0].getPath());
   }
 
   private void testFileStatusAttr() throws Exception {
@@ -529,7 +528,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     // LocalFileSystem writes checksum files next to the data files, which
     // show up when listing via LFS. This makes the listings not compare
     // properly.
-    Assume.assumeFalse(isLocalFS());
+    assumeFalse(isLocalFS());
 
     FileSystem proxyFs = FileSystem.get(getProxiedFSConf());
     Configuration conf = new Configuration();
@@ -555,13 +554,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     RemoteIterator<FileStatus> si = proxyFs.listStatusIterator(dir1);
     FileStatus statusl = si.next();
     FileStatus status = proxyFs.getFileStatus(file1);
-    Assertions.assertEquals(file1.getName(), statusl.getPath().getName());
-    Assertions.assertEquals(status.getPath(), statusl.getPath());
+    assertEquals(file1.getName(), statusl.getPath().getName());
+    assertEquals(status.getPath(), statusl.getPath());
 
     si = proxyFs.listStatusIterator(file1);
     statusl = si.next();
-    Assertions.assertEquals(file1.getName(), statusl.getPath().getName());
-    Assertions.assertEquals(status.getPath(), statusl.getPath());
+    assertEquals(file1.getName(), statusl.getPath().getName());
+    assertEquals(status.getPath(), statusl.getPath());
   }
 
   private void testWorkingdirectory() throws Exception {
@@ -845,7 +844,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.setXAttr(path, name4, value4);
       try {
         fs.setXAttr(path, name5, value1);
-        Assertions.fail("Set xAttr with incorrect name format should fail.");
+        fail("Set xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -910,7 +909,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       final String name5 = "a1";
       try {
         value = fs.getXAttr(path, name5);
-        Assertions.fail("Get xAttr with incorrect name format should fail.");
+        fail("Get xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -961,7 +960,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       fs.removeXAttr(path, name4);
       try {
         fs.removeXAttr(path, name5);
-        Assertions.fail("Remove xAttr with incorrect name format should fail.");
+        fail("Remove xAttr with incorrect name format should fail.");
       } catch (IOException e) {
       } catch (IllegalArgumentException e) {
       }
@@ -1151,7 +1150,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
   }
 
   private void testErasureCoding() throws Exception {
-    Assume.assumeFalse("Assume its not a local FS!", isLocalFS());
+    assumeFalse(isLocalFS(), "Assume its not a local FS!");
     FileSystem proxyFs = FileSystem.get(getProxiedFSConf());
     FileSystem httpFS = getHttpFSFileSystem();
     Path filePath = new Path(getProxiedFSTestDir(), "foo.txt");
@@ -1169,13 +1168,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
   }
 
   private void testStoragePolicy() throws Exception {
-    Assume.assumeFalse("Assume its not a local FS", isLocalFS());
+    assumeFalse(isLocalFS(), "Assume its not a local FS");
     FileSystem fs = FileSystem.get(getProxiedFSConf());
     fs.mkdirs(getProxiedFSTestDir());
     Path path = new Path(getProxiedFSTestDir(), "policy.txt");
     FileSystem httpfs = getHttpFSFileSystem();
     // test getAllStoragePolicies
-    Assertions.assertArrayEquals(
+    assertArrayEquals(
     
        fs.getAllStoragePolicies().toArray(), httpfs.getAllStoragePolicies().toArray(), "Policy array returned from the DFS and HttpFS should be equals");
 
@@ -1189,12 +1188,10 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     BlockStoragePolicySpi dfsPolicy = fs.getStoragePolicy(path);
     // get policy from webhdfs
     BlockStoragePolicySpi httpFsPolicy = httpfs.getStoragePolicy(path);
+    assertEquals(HdfsConstants.COLD_STORAGE_POLICY_NAME.toString(),
+        httpFsPolicy.getName(), "Storage policy returned from the get API should" +
+        " be same as set policy");
     assertEquals(
-        "Storage policy returned from the get API should"
-            + " be same as set policy",
-            HdfsConstants.COLD_STORAGE_POLICY_NAME.toString(),
-            httpFsPolicy.getName());
-    Assertions.assertEquals(
     
        httpFsPolicy, dfsPolicy, "Storage policy returned from the DFS and HttpFS should be equals");
     // unset policy
@@ -1377,7 +1374,6 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     }
   }
 
-  @Parameterized.Parameters
   public static Collection operations() {
     Object[][] ops = new Object[Operation.values().length][];
     for (int i = 0; i < Operation.values().length; i++) {
@@ -1390,24 +1386,28 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
 
   private Operation operation;
 
-  public BaseTestHttpFSWith(Operation operation) {
-    this.operation = operation;
+  public void initBaseTestHttpFSWith(Operation pOperation) {
+    this.operation = pOperation;
   }
 
-  @Test
+  @MethodSource("operations")
+  @ParameterizedTest
   @TestDir
   @TestJetty
   @TestHdfs
-  public void testOperation() throws Exception {
+  public void testOperation(Operation pOperation) throws Exception {
+    initBaseTestHttpFSWith(pOperation);
     createHttpFSServer();
     operation(operation);
   }
 
-  @Test
+  @MethodSource("operations")
+  @ParameterizedTest
   @TestDir
   @TestJetty
   @TestHdfs
-  public void testOperationDoAs() throws Exception {
+  public void testOperationDoAs(Operation pOperation) throws Exception {
+    initBaseTestHttpFSWith(pOperation);
     createHttpFSServer();
     UserGroupInformation ugi = UserGroupInformation.createProxyUser(HadoopUsersConfTestHelper.getHadoopUsers()[0],
                                                                     UserGroupInformation.getCurrentUser());
@@ -1538,7 +1538,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.allowSnapshot(path);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " doesn't support allowSnapshot");
       }
       // Check FileStatus
@@ -1567,7 +1567,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.disallowSnapshot(path);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " doesn't support disallowSnapshot");
       }
       // Check FileStatus
@@ -1610,11 +1610,11 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           // Expect SnapshotException
         }
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " doesn't support disallowSnapshot");
       }
       if (disallowSuccess) {
-        Assertions.fail("disallowSnapshot doesn't throw SnapshotException when "
+        fail("disallowSnapshot doesn't throw SnapshotException when "
             + "disallowing snapshot on a directory with at least one snapshot");
       }
       // Check FileStatus, should still be enabled since
@@ -1636,7 +1636,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -1656,13 +1656,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
           diffReport = webHdfsFileSystem.getSnapshotDiffReport(path, "snap1", "snap2");
         } else {
-          Assertions.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
+          fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
         }
         // Verify result with DFS
         DistributedFileSystem dfs =
             (DistributedFileSystem) FileSystem.get(path.toUri(), this.getProxiedFSConf());
         SnapshotDiffReport dfsDiffReport = dfs.getSnapshotDiffReport(path, "snap1", "snap2");
-        Assertions.assertEquals(diffReport.toString(), dfsDiffReport.toString());
+        assertEquals(diffReport.toString(), dfsDiffReport.toString());
       } finally {
         // Cleanup
         fs.deleteSnapshot(path, "snap2");
@@ -1683,7 +1683,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         webHdfsFileSystem.getSnapshotDiffReport(path, oldsnapshotname,
             snapshotname);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " doesn't support getSnapshotDiff");
       }
     } catch (SnapshotException|IllegalArgumentException|RemoteException e) {
@@ -1691,12 +1691,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // or RemoteException(IllegalArgumentException)
       if (e instanceof RemoteException) {
         // Check RemoteException class name, should be IllegalArgumentException
-        Assertions.assertEquals(((RemoteException) e).getClassName()
+        assertEquals(((RemoteException) e).getClassName()
             .compareTo(java.lang.IllegalArgumentException.class.getName()), 0);
       }
       return;
     }
-    Assertions.fail("getSnapshotDiff illegal param didn't throw Exception");
+    fail("getSnapshotDiff illegal param didn't throw Exception");
   }
 
   private void testGetSnapshotDiffIllegalParam() throws Exception {
@@ -1709,7 +1709,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Check FileStatus
       assertTrue(
          fs.getFileStatus(path).isSnapshotEnabled(), "Snapshot should be allowed by DFS");
-      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Get snapshot diff
       testGetSnapshotDiffIllegalParamCase(fs, path, "", "");
       testGetSnapshotDiffIllegalParamCase(fs, path, "snap1", "");
@@ -1731,12 +1731,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       sds = webHdfsFileSystem.getSnapshottableDirectoryList();
     } else {
-      Assertions.fail(fs.getClass().getSimpleName() +
+      fail(fs.getClass().getSimpleName() +
           " doesn't support getSnapshottableDirListing");
     }
     // Verify result with DFS
     SnapshottableDirectoryStatus[] dfssds = dfs.getSnapshottableDirListing();
-    Assertions.assertEquals(JsonUtil.toJsonString(sds),
+    assertEquals(JsonUtil.toJsonString(sds),
         JsonUtil.toJsonString(dfssds));
   }
 
@@ -1748,7 +1748,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -1766,7 +1766,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         snapshotStatus = webHdfsFileSystem.getSnapshotListing(path);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " doesn't support getSnapshotDiff");
       }
       // Verify result with DFS
@@ -1774,7 +1774,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
           FileSystem.get(path.toUri(), this.getProxiedFSConf());
       SnapshotStatus[] dfsStatus =
           dfs.getSnapshotListing(path);
-      Assertions.assertEquals(JsonUtil.toJsonString(snapshotStatus),
+      assertEquals(JsonUtil.toJsonString(snapshotStatus),
           JsonUtil.toJsonString(dfsStatus));
       // Cleanup
       fs.deleteSnapshot(path, "snap2");
@@ -1794,12 +1794,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Verify response when there is no snapshottable directory
       verifyGetSnapshottableDirListing(fs, dfs);
       createSnapshotTestsPreconditions(path1);
-      Assertions.assertTrue(fs.getFileStatus(path1).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path1).isSnapshotEnabled());
       // Verify response when there is one snapshottable directory
       verifyGetSnapshottableDirListing(fs, dfs);
       Path path2 = new Path("/tmp/tmp-snap-dirlist-test-2");
       createSnapshotTestsPreconditions(path2);
-      Assertions.assertTrue(fs.getFileStatus(path2).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path2).isSnapshotEnabled());
       // Verify response when there are two snapshottable directories
       verifyGetSnapshottableDirListing(fs, dfs);
 
@@ -1826,7 +1826,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     FileSystem httpfs = getHttpFSFileSystem(conf);
     if (!(httpfs instanceof WebHdfsFileSystem)
         && !(httpfs instanceof HttpFSFileSystem)) {
-      Assertions.fail(httpfs.getClass().getSimpleName() +
+      fail(httpfs.getClass().getSimpleName() +
           " doesn't support custom user and group name pattern. "
           + "Only WebHdfsFileSystem and HttpFSFileSystem support it.");
     }
@@ -1854,8 +1854,8 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     for (AclEntry aclEntry : httpfsAclStat.getEntries()) {
       strEntries.add(aclEntry.toStringStable());
     }
-    Assertions.assertTrue(strEntries.contains(aclUser));
-    Assertions.assertTrue(strEntries.contains(aclGroup));
+    assertTrue(strEntries.contains(aclUser));
+    assertTrue(strEntries.contains(aclGroup));
     // Clean up
     proxyFs.delete(new Path(dir), true);
   }
@@ -1870,12 +1870,12 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       sds = webHdfsFileSystem.getServerDefaults();
     } else {
-      Assertions.fail(
+      fail(
           fs.getClass().getSimpleName() + " doesn't support getServerDefaults");
     }
     // Verify result with DFS
     FsServerDefaults dfssds = dfs.getServerDefaults();
-    Assertions.assertEquals(JsonUtil.toJsonString(sds),
+    assertEquals(JsonUtil.toJsonString(sds),
         JsonUtil.toJsonString(dfssds));
   }
 
@@ -1913,7 +1913,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
       webHdfsFileSystem.access(p1, FsAction.READ);
     } else {
-      Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
+      fail(fs.getClass().getSimpleName() + " doesn't support access");
     }
   }
 
@@ -1939,7 +1939,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertEquals(ecPolicy, ecPolicy1);
         httpFS.unsetErasureCodingPolicy(p1);
         ecPolicy1 = httpFS.getErasureCodingPolicy(p1);
-        Assertions.assertNull(ecPolicy1);
+        assertNull(ecPolicy1);
       } else if (fs instanceof WebHdfsFileSystem) {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) fs;
         webHdfsFileSystem.setErasureCodingPolicy(p1, ecPolicyName);
@@ -1948,9 +1948,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertEquals(ecPolicy, ecPolicy1);
         webHdfsFileSystem.unsetErasureCodingPolicy(p1);
         ecPolicy1 = dfs.getErasureCodingPolicy(p1);
-        Assertions.assertNull(ecPolicy1);
+        assertNull(ecPolicy1);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
     }
   }
@@ -1985,7 +1985,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         assertTrue(xAttrs
             .containsKey(HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY));
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
       dfs.delete(path1, true);
     }
@@ -2017,7 +2017,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         blockLocations = webHdfsFileSystem.getFileBlockLocations(testFile, 0, 1);
         assertNotNull(blockLocations);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() + " doesn't support access");
+        fail(fs.getClass().getSimpleName() + " doesn't support access");
       }
     }
   }
@@ -2030,7 +2030,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       // Get the FileSystem instance that's being tested
       FileSystem fs = this.getHttpFSFileSystem();
       // Check FileStatus
-      Assertions.assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
+      assertTrue(fs.getFileStatus(path).isSnapshotEnabled());
       // Create a file and take a snapshot
       Path file1 = new Path(path, "file1");
       testCreate(file1, false);
@@ -2053,7 +2053,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
               .getSnapshotDiffReportListing(path.toUri().getPath(), "snap1", "snap2", emptyBytes,
                   -1);
         } else {
-          Assertions.fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
+          fail(fs.getClass().getSimpleName() + " doesn't support getSnapshotDiff");
         }
         // Verify result with DFS
         DistributedFileSystem dfs =
@@ -2114,7 +2114,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       httpFs.close();
       dfs.close();
     } else {
-      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
@@ -2141,7 +2141,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) httpFs;
         diffErasureCodingPolicies = webHdfsFileSystem.getAllErasureCodingPolicies();
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " is not of type HttpFSFileSystem or WebHdfsFileSystem");
       }
 
@@ -2149,7 +2149,7 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
       assertEquals(dfsAllErasureCodingPolicies.size(), diffErasureCodingPolicies.size());
       assertTrue(dfsAllErasureCodingPolicies.containsAll(diffErasureCodingPolicies));
     } else {
-      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
@@ -2191,13 +2191,13 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
     Map<String, String> diffErasureCodingCodecs = diffErasureCodingCodecsRef.get();
 
     //Validate testGetECCodecs are the same as DistributedFileSystem
-    Assertions.assertEquals(dfsErasureCodingCodecs.size(), diffErasureCodingCodecs.size());
+    assertEquals(dfsErasureCodingCodecs.size(), diffErasureCodingCodecs.size());
 
     for (Map.Entry<String, String> entry : dfsErasureCodingCodecs.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
-      Assertions.assertTrue(diffErasureCodingCodecs.containsKey(key));
-      Assertions.assertEquals(value, diffErasureCodingCodecs.get(key));
+      assertTrue(diffErasureCodingCodecs.containsKey(key));
+      assertEquals(value, diffErasureCodingCodecs.get(key));
     }
   }
 
@@ -2229,38 +2229,38 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         WebHdfsFileSystem webHdfsFileSystem = (WebHdfsFileSystem) httpFs;
         diffTrashRoots = webHdfsFileSystem.getTrashRoots(true);
       } else {
-        Assertions.fail(fs.getClass().getSimpleName() +
+        fail(fs.getClass().getSimpleName() +
             " is not of type HttpFSFileSystem or WebHdfsFileSystem");
       }
 
       // Validate getTrashRoots are the same as DistributedFileSystem
       assertEquals(dfsTrashRoots.size(), diffTrashRoots.size());
     } else {
-      Assertions.fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
+      fail(fs.getClass().getSimpleName() + " is not of type DistributedFileSystem.");
     }
   }
 
   private void assertHttpFsReportListingWithDfsClient(SnapshotDiffReportListing diffReportListing,
       SnapshotDiffReportListing dfsDiffReportListing) {
-    Assertions.assertEquals(diffReportListing.getCreateList().size(),
+    assertEquals(diffReportListing.getCreateList().size(),
         dfsDiffReportListing.getCreateList().size());
-    Assertions.assertEquals(diffReportListing.getDeleteList().size(),
+    assertEquals(diffReportListing.getDeleteList().size(),
         dfsDiffReportListing.getDeleteList().size());
-    Assertions.assertEquals(diffReportListing.getModifyList().size(),
+    assertEquals(diffReportListing.getModifyList().size(),
         dfsDiffReportListing.getModifyList().size());
-    Assertions.assertEquals(diffReportListing.getIsFromEarlier(),
+    assertEquals(diffReportListing.getIsFromEarlier(),
         dfsDiffReportListing.getIsFromEarlier());
-    Assertions.assertEquals(diffReportListing.getLastIndex(), dfsDiffReportListing.getLastIndex());
-    Assertions.assertEquals(DFSUtil.bytes2String(diffReportListing.getLastPath()),
+    assertEquals(diffReportListing.getLastIndex(), dfsDiffReportListing.getLastIndex());
+    assertEquals(DFSUtil.bytes2String(diffReportListing.getLastPath()),
         DFSUtil.bytes2String(dfsDiffReportListing.getLastPath()));
     int i = 0;
     for (SnapshotDiffReportListing.DiffReportListingEntry entry : diffReportListing
         .getCreateList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getCreateList().get(i);
-      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }
@@ -2269,9 +2269,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         .getDeleteList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getDeleteList().get(i);
-      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }
@@ -2280,9 +2280,9 @@ public abstract class BaseTestHttpFSWith extends HFSTestCase {
         .getModifyList()) {
       SnapshotDiffReportListing.DiffReportListingEntry dfsDiffEntry =
           dfsDiffReportListing.getModifyList().get(i);
-      Assertions.assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
-      Assertions.assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
-      Assertions.assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
+      assertEquals(entry.getDirId(), dfsDiffEntry.getDirId());
+      assertEquals(entry.getFileId(), dfsDiffEntry.getFileId());
+      assertArrayEquals(DFSUtilClient.byteArray2bytes(entry.getSourcePath()),
           DFSUtilClient.byteArray2bytes(dfsDiffEntry.getSourcePath()));
       i++;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithSWebhdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithSWebhdfsFileSystem.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdfs.web.SWebHdfsFileSystem;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -69,7 +69,7 @@ public class TestHttpFSFWithSWebhdfsFileSystem
         "serverP");
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws Exception {
     new File(classpathDir, "ssl-client.xml").delete();
     new File(classpathDir, "ssl-server.xml").delete();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithSWebhdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithSWebhdfsFileSystem.java
@@ -26,15 +26,12 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestJettyHelper;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.util.UUID;
 
-@RunWith(value = Parameterized.class)
 public class TestHttpFSFWithSWebhdfsFileSystem
   extends TestHttpFSWithHttpFSFileSystem {
   private static String classpathDir;
@@ -76,8 +73,7 @@ public class TestHttpFSFWithSWebhdfsFileSystem
     KeyStoreTestUtil.cleanupSSLConfig(keyStoreDir, classpathDir);
   }
 
-  public TestHttpFSFWithSWebhdfsFileSystem(Operation operation) {
-    super(operation);
+  public TestHttpFSFWithSWebhdfsFileSystem() {
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithWebhdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFWithWebhdfsFileSystem.java
@@ -19,15 +19,11 @@
 package org.apache.hadoop.fs.http.client;
 
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(value = Parameterized.class)
 public class TestHttpFSFWithWebhdfsFileSystem
   extends TestHttpFSWithHttpFSFileSystem {
 
-  public TestHttpFSFWithWebhdfsFileSystem(Operation operation) {
-    super(operation);
+  public TestHttpFSFWithWebhdfsFileSystem() {
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFileSystemLocalFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFileSystemLocalFileSystem.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestDirHelper;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -86,7 +86,7 @@ public class TestHttpFSFileSystemLocalFileSystem extends BaseTestHttpFSWith {
       FileStatus status1 = fs.getFileStatus(path);
       fs.close();
       FsPermission permission2 = status1.getPermission();
-      Assert.assertEquals(permission2, permission1);
+      Assertions.assertEquals(permission2, permission1);
 
       // sticky bit not supported on Windows with local file system, so the
       // subclass skips that part of the test

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFileSystemLocalFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSFileSystemLocalFileSystem.java
@@ -27,13 +27,11 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestDirHelper;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.File;
 
-@RunWith(value = Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TestHttpFSFileSystemLocalFileSystem extends BaseTestHttpFSWith {
 
   private static String PATH_PREFIX;
@@ -45,8 +43,7 @@ public class TestHttpFSFileSystemLocalFileSystem extends BaseTestHttpFSWith {
     PATH_PREFIX = file.getAbsolutePath();
   }
 
-  public TestHttpFSFileSystemLocalFileSystem(Operation operation) {
-    super(operation);
+  public TestHttpFSFileSystemLocalFileSystem() {
   }
 
   @Override
@@ -86,7 +83,7 @@ public class TestHttpFSFileSystemLocalFileSystem extends BaseTestHttpFSWith {
       FileStatus status1 = fs.getFileStatus(path);
       fs.close();
       FsPermission permission2 = status1.getPermission();
-      Assertions.assertEquals(permission2, permission1);
+      assertEquals(permission2, permission1);
 
       // sticky bit not supported on Windows with local file system, so the
       // subclass skips that part of the test

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSWithHttpFSFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/client/TestHttpFSWithHttpFSFileSystem.java
@@ -22,14 +22,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.TestHdfsHelper;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(value = Parameterized.class)
 public class TestHttpFSWithHttpFSFileSystem extends BaseTestHttpFSWith {
 
-  public TestHttpFSWithHttpFSFileSystem(Operation operation) {
-    super(operation);
+  public TestHttpFSWithHttpFSFileSystem() {
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestCheckUploadContentTypeFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestCheckUploadContentTypeFilter.java
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.fs.http.client.HttpFSFileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestCheckUploadContentTypeFilter {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSAccessControlled.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSAccessControlled.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -43,6 +42,9 @@ import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.MessageFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test class ensures that everything works as expected when
@@ -93,9 +95,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
-    Assertions.assertTrue(new File(homeDir, "log").mkdir());
-    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
+    assertTrue(new File(homeDir, "conf").mkdir());
+    assertTrue(new File(homeDir, "log").mkdir());
+    assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -175,9 +177,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -207,9 +209,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -239,9 +241,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -271,9 +273,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
+      assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSAccessControlled.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSAccessControlled.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -93,9 +93,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assert.assertTrue(new File(homeDir, "conf").mkdir());
-    Assert.assertTrue(new File(homeDir, "log").mkdir());
-    Assert.assertTrue(new File(homeDir, "temp").mkdir());
+    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
+    Assertions.assertTrue(new File(homeDir, "log").mkdir());
+    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -175,9 +175,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assert.assertEquals( outMsg, HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_FORBIDDEN, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -207,9 +207,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_FORBIDDEN, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -239,9 +239,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_FORBIDDEN, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 
@@ -271,9 +271,9 @@ public class TestHttpFSAccessControlled extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if ( expectOK ) {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp, outMsg);
     } else {
-      Assert.assertEquals(outMsg, HttpURLConnection.HTTP_FORBIDDEN, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, resp, outMsg);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
@@ -17,8 +17,12 @@
  */
 package org.apache.hadoop.fs.http.server;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -205,9 +209,9 @@ public class TestHttpFSServer extends HFSTestCase {
   private Configuration createHttpFSConf(boolean addDelegationTokenAuthHandler,
                                          boolean sslEnabled) throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
-    Assertions.assertTrue(new File(homeDir, "log").mkdir());
-    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
+    assertTrue(new File(homeDir, "conf").mkdir());
+    assertTrue(new File(homeDir, "log").mkdir());
+    assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -269,7 +273,7 @@ public class TestHttpFSServer extends HFSTestCase {
     File homeDir = TestDirHelper.getTestDir();
     // HDFS configuration
     File hadoopConfDir = new File(new File(homeDir, "conf"), "hadoop-conf");
-    Assertions.assertTrue(hadoopConfDir.exists());
+    assertTrue(hadoopConfDir.exists());
 
     File siteFile = new File(hadoopConfDir, sitename);
     OutputStream os = new FileOutputStream(siteFile);
@@ -313,7 +317,7 @@ public class TestHttpFSServer extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY");
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
+    assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
                         conn.getResponseCode());
 
     String tokenSigned = getSignedTokenString();
@@ -323,7 +327,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty("Cookie",
                             AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     JSONObject json = (JSONObject)new JSONParser().parse(
@@ -336,7 +340,7 @@ public class TestHttpFSServer extends HFSTestCase {
     Token<AbstractDelegationTokenIdentifier> dToken =
         new Token<AbstractDelegationTokenIdentifier>();
     dToken.decodeFromUrlString(tokenStr);
-    Assertions.assertEquals(sslEnabled ?
+    assertEquals(sslEnabled ?
         WebHdfsConstants.SWEBHDFS_TOKEN_KIND :
         WebHdfsConstants.WEBHDFS_TOKEN_KIND,
         dToken.getKind());
@@ -344,14 +348,14 @@ public class TestHttpFSServer extends HFSTestCase {
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
-    Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
+    assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
@@ -360,27 +364,27 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.setRequestProperty("Cookie",
                             AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=CANCELDELEGATIONTOKEN&token=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+    assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
                         conn.getResponseCode());
 
     // getTrash test with delegation
     url = new URL(TestJettyHelper.getJettyURL(),
         "/webhdfs/v1/?op=GETTRASHROOT&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+    assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
@@ -388,7 +392,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty("Cookie",
         AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
         conn.getResponseCode());
   }
 
@@ -403,26 +407,26 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format("/webhdfs/v1?user.name={0}&op=instrumentation",
                              "nobody"));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(),
+    assertEquals(conn.getResponseCode(),
                         HttpURLConnection.HTTP_UNAUTHORIZED);
 
     url = new URL(TestJettyHelper.getJettyURL(),
         MessageFormat.format("/webhdfs/v1?user.name={0}&op=instrumentation",
                              HadoopUsersConfTestHelper.getHadoopUsers()[0]));
     conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     String line = reader.readLine();
     reader.close();
-    Assertions.assertTrue(line.contains("\"counters\":{"));
+    assertTrue(line.contains("\"counters\":{"));
 
     url = new URL(TestJettyHelper.getJettyURL(),
         MessageFormat.format(
             "/webhdfs/v1/foo?user.name={0}&op=instrumentation",
             HadoopUsersConfTestHelper.getHadoopUsers()[0]));
     conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(),
+    assertEquals(conn.getResponseCode(),
                         HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
@@ -439,12 +443,12 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format("/webhdfs/v1/?user.name={0}&op=liststatus",
                              user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     reader.readLine();
     reader.close();
-    Assertions.assertEquals(1 + oldOpsListStatus,
+    assertEquals(1 + oldOpsListStatus,
         (long) metricsGetter.get("LISTSTATUS").call());
   }
 
@@ -462,11 +466,11 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     getStatus("/tmp/sub-tmp", "LISTSTATUS");
     long opsStat =
         metricsGetter.get("MKDIRS").call();
-    Assertions.assertEquals(1 + oldMkdirOpsStat, opsStat);
+    assertEquals(1 + oldMkdirOpsStat, opsStat);
   }
 
   @Test
@@ -486,12 +490,12 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format(
             "/webhdfs/v1/tmp?user.name={0}&op=liststatus&filter=f*", user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     reader.readLine();
     reader.close();
-    Assertions.assertEquals(1 + oldOpsListStatus,
+    assertEquals(1 + oldOpsListStatus,
         (long) metricsGetter.get("LISTSTATUS").call());
   }
 
@@ -539,7 +543,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.addRequestProperty("Content-Type", "application/octet-stream");
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
   }
 
   /**
@@ -577,8 +581,8 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
-    Assertions.assertEquals(1 + oldOpsMkdir,
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(1 + oldOpsMkdir,
         (long) metricsGetter.get("MKDIRS").call());
   }
 
@@ -606,13 +610,13 @@ public class TestHttpFSServer extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(), pathOps);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
 
     BufferedReader reader =
             new BufferedReader(new InputStreamReader(conn.getInputStream()));
     long opsStat =
         metricsGetter.getOrDefault(command, defaultExitMetricGetter).call();
-    Assertions.assertEquals(oldOpsStat + 1L, opsStat);
+    assertEquals(oldOpsStat + 1L, opsStat);
     return reader.readLine();
   }
 
@@ -624,7 +628,7 @@ public class TestHttpFSServer extends HFSTestCase {
    */
   private void putCmd(String filename, String command,
                       String params) throws Exception {
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+    assertEquals(HttpURLConnection.HTTP_OK,
             putCmdWithReturn(filename, command, params).getResponseCode());
   }
 
@@ -772,19 +776,19 @@ public class TestHttpFSServer extends HFSTestCase {
 
     createWithHttp("/perm/none", null);
     String statusJson = getStatus("/perm/none", "GETFILESTATUS");
-    Assertions.assertTrue("755".equals(getPerms(statusJson)));
+    assertTrue("755".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-777", "777");
     statusJson = getStatus("/perm/p-777", "GETFILESTATUS");
-    Assertions.assertTrue("777".equals(getPerms(statusJson)));
+    assertTrue("777".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-654", "654");
     statusJson = getStatus("/perm/p-654", "GETFILESTATUS");
-    Assertions.assertTrue("654".equals(getPerms(statusJson)));
+    assertTrue("654".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-321", "321");
     statusJson = getStatus("/perm/p-321", "GETFILESTATUS");
-    Assertions.assertTrue("321".equals(getPerms(statusJson)));
+    assertTrue("321".equals(getPerms(statusJson)));
   }
 
   /**
@@ -810,29 +814,29 @@ public class TestHttpFSServer extends HFSTestCase {
     createWithHttp(path, null);
     String statusJson = getStatus(path, "GETXATTRS");
     Map<String, byte[]> xAttrs = getXAttrs(statusJson);
-    Assertions.assertEquals(0, xAttrs.size());
+    assertEquals(0, xAttrs.size());
 
     // Set two xattrs
     putCmd(path, "SETXATTR", setXAttrParam(name1, value1));
     putCmd(path, "SETXATTR", setXAttrParam(name2, value2));
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assertions.assertEquals(2, xAttrs.size());
-    Assertions.assertArrayEquals(value1, xAttrs.get(name1));
-    Assertions.assertArrayEquals(value2, xAttrs.get(name2));
+    assertEquals(2, xAttrs.size());
+    assertArrayEquals(value1, xAttrs.get(name1));
+    assertArrayEquals(value2, xAttrs.get(name2));
 
     // Remove one xattr
     putCmd(path, "REMOVEXATTR", "xattr.name=" + name1);
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assertions.assertEquals(1, xAttrs.size());
-    Assertions.assertArrayEquals(value2, xAttrs.get(name2));
+    assertEquals(1, xAttrs.size());
+    assertArrayEquals(value2, xAttrs.get(name2));
 
     // Remove another xattr, then there is no xattr
     putCmd(path, "REMOVEXATTR", "xattr.name=" + name2);
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assertions.assertEquals(0, xAttrs.size());
+    assertEquals(0, xAttrs.size());
   }
 
   /** Params for setting an xAttr. */
@@ -881,14 +885,14 @@ public class TestHttpFSServer extends HFSTestCase {
 
     /* getfilestatus and liststatus don't have 'aclBit' in their reply */
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
 
     /* getaclstatus works and returns no entries */
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 0);
+    assertTrue(aclEntries.size() == 0);
 
     /*
      * Now set an ACL on the file.  (getfile|list)status have aclBit,
@@ -896,41 +900,41 @@ public class TestHttpFSServer extends HFSTestCase {
      */
     putCmd(path, "SETACL", aclSpec);
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 2);
-    Assertions.assertTrue(aclEntries.contains(aclUser1));
-    Assertions.assertTrue(aclEntries.contains(aclGroup1));
+    assertTrue(aclEntries.size() == 2);
+    assertTrue(aclEntries.contains(aclUser1));
+    assertTrue(aclEntries.contains(aclGroup1));
 
     /* Modify acl entries to add another user acl */
     putCmd(path, "MODIFYACLENTRIES", modAclSpec);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 3);
-    Assertions.assertTrue(aclEntries.contains(aclUser1));
-    Assertions.assertTrue(aclEntries.contains(aclUser2));
-    Assertions.assertTrue(aclEntries.contains(aclGroup1));
+    assertTrue(aclEntries.size() == 3);
+    assertTrue(aclEntries.contains(aclUser1));
+    assertTrue(aclEntries.contains(aclUser2));
+    assertTrue(aclEntries.contains(aclGroup1));
 
     /* Remove the first user acl entry and verify */
     putCmd(path, "REMOVEACLENTRIES", remAclSpec);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 2);
-    Assertions.assertTrue(aclEntries.contains(aclUser2));
-    Assertions.assertTrue(aclEntries.contains(aclGroup1));
+    assertTrue(aclEntries.size() == 2);
+    assertTrue(aclEntries.contains(aclUser2));
+    assertTrue(aclEntries.contains(aclGroup1));
 
     /* Remove all acls and verify */
     putCmd(path, "REMOVEACL", null);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 0);
+    assertTrue(aclEntries.size() == 0);
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
   }
 
   /**
@@ -962,30 +966,30 @@ public class TestHttpFSServer extends HFSTestCase {
 
     /* getfilestatus and liststatus don't have 'aclBit' in their reply */
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
 
     /* No ACLs, either */
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 0);
+    assertTrue(aclEntries.size() == 0);
 
     /* Give it a default ACL and verify */
     putCmd(dir, "SETACL", defSpec1);
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 5);
+    assertTrue(aclEntries.size() == 5);
     /* 4 Entries are default:(user|group|mask|other):perm */
-    Assertions.assertTrue(aclEntries.contains(defUser1));
+    assertTrue(aclEntries.contains(defUser1));
 
     /* Remove the default ACL and re-verify */
     putCmd(dir, "REMOVEDEFAULTACL", null);
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
+    assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.size() == 0);
+    assertTrue(aclEntries.size() == 0);
   }
 
   @Test
@@ -1026,8 +1030,8 @@ public class TestHttpFSServer extends HFSTestCase {
     // Verify ACL
     String statusJson = getStatus(path, "GETACLSTATUS");
     List<String> aclEntries = getAclEntries(statusJson);
-    Assertions.assertTrue(aclEntries.contains(aclUser));
-    Assertions.assertTrue(aclEntries.contains(aclGroup));
+    assertTrue(aclEntries.contains(aclUser));
+    assertTrue(aclEntries.contains(aclGroup));
   }
 
   @Test
@@ -1050,11 +1054,11 @@ public class TestHttpFSServer extends HFSTestCase {
             "/webhdfs/v1/tmp/foo?user.name={0}&op=open&offset=1&length=2",
             user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     InputStream is = conn.getInputStream();
-    Assertions.assertEquals(1, is.read());
-    Assertions.assertEquals(2, is.read());
-    Assertions.assertEquals(-1, is.read());
+    assertEquals(1, is.read());
+    assertEquals(2, is.read());
+    assertEquals(-1, is.read());
   }
 
   @Test
@@ -1089,8 +1093,8 @@ public class TestHttpFSServer extends HFSTestCase {
     AclStatus aclStatus = fs.getAclStatus(new Path(notUnmaskedFile));
     AclEntry theAcl = findAclWithName(aclStatus, "user2");
 
-    Assertions.assertNotNull(theAcl);
-    Assertions.assertEquals(FsAction.NONE,
+    assertNotNull(theAcl);
+    assertEquals(FsAction.NONE,
         aclStatus.getEffectivePermission(theAcl));
 
     // Create another file, this time pass a mask of 777. Now the inherited
@@ -1100,8 +1104,8 @@ public class TestHttpFSServer extends HFSTestCase {
     aclStatus = fs.getAclStatus(new Path(unmaskedFile));
     theAcl = findAclWithName(aclStatus, "user2");
 
-    Assertions.assertNotNull(theAcl);
-    Assertions.assertEquals(FsAction.READ_WRITE,
+    assertNotNull(theAcl);
+    assertEquals(FsAction.READ_WRITE,
         aclStatus.getEffectivePermission(theAcl));
   }
 
@@ -1137,8 +1141,8 @@ public class TestHttpFSServer extends HFSTestCase {
     AclStatus aclStatus = fs.getAclStatus(new Path(notUnmaskedDir));
     AclEntry theAcl = findAclWithName(aclStatus, "user2");
 
-    Assertions.assertNotNull(theAcl);
-    Assertions.assertEquals(FsAction.NONE,
+    assertNotNull(theAcl);
+    assertEquals(FsAction.NONE,
         aclStatus.getEffectivePermission(theAcl));
 
     // Create another file, this time pass a mask of 777. Now the inherited
@@ -1148,8 +1152,8 @@ public class TestHttpFSServer extends HFSTestCase {
     aclStatus = fs.getAclStatus(new Path(unmaskedDir));
     theAcl = findAclWithName(aclStatus, "user2");
 
-    Assertions.assertNotNull(theAcl);
-    Assertions.assertEquals(FsAction.READ_WRITE,
+    assertNotNull(theAcl);
+    assertEquals(FsAction.READ_WRITE,
         aclStatus.getEffectivePermission(theAcl));
   }
 
@@ -1167,7 +1171,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setDoInput(true);
     conn.setDoOutput(true);
     conn.setRequestMethod("PUT");
-    Assertions.assertEquals(conn.getResponseCode(),
+    assertEquals(conn.getResponseCode(),
         HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
@@ -1183,7 +1187,7 @@ public class TestHttpFSServer extends HFSTestCase {
 
     Path expectedPath = new Path(FileSystem.USER_HOME_PREFIX,
         new Path(user, FileSystem.TRASH_PREFIX));
-    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    assertEquals(expectedPath.toUri().getPath(), trashPath);
 
     byte[] array = new byte[]{0, 1, 2, 3};
     FileSystem fs = FileSystem.get(TestHdfsHelper.getHdfsConf());
@@ -1194,7 +1198,7 @@ public class TestHttpFSServer extends HFSTestCase {
 
     trashJson = getStatus("/tmp/foo", "GETTRASHROOT");
     trashPath = getPath(trashJson);
-    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    assertEquals(expectedPath.toUri().getPath(), trashPath);
 
     //TestHdfsHelp has already set up EZ environment
     final Path ezFile = TestHdfsHelper.ENCRYPTED_FILE;
@@ -1202,7 +1206,7 @@ public class TestHttpFSServer extends HFSTestCase {
     trashJson = getStatus(ezFile.toUri().getPath(), "GETTRASHROOT");
     trashPath = getPath(trashJson);
     expectedPath = new Path(ezPath, new Path(FileSystem.TRASH_PREFIX, user));
-    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    assertEquals(expectedPath.toUri().getPath(), trashPath);
   }
 
   @Test
@@ -1226,7 +1230,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
 
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
     //needed to make the given dir snapshottable
     Path snapshottablePath = new Path("/tmp/tmp-snap-test");
@@ -1259,7 +1263,7 @@ public class TestHttpFSServer extends HFSTestCase {
     DistributedFileSystem dfs = (DistributedFileSystem) FileSystem.get(
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // FileStatus should have snapshot enabled bit unset by default
-    Assertions.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send a request with ALLOWSNAPSHOT API
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(), MessageFormat.format(
@@ -1269,9 +1273,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should have snapshot enabled bit set
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.delete(path, true);
   }
@@ -1292,7 +1296,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Allow snapshot
     dfs.allowSnapshot(path);
     // FileStatus should have snapshot enabled bit set so far
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send a request with DISALLOWSNAPSHOT API
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(), MessageFormat.format(
@@ -1302,9 +1306,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should not have snapshot enabled bit set
-    Assertions.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.delete(path, true);
   }
@@ -1325,7 +1329,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Allow snapshot
     dfs.allowSnapshot(path);
     // FileStatus should have snapshot enabled bit set so far
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Create some snapshots
     dfs.createSnapshot(path, "snap-01");
     dfs.createSnapshot(path, "snap-02");
@@ -1338,9 +1342,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should not return HTTP_OK
-    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should still have snapshot enabled bit set
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.deleteSnapshot(path, "snap-02");
     dfs.deleteSnapshot(path, "snap-01");
@@ -1356,17 +1360,17 @@ public class TestHttpFSServer extends HFSTestCase {
     final HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-with-name");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     final BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
     String result = reader.readLine();
     //Validates if the content format is correct
-    Assertions.assertTrue(result.
+    assertTrue(result.
         equals("{\"Path\":\"/tmp/tmp-snap-test/.snapshot/snap-with-name\"}"));
     //Validates if the snapshot is properly created under .snapshot folder
     result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assertions.assertTrue(result.contains("snap-with-name"));
+    assertTrue(result.contains("snap-with-name"));
   }
 
   @Test
@@ -1378,19 +1382,19 @@ public class TestHttpFSServer extends HFSTestCase {
     final HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     final BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     String result = reader.readLine();
     //Validates if the content format is correct
-    Assertions.assertTrue(Pattern.matches(
+    assertTrue(Pattern.matches(
         "(\\{\\\"Path\\\"\\:\\\"/tmp/tmp-snap-test/.snapshot/s)" +
             "(\\d{8})(-)(\\d{6})(\\.)(\\d{3})(\\\"\\})", result));
     //Validates if the snapshot is properly created under .snapshot folder
     result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
 
-    Assertions.assertTrue(Pattern.matches("(.+)(\\\"pathSuffix\\\":\\\"s)" +
+    assertTrue(Pattern.matches("(.+)(\\\"pathSuffix\\\":\\\"s)" +
             "(\\d{8})(-)(\\d{6})(\\.)(\\d{3})(\\\")(.+)",
         result));
   }
@@ -1404,18 +1408,18 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-to-rename");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     conn = snapshotTestPreconditions("PUT",
         "RENAMESNAPSHOT",
         "oldsnapshotname=snap-to-rename" +
             "&snapshotname=snap-renamed");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     //Validates the snapshot is properly renamed under .snapshot folder
     String result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assertions.assertTrue(result.contains("snap-renamed"));
+    assertTrue(result.contains("snap-renamed"));
     //There should be no snapshot named snap-to-rename now
-    Assertions.assertFalse(result.contains("snap-to-rename"));
+    assertFalse(result.contains("snap-to-rename"));
   }
 
   @Test
@@ -1436,15 +1440,15 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-to-delete");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     conn = snapshotTestPreconditions("DELETE",
         "DELETESNAPSHOT",
         "snapshotname=snap-to-delete");
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     //Validates the snapshot is not under .snapshot folder anymore
     String result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assertions.assertFalse(result.contains("snap-to-delete"));
+    assertFalse(result.contains("snap-to-delete"));
   }
 
   private HttpURLConnection sendRequestToHttpFSServer(String path, String op,
@@ -1481,7 +1485,7 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot
     dfs.allowSnapshot(path);
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Create a file and take a snapshot
     String file1 = pathStr + "/file1";
     createWithHttp(file1, null);
@@ -1495,7 +1499,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestGetSnapshotDiff(pathStr,
         "snap1", "snap2");
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1504,7 +1508,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Verify the content of diff with DFS API.
     SnapshotDiffReport dfsDiffReport = dfs.getSnapshotDiffReport(path,
         "snap1", "snap2");
-    Assertions.assertEquals(result, JsonUtil.toJsonString(dfsDiffReport));
+    assertEquals(result, JsonUtil.toJsonString(dfsDiffReport));
     // Clean up
     dfs.deleteSnapshot(path, "snap2");
     dfs.deleteSnapshot(path, "snap1");
@@ -1526,17 +1530,17 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot
     dfs.allowSnapshot(path);
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send requests with GETSNAPSHOTDIFF API
     // Snapshots snap1 and snap2 are not created, expect failures but not NPE
     HttpURLConnection conn = sendRequestGetSnapshotDiff(pathStr, "", "");
-    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "snap1", "");
-    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "", "snap2");
-    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "snap1", "snap2");
-    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Clean up
     dfs.delete(path, true);
   }
@@ -1547,7 +1551,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestToHttpFSServer("/",
         "GETSNAPSHOTTABLEDIRECTORYLIST", "");
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1555,7 +1559,7 @@ public class TestHttpFSServer extends HFSTestCase {
     String dirLst = reader.readLine();
     // Verify the content of diff with DFS API.
     SnapshottableDirectoryStatus[] dfsDirLst = dfs.getSnapshottableDirListing();
-    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   private void verifyGetSnapshotList(DistributedFileSystem dfs, Path path)
@@ -1564,7 +1568,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestToHttpFSServer(path.toString(),
         "GETSNAPSHOTLIST", "");
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1572,7 +1576,7 @@ public class TestHttpFSServer extends HFSTestCase {
     String dirLst = reader.readLine();
     // Verify the content of status with DFS API.
     SnapshotStatus[] dfsDirLst = dfs.getSnapshotListing(path);
-    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   @Test
@@ -1594,12 +1598,12 @@ public class TestHttpFSServer extends HFSTestCase {
     verifyGetSnapshottableDirectoryList(dfs);
     // Enable snapshot for path1
     dfs.allowSnapshot(path1);
-    Assertions.assertTrue(dfs.getFileStatus(path1).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path1).isSnapshotEnabled());
     // Verify response when there is one snapshottable directory
     verifyGetSnapshottableDirectoryList(dfs);
     // Enable snapshot for path2
     dfs.allowSnapshot(path2);
-    Assertions.assertTrue(dfs.getFileStatus(path2).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path2).isSnapshotEnabled());
     // Verify response when there are two snapshottable directories
     verifyGetSnapshottableDirectoryList(dfs);
 
@@ -1625,7 +1629,7 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot for path1
     dfs.allowSnapshot(path);
-    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Verify response when there is one snapshottable directory
     verifyGetSnapshotList(dfs, path);
     // Create a file and take a snapshot
@@ -1659,14 +1663,14 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.PUT);
     conn.connect();
     // Verify that it returned the final write location
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     JSONObject json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     String location = (String)json.get("Location");
-    Assertions.assertTrue(location.contains(DataParam.NAME));
-    Assertions.assertFalse(location.contains(NoRedirectParam.NAME));
-    Assertions.assertTrue(location.contains("CREATE"));
-    Assertions.assertTrue(
+    assertTrue(location.contains(DataParam.NAME));
+    assertFalse(location.contains(NoRedirectParam.NAME));
+    assertTrue(location.contains("CREATE"));
+    assertTrue(
        location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually write the file
@@ -1681,12 +1685,12 @@ public class TestHttpFSServer extends HFSTestCase {
     os.write(testContent.getBytes());
     os.close();
     // Verify that it created the file and returned the location
-    Assertions.assertEquals(
+    assertEquals(
         HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assertions.assertEquals(
+    assertEquals(
         TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path, location);
 
 
@@ -1698,13 +1702,13 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we got the final location to read from
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assertions.assertTrue(!location.contains(NoRedirectParam.NAME));
-    Assertions.assertTrue(location.contains("OPEN"));
-    Assertions.assertTrue(
+    assertTrue(!location.contains(NoRedirectParam.NAME));
+    assertTrue(location.contains("OPEN"));
+    assertTrue(
        location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually read
@@ -1713,9 +1717,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we read what we wrote
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     String content = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
-    Assertions.assertEquals(testContent, content);
+    assertEquals(testContent, content);
 
 
     // Get the checksum of the file which shouldn't redirect
@@ -1726,13 +1730,13 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we got the final location to write to
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assertions.assertTrue(!location.contains(NoRedirectParam.NAME));
-    Assertions.assertTrue(location.contains("GETFILECHECKSUM"));
-    Assertions.assertTrue(
+    assertTrue(!location.contains(NoRedirectParam.NAME));
+    assertTrue(location.contains("GETFILECHECKSUM"));
+    assertTrue(
        location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually get the checksum
@@ -1741,15 +1745,15 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we read what we wrote
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     JSONObject checksum = (JSONObject)json.get("FileChecksum");
-    Assertions.assertEquals(
+    assertEquals(
         "0000020000000000000000001b9c0a445fed3c0bf1e1aa7438d96b1500000000",
         checksum.get("bytes"));
-    Assertions.assertEquals(28L, checksum.get("length"));
-    Assertions.assertEquals("MD5-of-0MD5-of-512CRC32C", checksum.get("algorithm"));
+    assertEquals(28L, checksum.get("length"));
+    assertEquals("MD5-of-0MD5-of-512CRC32C", checksum.get("algorithm"));
   }
 
   private void verifyGetServerDefaults(DistributedFileSystem dfs)
@@ -1758,15 +1762,15 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn =
         sendRequestToHttpFSServer("/", "GETSERVERDEFAULTS", "");
     // Should return HTTP_OK
-    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
     // The response should be a one-line JSON string.
     String dirLst = reader.readLine();
     FsServerDefaults dfsDirLst = dfs.getServerDefaults();
-    Assertions.assertNotNull(dfsDirLst);
-    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    assertNotNull(dfsDirLst);
+    assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   @Test
@@ -1797,10 +1801,10 @@ public class TestHttpFSServer extends HFSTestCase {
 
     HttpURLConnection conn =
         sendRequestToHttpFSServer(dir, "CHECKACCESS", "fsaction=r--");
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     HttpURLConnection conn1 =
         sendRequestToHttpFSServer(dir, "CHECKACCESS", "fsaction=-w-");
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn1.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn1.getResponseCode());
   }
 
   @Test
@@ -1862,19 +1866,19 @@ public class TestHttpFSServer extends HFSTestCase {
 
     HttpURLConnection conn =
         putCmdWithReturn(dir, "SETECPOLICY", "ecpolicy=" + ecPolicyName);
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
 
     HttpURLConnection conn1 = sendRequestToHttpFSServer(dir, "GETECPOLICY", "");
     // Should return HTTP_OK
-    Assertions.assertEquals(conn1.getResponseCode(), HttpURLConnection.HTTP_OK);
+    assertEquals(conn1.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn1.getInputStream()));
     // The response should be a one-line JSON string.
     String dirLst = reader.readLine();
     ErasureCodingPolicy dfsDirLst = dfs.getErasureCodingPolicy(path1);
-    Assertions.assertNotNull(dfsDirLst);
-    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    assertNotNull(dfsDirLst);
+    assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
 
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(),
@@ -1883,18 +1887,18 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn2 = (HttpURLConnection) url.openConnection();
     conn2.setRequestMethod("POST");
     conn2.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn2.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn2.getResponseCode());
 
     // response should be null
     dfsDirLst = dfs.getErasureCodingPolicy(path1);
-    Assertions.assertNull(dfsDirLst);
+    assertNull(dfsDirLst);
 
     // test put opeartion with path as "/"
     final String dir1 = "/";
     HttpURLConnection conn3 =
         putCmdWithReturn(dir1, "SETECPOLICY", "ecpolicy=" + ecPolicyName);
     // Should return HTTP_OK
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn3.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn3.getResponseCode());
 
     // test post operation with path as "/"
     final String dir2 = "/";
@@ -1904,7 +1908,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn4 = (HttpURLConnection) url1.openConnection();
     conn4.setRequestMethod("POST");
     conn4.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn4.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn4.getResponseCode());
   }
 
   @Test
@@ -1927,7 +1931,7 @@ public class TestHttpFSServer extends HFSTestCase {
     assertEquals(HdfsConstants.COLD_STORAGE_POLICY_NAME,
         storagePolicy.getName());
     HttpURLConnection conn = putCmdWithReturn(dir, "SATISFYSTORAGEPOLICY", "");
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     Map<String, byte[]> xAttrs = dfs.getXAttrs(path1);
     assertTrue(
         xAttrs.containsKey(HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY));
@@ -1952,14 +1956,14 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestProperty("Content-Type", MediaType.APPLICATION_OCTET_STREAM);
     conn.setDoOutput(true);
     conn.connect();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     JSONObject json = (JSONObject) new JSONParser()
         .parse(new InputStreamReader(conn.getInputStream()));
 
     // get the location to write
     String location = (String) json.get("Location");
-    Assertions.assertTrue(location.contains(DataParam.NAME));
-    Assertions.assertTrue(location.contains("CREATE"));
+    assertTrue(location.contains(DataParam.NAME));
+    assertTrue(location.contains("CREATE"));
     url = new URL(location);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod(HttpMethod.PUT);
@@ -1971,11 +1975,11 @@ public class TestHttpFSServer extends HFSTestCase {
     os.write(writeStr.getBytes());
     os.close();
     // Verify that file got created
-    Assertions.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
     json = (JSONObject) new JSONParser()
         .parse(new InputStreamReader(conn.getInputStream()));
     location = (String) json.get("Location");
-    Assertions.assertEquals(TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path,
+    assertEquals(TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path,
         location);
   }
 
@@ -2024,9 +2028,9 @@ public class TestHttpFSServer extends HFSTestCase {
     createWithHttp(file1, null);
     HttpURLConnection conn = sendRequestToHttpFSServer(file1,
         "GETFILEBLOCKLOCATIONS", "length=10&offset10");
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     BlockLocation[] locations1 = dfs.getFileBlockLocations(new Path(file1), 0, 1);
-    Assertions.assertNotNull(locations1);
+    assertNotNull(locations1);
 
     Map<?, ?> jsonMap = JsonSerialization.mapReader().readValue(conn.getInputStream());
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.fs.http.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
@@ -45,7 +45,7 @@ import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthentica
 import org.apache.hadoop.security.token.delegation.web.KerberosDelegationTokenAuthenticationHandler;
 import org.apache.hadoop.util.JsonSerialization;
 import org.json.simple.JSONArray;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -106,7 +106,7 @@ import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -205,9 +205,9 @@ public class TestHttpFSServer extends HFSTestCase {
   private Configuration createHttpFSConf(boolean addDelegationTokenAuthHandler,
                                          boolean sslEnabled) throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assert.assertTrue(new File(homeDir, "conf").mkdir());
-    Assert.assertTrue(new File(homeDir, "log").mkdir());
-    Assert.assertTrue(new File(homeDir, "temp").mkdir());
+    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
+    Assertions.assertTrue(new File(homeDir, "log").mkdir());
+    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -269,7 +269,7 @@ public class TestHttpFSServer extends HFSTestCase {
     File homeDir = TestDirHelper.getTestDir();
     // HDFS configuration
     File hadoopConfDir = new File(new File(homeDir, "conf"), "hadoop-conf");
-    Assert.assertTrue(hadoopConfDir.exists());
+    Assertions.assertTrue(hadoopConfDir.exists());
 
     File siteFile = new File(hadoopConfDir, sitename);
     OutputStream os = new FileOutputStream(siteFile);
@@ -313,7 +313,7 @@ public class TestHttpFSServer extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY");
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
+    Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
                         conn.getResponseCode());
 
     String tokenSigned = getSignedTokenString();
@@ -323,7 +323,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty("Cookie",
                             AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     JSONObject json = (JSONObject)new JSONParser().parse(
@@ -336,7 +336,7 @@ public class TestHttpFSServer extends HFSTestCase {
     Token<AbstractDelegationTokenIdentifier> dToken =
         new Token<AbstractDelegationTokenIdentifier>();
     dToken.decodeFromUrlString(tokenStr);
-    Assert.assertEquals(sslEnabled ?
+    Assertions.assertEquals(sslEnabled ?
         WebHdfsConstants.SWEBHDFS_TOKEN_KIND :
         WebHdfsConstants.WEBHDFS_TOKEN_KIND,
         dToken.getKind());
@@ -344,14 +344,14 @@ public class TestHttpFSServer extends HFSTestCase {
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
-    Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
+    Assertions.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
@@ -360,27 +360,27 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.setRequestProperty("Cookie",
                             AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=CANCELDELEGATIONTOKEN&token=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
                         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
                   "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+    Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
                         conn.getResponseCode());
 
     // getTrash test with delegation
     url = new URL(TestJettyHelper.getJettyURL(),
         "/webhdfs/v1/?op=GETTRASHROOT&delegation=" + tokenStr);
     conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+    Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
         conn.getResponseCode());
 
     url = new URL(TestJettyHelper.getJettyURL(),
@@ -388,7 +388,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty("Cookie",
         AuthenticatedURL.AUTH_COOKIE  + "=" + tokenSigned);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
         conn.getResponseCode());
   }
 
@@ -403,26 +403,26 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format("/webhdfs/v1?user.name={0}&op=instrumentation",
                              "nobody"));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(),
+    Assertions.assertEquals(conn.getResponseCode(),
                         HttpURLConnection.HTTP_UNAUTHORIZED);
 
     url = new URL(TestJettyHelper.getJettyURL(),
         MessageFormat.format("/webhdfs/v1?user.name={0}&op=instrumentation",
                              HadoopUsersConfTestHelper.getHadoopUsers()[0]));
     conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     String line = reader.readLine();
     reader.close();
-    Assert.assertTrue(line.contains("\"counters\":{"));
+    Assertions.assertTrue(line.contains("\"counters\":{"));
 
     url = new URL(TestJettyHelper.getJettyURL(),
         MessageFormat.format(
             "/webhdfs/v1/foo?user.name={0}&op=instrumentation",
             HadoopUsersConfTestHelper.getHadoopUsers()[0]));
     conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(),
+    Assertions.assertEquals(conn.getResponseCode(),
                         HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
@@ -439,12 +439,12 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format("/webhdfs/v1/?user.name={0}&op=liststatus",
                              user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     reader.readLine();
     reader.close();
-    Assert.assertEquals(1 + oldOpsListStatus,
+    Assertions.assertEquals(1 + oldOpsListStatus,
         (long) metricsGetter.get("LISTSTATUS").call());
   }
 
@@ -462,11 +462,11 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     getStatus("/tmp/sub-tmp", "LISTSTATUS");
     long opsStat =
         metricsGetter.get("MKDIRS").call();
-    Assert.assertEquals(1 + oldMkdirOpsStat, opsStat);
+    Assertions.assertEquals(1 + oldMkdirOpsStat, opsStat);
   }
 
   @Test
@@ -486,12 +486,12 @@ public class TestHttpFSServer extends HFSTestCase {
         MessageFormat.format(
             "/webhdfs/v1/tmp?user.name={0}&op=liststatus&filter=f*", user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     reader.readLine();
     reader.close();
-    Assert.assertEquals(1 + oldOpsListStatus,
+    Assertions.assertEquals(1 + oldOpsListStatus,
         (long) metricsGetter.get("LISTSTATUS").call());
   }
 
@@ -539,7 +539,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.addRequestProperty("Content-Type", "application/octet-stream");
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
   }
 
   /**
@@ -577,8 +577,8 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("PUT");
     conn.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
-    Assert.assertEquals(1 + oldOpsMkdir,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(1 + oldOpsMkdir,
         (long) metricsGetter.get("MKDIRS").call());
   }
 
@@ -606,13 +606,13 @@ public class TestHttpFSServer extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(), pathOps);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
 
     BufferedReader reader =
             new BufferedReader(new InputStreamReader(conn.getInputStream()));
     long opsStat =
         metricsGetter.getOrDefault(command, defaultExitMetricGetter).call();
-    Assert.assertEquals(oldOpsStat + 1L, opsStat);
+    Assertions.assertEquals(oldOpsStat + 1L, opsStat);
     return reader.readLine();
   }
 
@@ -624,7 +624,7 @@ public class TestHttpFSServer extends HFSTestCase {
    */
   private void putCmd(String filename, String command,
                       String params) throws Exception {
-    Assert.assertEquals(HttpURLConnection.HTTP_OK,
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK,
             putCmdWithReturn(filename, command, params).getResponseCode());
   }
 
@@ -772,19 +772,19 @@ public class TestHttpFSServer extends HFSTestCase {
 
     createWithHttp("/perm/none", null);
     String statusJson = getStatus("/perm/none", "GETFILESTATUS");
-    Assert.assertTrue("755".equals(getPerms(statusJson)));
+    Assertions.assertTrue("755".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-777", "777");
     statusJson = getStatus("/perm/p-777", "GETFILESTATUS");
-    Assert.assertTrue("777".equals(getPerms(statusJson)));
+    Assertions.assertTrue("777".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-654", "654");
     statusJson = getStatus("/perm/p-654", "GETFILESTATUS");
-    Assert.assertTrue("654".equals(getPerms(statusJson)));
+    Assertions.assertTrue("654".equals(getPerms(statusJson)));
 
     createWithHttp("/perm/p-321", "321");
     statusJson = getStatus("/perm/p-321", "GETFILESTATUS");
-    Assert.assertTrue("321".equals(getPerms(statusJson)));
+    Assertions.assertTrue("321".equals(getPerms(statusJson)));
   }
 
   /**
@@ -810,29 +810,29 @@ public class TestHttpFSServer extends HFSTestCase {
     createWithHttp(path, null);
     String statusJson = getStatus(path, "GETXATTRS");
     Map<String, byte[]> xAttrs = getXAttrs(statusJson);
-    Assert.assertEquals(0, xAttrs.size());
+    Assertions.assertEquals(0, xAttrs.size());
 
     // Set two xattrs
     putCmd(path, "SETXATTR", setXAttrParam(name1, value1));
     putCmd(path, "SETXATTR", setXAttrParam(name2, value2));
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assert.assertEquals(2, xAttrs.size());
-    Assert.assertArrayEquals(value1, xAttrs.get(name1));
-    Assert.assertArrayEquals(value2, xAttrs.get(name2));
+    Assertions.assertEquals(2, xAttrs.size());
+    Assertions.assertArrayEquals(value1, xAttrs.get(name1));
+    Assertions.assertArrayEquals(value2, xAttrs.get(name2));
 
     // Remove one xattr
     putCmd(path, "REMOVEXATTR", "xattr.name=" + name1);
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assert.assertEquals(1, xAttrs.size());
-    Assert.assertArrayEquals(value2, xAttrs.get(name2));
+    Assertions.assertEquals(1, xAttrs.size());
+    Assertions.assertArrayEquals(value2, xAttrs.get(name2));
 
     // Remove another xattr, then there is no xattr
     putCmd(path, "REMOVEXATTR", "xattr.name=" + name2);
     statusJson = getStatus(path, "GETXATTRS");
     xAttrs = getXAttrs(statusJson);
-    Assert.assertEquals(0, xAttrs.size());
+    Assertions.assertEquals(0, xAttrs.size());
   }
 
   /** Params for setting an xAttr. */
@@ -881,14 +881,14 @@ public class TestHttpFSServer extends HFSTestCase {
 
     /* getfilestatus and liststatus don't have 'aclBit' in their reply */
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
 
     /* getaclstatus works and returns no entries */
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 0);
+    Assertions.assertTrue(aclEntries.size() == 0);
 
     /*
      * Now set an ACL on the file.  (getfile|list)status have aclBit,
@@ -896,41 +896,41 @@ public class TestHttpFSServer extends HFSTestCase {
      */
     putCmd(path, "SETACL", aclSpec);
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assert.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assert.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 2);
-    Assert.assertTrue(aclEntries.contains(aclUser1));
-    Assert.assertTrue(aclEntries.contains(aclGroup1));
+    Assertions.assertTrue(aclEntries.size() == 2);
+    Assertions.assertTrue(aclEntries.contains(aclUser1));
+    Assertions.assertTrue(aclEntries.contains(aclGroup1));
 
     /* Modify acl entries to add another user acl */
     putCmd(path, "MODIFYACLENTRIES", modAclSpec);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 3);
-    Assert.assertTrue(aclEntries.contains(aclUser1));
-    Assert.assertTrue(aclEntries.contains(aclUser2));
-    Assert.assertTrue(aclEntries.contains(aclGroup1));
+    Assertions.assertTrue(aclEntries.size() == 3);
+    Assertions.assertTrue(aclEntries.contains(aclUser1));
+    Assertions.assertTrue(aclEntries.contains(aclUser2));
+    Assertions.assertTrue(aclEntries.contains(aclGroup1));
 
     /* Remove the first user acl entry and verify */
     putCmd(path, "REMOVEACLENTRIES", remAclSpec);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 2);
-    Assert.assertTrue(aclEntries.contains(aclUser2));
-    Assert.assertTrue(aclEntries.contains(aclGroup1));
+    Assertions.assertTrue(aclEntries.size() == 2);
+    Assertions.assertTrue(aclEntries.contains(aclUser2));
+    Assertions.assertTrue(aclEntries.contains(aclGroup1));
 
     /* Remove all acls and verify */
     putCmd(path, "REMOVEACL", null);
     statusJson = getStatus(path, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 0);
+    Assertions.assertTrue(aclEntries.size() == 0);
     statusJson = getStatus(path, "GETFILESTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "LISTSTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
   }
 
   /**
@@ -962,30 +962,30 @@ public class TestHttpFSServer extends HFSTestCase {
 
     /* getfilestatus and liststatus don't have 'aclBit' in their reply */
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
 
     /* No ACLs, either */
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 0);
+    Assertions.assertTrue(aclEntries.size() == 0);
 
     /* Give it a default ACL and verify */
     putCmd(dir, "SETACL", defSpec1);
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assert.assertNotEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertNotEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 5);
+    Assertions.assertTrue(aclEntries.size() == 5);
     /* 4 Entries are default:(user|group|mask|other):perm */
-    Assert.assertTrue(aclEntries.contains(defUser1));
+    Assertions.assertTrue(aclEntries.contains(defUser1));
 
     /* Remove the default ACL and re-verify */
     putCmd(dir, "REMOVEDEFAULTACL", null);
     statusJson = getStatus(dir, "GETFILESTATUS");
-    Assert.assertEquals(-1, statusJson.indexOf("aclBit"));
+    Assertions.assertEquals(-1, statusJson.indexOf("aclBit"));
     statusJson = getStatus(dir, "GETACLSTATUS");
     aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.size() == 0);
+    Assertions.assertTrue(aclEntries.size() == 0);
   }
 
   @Test
@@ -1026,8 +1026,8 @@ public class TestHttpFSServer extends HFSTestCase {
     // Verify ACL
     String statusJson = getStatus(path, "GETACLSTATUS");
     List<String> aclEntries = getAclEntries(statusJson);
-    Assert.assertTrue(aclEntries.contains(aclUser));
-    Assert.assertTrue(aclEntries.contains(aclGroup));
+    Assertions.assertTrue(aclEntries.contains(aclUser));
+    Assertions.assertTrue(aclEntries.contains(aclGroup));
   }
 
   @Test
@@ -1050,11 +1050,11 @@ public class TestHttpFSServer extends HFSTestCase {
             "/webhdfs/v1/tmp/foo?user.name={0}&op=open&offset=1&length=2",
             user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     InputStream is = conn.getInputStream();
-    Assert.assertEquals(1, is.read());
-    Assert.assertEquals(2, is.read());
-    Assert.assertEquals(-1, is.read());
+    Assertions.assertEquals(1, is.read());
+    Assertions.assertEquals(2, is.read());
+    Assertions.assertEquals(-1, is.read());
   }
 
   @Test
@@ -1089,8 +1089,8 @@ public class TestHttpFSServer extends HFSTestCase {
     AclStatus aclStatus = fs.getAclStatus(new Path(notUnmaskedFile));
     AclEntry theAcl = findAclWithName(aclStatus, "user2");
 
-    Assert.assertNotNull(theAcl);
-    Assert.assertEquals(FsAction.NONE,
+    Assertions.assertNotNull(theAcl);
+    Assertions.assertEquals(FsAction.NONE,
         aclStatus.getEffectivePermission(theAcl));
 
     // Create another file, this time pass a mask of 777. Now the inherited
@@ -1100,8 +1100,8 @@ public class TestHttpFSServer extends HFSTestCase {
     aclStatus = fs.getAclStatus(new Path(unmaskedFile));
     theAcl = findAclWithName(aclStatus, "user2");
 
-    Assert.assertNotNull(theAcl);
-    Assert.assertEquals(FsAction.READ_WRITE,
+    Assertions.assertNotNull(theAcl);
+    Assertions.assertEquals(FsAction.READ_WRITE,
         aclStatus.getEffectivePermission(theAcl));
   }
 
@@ -1137,8 +1137,8 @@ public class TestHttpFSServer extends HFSTestCase {
     AclStatus aclStatus = fs.getAclStatus(new Path(notUnmaskedDir));
     AclEntry theAcl = findAclWithName(aclStatus, "user2");
 
-    Assert.assertNotNull(theAcl);
-    Assert.assertEquals(FsAction.NONE,
+    Assertions.assertNotNull(theAcl);
+    Assertions.assertEquals(FsAction.NONE,
         aclStatus.getEffectivePermission(theAcl));
 
     // Create another file, this time pass a mask of 777. Now the inherited
@@ -1148,8 +1148,8 @@ public class TestHttpFSServer extends HFSTestCase {
     aclStatus = fs.getAclStatus(new Path(unmaskedDir));
     theAcl = findAclWithName(aclStatus, "user2");
 
-    Assert.assertNotNull(theAcl);
-    Assert.assertEquals(FsAction.READ_WRITE,
+    Assertions.assertNotNull(theAcl);
+    Assertions.assertEquals(FsAction.READ_WRITE,
         aclStatus.getEffectivePermission(theAcl));
   }
 
@@ -1167,7 +1167,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setDoInput(true);
     conn.setDoOutput(true);
     conn.setRequestMethod("PUT");
-    Assert.assertEquals(conn.getResponseCode(),
+    Assertions.assertEquals(conn.getResponseCode(),
         HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
@@ -1183,7 +1183,7 @@ public class TestHttpFSServer extends HFSTestCase {
 
     Path expectedPath = new Path(FileSystem.USER_HOME_PREFIX,
         new Path(user, FileSystem.TRASH_PREFIX));
-    Assert.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
 
     byte[] array = new byte[]{0, 1, 2, 3};
     FileSystem fs = FileSystem.get(TestHdfsHelper.getHdfsConf());
@@ -1194,7 +1194,7 @@ public class TestHttpFSServer extends HFSTestCase {
 
     trashJson = getStatus("/tmp/foo", "GETTRASHROOT");
     trashPath = getPath(trashJson);
-    Assert.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
 
     //TestHdfsHelp has already set up EZ environment
     final Path ezFile = TestHdfsHelper.ENCRYPTED_FILE;
@@ -1202,7 +1202,7 @@ public class TestHttpFSServer extends HFSTestCase {
     trashJson = getStatus(ezFile.toUri().getPath(), "GETTRASHROOT");
     trashPath = getPath(trashJson);
     expectedPath = new Path(ezPath, new Path(FileSystem.TRASH_PREFIX, user));
-    Assert.assertEquals(expectedPath.toUri().getPath(), trashPath);
+    Assertions.assertEquals(expectedPath.toUri().getPath(), trashPath);
   }
 
   @Test
@@ -1226,7 +1226,7 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
 
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
     //needed to make the given dir snapshottable
     Path snapshottablePath = new Path("/tmp/tmp-snap-test");
@@ -1259,7 +1259,7 @@ public class TestHttpFSServer extends HFSTestCase {
     DistributedFileSystem dfs = (DistributedFileSystem) FileSystem.get(
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // FileStatus should have snapshot enabled bit unset by default
-    Assert.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send a request with ALLOWSNAPSHOT API
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(), MessageFormat.format(
@@ -1269,9 +1269,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should have snapshot enabled bit set
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.delete(path, true);
   }
@@ -1292,7 +1292,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Allow snapshot
     dfs.allowSnapshot(path);
     // FileStatus should have snapshot enabled bit set so far
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send a request with DISALLOWSNAPSHOT API
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(), MessageFormat.format(
@@ -1302,9 +1302,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should not have snapshot enabled bit set
-    Assert.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertFalse(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.delete(path, true);
   }
@@ -1325,7 +1325,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Allow snapshot
     dfs.allowSnapshot(path);
     // FileStatus should have snapshot enabled bit set so far
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Create some snapshots
     dfs.createSnapshot(path, "snap-01");
     dfs.createSnapshot(path, "snap-02");
@@ -1338,9 +1338,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     // Should not return HTTP_OK
-    Assert.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // FileStatus should still have snapshot enabled bit set
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Clean up
     dfs.deleteSnapshot(path, "snap-02");
     dfs.deleteSnapshot(path, "snap-01");
@@ -1356,17 +1356,17 @@ public class TestHttpFSServer extends HFSTestCase {
     final HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-with-name");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     final BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
     String result = reader.readLine();
     //Validates if the content format is correct
-    Assert.assertTrue(result.
+    Assertions.assertTrue(result.
         equals("{\"Path\":\"/tmp/tmp-snap-test/.snapshot/snap-with-name\"}"));
     //Validates if the snapshot is properly created under .snapshot folder
     result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assert.assertTrue(result.contains("snap-with-name"));
+    Assertions.assertTrue(result.contains("snap-with-name"));
   }
 
   @Test
@@ -1378,19 +1378,19 @@ public class TestHttpFSServer extends HFSTestCase {
     final HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     final BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()));
     String result = reader.readLine();
     //Validates if the content format is correct
-    Assert.assertTrue(Pattern.matches(
+    Assertions.assertTrue(Pattern.matches(
         "(\\{\\\"Path\\\"\\:\\\"/tmp/tmp-snap-test/.snapshot/s)" +
             "(\\d{8})(-)(\\d{6})(\\.)(\\d{3})(\\\"\\})", result));
     //Validates if the snapshot is properly created under .snapshot folder
     result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
 
-    Assert.assertTrue(Pattern.matches("(.+)(\\\"pathSuffix\\\":\\\"s)" +
+    Assertions.assertTrue(Pattern.matches("(.+)(\\\"pathSuffix\\\":\\\"s)" +
             "(\\d{8})(-)(\\d{6})(\\.)(\\d{3})(\\\")(.+)",
         result));
   }
@@ -1404,18 +1404,18 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-to-rename");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     conn = snapshotTestPreconditions("PUT",
         "RENAMESNAPSHOT",
         "oldsnapshotname=snap-to-rename" +
             "&snapshotname=snap-renamed");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     //Validates the snapshot is properly renamed under .snapshot folder
     String result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assert.assertTrue(result.contains("snap-renamed"));
+    Assertions.assertTrue(result.contains("snap-renamed"));
     //There should be no snapshot named snap-to-rename now
-    Assert.assertFalse(result.contains("snap-to-rename"));
+    Assertions.assertFalse(result.contains("snap-to-rename"));
   }
 
   @Test
@@ -1436,15 +1436,15 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = snapshotTestPreconditions("PUT",
         "CREATESNAPSHOT",
         "snapshotname=snap-to-delete");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     conn = snapshotTestPreconditions("DELETE",
         "DELETESNAPSHOT",
         "snapshotname=snap-to-delete");
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     //Validates the snapshot is not under .snapshot folder anymore
     String result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
-    Assert.assertFalse(result.contains("snap-to-delete"));
+    Assertions.assertFalse(result.contains("snap-to-delete"));
   }
 
   private HttpURLConnection sendRequestToHttpFSServer(String path, String op,
@@ -1481,7 +1481,7 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot
     dfs.allowSnapshot(path);
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Create a file and take a snapshot
     String file1 = pathStr + "/file1";
     createWithHttp(file1, null);
@@ -1495,7 +1495,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestGetSnapshotDiff(pathStr,
         "snap1", "snap2");
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1504,7 +1504,7 @@ public class TestHttpFSServer extends HFSTestCase {
     // Verify the content of diff with DFS API.
     SnapshotDiffReport dfsDiffReport = dfs.getSnapshotDiffReport(path,
         "snap1", "snap2");
-    Assert.assertEquals(result, JsonUtil.toJsonString(dfsDiffReport));
+    Assertions.assertEquals(result, JsonUtil.toJsonString(dfsDiffReport));
     // Clean up
     dfs.deleteSnapshot(path, "snap2");
     dfs.deleteSnapshot(path, "snap1");
@@ -1526,17 +1526,17 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot
     dfs.allowSnapshot(path);
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Send requests with GETSNAPSHOTDIFF API
     // Snapshots snap1 and snap2 are not created, expect failures but not NPE
     HttpURLConnection conn = sendRequestGetSnapshotDiff(pathStr, "", "");
-    Assert.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "snap1", "");
-    Assert.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "", "snap2");
-    Assert.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     sendRequestGetSnapshotDiff(pathStr, "snap1", "snap2");
-    Assert.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertNotEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Clean up
     dfs.delete(path, true);
   }
@@ -1547,7 +1547,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestToHttpFSServer("/",
         "GETSNAPSHOTTABLEDIRECTORYLIST", "");
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1555,7 +1555,7 @@ public class TestHttpFSServer extends HFSTestCase {
     String dirLst = reader.readLine();
     // Verify the content of diff with DFS API.
     SnapshottableDirectoryStatus[] dfsDirLst = dfs.getSnapshottableDirListing();
-    Assert.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   private void verifyGetSnapshotList(DistributedFileSystem dfs, Path path)
@@ -1564,7 +1564,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn = sendRequestToHttpFSServer(path.toString(),
         "GETSNAPSHOTLIST", "");
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -1572,7 +1572,7 @@ public class TestHttpFSServer extends HFSTestCase {
     String dirLst = reader.readLine();
     // Verify the content of status with DFS API.
     SnapshotStatus[] dfsDirLst = dfs.getSnapshotListing(path);
-    Assert.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   @Test
@@ -1594,12 +1594,12 @@ public class TestHttpFSServer extends HFSTestCase {
     verifyGetSnapshottableDirectoryList(dfs);
     // Enable snapshot for path1
     dfs.allowSnapshot(path1);
-    Assert.assertTrue(dfs.getFileStatus(path1).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path1).isSnapshotEnabled());
     // Verify response when there is one snapshottable directory
     verifyGetSnapshottableDirectoryList(dfs);
     // Enable snapshot for path2
     dfs.allowSnapshot(path2);
-    Assert.assertTrue(dfs.getFileStatus(path2).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path2).isSnapshotEnabled());
     // Verify response when there are two snapshottable directories
     verifyGetSnapshottableDirectoryList(dfs);
 
@@ -1625,7 +1625,7 @@ public class TestHttpFSServer extends HFSTestCase {
         path.toUri(), TestHdfsHelper.getHdfsConf());
     // Enable snapshot for path1
     dfs.allowSnapshot(path);
-    Assert.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
+    Assertions.assertTrue(dfs.getFileStatus(path).isSnapshotEnabled());
     // Verify response when there is one snapshottable directory
     verifyGetSnapshotList(dfs, path);
     // Create a file and take a snapshot
@@ -1659,15 +1659,15 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.PUT);
     conn.connect();
     // Verify that it returned the final write location
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     JSONObject json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     String location = (String)json.get("Location");
-    Assert.assertTrue(location.contains(DataParam.NAME));
-    Assert.assertFalse(location.contains(NoRedirectParam.NAME));
-    Assert.assertTrue(location.contains("CREATE"));
-    Assert.assertTrue("Wrong location: " + location,
-        location.startsWith(TestJettyHelper.getJettyURL().toString()));
+    Assertions.assertTrue(location.contains(DataParam.NAME));
+    Assertions.assertFalse(location.contains(NoRedirectParam.NAME));
+    Assertions.assertTrue(location.contains("CREATE"));
+    Assertions.assertTrue(
+       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually write the file
     url = new URL(location);
@@ -1681,12 +1681,12 @@ public class TestHttpFSServer extends HFSTestCase {
     os.write(testContent.getBytes());
     os.close();
     // Verify that it created the file and returned the location
-    Assert.assertEquals(
+    Assertions.assertEquals(
         HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path, location);
 
 
@@ -1698,14 +1698,14 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we got the final location to read from
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assert.assertTrue(!location.contains(NoRedirectParam.NAME));
-    Assert.assertTrue(location.contains("OPEN"));
-    Assert.assertTrue("Wrong location: " + location,
-        location.startsWith(TestJettyHelper.getJettyURL().toString()));
+    Assertions.assertTrue(!location.contains(NoRedirectParam.NAME));
+    Assertions.assertTrue(location.contains("OPEN"));
+    Assertions.assertTrue(
+       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually read
     url = new URL(location);
@@ -1713,9 +1713,9 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we read what we wrote
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     String content = IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
-    Assert.assertEquals(testContent, content);
+    Assertions.assertEquals(testContent, content);
 
 
     // Get the checksum of the file which shouldn't redirect
@@ -1726,14 +1726,14 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we got the final location to write to
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     location = (String)json.get("Location");
-    Assert.assertTrue(!location.contains(NoRedirectParam.NAME));
-    Assert.assertTrue(location.contains("GETFILECHECKSUM"));
-    Assert.assertTrue("Wrong location: " + location,
-        location.startsWith(TestJettyHelper.getJettyURL().toString()));
+    Assertions.assertTrue(!location.contains(NoRedirectParam.NAME));
+    Assertions.assertTrue(location.contains("GETFILECHECKSUM"));
+    Assertions.assertTrue(
+       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
 
     // Use the location to actually get the checksum
     url = new URL(location);
@@ -1741,15 +1741,15 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestMethod(HttpMethod.GET);
     conn.connect();
     // Verify that we read what we wrote
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     json = (JSONObject)new JSONParser().parse(
         new InputStreamReader(conn.getInputStream()));
     JSONObject checksum = (JSONObject)json.get("FileChecksum");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "0000020000000000000000001b9c0a445fed3c0bf1e1aa7438d96b1500000000",
         checksum.get("bytes"));
-    Assert.assertEquals(28L, checksum.get("length"));
-    Assert.assertEquals("MD5-of-0MD5-of-512CRC32C", checksum.get("algorithm"));
+    Assertions.assertEquals(28L, checksum.get("length"));
+    Assertions.assertEquals("MD5-of-0MD5-of-512CRC32C", checksum.get("algorithm"));
   }
 
   private void verifyGetServerDefaults(DistributedFileSystem dfs)
@@ -1758,15 +1758,15 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn =
         sendRequestToHttpFSServer("/", "GETSERVERDEFAULTS", "");
     // Should return HTTP_OK
-    Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn.getInputStream()));
     // The response should be a one-line JSON string.
     String dirLst = reader.readLine();
     FsServerDefaults dfsDirLst = dfs.getServerDefaults();
-    Assert.assertNotNull(dfsDirLst);
-    Assert.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    Assertions.assertNotNull(dfsDirLst);
+    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
   }
 
   @Test
@@ -1797,10 +1797,10 @@ public class TestHttpFSServer extends HFSTestCase {
 
     HttpURLConnection conn =
         sendRequestToHttpFSServer(dir, "CHECKACCESS", "fsaction=r--");
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     HttpURLConnection conn1 =
         sendRequestToHttpFSServer(dir, "CHECKACCESS", "fsaction=-w-");
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn1.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn1.getResponseCode());
   }
 
   @Test
@@ -1831,8 +1831,8 @@ public class TestHttpFSServer extends HFSTestCase {
     JSONObject jsonObject = (JSONObject) parser.parse(getFileStatusResponse);
     JSONObject details = (JSONObject) jsonObject.get("FileStatus");
     String ecpolicyForECfile = (String) details.get("ecPolicy");
-    assertEquals("EC policy for ecFile should match the set EC policy",
-        ecpolicyForECfile, ecPolicyName);
+    assertEquals(
+       ecpolicyForECfile, ecPolicyName, "EC policy for ecFile should match the set EC policy");
 
     // Verify httpFs getFileStatus with WEBHDFS REST API
     WebHdfsFileSystem httpfsWebHdfs = (WebHdfsFileSystem) FileSystem.get(
@@ -1862,19 +1862,19 @@ public class TestHttpFSServer extends HFSTestCase {
 
     HttpURLConnection conn =
         putCmdWithReturn(dir, "SETECPOLICY", "ecpolicy=" + ecPolicyName);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
 
     HttpURLConnection conn1 = sendRequestToHttpFSServer(dir, "GETECPOLICY", "");
     // Should return HTTP_OK
-    Assert.assertEquals(conn1.getResponseCode(), HttpURLConnection.HTTP_OK);
+    Assertions.assertEquals(conn1.getResponseCode(), HttpURLConnection.HTTP_OK);
     // Verify the response
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(conn1.getInputStream()));
     // The response should be a one-line JSON string.
     String dirLst = reader.readLine();
     ErasureCodingPolicy dfsDirLst = dfs.getErasureCodingPolicy(path1);
-    Assert.assertNotNull(dfsDirLst);
-    Assert.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
+    Assertions.assertNotNull(dfsDirLst);
+    Assertions.assertEquals(dirLst, JsonUtil.toJsonString(dfsDirLst));
 
     String user = HadoopUsersConfTestHelper.getHadoopUsers()[0];
     URL url = new URL(TestJettyHelper.getJettyURL(),
@@ -1883,18 +1883,18 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn2 = (HttpURLConnection) url.openConnection();
     conn2.setRequestMethod("POST");
     conn2.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn2.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn2.getResponseCode());
 
     // response should be null
     dfsDirLst = dfs.getErasureCodingPolicy(path1);
-    Assert.assertNull(dfsDirLst);
+    Assertions.assertNull(dfsDirLst);
 
     // test put opeartion with path as "/"
     final String dir1 = "/";
     HttpURLConnection conn3 =
         putCmdWithReturn(dir1, "SETECPOLICY", "ecpolicy=" + ecPolicyName);
     // Should return HTTP_OK
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn3.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn3.getResponseCode());
 
     // test post operation with path as "/"
     final String dir2 = "/";
@@ -1904,7 +1904,7 @@ public class TestHttpFSServer extends HFSTestCase {
     HttpURLConnection conn4 = (HttpURLConnection) url1.openConnection();
     conn4.setRequestMethod("POST");
     conn4.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn4.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn4.getResponseCode());
   }
 
   @Test
@@ -1927,7 +1927,7 @@ public class TestHttpFSServer extends HFSTestCase {
     assertEquals(HdfsConstants.COLD_STORAGE_POLICY_NAME,
         storagePolicy.getName());
     HttpURLConnection conn = putCmdWithReturn(dir, "SATISFYSTORAGEPOLICY", "");
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     Map<String, byte[]> xAttrs = dfs.getXAttrs(path1);
     assertTrue(
         xAttrs.containsKey(HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY));
@@ -1952,14 +1952,14 @@ public class TestHttpFSServer extends HFSTestCase {
     conn.setRequestProperty("Content-Type", MediaType.APPLICATION_OCTET_STREAM);
     conn.setDoOutput(true);
     conn.connect();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     JSONObject json = (JSONObject) new JSONParser()
         .parse(new InputStreamReader(conn.getInputStream()));
 
     // get the location to write
     String location = (String) json.get("Location");
-    Assert.assertTrue(location.contains(DataParam.NAME));
-    Assert.assertTrue(location.contains("CREATE"));
+    Assertions.assertTrue(location.contains(DataParam.NAME));
+    Assertions.assertTrue(location.contains("CREATE"));
     url = new URL(location);
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod(HttpMethod.PUT);
@@ -1971,11 +1971,11 @@ public class TestHttpFSServer extends HFSTestCase {
     os.write(writeStr.getBytes());
     os.close();
     // Verify that file got created
-    Assert.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_CREATED, conn.getResponseCode());
     json = (JSONObject) new JSONParser()
         .parse(new InputStreamReader(conn.getInputStream()));
     location = (String) json.get("Location");
-    Assert.assertEquals(TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path,
+    Assertions.assertEquals(TestJettyHelper.getJettyURL() + "/webhdfs/v1" + path,
         location);
   }
 
@@ -2024,9 +2024,9 @@ public class TestHttpFSServer extends HFSTestCase {
     createWithHttp(file1, null);
     HttpURLConnection conn = sendRequestToHttpFSServer(file1,
         "GETFILEBLOCKLOCATIONS", "length=10&offset10");
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     BlockLocation[] locations1 = dfs.getFileBlockLocations(new Path(file1), 0, 1);
-    Assert.assertNotNull(locations1);
+    Assertions.assertNotNull(locations1);
 
     Map<?, ?> jsonMap = JsonSerialization.mapReader().readValue(conn.getInputStream());
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthentica
 import org.apache.hadoop.security.token.delegation.web.KerberosDelegationTokenAuthenticationHandler;
 import org.apache.hadoop.util.JsonSerialization;
 import org.json.simple.JSONArray;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -1670,8 +1669,8 @@ public class TestHttpFSServer extends HFSTestCase {
     assertTrue(location.contains(DataParam.NAME));
     assertFalse(location.contains(NoRedirectParam.NAME));
     assertTrue(location.contains("CREATE"));
-    assertTrue(
-       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
+    assertTrue(location.startsWith(TestJettyHelper.getJettyURL().toString()),
+        "Wrong location: " + location);
 
     // Use the location to actually write the file
     url = new URL(location);
@@ -1708,8 +1707,8 @@ public class TestHttpFSServer extends HFSTestCase {
     location = (String)json.get("Location");
     assertTrue(!location.contains(NoRedirectParam.NAME));
     assertTrue(location.contains("OPEN"));
-    assertTrue(
-       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
+    assertTrue(location.startsWith(TestJettyHelper.getJettyURL().toString()),
+        "Wrong location: " + location);
 
     // Use the location to actually read
     url = new URL(location);
@@ -1736,8 +1735,8 @@ public class TestHttpFSServer extends HFSTestCase {
     location = (String)json.get("Location");
     assertTrue(!location.contains(NoRedirectParam.NAME));
     assertTrue(location.contains("GETFILECHECKSUM"));
-    assertTrue(
-       location.startsWith(TestJettyHelper.getJettyURL().toString()), "Wrong location: " + location);
+    assertTrue(location.startsWith(TestJettyHelper.getJettyURL().toString()),
+        "Wrong location: " + location);
 
     // Use the location to actually get the checksum
     url = new URL(location);
@@ -1835,8 +1834,8 @@ public class TestHttpFSServer extends HFSTestCase {
     JSONObject jsonObject = (JSONObject) parser.parse(getFileStatusResponse);
     JSONObject details = (JSONObject) jsonObject.get("FileStatus");
     String ecpolicyForECfile = (String) details.get("ecPolicy");
-    assertEquals(
-       ecpolicyForECfile, ecPolicyName, "EC policy for ecFile should match the set EC policy");
+    assertEquals(ecpolicyForECfile, ecPolicyName,
+        "EC policy for ecFile should match the set EC policy");
 
     // Verify httpFs getFileStatus with WEBHDFS REST API
     WebHdfsFileSystem httpfsWebHdfs = (WebHdfsFileSystem) FileSystem.get(

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoACLs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoACLs.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -99,9 +99,9 @@ public class TestHttpFSServerNoACLs extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assert.assertTrue(new File(homeDir, "conf").mkdir());
-    Assert.assertTrue(new File(homeDir, "log").mkdir());
-    Assert.assertTrue(new File(homeDir, "temp").mkdir());
+    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
+    Assertions.assertTrue(new File(homeDir, "log").mkdir());
+    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -182,17 +182,17 @@ public class TestHttpFSServerNoACLs extends HTestCase {
     int resp = conn.getResponseCode();
     BufferedReader reader;
     if (expectOK) {
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp);
       reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
       String res = reader.readLine();
-      Assert.assertTrue(!res.contains("aclBit"));
-      Assert.assertTrue(res.contains("owner")); // basic sanity check
+      Assertions.assertTrue(!res.contains("aclBit"));
+      Assertions.assertTrue(res.contains("owner")); // basic sanity check
     } else {
-      Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
       reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
       String res = reader.readLine();
-      Assert.assertTrue(res.contains("AclException"));
-      Assert.assertTrue(res.contains("Support for ACLs has been disabled"));
+      Assertions.assertTrue(res.contains("AclException"));
+      Assertions.assertTrue(res.contains("Support for ACLs has been disabled"));
     }
   }
 
@@ -219,14 +219,14 @@ public class TestHttpFSServerNoACLs extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if (expectOK) {
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp);
     } else {
-      Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+      Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
       BufferedReader reader;
       reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
       String err = reader.readLine();
-      Assert.assertTrue(err.contains("AclException"));
-      Assert.assertTrue(err.contains("Support for ACLs has been disabled"));
+      Assertions.assertTrue(err.contains("AclException"));
+      Assertions.assertTrue(err.contains("Support for ACLs has been disabled"));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoACLs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoACLs.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -46,6 +45,9 @@ import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.MessageFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test class ensures that everything works as expected when ACL
@@ -99,9 +101,9 @@ public class TestHttpFSServerNoACLs extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
-    Assertions.assertTrue(new File(homeDir, "log").mkdir());
-    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
+    assertTrue(new File(homeDir, "conf").mkdir());
+    assertTrue(new File(homeDir, "log").mkdir());
+    assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -182,17 +184,17 @@ public class TestHttpFSServerNoACLs extends HTestCase {
     int resp = conn.getResponseCode();
     BufferedReader reader;
     if (expectOK) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp);
+      assertEquals(HttpURLConnection.HTTP_OK, resp);
       reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
       String res = reader.readLine();
-      Assertions.assertTrue(!res.contains("aclBit"));
-      Assertions.assertTrue(res.contains("owner")); // basic sanity check
+      assertTrue(!res.contains("aclBit"));
+      assertTrue(res.contains("owner")); // basic sanity check
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+      assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
       reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
       String res = reader.readLine();
-      Assertions.assertTrue(res.contains("AclException"));
-      Assertions.assertTrue(res.contains("Support for ACLs has been disabled"));
+      assertTrue(res.contains("AclException"));
+      assertTrue(res.contains("Support for ACLs has been disabled"));
     }
   }
 
@@ -219,14 +221,14 @@ public class TestHttpFSServerNoACLs extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     if (expectOK) {
-      Assertions.assertEquals(HttpURLConnection.HTTP_OK, resp);
+      assertEquals(HttpURLConnection.HTTP_OK, resp);
     } else {
-      Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+      assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
       BufferedReader reader;
       reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
       String err = reader.readLine();
-      Assertions.assertTrue(err.contains("AclException"));
-      Assertions.assertTrue(err.contains("Support for ACLs has been disabled"));
+      assertTrue(err.contains("AclException"));
+      assertTrue(err.contains("Support for ACLs has been disabled"));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoXAttrs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoXAttrs.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestHdfs;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -47,6 +46,9 @@ import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.MessageFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test class ensures that everything works as expected when XAttr
@@ -100,9 +102,9 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
-    Assertions.assertTrue(new File(homeDir, "log").mkdir());
-    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
+    assertTrue(new File(homeDir, "conf").mkdir());
+    assertTrue(new File(homeDir, "log").mkdir());
+    assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -181,12 +183,12 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     BufferedReader reader;
-    Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+    assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
     reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
     String res = reader.readLine();
-    Assertions.assertTrue(res.contains("RemoteException"));
-    Assertions.assertTrue(res.contains("XAttr"));
-    Assertions.assertTrue(res.contains("rejected"));
+    assertTrue(res.contains("RemoteException"));
+    assertTrue(res.contains("XAttr"));
+    assertTrue(res.contains("rejected"));
   }
 
   /**
@@ -211,13 +213,13 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     int resp = conn.getResponseCode();
-    Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+    assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
     BufferedReader reader;
     reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
     String err = reader.readLine();
-    Assertions.assertTrue(err.contains("RemoteException"));
-    Assertions.assertTrue(err.contains("XAttr"));
-    Assertions.assertTrue(err.contains("rejected"));
+    assertTrue(err.contains("RemoteException"));
+    assertTrue(err.contains("XAttr"));
+    assertTrue(err.contains("rejected"));
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoXAttrs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerNoXAttrs.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestHdfs;
 import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -100,9 +100,9 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
    */
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assert.assertTrue(new File(homeDir, "conf").mkdir());
-    Assert.assertTrue(new File(homeDir, "log").mkdir());
-    Assert.assertTrue(new File(homeDir, "temp").mkdir());
+    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
+    Assertions.assertTrue(new File(homeDir, "log").mkdir());
+    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -181,12 +181,12 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
     conn.connect();
     int resp = conn.getResponseCode();
     BufferedReader reader;
-    Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+    Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
     reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
     String res = reader.readLine();
-    Assert.assertTrue(res.contains("RemoteException"));
-    Assert.assertTrue(res.contains("XAttr"));
-    Assert.assertTrue(res.contains("rejected"));
+    Assertions.assertTrue(res.contains("RemoteException"));
+    Assertions.assertTrue(res.contains("XAttr"));
+    Assertions.assertTrue(res.contains("rejected"));
   }
 
   /**
@@ -211,13 +211,13 @@ public class TestHttpFSServerNoXAttrs extends HTestCase {
     conn.setRequestMethod("PUT");
     conn.connect();
     int resp = conn.getResponseCode();
-    Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
+    Assertions.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, resp);
     BufferedReader reader;
     reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
     String err = reader.readLine();
-    Assert.assertTrue(err.contains("RemoteException"));
-    Assert.assertTrue(err.contains("XAttr"));
-    Assert.assertTrue(err.contains("rejected"));
+    Assertions.assertTrue(err.contains("RemoteException"));
+    Assertions.assertTrue(err.contains("XAttr"));
+    Assertions.assertTrue(err.contains("rejected"));
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
@@ -187,7 +187,8 @@ public class TestHttpFSServerWebServer {
         server.getWebAppContext().getServletContext()
             .getAttribute(SIGNER_SECRET_PROVIDER_ATTRIBUTE);
     assertNotNull(secretProvider, "The secret provider must not be null");
-    assertEquals(expected, secretProvider.getClass(), "The secret provider must match the following");
+    assertEquals(expected, secretProvider.getClass(),
+        "The secret provider must match the following");
   }
 
   private void assertServiceRespondsWithOK(URL serviceURL)

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
@@ -37,11 +37,11 @@ import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.HadoopUsersConfTestHelper;
 import org.apache.hadoop.util.Shell;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.After;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 import static org.apache.hadoop.security.authentication.server.AuthenticationFilter.SIGNER_SECRET_PROVIDER_ATTRIBUTE;
@@ -57,7 +57,7 @@ public class TestHttpFSServerWebServer {
   private File secretFile;
   private HttpFSServerWebServer webServer;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     File homeDir = GenericTestUtils.setupTestRootDir(TestHttpFSServerWebServer.class);
     File confDir = new File(homeDir, "etc/hadoop");
@@ -85,7 +85,7 @@ public class TestHttpFSServerWebServer {
         "httpfs-signature-custom.secret");
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (webServer != null) {
       webServer.stop();
@@ -187,8 +187,8 @@ public class TestHttpFSServerWebServer {
     SignerSecretProvider secretProvider = (SignerSecretProvider)
         server.getWebAppContext().getServletContext()
             .getAttribute(SIGNER_SECRET_PROVIDER_ATTRIBUTE);
-    Assert.assertNotNull("The secret provider must not be null", secretProvider);
-    Assert.assertEquals("The secret provider must match the following", expected, secretProvider.getClass());
+    Assertions.assertNotNull(secretProvider, "The secret provider must not be null");
+    Assertions.assertEquals(expected, secretProvider.getClass(), "The secret provider must match the following");
   }
 
   private void assertServiceRespondsWithOK(URL serviceURL)
@@ -197,7 +197,7 @@ public class TestHttpFSServerWebServer {
     URL url = new URL(serviceURL, MessageFormat.format(
         "/webhdfs/v1/?user.name={0}&op=liststatus", user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     try (BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()))) {
       reader.readLine();
@@ -247,7 +247,7 @@ public class TestHttpFSServerWebServer {
   }
 
   private void createSecretFile(String content) throws IOException {
-    Assert.assertTrue(secretFile.createNewFile());
+    Assertions.assertTrue(secretFile.createNewFile());
     FileUtils.writeStringToFile(secretFile, content, StandardCharsets.UTF_8);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServerWebServer.java
@@ -37,22 +37,21 @@ import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.HadoopUsersConfTestHelper;
 import org.apache.hadoop.util.Shell;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.security.authentication.server.AuthenticationFilter.SIGNER_SECRET_PROVIDER_ATTRIBUTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test {@link HttpFSServerWebServer}.
  */
+@Timeout(30)
 public class TestHttpFSServerWebServer {
-
-  @Rule
-  public Timeout timeout = new Timeout(30000);
 
   private File secretFile;
   private HttpFSServerWebServer webServer;
@@ -187,8 +186,8 @@ public class TestHttpFSServerWebServer {
     SignerSecretProvider secretProvider = (SignerSecretProvider)
         server.getWebAppContext().getServletContext()
             .getAttribute(SIGNER_SECRET_PROVIDER_ATTRIBUTE);
-    Assertions.assertNotNull(secretProvider, "The secret provider must not be null");
-    Assertions.assertEquals(expected, secretProvider.getClass(), "The secret provider must match the following");
+    assertNotNull(secretProvider, "The secret provider must not be null");
+    assertEquals(expected, secretProvider.getClass(), "The secret provider must match the following");
   }
 
   private void assertServiceRespondsWithOK(URL serviceURL)
@@ -197,7 +196,7 @@ public class TestHttpFSServerWebServer {
     URL url = new URL(serviceURL, MessageFormat.format(
         "/webhdfs/v1/?user.name={0}&op=liststatus", user));
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     try (BufferedReader reader = new BufferedReader(
         new InputStreamReader(conn.getInputStream()))) {
       reader.readLine();
@@ -247,7 +246,7 @@ public class TestHttpFSServerWebServer {
   }
 
   private void createSecretFile(String content) throws IOException {
-    Assertions.assertTrue(secretFile.createNewFile());
+    assertTrue(secretFile.createNewFile());
     FileUtils.writeStringToFile(secretFile, content, StandardCharsets.UTF_8);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSWithKerberos.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSWithKerberos.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.test.TestJettyHelper;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -56,6 +55,9 @@ import java.net.URL;
 import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.Callable;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class TestHttpFSWithKerberos extends HFSTestCase {
 
   @AfterEach
@@ -66,9 +68,9 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
 
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
-    Assertions.assertTrue(new File(homeDir, "log").mkdir());
-    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
+    assertTrue(new File(homeDir, "conf").mkdir());
+    assertTrue(new File(homeDir, "log").mkdir());
+    assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -125,7 +127,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
         AuthenticatedURL aUrl = new AuthenticatedURL();
         AuthenticatedURL.Token aToken = new AuthenticatedURL.Token();
         HttpURLConnection conn = aUrl.openConnection(url, aToken);
-        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
         return null;
       }
     });
@@ -141,8 +143,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY");
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assertions.assertEquals(conn.getResponseCode(),
-                        HttpURLConnection.HTTP_UNAUTHORIZED);
+    assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 
   @Test
@@ -161,7 +162,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
         AuthenticatedURL aUrl = new AuthenticatedURL();
         AuthenticatedURL.Token aToken = new AuthenticatedURL.Token();
         HttpURLConnection conn = aUrl.openConnection(url, aToken);
-        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
         JSONObject json = (JSONObject) new JSONParser()
           .parse(new InputStreamReader(conn.getInputStream()));
         json =
@@ -175,22 +176,21 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" +
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
-        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //try to renew the delegation token without SPNEGO credentials
         url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
         conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("PUT");
-        Assertions.assertEquals(conn.getResponseCode(),
-                            HttpURLConnection.HTTP_UNAUTHORIZED);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_UNAUTHORIZED);
 
         //renew the delegation token with SPNEGO credentials
         url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
         conn = aUrl.openConnection(url, aToken);
         conn.setRequestMethod("PUT");
-        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //cancel delegation token, no need for SPNEGO credentials
         url = new URL(TestJettyHelper.getJettyURL(),
@@ -198,15 +198,14 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("PUT");
-        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //try to access httpfs with the canceled delegation token
         url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" +
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
-        Assertions.assertEquals(conn.getResponseCode(),
-                            HttpURLConnection.HTTP_UNAUTHORIZED);
+        assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_UNAUTHORIZED);
         return null;
       }
     });
@@ -224,7 +223,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
     FileSystem fs = FileSystem.get(uri, conf);
     Token<?> tokens[] = fs.addDelegationTokens("foo", null);
     fs.close();
-    Assertions.assertEquals(1, tokens.length);
+    assertEquals(1, tokens.length);
     fs = FileSystem.get(uri, conf);
     ((DelegationTokenRenewer.Renewable) fs).setDelegationToken(tokens[0]);
     fs.listStatus(new Path("/"));

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSWithKerberos.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSWithKerberos.java
@@ -38,9 +38,9 @@ import org.apache.hadoop.test.TestJetty;
 import org.apache.hadoop.test.TestJettyHelper;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -58,7 +58,7 @@ import java.util.concurrent.Callable;
 
 public class TestHttpFSWithKerberos extends HFSTestCase {
 
-  @After
+  @AfterEach
   public void resetUGI() {
     Configuration conf = new Configuration();
     UserGroupInformation.setConfiguration(conf);
@@ -66,9 +66,9 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
 
   private void createHttpFSServer() throws Exception {
     File homeDir = TestDirHelper.getTestDir();
-    Assert.assertTrue(new File(homeDir, "conf").mkdir());
-    Assert.assertTrue(new File(homeDir, "log").mkdir());
-    Assert.assertTrue(new File(homeDir, "temp").mkdir());
+    Assertions.assertTrue(new File(homeDir, "conf").mkdir());
+    Assertions.assertTrue(new File(homeDir, "log").mkdir());
+    Assertions.assertTrue(new File(homeDir, "temp").mkdir());
     HttpFSServerWebApp.setHomeDirForCurrentThread(homeDir.getAbsolutePath());
 
     File secretFile = new File(new File(homeDir, "conf"), "secret");
@@ -125,7 +125,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
         AuthenticatedURL aUrl = new AuthenticatedURL();
         AuthenticatedURL.Token aToken = new AuthenticatedURL.Token();
         HttpURLConnection conn = aUrl.openConnection(url, aToken);
-        Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
         return null;
       }
     });
@@ -141,7 +141,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
     URL url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY");
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(conn.getResponseCode(),
+    Assertions.assertEquals(conn.getResponseCode(),
                         HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 
@@ -161,7 +161,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
         AuthenticatedURL aUrl = new AuthenticatedURL();
         AuthenticatedURL.Token aToken = new AuthenticatedURL.Token();
         HttpURLConnection conn = aUrl.openConnection(url, aToken);
-        Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
         JSONObject json = (JSONObject) new JSONParser()
           .parse(new InputStreamReader(conn.getInputStream()));
         json =
@@ -175,14 +175,14 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" +
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
-        Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //try to renew the delegation token without SPNEGO credentials
         url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
         conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("PUT");
-        Assert.assertEquals(conn.getResponseCode(),
+        Assertions.assertEquals(conn.getResponseCode(),
                             HttpURLConnection.HTTP_UNAUTHORIZED);
 
         //renew the delegation token with SPNEGO credentials
@@ -190,7 +190,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
                       "/webhdfs/v1/?op=RENEWDELEGATIONTOKEN&token=" + tokenStr);
         conn = aUrl.openConnection(url, aToken);
         conn.setRequestMethod("PUT");
-        Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //cancel delegation token, no need for SPNEGO credentials
         url = new URL(TestJettyHelper.getJettyURL(),
@@ -198,14 +198,14 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("PUT");
-        Assert.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assertions.assertEquals(conn.getResponseCode(), HttpURLConnection.HTTP_OK);
 
         //try to access httpfs with the canceled delegation token
         url = new URL(TestJettyHelper.getJettyURL(),
                       "/webhdfs/v1/?op=GETHOMEDIRECTORY&delegation=" +
                       tokenStr);
         conn = (HttpURLConnection) url.openConnection();
-        Assert.assertEquals(conn.getResponseCode(),
+        Assertions.assertEquals(conn.getResponseCode(),
                             HttpURLConnection.HTTP_UNAUTHORIZED);
         return null;
       }
@@ -224,7 +224,7 @@ public class TestHttpFSWithKerberos extends HFSTestCase {
     FileSystem fs = FileSystem.get(uri, conf);
     Token<?> tokens[] = fs.addDelegationTokens("foo", null);
     fs.close();
-    Assert.assertEquals(1, tokens.length);
+    Assertions.assertEquals(1, tokens.length);
     fs = FileSystem.get(uri, conf);
     ((DelegationTokenRenewer.Renewable) fs).setDelegationToken(tokens[0]);
     fs.listStatus(new Path("/"));

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/lang/TestRunnableCallable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/lang/TestRunnableCallable.java
@@ -19,13 +19,12 @@
 package org.apache.hadoop.lib.lang;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.Callable;
 
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestRunnableCallable extends HTestCase {
 
@@ -86,11 +85,13 @@ public class TestRunnableCallable extends HTestCase {
     assertEquals(rc.toString(), "C");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void callableExRun() throws Exception {
-    CEx c = new CEx();
-    RunnableCallable rc = new RunnableCallable(c);
-    rc.run();
+    assertThrows(RuntimeException.class, ()->{
+      CEx c = new CEx();
+      RunnableCallable rc = new RunnableCallable(c);
+      rc.run();
+    });
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/lang/TestXException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/lang/TestXException.java
@@ -19,11 +19,11 @@
 package org.apache.hadoop.lib.lang;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestXException extends HTestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestBaseService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestBaseService.java
@@ -18,13 +18,13 @@
 
 package org.apache.hadoop.lib.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestBaseService extends HTestCase {

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
@@ -18,6 +18,14 @@
 
 package org.apache.hadoop.lib.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
@@ -37,8 +45,6 @@ import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestException;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class TestServer extends HTestCase {
 
@@ -104,12 +110,14 @@ public class TestServer extends HTestCase {
   @TestException(exception = ServerException.class, msgRegExp = "S02.*")
   @TestDir
   public void initHomeDirNotDir() throws Exception {
-    File homeDir = new File(TestDirHelper.getTestDir(), "home");
-    new FileOutputStream(homeDir).close();
-    Configuration conf = new Configuration(false);
-    conf.set("server.services", TestService.class.getName());
-    Server server = new Server("server", homeDir.getAbsolutePath(), conf);
-    server.init();
+    assertThrows(ServerException.class, () -> {
+      File homeDir = new File(TestDirHelper.getTestDir(), "home");
+      new FileOutputStream(homeDir).close();
+      Configuration conf = new Configuration(false);
+      conf.set("server.services", TestService.class.getName());
+      Server server = new Server("server", homeDir.getAbsolutePath(), conf);
+      server.init();
+    });
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
@@ -18,13 +18,6 @@
 
 package org.apache.hadoop.lib.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
@@ -43,7 +36,9 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.test.TestException;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestServer extends HTestCase {
 
@@ -283,13 +278,15 @@ public class TestServer extends HTestCase {
     server.destroy();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   @TestDir
   public void nonSeteableStatus() throws Exception {
-    Configuration conf = new Configuration(false);
-    Server server = createServer(conf);
-    server.init();
-    server.setStatus(Server.Status.SHUTDOWN);
+    assertThrows(IllegalArgumentException.class, ()->{
+      Configuration conf = new Configuration(false);
+      Server server = createServer(conf);
+      server.init();
+      server.setStatus(Server.Status.SHUTDOWN);
+    });
   }
 
   public static class TestService implements Service {
@@ -422,34 +419,42 @@ public class TestServer extends HTestCase {
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   @TestDir
   public void illegalState1() throws Exception {
-    Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
-    server.destroy();
+    assertThrows(IllegalStateException.class, ()->{
+      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      server.destroy();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   @TestDir
   public void illegalState2() throws Exception {
-    Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
-    server.get(Object.class);
+    assertThrows(IllegalStateException.class, () -> {
+      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      server.get(Object.class);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   @TestDir
   public void illegalState3() throws Exception {
-    Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
-    server.setService(null);
+    assertThrows(IllegalStateException.class, () -> {
+      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      server.setService(null);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   @TestDir
   public void illegalState4() throws Exception {
-    String dir = TestDirHelper.getTestDir().getAbsolutePath();
-    Server server = new Server("server", dir, dir, dir, dir, new Configuration(false));
-    server.init();
-    server.init();
+    assertThrows(IllegalStateException.class, () -> {
+      String dir = TestDirHelper.getTestDir().getAbsolutePath();
+      Server server = new Server("server", dir, dir, dir, dir, new Configuration(false));
+      server.init();
+      server.init();
+    });
   }
 
   private static List<String> ORDER = new ArrayList<String>();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServer.java
@@ -431,7 +431,8 @@ public class TestServer extends HTestCase {
   @TestDir
   public void illegalState1() throws Exception {
     assertThrows(IllegalStateException.class, ()->{
-      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      Server server = new Server("server",
+          TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
       server.destroy();
     });
   }
@@ -440,7 +441,8 @@ public class TestServer extends HTestCase {
   @TestDir
   public void illegalState2() throws Exception {
     assertThrows(IllegalStateException.class, () -> {
-      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      Server server = new Server("server",
+          TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
       server.get(Object.class);
     });
   }
@@ -449,7 +451,8 @@ public class TestServer extends HTestCase {
   @TestDir
   public void illegalState3() throws Exception {
     assertThrows(IllegalStateException.class, () -> {
-      Server server = new Server("server", TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
+      Server server = new Server("server",
+          TestDirHelper.getTestDir().getAbsolutePath(), new Configuration(false));
       server.setService(null);
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServerConstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServerConstructor.java
@@ -23,9 +23,11 @@ import java.util.Collection;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @RunWith(value = Parameterized.class)
 public class TestServerConstructor extends HTestCase {
@@ -68,9 +70,11 @@ public class TestServerConstructor extends HTestCase {
   }
 
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void constructorFail() {
-    new Server(name, homeDir, configDir, logDir, tempDir, conf);
+    assertThrows(IllegalArgumentException.class, ()->{
+      new Server(name, homeDir, configDir, logDir, tempDir, conf);
+    });
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServerConstructor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/server/TestServerConstructor.java
@@ -23,16 +23,13 @@ import java.util.Collection;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.HTestCase;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(value = Parameterized.class)
 public class TestServerConstructor extends HTestCase {
 
-  @Parameterized.Parameters
   public static Collection constructorFailParams() {
     return Arrays.asList(new Object[][]{
       {null, null, null, null, null, null},
@@ -59,20 +56,22 @@ public class TestServerConstructor extends HTestCase {
   private String tempDir;
   private Configuration conf;
 
-  public TestServerConstructor(String name, String homeDir, String configDir, String logDir, String tempDir,
-                               Configuration conf) {
-    this.name = name;
-    this.homeDir = homeDir;
-    this.configDir = configDir;
-    this.logDir = logDir;
-    this.tempDir = tempDir;
-    this.conf = conf;
+  public void initTestServerConstructor(String pName, String pHomeDir,
+      String pConfigDir, String pLogDir, String pTempDir, Configuration pConf) {
+    this.name = pName;
+    this.homeDir = pHomeDir;
+    this.configDir = pConfigDir;
+    this.logDir = pLogDir;
+    this.tempDir = pTempDir;
+    this.conf = pConf;
   }
 
-
-  @Test
-  public void constructorFail() {
-    assertThrows(IllegalArgumentException.class, ()->{
+  @ParameterizedTest
+  @MethodSource("constructorFailParams")
+  public void constructorFail(String pName, String pHomeDir,
+      String pConfigDir, String pLogDir, String pTempDir, Configuration pConf) {
+    initTestServerConstructor(pName, pHomeDir, pConfigDir, pLogDir, pTempDir, pConf);
+    assertThrows(IllegalArgumentException.class, () -> {
       new Server(name, homeDir, configDir, logDir, tempDir, conf);
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/hadoop/TestFileSystemAccessService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/hadoop/TestFileSystemAccessService.java
@@ -41,9 +41,12 @@ import org.apache.hadoop.test.TestException;
 import org.apache.hadoop.test.TestHdfs;
 import org.apache.hadoop.test.TestHdfsHelper;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFileSystemAccessService extends HFSTestCase {
 
@@ -74,7 +77,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     conf.set("server.services", services);
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
-    Assertions.assertNotNull(server.get(FileSystemAccess.class));
+    assertNotNull(server.get(FileSystemAccess.class));
     server.destroy();
   }
 
@@ -161,7 +164,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
     FileSystemAccessService fsAccess = (FileSystemAccessService) server.get(FileSystemAccess.class);
-    Assertions.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "FOO");
+    assertEquals(fsAccess.serviceHadoopConf.get("foo"), "FOO");
     server.destroy();
   }
 
@@ -189,7 +192,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
     FileSystemAccessService fsAccess = (FileSystemAccessService) server.get(FileSystemAccess.class);
-    Assertions.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "BAR");
+    assertEquals(fsAccess.serviceHadoopConf.get("foo"), "BAR");
     server.destroy();
   }
 
@@ -267,15 +270,15 @@ public class TestFileSystemAccessService extends HFSTestCase {
     server.init();
     FileSystemAccess hadoop = server.get(FileSystemAccess.class);
     FileSystem fs = hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
-    Assertions.assertNotNull(fs);
+    assertNotNull(fs);
     fs.mkdirs(new Path("/tmp/foo"));
     hadoop.releaseFileSystem(fs);
     try {
       fs.mkdirs(new Path("/tmp/foo"));
-      Assertions.fail();
+      fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
     server.destroy();
   }
@@ -313,10 +316,10 @@ public class TestFileSystemAccessService extends HFSTestCase {
     });
     try {
       fsa[0].mkdirs(new Path("/tmp/foo"));
-      Assertions.fail();
+      fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
     server.destroy();
   }
@@ -381,19 +384,19 @@ public class TestFileSystemAccessService extends HFSTestCase {
           throw new IOException();
         }
       });
-      Assertions.fail();
+      fail();
     } catch (FileSystemAccessException ex) {
-      Assertions.assertEquals(ex.getError(), FileSystemAccessException.ERROR.H03);
+      assertEquals(ex.getError(), FileSystemAccessException.ERROR.H03);
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
 
     try {
       fsa[0].mkdirs(new Path("/tmp/foo"));
-      Assertions.fail();
+      fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
     server.destroy();
   }
@@ -424,7 +427,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
 
       FileSystem fs1 =
         hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
-      Assertions.assertNotNull(fs1);
+      assertNotNull(fs1);
       fs1.mkdirs(new Path("/tmp/foo1"));
       hadoop.releaseFileSystem(fs1);
 
@@ -435,7 +438,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
         hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
 
       //should be same instance because of caching
-      Assertions.assertEquals(fs1, fs2);
+      assertEquals(fs1, fs2);
 
       Thread.sleep(4 * 1000);
 
@@ -453,10 +456,10 @@ public class TestFileSystemAccessService extends HFSTestCase {
       //should not be around as lease count is 0
       try {
         fs2.mkdirs(new Path("/tmp/foo"));
-        Assertions.fail();
+        fail();
       } catch (IOException ex) {
       } catch (Exception ex) {
-        Assertions.fail();
+        fail();
       }
     } finally {
       server.destroy();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/hadoop/TestFileSystemAccessService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/hadoop/TestFileSystemAccessService.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.test.TestException;
 import org.apache.hadoop.test.TestHdfs;
 import org.apache.hadoop.test.TestHdfsHelper;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestFileSystemAccessService extends HFSTestCase {
 
@@ -55,7 +55,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     os.close();
   }
 
-  @Before
+  @BeforeEach
   public void createHadoopConf() throws Exception {
     Configuration hadoopConf = new Configuration(false);
     hadoopConf.set("foo", "FOO");
@@ -74,7 +74,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     conf.set("server.services", services);
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
-    Assert.assertNotNull(server.get(FileSystemAccess.class));
+    Assertions.assertNotNull(server.get(FileSystemAccess.class));
     server.destroy();
   }
 
@@ -161,7 +161,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
     FileSystemAccessService fsAccess = (FileSystemAccessService) server.get(FileSystemAccess.class);
-    Assert.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "FOO");
+    Assertions.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "FOO");
     server.destroy();
   }
 
@@ -189,7 +189,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
     Server server = new Server("server", dir, dir, dir, dir, conf);
     server.init();
     FileSystemAccessService fsAccess = (FileSystemAccessService) server.get(FileSystemAccess.class);
-    Assert.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "BAR");
+    Assertions.assertEquals(fsAccess.serviceHadoopConf.get("foo"), "BAR");
     server.destroy();
   }
 
@@ -267,15 +267,15 @@ public class TestFileSystemAccessService extends HFSTestCase {
     server.init();
     FileSystemAccess hadoop = server.get(FileSystemAccess.class);
     FileSystem fs = hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
-    Assert.assertNotNull(fs);
+    Assertions.assertNotNull(fs);
     fs.mkdirs(new Path("/tmp/foo"));
     hadoop.releaseFileSystem(fs);
     try {
       fs.mkdirs(new Path("/tmp/foo"));
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
     server.destroy();
   }
@@ -313,10 +313,10 @@ public class TestFileSystemAccessService extends HFSTestCase {
     });
     try {
       fsa[0].mkdirs(new Path("/tmp/foo"));
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
     server.destroy();
   }
@@ -381,19 +381,19 @@ public class TestFileSystemAccessService extends HFSTestCase {
           throw new IOException();
         }
       });
-      Assert.fail();
+      Assertions.fail();
     } catch (FileSystemAccessException ex) {
-      Assert.assertEquals(ex.getError(), FileSystemAccessException.ERROR.H03);
+      Assertions.assertEquals(ex.getError(), FileSystemAccessException.ERROR.H03);
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
 
     try {
       fsa[0].mkdirs(new Path("/tmp/foo"));
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
     server.destroy();
   }
@@ -424,7 +424,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
 
       FileSystem fs1 =
         hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
-      Assert.assertNotNull(fs1);
+      Assertions.assertNotNull(fs1);
       fs1.mkdirs(new Path("/tmp/foo1"));
       hadoop.releaseFileSystem(fs1);
 
@@ -435,7 +435,7 @@ public class TestFileSystemAccessService extends HFSTestCase {
         hadoop.createFileSystem("u", hadoop.getFileSystemConfiguration());
 
       //should be same instance because of caching
-      Assert.assertEquals(fs1, fs2);
+      Assertions.assertEquals(fs1, fs2);
 
       Thread.sleep(4 * 1000);
 
@@ -453,10 +453,10 @@ public class TestFileSystemAccessService extends HFSTestCase {
       //should not be around as lease count is 0
       try {
         fs2.mkdirs(new Path("/tmp/foo"));
-        Assert.fail();
+        Assertions.fail();
       } catch (IOException ex) {
       } catch (Exception ex) {
-        Assert.fail();
+        Assertions.fail();
       }
     } finally {
       server.destroy();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.lib.service.instrumentation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -39,7 +39,7 @@ import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInstrumentationService extends HTestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/scheduler/TestSchedulerService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/scheduler/TestSchedulerService.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.lib.service.scheduler;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ import org.apache.hadoop.test.HTestCase;
 import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSchedulerService extends HTestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.lib.service.security;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +28,9 @@ import org.apache.hadoop.test.HTestCase;
 import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestGroupsService extends HTestCase {
 
@@ -50,15 +49,17 @@ public class TestGroupsService extends HTestCase {
     server.destroy();
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   @TestDir
   public void invalidGroupsMapping() throws Exception {
-    String dir = TestDirHelper.getTestDir().getAbsolutePath();
-    Configuration conf = new Configuration(false);
-    conf.set("server.services", StringUtils.join(",", Arrays.asList(GroupsService.class.getName())));
-    conf.set("server.groups.hadoop.security.group.mapping", String.class.getName());
-    Server server = new Server("server", dir, dir, dir, dir, conf);
-    server.init();
+    assertThrows(RuntimeException.class, () -> {
+      String dir = TestDirHelper.getTestDir().getAbsolutePath();
+      Configuration conf = new Configuration(false);
+      conf.set("server.services", StringUtils.join(",", Arrays.asList(GroupsService.class.getName())));
+      conf.set("server.groups.hadoop.security.group.mapping", String.class.getName());
+      Server server = new Server("server", dir, dir, dir, dir, conf);
+      server.init();
+    });
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.lib.service.security;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,8 +33,6 @@ import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class TestGroupsService extends HTestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/security/TestGroupsService.java
@@ -57,7 +57,8 @@ public class TestGroupsService extends HTestCase {
     assertThrows(RuntimeException.class, () -> {
       String dir = TestDirHelper.getTestDir().getAbsolutePath();
       Configuration conf = new Configuration(false);
-      conf.set("server.services", StringUtils.join(",", Arrays.asList(GroupsService.class.getName())));
+      conf.set("server.services", StringUtils.join(",",
+          Arrays.asList(GroupsService.class.getName())));
       conf.set("server.groups.hadoop.security.group.mapping", String.class.getName());
       Server server = new Server("server", dir, dir, dir, dir, conf);
       server.init();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestHostnameFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestHostnameFilter.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.lib.servlet;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,7 +31,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestMDCFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestMDCFilter.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.lib.servlet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -34,7 +34,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.MDC;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/servlet/TestServerWebApp.java
@@ -18,22 +18,25 @@
 
 package org.apache.hadoop.lib.servlet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.hadoop.lib.server.Server;
 import org.apache.hadoop.test.HTestCase;
 import org.apache.hadoop.test.TestDir;
 import org.apache.hadoop.test.TestDirHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
 public class TestServerWebApp extends HTestCase {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void getHomeDirNotDef() {
-    ServerWebApp.getHomeDir("TestServerWebApp00");
+    assertThrows(IllegalArgumentException.class, () -> {
+      ServerWebApp.getHomeDir("TestServerWebApp00");
+    });
   }
 
   @Test
@@ -63,19 +66,21 @@ public class TestServerWebApp extends HTestCase {
     assertEquals(server.getStatus(), Server.Status.SHUTDOWN);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   @TestDir
   public void failedInit() throws Exception {
-    String dir = TestDirHelper.getTestDir().getAbsolutePath();
-    System.setProperty("TestServerWebApp2.home.dir", dir);
-    System.setProperty("TestServerWebApp2.config.dir", dir);
-    System.setProperty("TestServerWebApp2.log.dir", dir);
-    System.setProperty("TestServerWebApp2.temp.dir", dir);
-    System.setProperty("testserverwebapp2.services", "FOO");
-    ServerWebApp server = new ServerWebApp("TestServerWebApp2") {
-    };
+    assertThrows(RuntimeException.class, () -> {
+      String dir = TestDirHelper.getTestDir().getAbsolutePath();
+      System.setProperty("TestServerWebApp2.home.dir", dir);
+      System.setProperty("TestServerWebApp2.config.dir", dir);
+      System.setProperty("TestServerWebApp2.log.dir", dir);
+      System.setProperty("TestServerWebApp2.temp.dir", dir);
+      System.setProperty("testserverwebapp2.services", "FOO");
+      ServerWebApp server = new ServerWebApp("TestServerWebApp2") {
+      };
 
-    server.contextInitialized(null);
+      server.contextInitialized(null);
+    });
   }
 
   @Test
@@ -92,8 +97,8 @@ public class TestServerWebApp extends HTestCase {
     };
 
     InetSocketAddress address = server.resolveAuthority();
-    Assert.assertEquals("localhost", address.getHostName());
-    Assert.assertEquals(14000, address.getPort());
+    Assertions.assertEquals("localhost", address.getHostName());
+    Assertions.assertEquals(14000, address.getPort());
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestCheck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestCheck.java
@@ -19,13 +19,14 @@
 package org.apache.hadoop.lib.util;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.hadoop.test.HTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCheck extends HTestCase {
 
@@ -34,9 +35,11 @@ public class TestCheck extends HTestCase {
     assertEquals(Check.notNull("value", "name"), "value");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notNullNull() {
-    Check.notNull(null, "name");
+    assertThrows(IllegalArgumentException.class, ()->{
+      Check.notNull(null, "name");
+    });
   }
 
   @Test
@@ -45,14 +48,18 @@ public class TestCheck extends HTestCase {
     Check.notNullElements(Arrays.asList("a"), "name");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notNullElementsNullList() {
-    Check.notNullElements(null, "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notNullElements(null, "name");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notNullElementsNullElements() {
-    Check.notNullElements(Arrays.asList("a", "", null), "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notNullElements(Arrays.asList("a", "", null), "name");
+    });
   }
 
   @Test
@@ -61,20 +68,25 @@ public class TestCheck extends HTestCase {
     Check.notEmptyElements(Arrays.asList("a"), "name");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notEmptyElementsNullList() {
-    Check.notEmptyElements(null, "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notEmptyElements(null, "name");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notEmptyElementsNullElements() {
-    Check.notEmptyElements(Arrays.asList("a", null), "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notEmptyElements(Arrays.asList("a", null), "name");
+    });
   }
 
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notEmptyElementsEmptyElements() {
-    Check.notEmptyElements(Arrays.asList("a", ""), "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notEmptyElements(Arrays.asList("a", ""), "name");
+    });
   }
 
 
@@ -83,14 +95,18 @@ public class TestCheck extends HTestCase {
     assertEquals(Check.notEmpty("value", "name"), "value");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notEmptyNull() {
-    Check.notEmpty(null, "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notEmpty(null, "name");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void notEmptyEmpty() {
-    Check.notEmpty("", "name");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.notEmpty("", "name");
+    });
   }
 
   @Test
@@ -101,29 +117,39 @@ public class TestCheck extends HTestCase {
     assertEquals(Check.validIdentifier("_", 1, ""), "_");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void validIdentifierInvalid1() throws Exception {
-    Check.validIdentifier("!", 1, "");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.validIdentifier("!", 1, "");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void validIdentifierInvalid2() throws Exception {
-    Check.validIdentifier("a1", 1, "");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.validIdentifier("a1", 1, "");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void validIdentifierInvalid3() throws Exception {
-    Check.validIdentifier("1", 1, "");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.validIdentifier("1", 1, "");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void validIdentifierInvalid4() throws Exception {
-    Check.validIdentifier("`a", 2, "");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.validIdentifier("`a", 2, "");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void validIdentifierInvalid5() throws Exception {
-    Check.validIdentifier("[a", 2, "");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.validIdentifier("[a", 2, "");
+    });
   }
 
   @Test
@@ -131,14 +157,18 @@ public class TestCheck extends HTestCase {
     assertEquals(Check.gt0(120, "test"), 120);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void checkGTZeroZero() {
-    Check.gt0(0, "test");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.gt0(0, "test");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void checkGTZeroLessThanZero() {
-    Check.gt0(-1, "test");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.gt0(-1, "test");
+    });
   }
 
   @Test
@@ -147,9 +177,11 @@ public class TestCheck extends HTestCase {
     assertEquals(Check.ge0(0, "test"), 0);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void checkGELessThanZero() {
-    Check.ge0(-1, "test");
+    assertThrows(IllegalArgumentException.class, () -> {
+      Check.ge0(-1, "test");
+    });
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestCheck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestCheck.java
@@ -37,7 +37,7 @@ public class TestCheck extends HTestCase {
 
   @Test
   public void notNullNull() {
-    assertThrows(IllegalArgumentException.class, ()->{
+    assertThrows(IllegalArgumentException.class, () -> {
       Check.notNull(null, "name");
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestConfigurationUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/util/TestConfigurationUtils.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.lib.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestConfigurationUtils {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestInputStreamEntity.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestInputStreamEntity.java
@@ -18,13 +18,13 @@
 
 package org.apache.hadoop.lib.wsrs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInputStreamEntity {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestJSONMapProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestJSONMapProvider.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.lib.wsrs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJSONMapProvider {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestJSONProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestJSONProvider.java
@@ -18,14 +18,14 @@
 
 package org.apache.hadoop.lib.wsrs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJSONProvider {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestParam.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/wsrs/TestParam.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.lib.wsrs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestParam {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HFSTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HFSTestCase.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hadoop.test;
 
-import org.junit.Rule;
-import org.junit.rules.MethodRule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class HFSTestCase extends HTestCase {
 
-  @Rule
-  public MethodRule hdfsTestHelper = new TestHdfsHelper();
+  @RegisterExtension
+  public TestHdfsHelper hdfsTestHelper = new TestHdfsHelper();
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.MessageFormat;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/HTestCase.java
@@ -22,8 +22,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.text.MessageFormat;
 
 import org.apache.hadoop.util.Time;
-import org.junit.Rule;
-import org.junit.rules.MethodRule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class HTestCase {
 
@@ -37,14 +36,14 @@ public abstract class HTestCase {
 
   private float waitForRatio = WAITFOR_RATIO_DEFAULT;
 
-  @Rule
-  public MethodRule testDir = new TestDirHelper();
+  @RegisterExtension
+  public TestDirHelper testDir = new TestDirHelper();
 
-  @Rule
-  public MethodRule jettyTestHelper = new TestJettyHelper();
+  @RegisterExtension
+  public TestJettyHelper jettyTestHelper = new TestJettyHelper();
 
-  @Rule
-  public MethodRule exceptionHelper = new TestExceptionHelper();
+  @RegisterExtension
+  public TestExceptionHelper exceptionHelper = new TestExceptionHelper();
 
   /**
    * Sets the 'wait for ratio' used in the {@link #sleep(long)},

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestDirHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestDirHelper.java
@@ -19,15 +19,16 @@ package org.apache.hadoop.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
-import org.junit.rules.MethodRule;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class TestDirHelper implements MethodRule {
+public class TestDirHelper implements BeforeEachCallback, AfterEachCallback {
 
   @Test
   public void dummy() {
@@ -91,26 +92,6 @@ public class TestDirHelper implements MethodRule {
 
   private static final ThreadLocal<File> TEST_DIR_TL = new InheritableThreadLocal<File>();
 
-  @Override
-  public Statement apply(final Statement statement, final FrameworkMethod frameworkMethod, final Object o) {
-    return new Statement() {
-      @Override
-      public void evaluate() throws Throwable {
-        File testDir = null;
-        TestDir testDirAnnotation = frameworkMethod.getAnnotation(TestDir.class);
-        if (testDirAnnotation != null) {
-          testDir = resetTestCaseDir(frameworkMethod.getName());
-        }
-        try {
-          TEST_DIR_TL.set(testDir);
-          statement.evaluate();
-        } finally {
-          TEST_DIR_TL.remove();
-        }
-      }
-    };
-  }
-
   /**
    * Returns the local test directory for the current test, only available when the
    * test method has been annotated with {@link TestDir}.
@@ -136,7 +117,7 @@ public class TestDirHelper implements MethodRule {
       delete(dir);
     } catch (IOException ex) {
       throw new RuntimeException(MessageFormat.format("Could not delete test dir[{0}], {1}",
-                                                      dir, ex.getMessage()), ex);
+          dir, ex.getMessage()), ex);
     }
     if (!dir.mkdirs()) {
       throw new RuntimeException(MessageFormat.format("Could not create test dir[{0}]", dir));
@@ -144,4 +125,19 @@ public class TestDirHelper implements MethodRule {
     return dir;
   }
 
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    Method testMethod = context.getRequiredTestMethod();
+    File testDir = null;
+    TestDir testDirAnnotation = testMethod.getAnnotation(TestDir.class);
+    if (testDirAnnotation != null) {
+      testDir = resetTestCaseDir(testMethod.getName());
+    }
+    TEST_DIR_TL.set(testDir);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) throws Exception {
+    TEST_DIR_TL.remove();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestDirHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestDirHelper.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
@@ -19,49 +19,44 @@ package org.apache.hadoop.test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Method;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
-import org.junit.rules.MethodRule;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 
-public class TestExceptionHelper implements MethodRule {
+public class TestExceptionHelper implements TestExecutionExceptionHandler {
 
   @Test
   public void dummy() {
   }
 
   @Override
-  public Statement apply(final Statement statement, final FrameworkMethod frameworkMethod, final Object o) {
-    return new Statement() {
-      @Override
-      public void evaluate() throws Throwable {
-        TestException testExceptionAnnotation = frameworkMethod.getAnnotation(TestException.class);
-        try {
-          statement.evaluate();
-          if (testExceptionAnnotation != null) {
-            Class<? extends Throwable> klass = testExceptionAnnotation.exception();
-            fail("Expected Exception: " + klass.getSimpleName());
-          }
-        } catch (Throwable ex) {
-          if (testExceptionAnnotation != null) {
-            Class<? extends Throwable> klass = testExceptionAnnotation.exception();
-            if (klass.isInstance(ex)) {
-              String regExp = testExceptionAnnotation.msgRegExp();
-              Pattern pattern = Pattern.compile(regExp);
-              if (!pattern.matcher(ex.getMessage()).find()) {
-                fail("Expected Exception Message pattern: " + regExp + " got message: " + ex.getMessage());
-              }
-            } else {
-              fail("Expected Exception: " + klass.getSimpleName() + " got: " + ex.getClass().getSimpleName());
-            }
-          } else {
-            throw ex;
-          }
-        }
+  public void handleTestExecutionException(ExtensionContext context,
+      Throwable cause) throws Throwable {
+    Method testMethod = context.getRequiredTestMethod();
+    TestException testExceptionAnnotation = testMethod.getAnnotation(TestException.class);
+    try {
+      if (testExceptionAnnotation != null) {
+        Class<? extends Throwable> klass = testExceptionAnnotation.exception();
+        fail("Expected Exception: " + klass.getSimpleName());
       }
-    };
+    } catch (Throwable ex) {
+      if (testExceptionAnnotation != null) {
+        Class<? extends Throwable> klass = testExceptionAnnotation.exception();
+        if (klass.isInstance(cause)) {
+          String regExp = testExceptionAnnotation.msgRegExp();
+          Pattern pattern = Pattern.compile(regExp);
+          if (!pattern.matcher(cause.getMessage()).find()) {
+            fail("Expected Exception Message pattern: " + regExp + " got message: " + ex.getMessage());
+          }
+        } else {
+          fail("Expected Exception: " + klass.getSimpleName() + " got: " + ex.getClass().getSimpleName());
+        }
+      } else {
+        throw ex;
+      }
+    }
   }
-
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestExceptionHelper.java
@@ -49,10 +49,12 @@ public class TestExceptionHelper implements TestExecutionExceptionHandler {
           String regExp = testExceptionAnnotation.msgRegExp();
           Pattern pattern = Pattern.compile(regExp);
           if (!pattern.matcher(cause.getMessage()).find()) {
-            fail("Expected Exception Message pattern: " + regExp + " got message: " + ex.getMessage());
+            fail("Expected Exception Message pattern: " + regExp +
+                " got message: " + ex.getMessage());
           }
         } else {
-          fail("Expected Exception: " + klass.getSimpleName() + " got: " + ex.getClass().getSimpleName());
+          fail("Expected Exception: " + klass.getSimpleName() + " got: " +
+              ex.getClass().getSimpleName());
         }
       } else {
         throw ex;

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHFSTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHFSTestCase.java
@@ -39,7 +39,9 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestHFSTestCase extends HFSTestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHFSTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHFSTestCase.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,34 +36,46 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.Time;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestHFSTestCase extends HFSTestCase {
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testDirNoAnnotation() throws Exception {
-    TestDirHelper.getTestDir();
+    assertThrows(IllegalStateException.class, () -> {
+      TestDirHelper.getTestDir();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testJettyNoAnnotation() throws Exception {
-    TestJettyHelper.getJettyServer();
+    assertThrows(IllegalStateException.class, () -> {
+      TestJettyHelper.getJettyServer();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testJettyNoAnnotation2() throws Exception {
-    TestJettyHelper.getJettyURL();
+    assertThrows(IllegalStateException.class, () -> {
+      TestJettyHelper.getJettyURL();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testHdfsNoAnnotation() throws Exception {
-    TestHdfsHelper.getHdfsConf();
+    assertThrows(IllegalStateException.class, () -> {
+      TestHdfsHelper.getHdfsConf();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testHdfsNoAnnotation2() throws Exception {
-    TestHdfsHelper.getHdfsTestDir();
+    assertThrows(IllegalStateException.class, () -> {
+      TestHdfsHelper.getHdfsTestDir();
+    });
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHTestCase.java
@@ -34,13 +34,15 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestHTestCase extends HTestCase {
 
   @Test
   public void testDirNoAnnotation() throws Exception {
-    assertThrows(IllegalStateException.class, ()->{
+    assertThrows(IllegalStateException.class, () -> {
       TestDirHelper.getTestDir();
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHTestCase.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -34,24 +31,32 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.hadoop.util.Time;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.server.Server;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestHTestCase extends HTestCase {
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testDirNoAnnotation() throws Exception {
-    TestDirHelper.getTestDir();
+    assertThrows(IllegalStateException.class, ()->{
+      TestDirHelper.getTestDir();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testJettyNoAnnotation() throws Exception {
-    TestJettyHelper.getJettyServer();
+    assertThrows(IllegalStateException.class, () -> {
+      TestJettyHelper.getJettyServer();
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testJettyNoAnnotation2() throws Exception {
-    TestJettyHelper.getJettyURL();
+    assertThrows(IllegalStateException.class, () -> {
+      TestJettyHelper.getJettyURL();
+    });
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.test;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +37,7 @@ import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.StoragePolicySatisfierMode;
 import org.junit.jupiter.api.Test;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class TestHdfsHelper extends TestDirHelper {
 
@@ -54,27 +54,16 @@ public class TestHdfsHelper extends TestDirHelper {
 
   private static final ThreadLocal<Path> HDFS_TEST_DIR_TL = new InheritableThreadLocal<Path>();
 
-  @Override
-  public Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
-    TestHdfs testHdfsAnnotation = frameworkMethod.getAnnotation(TestHdfs.class);
-    if (testHdfsAnnotation != null) {
-      this.statement = new HdfsStatement(statement, frameworkMethod.getName());
-      statement = this.statement;
-    }
-    return super.apply(statement, frameworkMethod, o);
-  }
-
   public MiniDFSCluster getMiniDFSCluster() {
     return statement.getMiniDFSCluster();
   }
 
-  private static class HdfsStatement extends Statement {
-    private Statement statement;
+  private static class HdfsStatement {
+
     private String testName;
     private MiniDFSCluster miniHdfs = null;
 
-    public HdfsStatement(Statement statement, String testName) {
-      this.statement = statement;
+    public HdfsStatement(String testName) {
       this.testName = testName;
     }
 
@@ -82,21 +71,15 @@ public class TestHdfsHelper extends TestDirHelper {
       return miniHdfs;
     }
 
-    @Override
-    public void evaluate() throws Throwable {
+
+    public void evaluate() throws Exception {
       Configuration conf = HadoopUsersConfTestHelper.getBaseConf();
       if (Boolean.parseBoolean(System.getProperty(HADOOP_MINI_HDFS, "true"))) {
         miniHdfs = startMiniHdfs(conf);
         conf = miniHdfs.getConfiguration(0);
       }
-      try {
-        HDFS_CONF_TL.set(conf);
-        HDFS_TEST_DIR_TL.set(resetHdfsTestDir(conf));
-        statement.evaluate();
-      } finally {
-        HDFS_CONF_TL.remove();
-        HDFS_TEST_DIR_TL.remove();
-      }
+      HDFS_CONF_TL.set(conf);
+      HDFS_TEST_DIR_TL.set(resetHdfsTestDir(conf));
     }
 
     private static AtomicInteger counter = new AtomicInteger();
@@ -223,4 +206,22 @@ public class TestHdfsHelper extends TestDirHelper {
     return MINI_DFS;
   }
 
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    super.beforeEach(context);
+    Method testMethod = context.getRequiredTestMethod();
+    TestHdfs testHdfsAnnotation = testMethod.getAnnotation(TestHdfs.class);
+    if (testHdfsAnnotation != null) {
+      this.statement = new HdfsStatement(testMethod.getName());
+      this.statement.evaluate();
+    }
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) throws Exception {
+
+    super.afterEach(extensionContext);
+    HDFS_CONF_TL.remove();
+    HDFS_TEST_DIR_TL.remove();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
@@ -63,7 +63,7 @@ public class TestHdfsHelper extends TestDirHelper {
     private String testName;
     private MiniDFSCluster miniHdfs = null;
 
-    public HdfsStatement(String testName) {
+    HdfsStatement(String testName) {
       this.testName = testName;
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestHdfsHelper.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.hdfs.StripedFileTestUtil;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.StoragePolicySatisfierMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestJettyHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestJettyHelper.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.test;
 
+import java.io.File;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -34,11 +36,11 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.junit.rules.MethodRule;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class TestJettyHelper implements MethodRule {
+public class TestJettyHelper implements BeforeEachCallback, AfterEachCallback {
   private boolean ssl;
   private String keyStoreType;
   private String keyStore;
@@ -59,32 +61,6 @@ public class TestJettyHelper implements MethodRule {
 
   private static final ThreadLocal<TestJettyHelper> TEST_JETTY_TL =
       new InheritableThreadLocal<TestJettyHelper>();
-
-  @Override
-  public Statement apply(final Statement statement, final FrameworkMethod frameworkMethod, final Object o) {
-    return new Statement() {
-      @Override
-      public void evaluate() throws Throwable {
-        TestJetty testJetty = frameworkMethod.getAnnotation(TestJetty.class);
-        if (testJetty != null) {
-          server = createJettyServer();
-        }
-        try {
-          TEST_JETTY_TL.set(TestJettyHelper.this);
-          statement.evaluate();
-        } finally {
-          TEST_JETTY_TL.remove();
-          if (server != null && server.isRunning()) {
-            try {
-              server.stop();
-            } catch (Exception ex) {
-              throw new RuntimeException("Could not stop embedded servlet container, " + ex.getMessage(), ex);
-            }
-          }
-        }
-      }
-    };
-  }
 
   private Server createJettyServer() {
     try {
@@ -177,4 +153,25 @@ public class TestJettyHelper implements MethodRule {
     }
   }
 
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    TEST_JETTY_TL.remove();
+    if (server != null && server.isRunning()) {
+      try {
+        server.stop();
+      } catch (Exception ex) {
+        throw new RuntimeException("Could not stop embedded servlet container, " + ex.getMessage(), ex);
+      }
+    }
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    Method testMethod = context.getRequiredTestMethod();
+    TestJetty testJetty = testMethod.getAnnotation(TestJetty.class);
+    if (testJetty != null) {
+      server = createJettyServer();
+    }
+    TEST_JETTY_TL.set(TestJettyHelper.this);
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestJettyHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/test/TestJettyHelper.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.test;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -160,7 +159,8 @@ public class TestJettyHelper implements BeforeEachCallback, AfterEachCallback {
       try {
         server.stop();
       } catch (Exception ex) {
-        throw new RuntimeException("Could not stop embedded servlet container, " + ex.getMessage(), ex);
+        throw new RuntimeException("Could not stop embedded servlet container, " +
+            ex.getMessage(), ex);
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17719. Upgrade JUnit from 4 to 5 in hadoop-hdfs-httpfs.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

