### PR TITLE
YARN-11761. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-services-core.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/ServiceTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/ServiceTestUtils.java
@@ -54,8 +54,6 @@ import org.apache.hadoop.yarn.util.ProcfsBasedProcessTree;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +61,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/ServiceTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/ServiceTestUtils.java
@@ -51,6 +51,9 @@ import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
 import org.apache.hadoop.yarn.util.LinuxResourceCalculatorPlugin;
 import org.apache.hadoop.yarn.util.ProcfsBasedProcessTree;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
@@ -60,6 +63,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -393,17 +397,22 @@ public class ServiceTestUtils {
    * Watcher to initialize yarn service base path under target and deletes the
    * the test directory when finishes.
    */
-  public static class ServiceFSWatcher extends TestWatcher {
+  public static class ServiceFSWatcher implements BeforeEachCallback, AfterEachCallback {
     private YarnConfiguration conf;
     private SliderFileSystem fs;
     private java.nio.file.Path serviceBasePath;
 
     @Override
-    protected void starting(Description description) {
+    public void afterEach(ExtensionContext context) throws Exception {
+      delete(context);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
       conf = new YarnConfiguration();
-      delete(description);
+      delete(context);
       serviceBasePath = Paths.get("target",
-          description.getClassName(), description.getMethodName());
+          getClassName(context), getMethodName(context));
       conf.set(YARN_SERVICE_BASE_PATH, serviceBasePath.toString());
       try {
         Files.createDirectories(serviceBasePath);
@@ -415,14 +424,17 @@ public class ServiceTestUtils {
       }
     }
 
-    @Override
-    protected void finished(Description description) {
-      delete(description);
+    private void delete(ExtensionContext context) {
+      FileUtils.deleteQuietly(Paths.get("target", getClassName(context)).toFile());
     }
 
-    private void delete(Description description) {
-      FileUtils.deleteQuietly(Paths.get("target",
-          description.getClassName()).toFile());
+    private String getClassName(ExtensionContext context) {
+      Class<?> requiredTestClass = context.getRequiredTestClass();
+      return requiredTestClass.getName();
+    }
+
+    private String getMethodName(ExtensionContext context) {
+      return context.getTestMethod().get().getName();
     }
 
     /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.api.records.Service;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link UpgradeComponentsFinder.DefaultUpgradeComponentsFinder}.
@@ -44,9 +44,9 @@ public class TestDefaultUpgradeComponentsFinder {
     targetDef.getComponents().forEach(x -> x.setArtifact(
         TestServiceManager.createTestArtifact("v1")));
 
-    assertEquals("all components need upgrade",
-        targetDef.getComponents(), finder.findTargetComponentSpecs(currentDef,
-            targetDef));
+    assertEquals(
+       targetDef.getComponents(), finder.findTargetComponentSpecs(currentDef,
+            targetDef), "all components need upgrade");
   }
 
   @Test
@@ -60,7 +60,7 @@ public class TestDefaultUpgradeComponentsFinder {
 
     try {
       finder.findTargetComponentSpecs(currentDef, targetDef);
-      Assert.fail("Expected error since component does not exist in service "
+      Assertions.fail("Expected error since component does not exist in service "
           + "definition");
     } catch (UnsupportedOperationException usoe) {
       assertEquals(
@@ -83,9 +83,9 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.add(targetDef.getComponents().get(0));
 
-    assertEquals("single components needs upgrade",
-        expected, finder.findTargetComponentSpecs(currentDef,
-            targetDef));
+    assertEquals(
+       expected, finder.findTargetComponentSpecs(currentDef,
+            targetDef), "single components needs upgrade");
   }
 
   @Test
@@ -117,7 +117,7 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.addAll(targetDef.getComponents());
 
-    assertEquals("all components needs upgrade",
-        expected, finder.findTargetComponentSpecs(currentDef, targetDef));
+    assertEquals(
+       expected, finder.findTargetComponentSpecs(currentDef, targetDef), "all components needs upgrade");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.api.records.Service;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link UpgradeComponentsFinder.DefaultUpgradeComponentsFinder}.
@@ -44,9 +44,9 @@ public class TestDefaultUpgradeComponentsFinder {
     targetDef.getComponents().forEach(x -> x.setArtifact(
         TestServiceManager.createTestArtifact("v1")));
 
-    assertEquals(
-       targetDef.getComponents(), finder.findTargetComponentSpecs(currentDef,
-            targetDef), "all components need upgrade");
+    assertEquals(targetDef.getComponents(),
+        finder.findTargetComponentSpecs(currentDef,
+        targetDef), "all components need upgrade");
   }
 
   @Test
@@ -60,7 +60,7 @@ public class TestDefaultUpgradeComponentsFinder {
 
     try {
       finder.findTargetComponentSpecs(currentDef, targetDef);
-      Assertions.fail("Expected error since component does not exist in service "
+      fail("Expected error since component does not exist in service "
           + "definition");
     } catch (UnsupportedOperationException usoe) {
       assertEquals(
@@ -83,9 +83,8 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.add(targetDef.getComponents().get(0));
 
-    assertEquals(
-       expected, finder.findTargetComponentSpecs(currentDef,
-            targetDef), "single components needs upgrade");
+    assertEquals(expected, finder.findTargetComponentSpecs(currentDef,
+        targetDef), "single components needs upgrade");
   }
 
   @Test
@@ -117,7 +116,7 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.addAll(targetDef.getComponents());
 
-    assertEquals(
-       expected, finder.findTargetComponentSpecs(currentDef, targetDef), "all components needs upgrade");
+    assertEquals(expected, finder.findTargetComponentSpecs(currentDef, targetDef),
+        "all components needs upgrade");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceAM.java
@@ -52,11 +52,10 @@ import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.apache.hadoop.yarn.util.DockerClientConfigHandler;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +72,8 @@ import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.registry.client.api.RegistryConstants.KEY_REGISTRY_ZK_QUORUM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -84,7 +85,7 @@ public class TestServiceAM extends ServiceTestUtils{
   private File basedir;
   YarnConfiguration conf = new YarnConfiguration();
   TestingCluster zkCluster;
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -148,8 +149,7 @@ public class TestServiceAM extends ServiceTestUtils{
 
     am.waitForCompInstanceState(compa0, ComponentInstanceState.INIT);
     // still 1 pending instance
-    Assertions.assertEquals(1,
-        am.getComponent("compa").getPendingInstances().size());
+    assertEquals(1, am.getComponent("compa").getPendingInstances().size());
     am.stop();
   }
 
@@ -184,16 +184,15 @@ public class TestServiceAM extends ServiceTestUtils{
     am.waitForCompInstanceState(comp10, ComponentInstanceState.STARTED);
 
     // 0 pending instance
-    Assertions.assertEquals(0,
+    assertEquals(0,
         am.getComponent(comp1Name).getPendingInstances().size());
 
     GenericTestUtils.waitFor(() -> am.getCompInstance(comp1Name, comp1InstName)
         .getContainerStatus() != null, 2000, 200000);
 
-    Assertions.assertEquals(
-       org.apache.hadoop.yarn.api.records.ContainerState.RUNNING
-,         am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
-            .getState(), "container state");
+    assertEquals(org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
+        am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
+        .getState(), "container state");
     am.stop();
   }
 
@@ -228,17 +227,16 @@ public class TestServiceAM extends ServiceTestUtils{
         .equals(ComponentState.FLEXING), 100, 2000);
 
     // 1 pending instance
-    Assertions.assertEquals(1, am.getComponent(comp1Name).getPendingInstances()
+    assertEquals(1, am.getComponent(comp1Name).getPendingInstances()
         .size());
 
     am.feedContainerToComp(exampleApp, 2, comp1Name);
 
     GenericTestUtils.waitFor(() -> am.getCompInstance(comp1Name, comp1InstName)
         .getContainerStatus() != null, 2000, 200000);
-    Assertions.assertEquals(
-       org.apache.hadoop.yarn.api.records.ContainerState.RUNNING
-,         am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
-            .getState(), "container state");
+    assertEquals(org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
+        am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
+        .getState(), "container state");
   }
 
   // Test to verify that the AM doesn't wait for containers of a different app
@@ -272,17 +270,16 @@ public class TestServiceAM extends ServiceTestUtils{
     am.start();
     // 1 pending instance since the container in registry belongs to a different
     // app.
-    Assertions.assertEquals(1,
+    assertEquals(1,
         am.getComponent(comp1Name).getPendingInstances().size());
 
     am.feedContainerToComp(exampleApp, 1, comp1Name);
     GenericTestUtils.waitFor(() -> am.getCompInstance(comp1Name, comp1InstName)
         .getContainerStatus() != null, 2000, 200000);
 
-    Assertions.assertEquals(
-       org.apache.hadoop.yarn.api.records.ContainerState.RUNNING
-,         am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
-            .getState(), "container state");
+    assertEquals(org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
+        am.getCompInstance(comp1Name, comp1InstName).getContainerStatus()
+        .getState(), "container state");
     am.stop();
   }
 
@@ -318,13 +315,12 @@ public class TestServiceAM extends ServiceTestUtils{
 
     Collection<AMRMClient.ContainerRequest> rr =
         amrmClientAsync.getMatchingRequests(0);
-    Assertions.assertEquals(1, rr.size());
+    assertEquals(1, rr.size());
 
     org.apache.hadoop.yarn.api.records.Resource capability =
         rr.iterator().next().getCapability();
-    Assertions.assertEquals(3333L, capability.getResourceValue("resource-1"));
-    Assertions.assertEquals("Gi",
-        capability.getResourceInformation("resource-1").getUnits());
+    assertEquals(3333L, capability.getResourceValue("resource-1"));
+    assertEquals("Gi", capability.getResourceInformation("resource-1").getUnits());
 
     am.stop();
   }
@@ -436,8 +432,7 @@ public class TestServiceAM extends ServiceTestUtils{
 
     assertEquals(2, amCreds.numberOfTokens());
     for (Token<? extends TokenIdentifier> tk : amCreds.getAllTokens()) {
-      Assertions.assertTrue(
-          tk.getKind().equals(DockerCredentialTokenIdentifier.KIND));
+      assertTrue(tk.getKind().equals(DockerCredentialTokenIdentifier.KIND));
     }
 
     am.stop();
@@ -467,7 +462,7 @@ public class TestServiceAM extends ServiceTestUtils{
     GenericTestUtils.waitFor(() -> comp1inst0.getContainerStatus() != null,
         2000, 200000);
     // first host status will match the container nodeId
-    Assertions.assertEquals("localhost",
+    assertEquals("localhost",
         comp1inst0.getContainerStatus().getHost());
 
     LOG.info("Change the IP and host");
@@ -527,8 +522,7 @@ public class TestServiceAM extends ServiceTestUtils{
         am.getComponent(compA.getName()).getPendingInstances()
         .contains(compAinst0), 2000, 30000);
 
-    Assertions.assertEquals(1,
-        am.getComponent("compa").getPendingInstances().size());
+    assertEquals(1, am.getComponent("compa").getPendingInstances().size());
     am.stop();
   }
 
@@ -560,7 +554,7 @@ public class TestServiceAM extends ServiceTestUtils{
       am.close();
     } catch (Exception e) {
       LOG.error("Fail to sync sysfs.", e);
-      Assertions.fail("Fail to sync sysfs.");
+      fail("Fail to sync sysfs.");
     }
   }
 
@@ -599,14 +593,14 @@ public class TestServiceAM extends ServiceTestUtils{
 
     Collection<AMRMClient.ContainerRequest> rr =
         amrmClientAsync.getMatchingRequests(0);
-    Assertions.assertEquals(1, rr.size());
+    assertEquals(1, rr.size());
 
     org.apache.hadoop.yarn.api.records.Resource capability =
         rr.iterator().next().getCapability();
-    Assertions.assertEquals(1234L, capability.getResourceValue("test-resource"));
-    Assertions.assertEquals("Gi",
+    assertEquals(1234L, capability.getResourceValue("test-resource"));
+    assertEquals("Gi",
         capability.getResourceInformation("test-resource").getUnits());
-    Assertions.assertEquals(2, capability.getResourceInformation("test-resource")
+    assertEquals(2, capability.getResourceInformation("test-resource")
         .getAttributes().size());
     am.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceAM.java
@@ -86,7 +86,7 @@ public class TestServiceAM extends ServiceTestUtils{
   YarnConfiguration conf = new YarnConfiguration();
   TestingCluster zkCluster;
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @BeforeEach

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.hadoop.yarn.service.exceptions.SliderException;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,15 +51,17 @@ public class TestServiceManager {
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
-  @Test (timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testUpgrade");
     initUpgrade(context, "v2", false, false, false);
-    Assert.assertEquals("service not upgraded", ServiceState.UPGRADING,
-        context.getServiceManager().getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         context.getServiceManager().getServiceSpec().getState(), "service not upgraded");
   }
 
-  @Test (timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testRestartNothingToUpgrade()
       throws Exception {
     ServiceContext context = createServiceContext(
@@ -73,11 +76,12 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not re-started", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service not re-started");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testAutoFinalizeNothingToUpgrade() throws Exception {
     ServiceContext context = createServiceContext(
         "testAutoFinalizeNothingToUpgrade");
@@ -89,11 +93,12 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service stable", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service stable");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testRestartWithPendingUpgrade()
       throws Exception {
     ServiceContext context = createServiceContext("testRestart");
@@ -103,17 +108,18 @@ public class TestServiceManager {
     context.scheduler.getDispatcher().getEventHandler().handle(
         new ServiceEvent(ServiceEventType.START));
     context.scheduler.getDispatcher().stop();
-    Assert.assertEquals("service should still be upgrading",
-        ServiceState.UPGRADING, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.UPGRADING, manager.getServiceSpec().getState(), "service should still be upgrading");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testFinalize() throws Exception {
     ServiceContext context = createServiceContext("testCheckState");
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     //make components stable by upgrading all instances
     upgradeAndReadyAllInstances(context);
@@ -124,13 +130,14 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not re-started", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service not re-started");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testAutoFinalize() throws Exception {
     ServiceContext context = createServiceContext("testCheckStateAutoFinalize");
     ServiceManager manager = context.getServiceManager();
@@ -144,8 +151,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(() ->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not stable",
-        ServiceState.STABLE, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
@@ -165,13 +172,14 @@ public class TestServiceManager {
     try {
       manager.processUpgradeRequest("v2", true, false);
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof UnsupportedOperationException);
+      Assertions.assertTrue(ex instanceof UnsupportedOperationException);
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testExpressUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testExpressUpgrade");
     ServiceManager manager = context.getServiceManager();
@@ -191,19 +199,20 @@ public class TestServiceManager {
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
 
-    Assert.assertEquals("service not stable",
-        ServiceState.STABLE, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
     validateUpgradeFinalization(manager.getName(), "v2");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testCancelUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testCancelUpgrade");
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     List<String> comps = ServiceApiUtil.resolveCompsDependency(context.service);
     // wait till instances of first component are upgraded and ready
@@ -220,20 +229,21 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service upgrade not cancelled", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testCancelUpgradeAfterInitiate() throws Exception {
     ServiceContext context = createServiceContext("testCancelUpgrade");
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     // cancel upgrade
     context.scheduler.getDispatcher().getEventHandler().handle(
@@ -241,8 +251,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service upgrade not cancelled", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
@@ -250,14 +260,14 @@ public class TestServiceManager {
   private void validateUpgradeFinalization(String serviceName,
       String expectedVersion) throws IOException {
     Service savedSpec = ServiceApiUtil.loadService(rule.getFs(), serviceName);
-    Assert.assertEquals("service def not re-written", expectedVersion,
-        savedSpec.getVersion());
-    Assert.assertNotNull("app id not present", savedSpec.getId());
-    Assert.assertEquals("state not stable", ServiceState.STABLE,
-        savedSpec.getState());
+    Assertions.assertEquals(expectedVersion
+,         savedSpec.getVersion(), "service def not re-written");
+    Assertions.assertNotNull(savedSpec.getId(), "app id not present");
+    Assertions.assertEquals(ServiceState.STABLE
+,         savedSpec.getState(), "state not stable");
     savedSpec.getComponents().forEach(compSpec ->
-        Assert.assertEquals("comp not stable", ComponentState.STABLE,
-        compSpec.getState()));
+        Assertions.assertEquals(ComponentState.STABLE
+,         compSpec.getState(), "comp not stable"));
   }
 
   private void initUpgrade(ServiceContext context, String version,
@@ -426,6 +436,6 @@ public class TestServiceManager {
         upgradedDef);
   }
 
-  private static final int TIMEOUT = 10000;
+  private static final int TIMEOUT = 10;
   private static final int CHECK_EVERY_MILLIS = 100;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestServiceManager {
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
@@ -32,22 +32,26 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.hadoop.yarn.service.exceptions.SliderException;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 /**
  * Tests for {@link ServiceManager}.
  */
 public class TestServiceManager {
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -56,8 +60,8 @@ public class TestServiceManager {
   public void testUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testUpgrade");
     initUpgrade(context, "v2", false, false, false);
-    Assertions.assertEquals(ServiceState.UPGRADING
-,         context.getServiceManager().getServiceSpec().getState(), "service not upgraded");
+    assertEquals(ServiceState.UPGRADING,
+        context.getServiceManager().getServiceSpec().getState(), "service not upgraded");
   }
 
   @Test
@@ -76,8 +80,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(ServiceState.STABLE
-,         manager.getServiceSpec().getState(), "service not re-started");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service not re-started");
   }
 
   @Test
@@ -93,8 +97,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(ServiceState.STABLE
-,         manager.getServiceSpec().getState(), "service stable");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service stable");
   }
 
   @Test
@@ -108,8 +112,8 @@ public class TestServiceManager {
     context.scheduler.getDispatcher().getEventHandler().handle(
         new ServiceEvent(ServiceEventType.START));
     context.scheduler.getDispatcher().stop();
-    Assertions.assertEquals(
-       ServiceState.UPGRADING, manager.getServiceSpec().getState(), "service should still be upgrading");
+    assertEquals(ServiceState.UPGRADING,
+        manager.getServiceSpec().getState(), "service should still be upgrading");
   }
 
   @Test
@@ -118,8 +122,8 @@ public class TestServiceManager {
     ServiceContext context = createServiceContext("testCheckState");
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assertions.assertEquals(ServiceState.UPGRADING
-,         manager.getServiceSpec().getState(), "service not upgrading");
+    assertEquals(ServiceState.UPGRADING,
+        manager.getServiceSpec().getState(), "service not upgrading");
 
     //make components stable by upgrading all instances
     upgradeAndReadyAllInstances(context);
@@ -130,8 +134,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(ServiceState.STABLE
-,         manager.getServiceSpec().getState(), "service not re-started");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service not re-started");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
@@ -151,8 +155,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(() ->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(
-       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service not stable");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
@@ -172,10 +176,10 @@ public class TestServiceManager {
     try {
       manager.processUpgradeRequest("v2", true, false);
     } catch (Exception ex) {
-      Assertions.assertTrue(ex instanceof UnsupportedOperationException);
+      assertTrue(ex instanceof UnsupportedOperationException);
       return;
     }
-    Assertions.fail();
+    fail();
   }
 
   @Test
@@ -199,8 +203,8 @@ public class TestServiceManager {
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
 
-    Assertions.assertEquals(
-       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
+    assertEquals(ServiceState.STABLE, manager.getServiceSpec().getState(),
+        "service not stable");
     validateUpgradeFinalization(manager.getName(), "v2");
   }
 
@@ -211,8 +215,8 @@ public class TestServiceManager {
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assertions.assertEquals(ServiceState.UPGRADING
-,         manager.getServiceSpec().getState(), "service not upgrading");
+    assertEquals(ServiceState.UPGRADING,
+        manager.getServiceSpec().getState(), "service not upgrading");
 
     List<String> comps = ServiceApiUtil.resolveCompsDependency(context.service);
     // wait till instances of first component are upgraded and ready
@@ -229,8 +233,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(ServiceState.STABLE
-,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
@@ -242,8 +246,8 @@ public class TestServiceManager {
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assertions.assertEquals(ServiceState.UPGRADING
-,         manager.getServiceSpec().getState(), "service not upgrading");
+    assertEquals(ServiceState.UPGRADING,
+        manager.getServiceSpec().getState(), "service not upgrading");
 
     // cancel upgrade
     context.scheduler.getDispatcher().getEventHandler().handle(
@@ -251,8 +255,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assertions.assertEquals(ServiceState.STABLE
-,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
+    assertEquals(ServiceState.STABLE,
+        manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
@@ -260,14 +264,14 @@ public class TestServiceManager {
   private void validateUpgradeFinalization(String serviceName,
       String expectedVersion) throws IOException {
     Service savedSpec = ServiceApiUtil.loadService(rule.getFs(), serviceName);
-    Assertions.assertEquals(expectedVersion
-,         savedSpec.getVersion(), "service def not re-written");
-    Assertions.assertNotNull(savedSpec.getId(), "app id not present");
-    Assertions.assertEquals(ServiceState.STABLE
-,         savedSpec.getState(), "state not stable");
+    assertEquals(expectedVersion,
+        savedSpec.getVersion(), "service def not re-written");
+    assertNotNull(savedSpec.getId(), "app id not present");
+    assertEquals(ServiceState.STABLE,
+        savedSpec.getState(), "state not stable");
     savedSpec.getComponents().forEach(compSpec ->
-        Assertions.assertEquals(ComponentState.STABLE
-,         compSpec.getState(), "comp not stable"));
+        assertEquals(ComponentState.STABLE,
+            compSpec.getState(), "comp not stable"));
   }
 
   private void initUpgrade(ServiceContext context, String version,
@@ -436,6 +440,6 @@ public class TestServiceManager {
         upgradedDef);
   }
 
-  private static final int TIMEOUT = 10;
+  private static final int TIMEOUT = 10000;
   private static final int CHECK_EVERY_MILLIS = 100;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
@@ -50,12 +50,9 @@ import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +64,11 @@ import java.util.*;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.yarn.api.records.YarnApplicationState.FINISHED;
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConf.*;
 import static org.apache.hadoop.yarn.service.exceptions.LauncherExitCodes.EXIT_COMMAND_ARGUMENT_ERROR;
@@ -80,10 +82,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestYarnNativeServices.class);
-
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
-
+  
   @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");
@@ -112,7 +111,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     SliderFileSystem fileSystem = new SliderFileSystem(getConf());
     Path appDir = fileSystem.buildClusterDirPath(exampleApp.getName());
     // check app.json is persisted.
-    Assertions.assertTrue(
+    assertTrue(
         getFS().exists(new Path(appDir, exampleApp.getName() + ".json")));
     waitForServiceToBeStable(client, exampleApp);
 
@@ -141,22 +140,22 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     ApplicationReport report = client.getYarnClient()
         .getApplicationReport(ApplicationId.fromString(exampleApp.getId()));
     // AM unregisters with RM successfully
-    Assertions.assertEquals(FINISHED, report.getYarnApplicationState());
-    Assertions.assertEquals(FinalApplicationStatus.ENDED,
+    assertEquals(FINISHED, report.getYarnApplicationState());
+    assertEquals(FinalApplicationStatus.ENDED,
         report.getFinalApplicationStatus());
     String serviceZKPath = RegistryUtils.servicePath(RegistryUtils
         .currentUser(), YarnServiceConstants.APP_TYPE, exampleApp.getName());
-    Assertions.assertFalse(
+    assertFalse(
        getCuratorService().zkPathExists(serviceZKPath), "Registry ZK service path still exists after stop");
 
     LOG.info("Destroy the service");
     // destroy the service and check the app dir is deleted from fs.
-    Assertions.assertEquals(0, client.actionDestroy(exampleApp.getName()));
+    assertEquals(0, client.actionDestroy(exampleApp.getName()));
     // check the service dir on hdfs (in this case, local fs) are deleted.
-    Assertions.assertFalse(getFS().exists(appDir));
+    assertFalse(getFS().exists(appDir));
 
     // check that destroying again does not succeed
-    Assertions.assertEquals(EXIT_NOT_FOUND, client.actionDestroy(exampleApp.getName()));
+    assertEquals(EXIT_NOT_FOUND, client.actionDestroy(exampleApp.getName()));
   }
 
   // Save a service without starting it and ensure that stop does not NPE and
@@ -168,9 +167,9 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     ServiceClient client = createClient(getConf());
     Service exampleApp = createExampleApplication();
     client.actionBuild(exampleApp);
-    Assertions.assertEquals(EXIT_COMMAND_ARGUMENT_ERROR, client.actionStop(
+    assertEquals(EXIT_COMMAND_ARGUMENT_ERROR, client.actionStop(
         exampleApp.getName()));
-    Assertions.assertEquals(0, client.actionDestroy(exampleApp.getName()));
+    assertEquals(0, client.actionDestroy(exampleApp.getName()));
   }
 
   // Create compa with 2 containers
@@ -243,8 +242,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       getConf().set(YARN_SERVICE_BASE_PATH, userBBasePath.getAbsolutePath());
       client.actionBuild(userBApp);
     } catch (Exception e) {
-      Assertions
-          .fail("Exception should not be thrown - " + e.getLocalizedMessage());
+      fail("Exception should not be thrown - " + e.getLocalizedMessage());
     } finally {
       if (userABasePath != null) {
         getConf().set(YARN_SERVICE_BASE_PATH, userABasePath.getAbsolutePath());
@@ -290,7 +288,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       if (e.getLocalizedMessage() != null) {
         assertThat(e.getLocalizedMessage()).contains(expectedMsg);
       } else {
-        Assertions.fail("Message cannot be null. It has to say - " + expectedMsg);
+        fail("Message cannot be null. It has to say - " + expectedMsg);
       }
     } finally {
       // cleanup
@@ -309,7 +307,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       if (e.getLocalizedMessage() != null) {
         assertThat(e.getLocalizedMessage()).contains(expectedMsg);
       } else {
-        Assertions.fail("Message cannot be null. It has to say - " + expectedMsg);
+        fail("Message cannot be null. It has to say - " + expectedMsg);
       }
     } finally {
       // cleanup
@@ -352,7 +350,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     GenericTestUtils.waitFor(() ->
         getYarnCluster().getResourceManager().getServiceState() ==
             org.apache.hadoop.service.Service.STATE.STARTED, 2000, 200000);
-    Assertions.assertTrue(
+    assertTrue(
        getYarnCluster().waitForNodeManagersToConnect(5000), "node managers connected");
 
     ApplicationId exampleAppId = ApplicationId.fromString(exampleApp.getId());
@@ -376,7 +374,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     Multimap<String, String> containersAfterFailure = waitForAllCompToBeReady(
         client, exampleApp);
     containersBeforeFailure.keys().forEach(compName -> {
-      Assertions.assertEquals(
+      assertEquals(
          containersBeforeFailure.get(compName).size()
 ,           containersAfterFailure.get(compName) == null ? 0 :
               containersAfterFailure.get(compName).size(), "num containers after by restart for " + compName);
@@ -410,8 +408,8 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     SliderFileSystem fs = new SliderFileSystem(getConf());
     Service fromFs = ServiceApiUtil.loadServiceUpgrade(fs,
         service.getName(), service.getVersion());
-    Assertions.assertEquals(service.getName(), fromFs.getName());
-    Assertions.assertEquals(service.getVersion(), fromFs.getVersion());
+    assertEquals(service.getName(), fromFs.getName());
+    assertEquals(service.getVersion(), fromFs.getVersion());
 
     // upgrade containers
     Service liveService = client.getStatus(service.getName());
@@ -423,9 +421,9 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionStart(service.getName());
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    Assertions.assertEquals(ComponentState.STABLE
+    assertEquals(ComponentState.STABLE
 ,         active.getComponent(component.getName()).getState(), "component not stable");
-    Assertions.assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
+    assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
         .getEnv("key1"), "comp does not have new env");
     LOG.info("Stop/destroy service {}", service);
     client.actionStop(service.getName(), true);
@@ -457,13 +455,13 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // wait for upgrade to complete
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    Assertions.assertEquals(service.getVersion()
+    assertEquals(service.getVersion()
 ,         active.getVersion(), "version mismatch");
-    Assertions.assertEquals(ComponentState.STABLE
+    assertEquals(ComponentState.STABLE
 ,         active.getComponent(component.getName()).getState(), "component not stable");
-    Assertions.assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
+    assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
         .getEnv("key1"), "compa does not have new env");
-    Assertions.assertEquals("val2", active.getComponent(component2.getName()).getConfiguration()
+    assertEquals("val2", active.getComponent(component2.getName()).getConfiguration()
         .getEnv("key2"), "compb does not have new env");
     LOG.info("Stop/destroy service {}", service);
     client.actionStop(service.getName(), true);
@@ -504,9 +502,9 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionCancelUpgrade(service.getName());
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    Assertions.assertEquals(ComponentState.STABLE
+    assertEquals(ComponentState.STABLE
 ,         active.getComponent(component.getName()).getState(), "component not stable");
-    Assertions.assertEquals("val0",
+    assertEquals("val0",
         active.getComponent(component.getName()).getConfiguration()
             .getEnv("key1"),"comp does not have new env");
     LOG.info("Stop/destroy service {}", service);
@@ -554,9 +552,9 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // Check service is stable and all 3 containers are running
     Service service = client.getStatus(exampleApp.getName());
     Component component = service.getComponent("compa");
-    Assertions.assertEquals(ServiceState.STABLE
+    assertEquals(ServiceState.STABLE
 ,         service.getState(), "Service state should be STABLE");
-    Assertions.assertEquals(3
+    assertEquals(3
 ,         component.getContainers().size(), "3 containers are expected to be running");
     // Prepare a map of non-AM containers for later lookup
     Set<String> nonAMContainerIdSet = new HashSet<>();
@@ -578,7 +576,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         continue;
       }
       if (hosts.contains(contReport.getNodeHttpAddress())) {
-        Assertions.fail("Container " + contReport.getContainerId()
+        fail("Container " + contReport.getContainerId()
             + " came up in the same host as another container.");
       } else {
         hosts.add(contReport.getNodeHttpAddress());
@@ -595,18 +593,18 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // this test is that it has to wait that long. Setting a higher wait time
       // will add to the total time taken by tests to run.
       waitForServiceToBeStable(client, exampleApp, 10000);
-      Assertions.fail("Service should not be in a stable state. It should throw "
+      fail("Service should not be in a stable state. It should throw "
           + "a timeout exception.");
     } catch (Exception e) {
       // Check that service state is not STABLE and only 3 containers are
       // running and the fourth one should not get allocated.
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      Assertions.assertNotEquals(
+      assertNotEquals(
          ServiceState.STABLE, service.getState(), "Service state should not be STABLE");
-      Assertions.assertEquals(
+      assertEquals(
          ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      Assertions.assertEquals(3
+      assertEquals(3
 ,           component.getContainers().size(), "3 containers are expected to be running");
     }
 
@@ -624,18 +622,18 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // this test is that it has to wait that long. Setting a higher wait time
       // will add to the total time taken by tests to run.
       waitForServiceToBeStable(client, exampleApp, 10000);
-      Assertions.fail("Service should not be in a stable state. It should throw "
+      fail("Service should not be in a stable state. It should throw "
           + "a timeout exception.");
     } catch (Exception e) {
       // Check that service state is not STABLE and only 3 containers are
       // running and the fourth one should not get allocated.
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      Assertions.assertNotEquals(
+      assertNotEquals(
          ServiceState.STABLE, service.getState(), "Service state should not be STABLE");
-      Assertions.assertEquals(
+      assertEquals(
          ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      Assertions.assertEquals(3
+      assertEquals(3
 ,           component.getContainers().size(), "3 containers are expected to be running");
     }
 
@@ -692,7 +690,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         ApplicationReport ar = client.getYarnClient()
             .getApplicationReport(exampleAppId);
         YarnApplicationState state = ar.getYarnApplicationState();
-        Assertions.assertTrue(state == YarnApplicationState.RUNNING ||
+        assertTrue(state == YarnApplicationState.RUNNING ||
             state == YarnApplicationState.ACCEPTED);
         if (state != YarnApplicationState.RUNNING) {
           return false;
@@ -705,7 +703,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         if (appStatus2.getState() != ServiceState.STABLE) {
           return false;
         }
-        Assertions.assertEquals(getSortedContainerIds(appStatus1).toString(),
+        assertEquals(getSortedContainerIds(appStatus1).toString(),
             getSortedContainerIds(appStatus2).toString());
         return true;
       } catch (YarnException | IOException e) {
@@ -780,9 +778,9 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // Check service is stable and all 3 containers are running
     Service service = client.getStatus(exampleApp.getName());
     Component component = service.getComponent("compa");
-    Assertions.assertEquals(ServiceState.STABLE
+    assertEquals(ServiceState.STABLE
 ,         service.getState(), "Service state should be STABLE");
-    Assertions.assertEquals(3
+    assertEquals(3
 ,         component.getContainers().size(), "3 containers are expected to be running");
 
     // Flex compa up to 4 - will make health 75% (3 out of 4 running), but still
@@ -798,17 +796,17 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // the timeout the service should continue to run since health is 75%
       // which is above the threshold of 65%.
       waitForServiceToBeStable(client, exampleApp, 6000);
-      Assertions.fail("Service should not be in a stable state. It should throw "
+      fail("Service should not be in a stable state. It should throw "
           + "a timeout exception.");
     } catch (Exception e) {
       // Check that service state is STARTED and only 3 containers are running
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      Assertions.assertEquals(
+      assertEquals(
          ServiceState.STARTED, service.getState(), "Service state should be STARTED");
-      Assertions.assertEquals(
+      assertEquals(
          ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      Assertions.assertEquals(3
+      assertEquals(3
 ,           component.getContainers().size(), "3 containers are expected to be running");
     }
 
@@ -825,7 +823,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       waitForServiceToBeInState(client, exampleApp, ServiceState.FAILED,
           14000);
     } catch (Exception e) {
-      Assertions.fail("Should not have thrown exception");
+      fail("Should not have thrown exception");
     }
 
     LOG.info("Destroy service {}", exampleApp);
@@ -856,7 +854,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         String compInstanceName = containerList.get(index).getComponentInstanceName();
         String compName =
             compInstanceName.substring(0, compInstanceName.lastIndexOf('-'));
-        Assertions.assertEquals(comp, compName);
+        assertEquals(comp, compName);
         index++;
       }
     }
@@ -949,7 +947,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionStart(exampleApp.getName());
     waitForServiceToBeStable(client, exampleApp);
     Service service = client.getStatus(exampleApp.getName());
-    Assertions.assertEquals(
+    assertEquals(
        ServiceState.STABLE, service.getState(), "Restarted service state should be STABLE");
   }
 
@@ -982,7 +980,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     yarnClient.signalToContainer(attemptReport.getAMContainerId(),
         SignalContainerCommand.GRACEFUL_SHUTDOWN);
     waitForServiceToBeStable(client, exampleApp);
-    Assertions.assertEquals(ServiceState.STABLE, client.getStatus(
+    assertEquals(ServiceState.STABLE, client.getStatus(
         exampleApp.getName()).getState());
 
     // kill AM2 after 'yarn.service.am-failure.validity-interval-ms'
@@ -993,7 +991,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     yarnClient.signalToContainer(attemptReport.getAMContainerId(),
         SignalContainerCommand.GRACEFUL_SHUTDOWN);
     waitForServiceToBeStable(client, exampleApp);
-    Assertions.assertEquals(ServiceState.STABLE, client.getStatus(
+    assertEquals(ServiceState.STABLE, client.getStatus(
         exampleApp.getName()).getState());
   }
 
@@ -1020,16 +1018,16 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     ServiceClient client = createClient(getConf());
     try {
       client.actionCreate(createServiceWithSingleComp(1024000));
-      Assertions.fail("Service should throw YarnException as memory is " +
+      fail("Service should throw YarnException as memory is " +
           "configured as 1000GB, which is more than allowed");
     } catch (YarnException e) {
-      Assertions.assertTrue(true);
+      assertTrue(true);
     }
     Service service = createServiceWithSingleComp(128);
     try {
       client.actionCreate(service);
     } catch (SliderException e){
-      Assertions.fail("Not able to submit service as the files related to" +
+      fail("Not able to submit service as the files related to" +
           " failed service with same name are not cleared");
     }
     waitForServiceToBeStable(client,service);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
@@ -82,7 +82,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestYarnNativeServices.class);
-  
+
   @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");
@@ -145,8 +145,8 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         report.getFinalApplicationStatus());
     String serviceZKPath = RegistryUtils.servicePath(RegistryUtils
         .currentUser(), YarnServiceConstants.APP_TYPE, exampleApp.getName());
-    assertFalse(
-       getCuratorService().zkPathExists(serviceZKPath), "Registry ZK service path still exists after stop");
+    assertFalse(getCuratorService().zkPathExists(serviceZKPath),
+        "Registry ZK service path still exists after stop");
 
     LOG.info("Destroy the service");
     // destroy the service and check the app dir is deleted from fs.
@@ -350,8 +350,8 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     GenericTestUtils.waitFor(() ->
         getYarnCluster().getResourceManager().getServiceState() ==
             org.apache.hadoop.service.Service.STATE.STARTED, 2000, 200000);
-    assertTrue(
-       getYarnCluster().waitForNodeManagersToConnect(5000), "node managers connected");
+    assertTrue(getYarnCluster().waitForNodeManagersToConnect(5000),
+        "node managers connected");
 
     ApplicationId exampleAppId = ApplicationId.fromString(exampleApp.getId());
     ApplicationAttemptId applicationAttemptId = client.getYarnClient()
@@ -374,10 +374,10 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     Multimap<String, String> containersAfterFailure = waitForAllCompToBeReady(
         client, exampleApp);
     containersBeforeFailure.keys().forEach(compName -> {
-      assertEquals(
-         containersBeforeFailure.get(compName).size()
-,           containersAfterFailure.get(compName) == null ? 0 :
-              containersAfterFailure.get(compName).size(), "num containers after by restart for " + compName);
+      assertEquals(containersBeforeFailure.get(compName).size(),
+          containersAfterFailure.get(compName) == null ? 0 :
+          containersAfterFailure.get(compName).size(),
+          "num containers after by restart for " + compName);
     });
 
     LOG.info("Stop/destroy service {}", exampleApp);
@@ -421,8 +421,8 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionStart(service.getName());
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    assertEquals(ComponentState.STABLE
-,         active.getComponent(component.getName()).getState(), "component not stable");
+    assertEquals(ComponentState.STABLE,
+        active.getComponent(component.getName()).getState(), "component not stable");
     assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
         .getEnv("key1"), "comp does not have new env");
     LOG.info("Stop/destroy service {}", service);
@@ -455,10 +455,10 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // wait for upgrade to complete
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    assertEquals(service.getVersion()
-,         active.getVersion(), "version mismatch");
-    assertEquals(ComponentState.STABLE
-,         active.getComponent(component.getName()).getState(), "component not stable");
+    assertEquals(service.getVersion(),
+        active.getVersion(), "version mismatch");
+    assertEquals(ComponentState.STABLE,
+        active.getComponent(component.getName()).getState(), "component not stable");
     assertEquals("val1", active.getComponent(component.getName()).getConfiguration()
         .getEnv("key1"), "compa does not have new env");
     assertEquals("val2", active.getComponent(component2.getName()).getConfiguration()
@@ -502,11 +502,11 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionCancelUpgrade(service.getName());
     waitForServiceToBeStable(client, service);
     Service active = client.getStatus(service.getName());
-    assertEquals(ComponentState.STABLE
-,         active.getComponent(component.getName()).getState(), "component not stable");
+    assertEquals(ComponentState.STABLE,
+        active.getComponent(component.getName()).getState(), "component not stable");
     assertEquals("val0",
         active.getComponent(component.getName()).getConfiguration()
-            .getEnv("key1"),"comp does not have new env");
+        .getEnv("key1"),"comp does not have new env");
     LOG.info("Stop/destroy service {}", service);
     client.actionStop(service.getName(), true);
     client.actionDestroy(service.getName());
@@ -552,10 +552,10 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // Check service is stable and all 3 containers are running
     Service service = client.getStatus(exampleApp.getName());
     Component component = service.getComponent("compa");
-    assertEquals(ServiceState.STABLE
-,         service.getState(), "Service state should be STABLE");
-    assertEquals(3
-,         component.getContainers().size(), "3 containers are expected to be running");
+    assertEquals(ServiceState.STABLE,
+        service.getState(), "Service state should be STABLE");
+    assertEquals(3,
+        component.getContainers().size(), "3 containers are expected to be running");
     // Prepare a map of non-AM containers for later lookup
     Set<String> nonAMContainerIdSet = new HashSet<>();
     for (Container cont : component.getContainers()) {
@@ -600,12 +600,12 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // running and the fourth one should not get allocated.
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      assertNotEquals(
-         ServiceState.STABLE, service.getState(), "Service state should not be STABLE");
-      assertEquals(
-         ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      assertEquals(3
-,           component.getContainers().size(), "3 containers are expected to be running");
+      assertNotEquals(ServiceState.STABLE, service.getState(),
+          "Service state should not be STABLE");
+      assertEquals(ComponentState.FLEXING, component.getState(),
+          "Component state should be FLEXING");
+      assertEquals(3, component.getContainers().size(),
+          "3 containers are expected to be running");
     }
 
     // Flex compa down to 4 now, which is still more containers than the no of
@@ -629,12 +629,12 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // running and the fourth one should not get allocated.
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      assertNotEquals(
-         ServiceState.STABLE, service.getState(), "Service state should not be STABLE");
-      assertEquals(
-         ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      assertEquals(3
-,           component.getContainers().size(), "3 containers are expected to be running");
+      assertNotEquals(ServiceState.STABLE, service.getState(),
+          "Service state should not be STABLE");
+      assertEquals(ComponentState.FLEXING, component.getState(),
+          "Component state should be FLEXING");
+      assertEquals(3, component.getContainers().size(),
+          "3 containers are expected to be running");
     }
 
     // Finally flex compa down to 3, which is exactly the number of containers
@@ -778,10 +778,10 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     // Check service is stable and all 3 containers are running
     Service service = client.getStatus(exampleApp.getName());
     Component component = service.getComponent("compa");
-    assertEquals(ServiceState.STABLE
-,         service.getState(), "Service state should be STABLE");
-    assertEquals(3
-,         component.getContainers().size(), "3 containers are expected to be running");
+    assertEquals(ServiceState.STABLE,
+        service.getState(), "Service state should be STABLE");
+    assertEquals(3, component.getContainers().size(),
+        "3 containers are expected to be running");
 
     // Flex compa up to 4 - will make health 75% (3 out of 4 running), but still
     // above threshold of 65%, so service will continue to run.
@@ -802,12 +802,12 @@ public class TestYarnNativeServices extends ServiceTestUtils {
       // Check that service state is STARTED and only 3 containers are running
       service = client.getStatus(exampleApp.getName());
       component = service.getComponent("compa");
-      assertEquals(
-         ServiceState.STARTED, service.getState(), "Service state should be STARTED");
-      assertEquals(
-         ComponentState.FLEXING, component.getState(), "Component state should be FLEXING");
-      assertEquals(3
-,           component.getContainers().size(), "3 containers are expected to be running");
+      assertEquals(ServiceState.STARTED, service.getState(),
+          "Service state should be STARTED");
+      assertEquals(ComponentState.FLEXING, component.getState(),
+          "Component state should be FLEXING");
+      assertEquals(3, component.getContainers().size(),
+          "3 containers are expected to be running");
     }
 
     // Flex compa up to 5 - will make health 60% (3 out of 5 running), so
@@ -947,8 +947,8 @@ public class TestYarnNativeServices extends ServiceTestUtils {
     client.actionStart(exampleApp.getName());
     waitForServiceToBeStable(client, exampleApp);
     Service service = client.getStatus(exampleApp.getName());
-    assertEquals(
-       ServiceState.STABLE, service.getState(), "Restarted service state should be STABLE");
+    assertEquals(ServiceState.STABLE, service.getState(),
+        "Restarted service state should be STABLE");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestYarnNativeServices.java
@@ -506,7 +506,7 @@ public class TestYarnNativeServices extends ServiceTestUtils {
         active.getComponent(component.getName()).getState(), "component not stable");
     assertEquals("val0",
         active.getComponent(component.getName()).getConfiguration()
-        .getEnv("key1"),"comp does not have new env");
+        .getEnv("key1"), "comp does not have new env");
     LOG.info("Stop/destroy service {}", service);
     client.actionStop(service.getName(), true);
     client.actionDestroy(service.getName());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.conf.ExampleAppJson;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,9 +49,9 @@ public class TestBuildExternalComponents {
   // Check component names match with expected
   private static void checkComponentNames(List<Component> components,
       Set<String> expectedComponents) {
-    Assert.assertEquals(expectedComponents.size(), components.size());
+    Assertions.assertEquals(expectedComponents.size(), components.size());
     for (Component comp : components) {
-      Assert.assertTrue(expectedComponents.contains(comp.getName()));
+      Assertions.assertTrue(expectedComponents.contains(comp.getName()));
     }
   }
 
@@ -70,7 +70,7 @@ public class TestBuildExternalComponents {
     checkComponentNames(components, names);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     basedir = new File("target", "apps");
     if (basedir.exists()) {
@@ -81,7 +81,7 @@ public class TestBuildExternalComponents {
     conf.set(YARN_SERVICE_BASE_PATH, basedir.getAbsolutePath());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.yarn.service.conf.ExampleAppJson;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +36,8 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConf.YARN_SERVICE_BASE_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for building / resolving components of type SERVICE.
@@ -49,9 +50,9 @@ public class TestBuildExternalComponents {
   // Check component names match with expected
   private static void checkComponentNames(List<Component> components,
       Set<String> expectedComponents) {
-    Assertions.assertEquals(expectedComponents.size(), components.size());
+    assertEquals(expectedComponents.size(), components.size());
     for (Component comp : components) {
-      Assertions.assertTrue(expectedComponents.contains(comp.getName()));
+      assertTrue(expectedComponents.contains(comp.getName()));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -34,11 +34,12 @@ import org.apache.hadoop.yarn.service.conf.ExampleAppJson;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class TestServiceCLI {
         "-D", basedirProp, "-save", serviceName,
         ExampleAppJson.resourceName(appDef),
         "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private void buildApp(String serviceName, String appDef,
@@ -108,7 +109,7 @@ public class TestServiceCLI {
         "-appTypes", DUMMY_APP_TYPE,
         "-updateLifetime", lifetime,
         "-changeQueue", queue};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private static Path getDependencyTarGz(File dir) {
@@ -117,7 +118,7 @@ public class TestServiceCLI {
         .DEPENDENCY_TAR_GZ_FILE_EXT).getAbsolutePath());
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Throwable {
     basedir = new File("target", "apps");
     basedirProp = YARN_SERVICE_BASE_PATH + "=" + basedir.getAbsolutePath();
@@ -145,7 +146,7 @@ public class TestServiceCLI {
     createCLI();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);
@@ -153,7 +154,8 @@ public class TestServiceCLI {
     cli.stop();
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testFlexComponents() throws Throwable {
     // currently can only test building apps, since that is the only
     // operation that doesn't require an RM
@@ -176,7 +178,8 @@ public class TestServiceCLI {
     assertThat(result).isEqualTo(0);
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testInitiateAutoFinalizeServiceUpgrade() throws Exception {
     String[] args =  {"app", "-upgrade", "app-1",
         "-initiate", ExampleAppJson.resourceName(ExampleAppJson.APP_JSON),
@@ -233,40 +236,43 @@ public class TestServiceCLI {
     assertThat(result).isEqualTo(0);
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunch() throws Exception {
     fs.getFileSystem().create(new Path(basedir.getAbsolutePath(), "test.jar"))
         .close();
 
     Path defaultPath = new Path(dependencyTarGz.toString());
-    Assert.assertFalse("Dependency tarball should not exist before the test",
-        fs.isFile(defaultPath));
+    Assertions.assertFalse(
+       fs.isFile(defaultPath), "Dependency tarball should not exist before the test");
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
-    Assert.assertTrue("Dependency tarball did not exist after the test",
-        fs.isFile(defaultPath));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertTrue(
+       fs.isFile(defaultPath), "Dependency tarball did not exist after the test");
 
     File secondBaseDir = new File(dependencyTarGzBaseDir, "2");
     Path secondTarGz = getDependencyTarGz(secondBaseDir);
-    Assert.assertFalse("Dependency tarball should not exist before the test",
-        fs.isFile(secondTarGz));
+    Assertions.assertFalse(
+       fs.isFile(secondTarGz), "Dependency tarball should not exist before the test");
     String[] args2 = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dfsAdminAclProp, "-D", dependencyTarGzProp, "-enableFastLaunch",
         secondBaseDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args2));
-    Assert.assertTrue("Dependency tarball did not exist after the test",
-        fs.isFile(secondTarGz));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args2));
+    Assertions.assertTrue(
+       fs.isFile(secondTarGz), "Dependency tarball did not exist after the test");
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunchUserPermissions() throws Exception {
     String[] args = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dependencyTarGzProp, "-enableFastLaunch", "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunchFilePermissions() throws Exception {
     File badDir = new File(dependencyTarGzBaseDir, "bad");
     badDir.mkdir();
@@ -275,7 +281,7 @@ public class TestServiceCLI {
 
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
 
     badDir = new File(badDir, "child");
     badDir.mkdir();
@@ -284,7 +290,7 @@ public class TestServiceCLI {
 
     String[] args2 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
 
     badDir = new File(dependencyTarGzBaseDir, "badx");
     badDir.mkdir();
@@ -293,24 +299,24 @@ public class TestServiceCLI {
 
     String[] args3 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
   }
 
   private void checkApp(String serviceName, String compName, long count, Long
       lifetime, String queue) throws IOException {
     Service service = ServiceApiUtil.loadService(fs, serviceName);
-    Assert.assertEquals(serviceName, service.getName());
-    Assert.assertEquals(lifetime, service.getLifetime());
-    Assert.assertEquals(queue, service.getQueue());
+    Assertions.assertEquals(serviceName, service.getName());
+    Assertions.assertEquals(lifetime, service.getLifetime());
+    Assertions.assertEquals(queue, service.getQueue());
     List<Component> components = service.getComponents();
     for (Component component : components) {
       if (component.getName().equals(compName)) {
-        Assert.assertEquals(count, component.getNumberOfContainers()
+        Assertions.assertEquals(count, component.getNumberOfContainers()
             .longValue());
         return;
       }
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   private static final String DUMMY_APP_TYPE = "dummy";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -124,7 +123,7 @@ public class TestServiceCLI {
     basedirProp = YARN_SERVICE_BASE_PATH + "=" + basedir.getAbsolutePath();
     conf.set(YARN_SERVICE_BASE_PATH, basedir.getAbsolutePath());
     fs = new SliderFileSystem(conf);
-    dependencyTarGzBaseDir = tempDir.getRoot().toFile();
+    dependencyTarGzBaseDir = tempDir.toFile();
     fs.getFileSystem()
         .setPermission(new Path(dependencyTarGzBaseDir.getAbsolutePath()),
             new FsPermission("755"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -247,8 +247,8 @@ public class TestServiceCLI {
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         "-appTypes", DUMMY_APP_TYPE};
     assertEquals(EXIT_SUCCESS, runCLI(args));
-    assertTrue(
-       fs.isFile(defaultPath), "Dependency tarball did not exist after the test");
+    assertTrue(fs.isFile(defaultPath),
+        "Dependency tarball did not exist after the test");
 
     File secondBaseDir = new File(dependencyTarGzBaseDir, "2");
     Path secondTarGz = getDependencyTarGz(secondBaseDir);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -242,8 +242,8 @@ public class TestServiceCLI {
         .close();
 
     Path defaultPath = new Path(dependencyTarGz.toString());
-    assertFalse(
-       fs.isFile(defaultPath), "Dependency tarball should not exist before the test");
+    assertFalse(fs.isFile(defaultPath),
+        "Dependency tarball should not exist before the test");
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         "-appTypes", DUMMY_APP_TYPE};
     assertEquals(EXIT_SUCCESS, runCLI(args));
@@ -252,14 +252,14 @@ public class TestServiceCLI {
 
     File secondBaseDir = new File(dependencyTarGzBaseDir, "2");
     Path secondTarGz = getDependencyTarGz(secondBaseDir);
-    assertFalse(
-       fs.isFile(secondTarGz), "Dependency tarball should not exist before the test");
+    assertFalse(fs.isFile(secondTarGz),
+        "Dependency tarball should not exist before the test");
     String[] args2 = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dfsAdminAclProp, "-D", dependencyTarGzProp, "-enableFastLaunch",
         secondBaseDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
     assertEquals(EXIT_SUCCESS, runCLI(args2));
-    assertTrue(
-       fs.isFile(secondTarGz), "Dependency tarball did not exist after the test");
+    assertTrue(fs.isFile(secondTarGz),
+        "Dependency tarball did not exist after the test");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -37,10 +37,9 @@ import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,19 +51,20 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.spy;
 import static org.apache.hadoop.yarn.client.api.AppAdminClient.YARN_APP_ADMIN_CLIENT_PREFIX;
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConf.DEPENDENCY_TARBALL_PATH;
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConf.YARN_SERVICE_BASE_PATH;
 import static org.apache.hadoop.yarn.service.exceptions.LauncherExitCodes.EXIT_SUCCESS;
 import static org.apache.hadoop.yarn.service.exceptions.LauncherExitCodes.EXIT_UNAUTHORIZED;
-import static org.mockito.Mockito.spy;
 
 public class TestServiceCLI {
   private static final Logger LOG = LoggerFactory.getLogger(TestServiceCLI
       .class);
-
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private Configuration conf = new YarnConfiguration();
   private SliderFileSystem fs;
@@ -98,7 +98,7 @@ public class TestServiceCLI {
         "-D", basedirProp, "-save", serviceName,
         ExampleAppJson.resourceName(appDef),
         "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
+    assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private void buildApp(String serviceName, String appDef,
@@ -109,7 +109,7 @@ public class TestServiceCLI {
         "-appTypes", DUMMY_APP_TYPE,
         "-updateLifetime", lifetime,
         "-changeQueue", queue};
-    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
+    assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private static Path getDependencyTarGz(File dir) {
@@ -119,12 +119,12 @@ public class TestServiceCLI {
   }
 
   @BeforeEach
-  public void setup() throws Throwable {
+  public void setup(@TempDir java.nio.file.Path tempDir) throws Throwable {
     basedir = new File("target", "apps");
     basedirProp = YARN_SERVICE_BASE_PATH + "=" + basedir.getAbsolutePath();
     conf.set(YARN_SERVICE_BASE_PATH, basedir.getAbsolutePath());
     fs = new SliderFileSystem(conf);
-    dependencyTarGzBaseDir = tmpFolder.getRoot();
+    dependencyTarGzBaseDir = tempDir.getRoot().toFile();
     fs.getFileSystem()
         .setPermission(new Path(dependencyTarGzBaseDir.getAbsolutePath()),
             new FsPermission("755"));
@@ -243,23 +243,23 @@ public class TestServiceCLI {
         .close();
 
     Path defaultPath = new Path(dependencyTarGz.toString());
-    Assertions.assertFalse(
+    assertFalse(
        fs.isFile(defaultPath), "Dependency tarball should not exist before the test");
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
-    Assertions.assertTrue(
+    assertEquals(EXIT_SUCCESS, runCLI(args));
+    assertTrue(
        fs.isFile(defaultPath), "Dependency tarball did not exist after the test");
 
     File secondBaseDir = new File(dependencyTarGzBaseDir, "2");
     Path secondTarGz = getDependencyTarGz(secondBaseDir);
-    Assertions.assertFalse(
+    assertFalse(
        fs.isFile(secondTarGz), "Dependency tarball should not exist before the test");
     String[] args2 = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dfsAdminAclProp, "-D", dependencyTarGzProp, "-enableFastLaunch",
         secondBaseDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args2));
-    Assertions.assertTrue(
+    assertEquals(EXIT_SUCCESS, runCLI(args2));
+    assertTrue(
        fs.isFile(secondTarGz), "Dependency tarball did not exist after the test");
   }
 
@@ -268,7 +268,7 @@ public class TestServiceCLI {
   public void testEnableFastLaunchUserPermissions() throws Exception {
     String[] args = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dependencyTarGzProp, "-enableFastLaunch", "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
   }
 
   @Test
@@ -281,7 +281,7 @@ public class TestServiceCLI {
 
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
 
     badDir = new File(badDir, "child");
     badDir.mkdir();
@@ -290,7 +290,7 @@ public class TestServiceCLI {
 
     String[] args2 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
+    assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
 
     badDir = new File(dependencyTarGzBaseDir, "badx");
     badDir.mkdir();
@@ -299,24 +299,24 @@ public class TestServiceCLI {
 
     String[] args3 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
+    assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
   }
 
   private void checkApp(String serviceName, String compName, long count, Long
       lifetime, String queue) throws IOException {
     Service service = ServiceApiUtil.loadService(fs, serviceName);
-    Assertions.assertEquals(serviceName, service.getName());
-    Assertions.assertEquals(lifetime, service.getLifetime());
-    Assertions.assertEquals(queue, service.getQueue());
+    assertEquals(serviceName, service.getName());
+    assertEquals(lifetime, service.getLifetime());
+    assertEquals(queue, service.getQueue());
     List<Component> components = service.getComponents();
     for (Component component : components) {
       if (component.getName().equals(compName)) {
-        Assertions.assertEquals(count, component.getNumberOfContainers()
+        assertEquals(count, component.getNumberOfContainers()
             .longValue());
         return;
       }
     }
-    Assertions.fail();
+    fail();
   }
 
   private static final String DUMMY_APP_TYPE = "dummy";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
@@ -49,9 +49,9 @@ import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.apache.hadoop.yarn.service.exceptions.ErrorStrings;
 import org.apache.hadoop.yarn.service.utils.FilterUtils;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,12 +89,12 @@ public class TestServiceClient {
     client.getConfig().set("yarn.service.classpath", "{{VAR_1}},{{VAR_2}}");
     String newPath = client.addAMEnv().get("CLASSPATH");
 
-    Assert.assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
+    Assertions.assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
     //restoring the original value for service classpath
     client.getConfig().set("yarn.service.classpath", oldParam);
 
     newPath = client.addAMEnv().get("CLASSPATH");
-    Assert.assertEquals(originalPath, newPath);
+    Assertions.assertEquals(originalPath, newPath);
 
     client.stop();
   }
@@ -109,11 +109,11 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assert.assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
+      Assertions.assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
           ex.getMessage());
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -127,8 +127,8 @@ public class TestServiceClient {
 
     Service fromFs = ServiceApiUtil.loadServiceUpgrade(rule.getFs(),
         service.getName(), service.getVersion());
-    Assert.assertEquals(service.getName(), fromFs.getName());
-    Assert.assertEquals(service.getVersion(), fromFs.getVersion());
+    Assertions.assertEquals(service.getName(), fromFs.getName());
+    Assertions.assertEquals(service.getVersion(), fromFs.getVersion());
     client.stop();
   }
 
@@ -149,7 +149,7 @@ public class TestServiceClient {
     client.actionUpgrade(service, comp.getContainers());
     CompInstancesUpgradeResponseProto response = client.getLastProxyResponse(
         CompInstancesUpgradeResponseProto.class);
-    Assert.assertNotNull("upgrade did not complete", response);
+    Assertions.assertNotNull(response, "upgrade did not complete");
     client.stop();
   }
 
@@ -169,11 +169,11 @@ public class TestServiceClient {
 
     ComponentContainers[] compContainers = client.getContainers(
         service.getName(), Lists.newArrayList("compa"), "v1", null);
-    Assert.assertEquals("num comp", 1, compContainers.length);
-    Assert.assertEquals("comp name", "compa",
+    Assertions.assertEquals(1, compContainers.length, "num comp");
+    Assertions.assertEquals("comp name", "compa",
         compContainers[0].getComponentName());
-    Assert.assertEquals("num containers", 2,
-        compContainers[0].getContainers().size());
+    Assertions.assertEquals(2
+,         compContainers[0].getContainers().size(), "num containers");
     client.stop();
   }
 
@@ -191,13 +191,13 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assert.assertEquals("All the components of the service " +
+      Assertions.assertEquals("All the components of the service " +
               service.getName() + " have " + Component.RestartPolicyEnum.NEVER
               + " restart policy, so it cannot be upgraded.",
           ex.getMessage());
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   private Service createService() throws IOException,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
@@ -75,7 +75,7 @@ public class TestServiceClient {
       TestServiceClient.class);
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test
@@ -243,8 +243,8 @@ public class TestServiceClient {
 
       ApplicationAttemptReport attemptReport =
           ApplicationAttemptReport.newInstance(client.attemptId, "localhost", 0,
-              null, null, null,
-              YarnApplicationAttemptState.RUNNING, null);
+          null, null, null,
+          YarnApplicationAttemptState.RUNNING, null);
       when(yarnClient.getApplicationAttemptReport(any()))
           .thenReturn(attemptReport);
       when(yarnClient.getApplicationReport(client.appId)).thenReturn(appReport);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
@@ -49,9 +49,8 @@ import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.apache.hadoop.yarn.service.exceptions.ErrorStrings;
 import org.apache.hadoop.yarn.service.utils.FilterUtils;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +59,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +74,7 @@ public class TestServiceClient {
   private static final Logger LOG = LoggerFactory.getLogger(
       TestServiceClient.class);
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -89,12 +91,12 @@ public class TestServiceClient {
     client.getConfig().set("yarn.service.classpath", "{{VAR_1}},{{VAR_2}}");
     String newPath = client.addAMEnv().get("CLASSPATH");
 
-    Assertions.assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
+    assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
     //restoring the original value for service classpath
     client.getConfig().set("yarn.service.classpath", oldParam);
 
     newPath = client.addAMEnv().get("CLASSPATH");
-    Assertions.assertEquals(originalPath, newPath);
+    assertEquals(originalPath, newPath);
 
     client.stop();
   }
@@ -109,11 +111,11 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assertions.assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
+      assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
           ex.getMessage());
       return;
     }
-    Assertions.fail();
+    fail();
   }
 
   @Test
@@ -127,8 +129,8 @@ public class TestServiceClient {
 
     Service fromFs = ServiceApiUtil.loadServiceUpgrade(rule.getFs(),
         service.getName(), service.getVersion());
-    Assertions.assertEquals(service.getName(), fromFs.getName());
-    Assertions.assertEquals(service.getVersion(), fromFs.getVersion());
+    assertEquals(service.getName(), fromFs.getName());
+    assertEquals(service.getVersion(), fromFs.getVersion());
     client.stop();
   }
 
@@ -149,7 +151,7 @@ public class TestServiceClient {
     client.actionUpgrade(service, comp.getContainers());
     CompInstancesUpgradeResponseProto response = client.getLastProxyResponse(
         CompInstancesUpgradeResponseProto.class);
-    Assertions.assertNotNull(response, "upgrade did not complete");
+    assertNotNull(response, "upgrade did not complete");
     client.stop();
   }
 
@@ -169,11 +171,11 @@ public class TestServiceClient {
 
     ComponentContainers[] compContainers = client.getContainers(
         service.getName(), Lists.newArrayList("compa"), "v1", null);
-    Assertions.assertEquals(1, compContainers.length, "num comp");
-    Assertions.assertEquals("comp name", "compa",
-        compContainers[0].getComponentName());
-    Assertions.assertEquals(2
-,         compContainers[0].getContainers().size(), "num containers");
+    assertEquals(1, compContainers.length, "num comp");
+    assertEquals("compa",
+        compContainers[0].getComponentName(), "comp name");
+    assertEquals(2,
+        compContainers[0].getContainers().size(), "num containers");
     client.stop();
   }
 
@@ -191,13 +193,13 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assertions.assertEquals("All the components of the service " +
+      assertEquals("All the components of the service " +
               service.getName() + " have " + Component.RestartPolicyEnum.NEVER
               + " restart policy, so it cannot be upgraded.",
           ex.getMessage());
       return;
     }
-    Assertions.fail();
+    fail();
   }
 
   private Service createService() throws IOException,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
@@ -64,8 +64,8 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.UPGRADE);
     comp.handle(upgradeEvent);
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
   }
 
   @Test
@@ -83,17 +83,17 @@ public class TestComponent {
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
 
     // second instance finished upgrading
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("component did not upgrade successfully", "val1",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("component did not upgrade successfully", "val1",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -124,8 +124,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
   }
 
   @Test
@@ -137,10 +137,10 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.CANCEL_UPGRADE);
     comp.handle(upgradeEvent);
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -190,16 +190,16 @@ public class TestComponent {
     comp.handle(stopEvent);
     instance1.handle(new ComponentInstanceEvent(
         instance1.getContainer().getId(), STOP));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
-    Assert.assertEquals(
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
@@ -214,17 +214,17 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in flexing state",
-        ComponentState.FLEXING, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
     // new container get allocated
     context.assignNewContainer(context.attemptId, 10, comp);
 
     comp.handle(new ComponentEvent(comp.getName(),
             ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -249,9 +249,9 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -272,8 +272,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in flexing state",
-        ComponentState.FLEXING, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
 
     for (ComponentInstance instance : comp.getAllComponentInstances()) {
       // new container get allocated
@@ -283,9 +283,9 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -327,16 +327,16 @@ public class TestComponent {
         instance1.getContainer().getId(), STOP));
 
     // component should be in cancel upgrade
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
-    Assert.assertEquals(
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -362,11 +362,11 @@ public class TestComponent {
       ComponentInstance componentInstance = instanceIter.next();
       Container instanceContainer = componentInstance.getContainer();
 
-      Assert.assertEquals(0, comp.getNumSucceededInstances());
-      Assert.assertEquals(0, comp.getNumFailedInstances());
-      Assert.assertEquals(2, comp.getNumRunningInstances());
-      Assert.assertEquals(2, comp.getNumReadyInstances());
-      Assert.assertEquals(0, comp.getPendingInstances().size());
+      Assertions.assertEquals(0, comp.getNumSucceededInstances());
+      Assertions.assertEquals(0, comp.getNumFailedInstances());
+      Assertions.assertEquals(2, comp.getNumRunningInstances());
+      Assertions.assertEquals(2, comp.getNumReadyInstances());
+      Assertions.assertEquals(0, comp.getPendingInstances().size());
 
       //stop 1 container
       ContainerStatus containerStatus = ContainerStatus.newInstance(
@@ -380,15 +380,15 @@ public class TestComponent {
           new ComponentInstanceEvent(componentInstance.getContainer().getId(),
               ComponentInstanceEventType.STOP).setStatus(containerStatus));
 
-      Assert.assertEquals(1, comp.getNumSucceededInstances());
-      Assert.assertEquals(0, comp.getNumFailedInstances());
-      Assert.assertEquals(1, comp.getNumRunningInstances());
-      Assert.assertEquals(1, comp.getNumReadyInstances());
-      Assert.assertEquals(0, comp.getPendingInstances().size());
+      Assertions.assertEquals(1, comp.getNumSucceededInstances());
+      Assertions.assertEquals(0, comp.getNumFailedInstances());
+      Assertions.assertEquals(1, comp.getNumRunningInstances());
+      Assertions.assertEquals(1, comp.getNumReadyInstances());
+      Assertions.assertEquals(0, comp.getPendingInstances().size());
 
       org.apache.hadoop.yarn.service.component.ComponentState componentState =
           Component.checkIfStable(comp);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           org.apache.hadoop.yarn.service.component.ComponentState.STABLE,
           componentState);
     }
@@ -431,14 +431,14 @@ public class TestComponent {
 
       ComponentState componentState =
           comp.getComponentSpec().getState();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ComponentState.SUCCEEDED,
           componentState);
     }
 
     ServiceState serviceState =
         testService.getState();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }
@@ -484,7 +484,7 @@ public class TestComponent {
         }
         ComponentState componentState =
             comp.getComponentSpec().getState();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ComponentState.SUCCEEDED,
             componentState);
       }
@@ -492,7 +492,7 @@ public class TestComponent {
 
     ServiceState serviceState =
         testService.getState();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
@@ -52,7 +52,7 @@ public class TestComponent {
   static final Logger LOG = Logger.getLogger(TestComponent.class);
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test
@@ -124,8 +124,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in needs upgrade state");
   }
 
   @Test
@@ -137,8 +137,8 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.CANCEL_UPGRADE);
     comp.handle(upgradeEvent);
-    assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in need upgrade state");
 
     assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
@@ -197,8 +197,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in needs upgrade state");
     assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
@@ -214,8 +214,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
+    assertEquals(ComponentState.FLEXING, comp.getComponentSpec().getState(),
+        "component not in flexing state");
     // new container get allocated
     context.assignNewContainer(context.attemptId, 10, comp);
 
@@ -249,8 +249,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    assertEquals(ComponentState.STABLE, comp.getComponentSpec().getState(),
+        "component not in stable state");
     assertEquals("val0", comp.getComponentSpec().getConfiguration().getEnv("key1"),
         "cancel upgrade failed");
   }
@@ -272,8 +272,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
+    assertEquals(ComponentState.FLEXING, comp.getComponentSpec().getState(),
+        "component not in flexing state");
 
     for (ComponentInstance instance : comp.getAllComponentInstances()) {
       // new container get allocated
@@ -285,8 +285,8 @@ public class TestComponent {
 
     assertEquals(ComponentState.STABLE, comp.getComponentSpec().getState(),
         "component not in stable state");
-    assertEquals("val0",
-        comp.getComponentSpec().getConfiguration().getEnv("key1"), "cancel upgrade failed");
+    assertEquals("val0", comp.getComponentSpec().getConfiguration().getEnv("key1"),
+        "cancel upgrade failed");
   }
 
   private void cancelUpgradeWhileUpgrading(
@@ -334,8 +334,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in needs upgrade state");
     assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Iterator;
 
@@ -43,6 +42,7 @@ import static org.apache.hadoop.yarn.service.component.instance.ComponentInstanc
 
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConstants
     .CONTAINER_STATE_REPORT_AS_SERVICE_STATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link Component}.
@@ -51,7 +51,7 @@ public class TestComponent {
 
   static final Logger LOG = Logger.getLogger(TestComponent.class);
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -64,8 +64,8 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.UPGRADE);
     comp.handle(upgradeEvent);
-    Assertions.assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in need upgrade state");
   }
 
   @Test
@@ -83,18 +83,18 @@ public class TestComponent {
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
-    Assertions.assertEquals(
-       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
+    assertEquals(ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(),
+        "component not in need upgrade state");
 
     // second instance finished upgrading
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
-       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
-    Assertions.assertEquals("component did not upgrade successfully", "val1",
-        comp.getComponentSpec().getConfiguration().getEnv("key1"));
+    assertEquals(ComponentState.STABLE, comp.getComponentSpec().getState(),
+        "component not in stable state");
+    assertEquals("val1", comp.getComponentSpec().getConfiguration().getEnv("key1"),
+        "component did not upgrade successfully");
   }
 
   @Test
@@ -124,7 +124,7 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
   }
 
@@ -137,10 +137,10 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.CANCEL_UPGRADE);
     comp.handle(upgradeEvent);
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
 
-    Assertions.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -190,16 +190,16 @@ public class TestComponent {
     comp.handle(stopEvent);
     instance1.handle(new ComponentInstanceEvent(
         instance1.getContainer().getId(), STOP));
-    Assertions.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
-    Assertions.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
@@ -214,7 +214,7 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
     // new container get allocated
     context.assignNewContainer(context.attemptId, 10, comp);
@@ -222,10 +222,10 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
             ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
-       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
-    Assertions.assertEquals("cancel upgrade failed", "val0",
-        comp.getComponentSpec().getConfiguration().getEnv("key1"));
+    assertEquals(ComponentState.STABLE, comp.getComponentSpec().getState(),
+        "component not in stable state");
+    assertEquals("val0", comp.getComponentSpec().getConfiguration().getEnv("key1"),
+        "cancel upgrade failed");
   }
 
   @Test
@@ -249,10 +249,10 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
-    Assertions.assertEquals("cancel upgrade failed", "val0",
-        comp.getComponentSpec().getConfiguration().getEnv("key1"));
+    assertEquals("val0", comp.getComponentSpec().getConfiguration().getEnv("key1"),
+        "cancel upgrade failed");
   }
 
   @Test
@@ -272,7 +272,7 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
 
     for (ComponentInstance instance : comp.getAllComponentInstances()) {
@@ -283,10 +283,10 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
-       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
-    Assertions.assertEquals("cancel upgrade failed", "val0",
-        comp.getComponentSpec().getConfiguration().getEnv("key1"));
+    assertEquals(ComponentState.STABLE, comp.getComponentSpec().getState(),
+        "component not in stable state");
+    assertEquals("val0",
+        comp.getComponentSpec().getConfiguration().getEnv("key1"), "cancel upgrade failed");
   }
 
   private void cancelUpgradeWhileUpgrading(
@@ -327,16 +327,16 @@ public class TestComponent {
         instance1.getContainer().getId(), STOP));
 
     // component should be in cancel upgrade
-    Assertions.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assertions.assertEquals(
+    assertEquals(
        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
-    Assertions.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -362,11 +362,11 @@ public class TestComponent {
       ComponentInstance componentInstance = instanceIter.next();
       Container instanceContainer = componentInstance.getContainer();
 
-      Assertions.assertEquals(0, comp.getNumSucceededInstances());
-      Assertions.assertEquals(0, comp.getNumFailedInstances());
-      Assertions.assertEquals(2, comp.getNumRunningInstances());
-      Assertions.assertEquals(2, comp.getNumReadyInstances());
-      Assertions.assertEquals(0, comp.getPendingInstances().size());
+      assertEquals(0, comp.getNumSucceededInstances());
+      assertEquals(0, comp.getNumFailedInstances());
+      assertEquals(2, comp.getNumRunningInstances());
+      assertEquals(2, comp.getNumReadyInstances());
+      assertEquals(0, comp.getPendingInstances().size());
 
       //stop 1 container
       ContainerStatus containerStatus = ContainerStatus.newInstance(
@@ -380,15 +380,15 @@ public class TestComponent {
           new ComponentInstanceEvent(componentInstance.getContainer().getId(),
               ComponentInstanceEventType.STOP).setStatus(containerStatus));
 
-      Assertions.assertEquals(1, comp.getNumSucceededInstances());
-      Assertions.assertEquals(0, comp.getNumFailedInstances());
-      Assertions.assertEquals(1, comp.getNumRunningInstances());
-      Assertions.assertEquals(1, comp.getNumReadyInstances());
-      Assertions.assertEquals(0, comp.getPendingInstances().size());
+      assertEquals(1, comp.getNumSucceededInstances());
+      assertEquals(0, comp.getNumFailedInstances());
+      assertEquals(1, comp.getNumRunningInstances());
+      assertEquals(1, comp.getNumReadyInstances());
+      assertEquals(0, comp.getPendingInstances().size());
 
       org.apache.hadoop.yarn.service.component.ComponentState componentState =
           Component.checkIfStable(comp);
-      Assertions.assertEquals(
+      assertEquals(
           org.apache.hadoop.yarn.service.component.ComponentState.STABLE,
           componentState);
     }
@@ -431,14 +431,14 @@ public class TestComponent {
 
       ComponentState componentState =
           comp.getComponentSpec().getState();
-      Assertions.assertEquals(
+      assertEquals(
           ComponentState.SUCCEEDED,
           componentState);
     }
 
     ServiceState serviceState =
         testService.getState();
-    Assertions.assertEquals(
+    assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }
@@ -484,7 +484,7 @@ public class TestComponent {
         }
         ComponentState componentState =
             comp.getComponentSpec().getState();
-        Assertions.assertEquals(
+        assertEquals(
             ComponentState.SUCCEEDED,
             componentState);
       }
@@ -492,7 +492,7 @@ public class TestComponent {
 
     ServiceState serviceState =
         testService.getState();
-    Assertions.assertEquals(
+    assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
@@ -27,11 +27,11 @@ import org.apache.hadoop.yarn.service.api.records.Container;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.client.ServiceClient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,13 +58,13 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");
     FileUtils.deleteQuietly(tmpYarnDir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     shutdown();
   }
@@ -129,19 +129,19 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
       throws IOException, YarnException {
     Service service = client.getStatus(APP_NAME);
     Component component = service.getComponent(COMPA);
-    Assert.assertEquals("Service state should be STABLE", ServiceState.STABLE,
-        service.getState());
-    Assert.assertEquals(instances.length + " containers are expected to be " +
-        "running", instances.length, component.getContainers().size());
+    Assertions.assertEquals(ServiceState.STABLE
+,         service.getState(), "Service state should be STABLE");
+    Assertions.assertEquals(instances.length, component.getContainers().size(), instances.length + " containers are expected to be " +
+        "running");
     Set<String> existingInstances = new HashSet<>();
     for (Container cont : component.getContainers()) {
       existingInstances.add(cont.getComponentInstanceName());
     }
-    Assert.assertEquals(instances.length + " instances are expected to be " +
-        "running", instances.length, existingInstances.size());
+    Assertions.assertEquals(instances.length, existingInstances.size(), instances.length + " instances are expected to be " +
+        "running");
     for (String instance : instances) {
-      Assert.assertTrue("Expected instance did not exist " + instance,
-          existingInstances.contains(instance));
+      Assertions.assertTrue(
+         existingInstances.contains(instance), "Expected instance did not exist " + instance);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
@@ -28,11 +28,8 @@ import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.client.ServiceClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +42,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Test decommissioning component instances.
  */
@@ -54,9 +54,6 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
 
   private static final String APP_NAME = "test-decommission";
   private static final String COMPA = "compa";
-
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @BeforeEach
   public void setup() throws Exception {
@@ -129,19 +126,19 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
       throws IOException, YarnException {
     Service service = client.getStatus(APP_NAME);
     Component component = service.getComponent(COMPA);
-    Assertions.assertEquals(ServiceState.STABLE
-,         service.getState(), "Service state should be STABLE");
-    Assertions.assertEquals(instances.length, component.getContainers().size(), instances.length + " containers are expected to be " +
-        "running");
+    assertEquals(ServiceState.STABLE,
+        service.getState(), "Service state should be STABLE");
+    assertEquals(instances.length, component.getContainers().size(),
+        instances.length + " containers are expected to be running");
     Set<String> existingInstances = new HashSet<>();
     for (Container cont : component.getContainers()) {
       existingInstances.add(cont.getComponentInstanceName());
     }
-    Assertions.assertEquals(instances.length, existingInstances.size(), instances.length + " instances are expected to be " +
-        "running");
+    assertEquals(instances.length, existingInstances.size(),
+        instances.length + " instances are expected to be running");
     for (String instance : instances) {
-      Assertions.assertTrue(
-         existingInstances.contains(instance), "Expected instance did not exist " + instance);
+      assertTrue(existingInstances.contains(instance),
+          "Expected instance did not exist " + instance);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentRestartPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentRestartPolicy.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.yarn.service.component;
 
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
@@ -42,9 +42,9 @@ import org.apache.hadoop.yarn.service.component.ComponentEvent;
 import org.apache.hadoop.yarn.service.component.ComponentEventType;
 import org.apache.hadoop.yarn.service.component.TestComponent;
 import org.apache.hadoop.yarn.service.utils.ServiceUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.file.Files;
@@ -90,8 +90,8 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     Container containerSpec = component.getComponentSpec().getContainer(
         instance.getContainer().getId().toString());
-    Assert.assertEquals("instance not upgrading", ContainerState.UPGRADING,
-        containerSpec.getState());
+    Assertions.assertEquals(ContainerState.UPGRADING
+,         containerSpec.getState(), "instance not upgrading");
   }
 
   @Test
@@ -110,15 +110,15 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assert.assertEquals("instance not running",
-        ContainerState.RUNNING_BUT_UNREADY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.RUNNING_BUT_UNREADY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not running");
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.BECOME_READY));
-    Assert.assertEquals("instance not ready", ContainerState.READY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.READY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not ready");
   }
 
 
@@ -145,9 +145,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assert.assertEquals("instance did not fail", ContainerState.FAILED_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -168,10 +168,10 @@ public class TestComponentInstance {
     // NM finished updgrae
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assert.assertEquals("instance not running",
-        ContainerState.RUNNING_BUT_UNREADY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.RUNNING_BUT_UNREADY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not running");
 
     ContainerStatus containerStatus = mock(ContainerStatus.class);
     when(containerStatus.getExitStatus()).thenReturn(
@@ -181,9 +181,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assert.assertEquals("instance did not fail", ContainerState.FAILED_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -202,9 +202,9 @@ public class TestComponentInstance {
         ComponentInstanceEventType.CANCEL_UPGRADE);
     instance.handle(cancelEvent);
 
-    Assert.assertEquals("instance not ready", ContainerState.READY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.READY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not ready");
   }
 
   @Test
@@ -225,8 +225,8 @@ public class TestComponentInstance {
 
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.STOP));
-    Assert.assertEquals("instance not init", ComponentInstanceState.INIT,
-        instance.getState());
+    Assertions.assertEquals(ComponentInstanceState.INIT
+,         instance.getState(), "instance not init");
   }
 
   @Test
@@ -244,10 +244,10 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assert.assertEquals("instance should start upgrading",
-        ContainerState.NEEDS_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.NEEDS_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance should start upgrading");
   }
 
   @Test
@@ -296,30 +296,30 @@ public class TestComponentInstance {
         LocalizationState.PENDING);
 
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assert.assertTrue("retriever should still be active",
-        instance.isLclRetrieverActive());
+    Assertions.assertTrue(
+       instance.isLclRetrieverActive(), "retriever should still be active");
 
     Container container = instance.getContainerSpec();
-    Assert.assertTrue(container.getLocalizationStatuses() != null);
-    Assert.assertEquals("dest file",
-        container.getLocalizationStatuses().get(0).getDestFile(),
-        status.getResourceKey());
-    Assert.assertEquals("state",
-        container.getLocalizationStatuses().get(0).getState(),
-        status.getLocalizationState());
+    Assertions.assertTrue(container.getLocalizationStatuses() != null);
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getDestFile()
+,         status.getResourceKey(), "dest file");
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getState()
+,         status.getLocalizationState(), "state");
 
     status = LocalizationStatus.newInstance("file1",
         LocalizationState.COMPLETED);
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assert.assertTrue("retriever should not be active",
-        !instance.isLclRetrieverActive());
-    Assert.assertTrue(container.getLocalizationStatuses() != null);
-    Assert.assertEquals("dest file",
-        container.getLocalizationStatuses().get(0).getDestFile(),
-        status.getResourceKey());
-    Assert.assertEquals("state",
-        container.getLocalizationStatuses().get(0).getState(),
-        status.getLocalizationState());
+    Assertions.assertTrue(
+       !instance.isLclRetrieverActive(), "retriever should not be active");
+    Assertions.assertTrue(container.getLocalizationStatuses() != null);
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getDestFile()
+,         status.getResourceKey(), "dest file");
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getState()
+,         status.getLocalizationState(), "state");
   }
 
   private void validateCancelWhileUpgrading(boolean upgradeSuccessful,
@@ -337,10 +337,10 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assert.assertEquals("instance should be upgrading",
-        ContainerState.UPGRADING,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.UPGRADING
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance should be upgrading");
 
     cancelCompUpgrade(component);
     ComponentInstanceEvent cancelEvent = new ComponentInstanceEvent(
@@ -361,9 +361,9 @@ public class TestComponentInstance {
           ComponentInstanceEventType.STOP));
     }
 
-    Assert.assertEquals("instance not upgrading", ContainerState.UPGRADING,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.UPGRADING
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not upgrading");
 
     // response for cancel received
     if (cancelUpgradeSuccessful) {
@@ -377,12 +377,12 @@ public class TestComponentInstance {
           instance.getContainer().getId(), ComponentInstanceEventType.STOP));
     }
     if (cancelUpgradeSuccessful) {
-      Assert.assertEquals("instance not ready", ContainerState.READY,
-          component.getComponentSpec().getContainer(instance.getContainer()
-              .getId().toString()).getState());
+      Assertions.assertEquals(ContainerState.READY
+,           component.getComponentSpec().getContainer(instance.getContainer()
+              .getId().toString()).getState(), "instance not ready");
     } else {
-      Assert.assertEquals("instance not init", ComponentInstanceState.INIT,
-          instance.getState());
+      Assertions.assertEquals(ComponentInstanceState.INIT
+,           instance.getState(), "instance not init");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
@@ -42,9 +42,8 @@ import org.apache.hadoop.yarn.service.component.ComponentEvent;
 import org.apache.hadoop.yarn.service.component.ComponentEventType;
 import org.apache.hadoop.yarn.service.component.TestComponent;
 import org.apache.hadoop.yarn.service.utils.ServiceUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.nio.file.Files;
@@ -56,6 +55,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,7 +72,7 @@ import static org.mockito.Mockito.when;
  */
 public class TestComponentInstance {
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -90,8 +91,8 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     Container containerSpec = component.getComponentSpec().getContainer(
         instance.getContainer().getId().toString());
-    Assertions.assertEquals(ContainerState.UPGRADING
-,         containerSpec.getState(), "instance not upgrading");
+    assertEquals(ContainerState.UPGRADING,
+        containerSpec.getState(), "instance not upgrading");
   }
 
   @Test
@@ -110,15 +111,14 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assertions.assertEquals(
-       ContainerState.RUNNING_BUT_UNREADY
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance not running");
+    assertEquals(ContainerState.RUNNING_BUT_UNREADY,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance not running");
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.BECOME_READY));
-    Assertions.assertEquals(ContainerState.READY
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance not ready");
+    assertEquals(ContainerState.READY,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance not ready");
   }
 
 
@@ -145,9 +145,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance did not fail");
+    assertEquals(ContainerState.FAILED_UPGRADE,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -168,10 +168,9 @@ public class TestComponentInstance {
     // NM finished updgrae
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assertions.assertEquals(
-       ContainerState.RUNNING_BUT_UNREADY
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance not running");
+    assertEquals(ContainerState.RUNNING_BUT_UNREADY,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance not running");
 
     ContainerStatus containerStatus = mock(ContainerStatus.class);
     when(containerStatus.getExitStatus()).thenReturn(
@@ -181,9 +180,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance did not fail");
+    assertEquals(ContainerState.FAILED_UPGRADE,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -202,9 +201,9 @@ public class TestComponentInstance {
         ComponentInstanceEventType.CANCEL_UPGRADE);
     instance.handle(cancelEvent);
 
-    Assertions.assertEquals(ContainerState.READY
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance not ready");
+    assertEquals(ContainerState.READY,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance not ready");
   }
 
   @Test
@@ -225,8 +224,8 @@ public class TestComponentInstance {
 
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.STOP));
-    Assertions.assertEquals(ComponentInstanceState.INIT
-,         instance.getState(), "instance not init");
+    assertEquals(ComponentInstanceState.INIT,
+        instance.getState(), "instance not init");
   }
 
   @Test
@@ -244,10 +243,9 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assertions.assertEquals(
-       ContainerState.NEEDS_UPGRADE
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance should start upgrading");
+    assertEquals(ContainerState.NEEDS_UPGRADE,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance should start upgrading");
   }
 
   @Test
@@ -296,30 +294,26 @@ public class TestComponentInstance {
         LocalizationState.PENDING);
 
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assertions.assertTrue(
-       instance.isLclRetrieverActive(), "retriever should still be active");
+    assertTrue(instance.isLclRetrieverActive(),
+        "retriever should still be active");
 
     Container container = instance.getContainerSpec();
-    Assertions.assertTrue(container.getLocalizationStatuses() != null);
-    Assertions.assertEquals(
-       container.getLocalizationStatuses().get(0).getDestFile()
-,         status.getResourceKey(), "dest file");
-    Assertions.assertEquals(
-       container.getLocalizationStatuses().get(0).getState()
-,         status.getLocalizationState(), "state");
+    assertTrue(container.getLocalizationStatuses() != null);
+    assertEquals(container.getLocalizationStatuses().get(0).getDestFile(),
+        status.getResourceKey(), "dest file");
+    assertEquals(container.getLocalizationStatuses().get(0).getState()
+,       status.getLocalizationState(), "state");
 
     status = LocalizationStatus.newInstance("file1",
         LocalizationState.COMPLETED);
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assertions.assertTrue(
-       !instance.isLclRetrieverActive(), "retriever should not be active");
-    Assertions.assertTrue(container.getLocalizationStatuses() != null);
-    Assertions.assertEquals(
-       container.getLocalizationStatuses().get(0).getDestFile()
-,         status.getResourceKey(), "dest file");
-    Assertions.assertEquals(
-       container.getLocalizationStatuses().get(0).getState()
-,         status.getLocalizationState(), "state");
+    assertTrue(!instance.isLclRetrieverActive(),
+        "retriever should not be active");
+    assertTrue(container.getLocalizationStatuses() != null);
+    assertEquals(container.getLocalizationStatuses().get(0).getDestFile(),
+        status.getResourceKey(), "dest file");
+    assertEquals(container.getLocalizationStatuses().get(0).getState(),
+        status.getLocalizationState(), "state");
   }
 
   private void validateCancelWhileUpgrading(boolean upgradeSuccessful,
@@ -337,10 +331,9 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assertions.assertEquals(
-       ContainerState.UPGRADING
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance should be upgrading");
+    assertEquals(ContainerState.UPGRADING,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance should be upgrading");
 
     cancelCompUpgrade(component);
     ComponentInstanceEvent cancelEvent = new ComponentInstanceEvent(
@@ -361,9 +354,9 @@ public class TestComponentInstance {
           ComponentInstanceEventType.STOP));
     }
 
-    Assertions.assertEquals(ContainerState.UPGRADING
-,         component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState(), "instance not upgrading");
+    assertEquals(ContainerState.UPGRADING,
+        component.getComponentSpec().getContainer(instance.getContainer()
+        .getId().toString()).getState(), "instance not upgrading");
 
     // response for cancel received
     if (cancelUpgradeSuccessful) {
@@ -377,12 +370,12 @@ public class TestComponentInstance {
           instance.getContainer().getId(), ComponentInstanceEventType.STOP));
     }
     if (cancelUpgradeSuccessful) {
-      Assertions.assertEquals(ContainerState.READY
-,           component.getComponentSpec().getContainer(instance.getContainer()
-              .getId().toString()).getState(), "instance not ready");
+      assertEquals(ContainerState.READY,
+          component.getComponentSpec().getContainer(instance.getContainer()
+          .getId().toString()).getState(), "instance not ready");
     } else {
-      Assertions.assertEquals(ComponentInstanceState.INIT
-,           instance.getState(), "instance not init");
+      assertEquals(ComponentInstanceState.INIT,
+          instance.getState(), "instance not init");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.when;
 public class TestComponentInstance {
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test
@@ -301,8 +301,8 @@ public class TestComponentInstance {
     assertTrue(container.getLocalizationStatuses() != null);
     assertEquals(container.getLocalizationStatuses().get(0).getDestFile(),
         status.getResourceKey(), "dest file");
-    assertEquals(container.getLocalizationStatuses().get(0).getState()
-,       status.getLocalizationState(), "state");
+    assertEquals(container.getLocalizationStatuses().get(0).getState(),
+        status.getLocalizationState(), "state");
 
     status = LocalizationStatus.newInstance("file1",
         LocalizationState.COMPLETED);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +41,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.service.conf.ExampleAppJson.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test global configuration resolution.
  */
-public class TestAppJsonResolve extends Assert {
+public class TestAppJsonResolve  {
   protected static final Logger LOG =
       LoggerFactory.getLogger(TestAppJsonResolve.class);
 
@@ -199,18 +200,18 @@ public class TestAppJsonResolve extends Assert {
 
     // Validate worker's resources
     Resource workerResource = orig.getComponent("worker").getResource();
-    Assert.assertEquals(1, workerResource.getCpus().intValue());
-    Assert.assertEquals(1024, workerResource.calcMemoryMB());
-    Assert.assertNotNull(workerResource.getAdditional());
-    Assert.assertEquals(2, workerResource.getAdditional().size());
-    Assert.assertEquals(3333, workerResource.getAdditional().get(
+    Assertions.assertEquals(1, workerResource.getCpus().intValue());
+    Assertions.assertEquals(1024, workerResource.calcMemoryMB());
+    Assertions.assertNotNull(workerResource.getAdditional());
+    Assertions.assertEquals(2, workerResource.getAdditional().size());
+    Assertions.assertEquals(3333, workerResource.getAdditional().get(
         "resource-1").getValue().longValue());
-    Assert.assertEquals("Gi", workerResource.getAdditional().get(
+    Assertions.assertEquals("Gi", workerResource.getAdditional().get(
         "resource-1").getUnit());
 
-    Assert.assertEquals(5, workerResource.getAdditional().get(
+    Assertions.assertEquals(5, workerResource.getAdditional().get(
         "yarn.io/gpu").getValue().longValue());
-    Assert.assertEquals("", workerResource.getAdditional().get(
+    Assertions.assertEquals("", workerResource.getAdditional().get(
         "yarn.io/gpu").getUnit());
 
     other = orig.getComponent("other").getConfiguration();
@@ -221,16 +222,16 @@ public class TestAppJsonResolve extends Assert {
   public void testSetResourceAttributes() throws IOException {
     Service orig = ExampleAppJson.loadResource(EXTERNAL_JSON_3);
     Component component = orig.getComponent("volume-service");
-    Assert.assertNotNull(component);
+    Assertions.assertNotNull(component);
     Map<String, ResourceInformation> adResource = component
         .getResource().getAdditional();
-    Assert.assertNotNull(adResource);
-    Assert.assertEquals(1, adResource.size());
+    Assertions.assertNotNull(adResource);
+    Assertions.assertEquals(1, adResource.size());
     Map.Entry<String, ResourceInformation> volume = adResource
         .entrySet().iterator().next();
-    Assert.assertEquals("yarn.io/csi-volume", volume.getKey());
-    Assert.assertEquals(100L, volume.getValue().getValue().longValue());
-    Assert.assertEquals(2, volume.getValue().getAttributes().size());
-    Assert.assertEquals(1, volume.getValue().getTags().size());
+    Assertions.assertEquals("yarn.io/csi-volume", volume.getKey());
+    Assertions.assertEquals(100L, volume.getValue().getValue().longValue());
+    Assertions.assertEquals(2, volume.getValue().getAttributes().size());
+    Assertions.assertEquals(1, volume.getValue().getTags().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +40,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.service.conf.ExampleAppJson.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test global configuration resolution.
@@ -200,18 +202,18 @@ public class TestAppJsonResolve  {
 
     // Validate worker's resources
     Resource workerResource = orig.getComponent("worker").getResource();
-    Assertions.assertEquals(1, workerResource.getCpus().intValue());
-    Assertions.assertEquals(1024, workerResource.calcMemoryMB());
-    Assertions.assertNotNull(workerResource.getAdditional());
-    Assertions.assertEquals(2, workerResource.getAdditional().size());
-    Assertions.assertEquals(3333, workerResource.getAdditional().get(
+    assertEquals(1, workerResource.getCpus().intValue());
+    assertEquals(1024, workerResource.calcMemoryMB());
+    assertNotNull(workerResource.getAdditional());
+    assertEquals(2, workerResource.getAdditional().size());
+    assertEquals(3333, workerResource.getAdditional().get(
         "resource-1").getValue().longValue());
-    Assertions.assertEquals("Gi", workerResource.getAdditional().get(
+    assertEquals("Gi", workerResource.getAdditional().get(
         "resource-1").getUnit());
 
-    Assertions.assertEquals(5, workerResource.getAdditional().get(
+    assertEquals(5, workerResource.getAdditional().get(
         "yarn.io/gpu").getValue().longValue());
-    Assertions.assertEquals("", workerResource.getAdditional().get(
+    assertEquals("", workerResource.getAdditional().get(
         "yarn.io/gpu").getUnit());
 
     other = orig.getComponent("other").getConfiguration();
@@ -222,16 +224,16 @@ public class TestAppJsonResolve  {
   public void testSetResourceAttributes() throws IOException {
     Service orig = ExampleAppJson.loadResource(EXTERNAL_JSON_3);
     Component component = orig.getComponent("volume-service");
-    Assertions.assertNotNull(component);
+    assertNotNull(component);
     Map<String, ResourceInformation> adResource = component
         .getResource().getAdditional();
-    Assertions.assertNotNull(adResource);
-    Assertions.assertEquals(1, adResource.size());
+    assertNotNull(adResource);
+    assertEquals(1, adResource.size());
     Map.Entry<String, ResourceInformation> volume = adResource
         .entrySet().iterator().next();
-    Assertions.assertEquals("yarn.io/csi-volume", volume.getKey());
-    Assertions.assertEquals(100L, volume.getValue().getValue().longValue());
-    Assertions.assertEquals(2, volume.getValue().getAttributes().size());
-    Assertions.assertEquals(1, volume.getValue().getTags().size());
+    assertEquals("yarn.io/csi-volume", volume.getKey());
+    assertEquals(100L, volume.getValue().getValue().longValue());
+    assertEquals(2, volume.getValue().getAttributes().size());
+    assertEquals(1, volume.getValue().getTags().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
@@ -23,28 +23,22 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.hadoop.yarn.service.ServiceTestUtils.JSON_SER_DESER;
 
-/**
- * Test loading example resources.
- */
-@RunWith(value = Parameterized.class)
-public class TestLoadExampleAppJson extends Assert {
+
+public class TestLoadExampleAppJson {
   private String resource;
 
   public TestLoadExampleAppJson(String resource) {
     this.resource = resource;
   }
 
-  @Parameterized.Parameters
   public static Collection<String[]> filenames() {
     String[][] stringArray = new String[ExampleAppJson
         .ALL_EXAMPLE_RESOURCES.size()][1];
@@ -55,7 +49,8 @@ public class TestLoadExampleAppJson extends Assert {
     return Arrays.asList(stringArray);
   }
 
-  @Test
+  @MethodSource("filenames")
+  @ParameterizedTest
   public void testLoadResource() throws Throwable {
     try {
       Service service = JSON_SER_DESER.fromResource(resource);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -32,11 +33,11 @@ import java.util.Collection;
 import static org.apache.hadoop.yarn.service.ServiceTestUtils.JSON_SER_DESER;
 
 
-public class TestLoadExampleAppJson {
+public class TestLoadExampleAppJson extends Assertions {
   private String resource;
 
-  public TestLoadExampleAppJson(String resource) {
-    this.resource = resource;
+  public void initTestLoadExampleAppJson(String pResource) {
+    this.resource = pResource;
   }
 
   public static Collection<String[]> filenames() {
@@ -51,7 +52,8 @@ public class TestLoadExampleAppJson {
 
   @MethodSource("filenames")
   @ParameterizedTest
-  public void testLoadResource() throws Throwable {
+  public void testLoadResource(String pResource) throws Throwable {
+    initTestLoadExampleAppJson(pResource);
     try {
       Service service = JSON_SER_DESER.fromResource(resource);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.yarn.service.conf;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ public class TestValidateServiceNames {
   void assertInvalidName(String name) {
     try {
       ServiceApiUtil.validateNameFormat(name, new Configuration());
-      Assert.fail();
+      Assertions.fail();
     } catch (IllegalArgumentException e) {
       //
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
@@ -20,11 +20,12 @@ package org.apache.hadoop.yarn.service.conf;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test cluster name validation.
@@ -38,7 +39,7 @@ public class TestValidateServiceNames {
   void assertInvalidName(String name) {
     try {
       ServiceApiUtil.validateNameFormat(name, new Configuration());
-      Assertions.fail();
+      fail();
     } catch (IllegalArgumentException e) {
       //
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.yarn.service.component.OnFailureRestartPolicy;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.provider.defaultImpl
     .DefaultProviderService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -53,7 +53,7 @@ public class TestAbstractLauncher {
 
   private AbstractLauncher launcher;
 
-  @Before
+  @BeforeEach
   public void setup() {
     launcher = new AbstractLauncher(mock(ServiceContext.class));
   }
@@ -68,7 +68,7 @@ public class TestAbstractLauncher {
     String dockerContainerMounts = launcher.containerLaunchContext
         .getEnvironment().get(AbstractLauncher.ENV_DOCKER_CONTAINER_MOUNTS);
 
-    Assert.assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
+    Assertions.assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.yarn.service.component.OnFailureRestartPolicy;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.provider.defaultImpl
     .DefaultProviderService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +40,7 @@ import static org.apache.hadoop.yarn.service.conf.YarnServiceConf
     .DEFAULT_CONTAINER_RETRY_INTERVAL;
 import static org.apache.hadoop.yarn.service.conf.YarnServiceConf
     .DEFAULT_CONTAINER_RETRY_MAX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -68,7 +68,7 @@ public class TestAbstractLauncher {
     String dockerContainerMounts = launcher.containerLaunchContext
         .getEnvironment().get(AbstractLauncher.ENV_DOCKER_CONTAINER_MOUNTS);
 
-    Assertions.assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
+    assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
   YarnConfiguration conf = new YarnConfiguration();
   TestingCluster zkCluster;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     basedir = new File("target", "apps");
     if (basedir.exists()) {
@@ -62,7 +62,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
     System.out.println("ZK cluster: " +  zkCluster.getConnectString());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);
@@ -100,9 +100,9 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.start();
 
     // compa ready
-    Assert.assertTrue(am.getComponent("compa").areDependenciesReady());
+    Assertions.assertTrue(am.getComponent("compa").areDependenciesReady());
     //compb not ready
-    Assert.assertFalse(am.getComponent("compb").areDependenciesReady());
+    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
 
     // feed 1 container to compa,
     am.feedContainerToComp(exampleApp, 1, "compa");
@@ -120,7 +120,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.waitForNumDesiredContainers("compa", 2);
 
     // compb dependencies not satisfied again.
-    Assert.assertFalse(am.getComponent("compb").areDependenciesReady());
+    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
     am.stop();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +39,8 @@ import java.util.Collections;
 
 import static org.apache.hadoop.registry.client.api.RegistryConstants
     .KEY_REGISTRY_ZK_QUORUM;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestServiceMonitor extends ServiceTestUtils {
 
@@ -100,9 +101,9 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.start();
 
     // compa ready
-    Assertions.assertTrue(am.getComponent("compa").areDependenciesReady());
+    assertTrue(am.getComponent("compa").areDependenciesReady());
     //compb not ready
-    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
+    assertFalse(am.getComponent("compb").areDependenciesReady());
 
     // feed 1 container to compa,
     am.feedContainerToComp(exampleApp, 1, "compa");
@@ -120,7 +121,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.waitForNumDesiredContainers("compa", 2);
 
     // compb dependencies not satisfied again.
-    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
+    assertFalse(am.getComponent("compb").areDependenciesReady());
     am.stop();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.service.monitor.probe;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.service.api.records.ReadinessCheck;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.invocation.InvocationOnMock;
@@ -32,8 +32,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,35 +89,35 @@ public class TestDefaultProbe {
       componentInstance, boolean expectDNSCheckFailure) {
     // on the first ping, null container status results in failure
     ProbeStatus probeStatus = probe.ping(componentInstance);
-    assertFalse("Expected failure for " + probeStatus.toString(),
-        probeStatus.isSuccess());
-    assertTrue("Expected IP failure for " + probeStatus.toString(),
-        probeStatus.toString().contains(
-        componentInstance.getCompInstanceName() + ": IP is not available yet"));
+    assertFalse(
+       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+    assertTrue(
+       probeStatus.toString().contains(
+        componentInstance.getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
 
     // on the second ping, container status is retrieved but there are no
     // IPs, resulting in failure
     probeStatus = probe.ping(componentInstance);
-    assertFalse("Expected failure for " + probeStatus.toString(),
-        probeStatus.isSuccess());
-    assertTrue("Expected IP failure for " + probeStatus.toString(),
-        probeStatus.toString().contains(componentInstance
-            .getCompInstanceName() + ": IP is not available yet"));
+    assertFalse(
+       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+    assertTrue(
+       probeStatus.toString().contains(componentInstance
+            .getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
 
     // on the third ping, IPs are retrieved and success depends on whether or
     // not a DNS lookup can be performed for the component instance hostname
     probeStatus = probe.ping(componentInstance);
     if (expectDNSCheckFailure) {
-      assertFalse("Expected failure for " + probeStatus.toString(),
-          probeStatus.isSuccess());
-      assertTrue("Expected DNS failure for " + probeStatus.toString(),
-          probeStatus.toString().contains(componentInstance
+      assertFalse(
+         probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+      assertTrue(
+         probeStatus.toString().contains(componentInstance
               .getCompInstanceName() + ": DNS checking is enabled, but lookup" +
               " for " + componentInstance.getHostname() + " is not available " +
-              "yet"));
+              "yet"), "Expected DNS failure for " + probeStatus.toString());
     } else {
-      assertTrue("Expected success for " + probeStatus.toString(),
-          probeStatus.isSuccess());
+      assertTrue(
+         probeStatus.isSuccess(), "Expected success for " + probeStatus.toString());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
@@ -20,9 +20,8 @@ package org.apache.hadoop.yarn.service.monitor.probe;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.service.api.records.ReadinessCheck;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -40,15 +39,13 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for default probe.
  */
-@RunWith(Parameterized.class)
 public class TestDefaultProbe {
-  private final DefaultProbe probe;
+  private DefaultProbe probe;
 
-  public TestDefaultProbe(Probe probe) {
-    this.probe = (DefaultProbe) probe;
+  public void initTestDefaultProbe(Probe paramProbe) {
+    this.probe = (DefaultProbe) paramProbe;
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     // test run 1: Default probe checks that container has an IP
     Probe p1 = MonitorUtils.getProbe(null);
@@ -71,8 +68,10 @@ public class TestDefaultProbe {
     return Arrays.asList(new Object[][] {{p1}, {p2}, {p3}});
   }
 
-  @Test
-  public void testDefaultProbe() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDefaultProbe(Probe paramProbe) {
+    initTestDefaultProbe(paramProbe);
     // component instance has a good hostname, so probe will eventually succeed
     // whether or not DNS checking is enabled
     ComponentInstance componentInstance =
@@ -89,35 +88,34 @@ public class TestDefaultProbe {
       componentInstance, boolean expectDNSCheckFailure) {
     // on the first ping, null container status results in failure
     ProbeStatus probeStatus = probe.ping(componentInstance);
-    assertFalse(
-       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
-    assertTrue(
-       probeStatus.toString().contains(
-        componentInstance.getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
+    assertFalse(probeStatus.isSuccess(),
+        "Expected failure for " + probeStatus.toString());
+    assertTrue(probeStatus.toString().contains(
+        componentInstance.getCompInstanceName() + ": IP is not available yet"),
+        "Expected IP failure for " + probeStatus.toString());
 
     // on the second ping, container status is retrieved but there are no
     // IPs, resulting in failure
     probeStatus = probe.ping(componentInstance);
-    assertFalse(
-       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
-    assertTrue(
-       probeStatus.toString().contains(componentInstance
-            .getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
+    assertFalse(probeStatus.isSuccess(),
+        "Expected failure for " + probeStatus.toString());
+    assertTrue(probeStatus.toString().contains(componentInstance
+        .getCompInstanceName() + ": IP is not available yet"),
+        "Expected IP failure for " + probeStatus.toString());
 
     // on the third ping, IPs are retrieved and success depends on whether or
     // not a DNS lookup can be performed for the component instance hostname
     probeStatus = probe.ping(componentInstance);
     if (expectDNSCheckFailure) {
-      assertFalse(
-         probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
-      assertTrue(
-         probeStatus.toString().contains(componentInstance
-              .getCompInstanceName() + ": DNS checking is enabled, but lookup" +
-              " for " + componentInstance.getHostname() + " is not available " +
-              "yet"), "Expected DNS failure for " + probeStatus.toString());
+      assertFalse(probeStatus.isSuccess(),
+          "Expected failure for " + probeStatus.toString());
+      assertTrue(probeStatus.toString().contains(componentInstance
+          .getCompInstanceName() + ": DNS checking is enabled, but lookup" +
+          " for " + componentInstance.getHostname() + " is not available " +
+          "yet"), "Expected DNS failure for " + probeStatus.toString());
     } else {
-      assertTrue(
-         probeStatus.isSuccess(), "Expected success for " + probeStatus.toString());
+      assertTrue(probeStatus.isSuccess(),
+          "Expected success for " + probeStatus.toString());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
@@ -36,11 +36,11 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.provider.docker.DockerProviderService;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
@@ -62,7 +62,7 @@ public class TestAbstractProviderService {
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     testService = TestServiceManager.createBaseDef("testService");
     serviceContext = new MockRunningServiceContext(rule, testService);
@@ -70,7 +70,7 @@ public class TestAbstractProviderService {
     rule.getFs().setAppDir(new Path("target/testAbstractProviderService"));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     FileUtils.deleteQuietly(
         new File(rule.getFs().getAppDir().toUri().getPath()));
@@ -91,8 +91,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assert.assertEquals("commands", Lists.newArrayList(clc.getLaunchCommand()),
-        launcher.getCommands());
+    Assertions.assertEquals(Lists.newArrayList(clc.getLaunchCommand())
+,         launcher.getCommands(), "commands");
   }
 
   @Test
@@ -110,8 +110,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assert.assertEquals("commands don't match.",
-        Lists.newArrayList("ls,-l, space"), launcher.getCommands());
+    Assertions.assertEquals(
+       Lists.newArrayList("ls,-l, space"), launcher.getCommands(), "commands don't match.");
   }
 
   @Test
@@ -132,8 +132,8 @@ public class TestAbstractProviderService {
     providerService.buildContainerLaunchContext(launcher, testService, instance,
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc);
 
-    Assert.assertEquals("artifact", clc.getArtifact().getId(),
-        launcher.getDockerImage());
+    Assertions.assertEquals(clc.getArtifact().getId()
+,         launcher.getDockerImage(), "artifact");
   }
 
   private static ContainerLaunchService.ComponentLaunchContext

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
@@ -59,7 +59,7 @@ public class TestAbstractProviderService {
   private AbstractLauncher launcher;
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @BeforeEach

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
@@ -37,15 +37,15 @@ import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.provider.docker.DockerProviderService;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +58,7 @@ public class TestAbstractProviderService {
   private Service testService;
   private AbstractLauncher launcher;
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -91,8 +91,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assertions.assertEquals(Lists.newArrayList(clc.getLaunchCommand())
-,         launcher.getCommands(), "commands");
+    assertEquals(Lists.newArrayList(clc.getLaunchCommand()),
+        launcher.getCommands(), "commands");
   }
 
   @Test
@@ -110,8 +110,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assertions.assertEquals(
-       Lists.newArrayList("ls,-l, space"), launcher.getCommands(), "commands don't match.");
+    assertEquals(Lists.newArrayList("ls,-l, space"),
+        launcher.getCommands(), "commands don't match.");
   }
 
   @Test
@@ -132,8 +132,8 @@ public class TestAbstractProviderService {
     providerService.buildContainerLaunchContext(launcher, testService, instance,
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc);
 
-    Assertions.assertEquals(clc.getArtifact().getId()
-,         launcher.getDockerImage(), "artifact");
+    assertEquals(clc.getArtifact().getId(),
+        launcher.getDockerImage(), "artifact");
   }
 
   private static ContainerLaunchService.ComponentLaunchContext

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -169,8 +169,8 @@ public class TestProviderUtils {
     Mockito.verify(launcher).addLocalResource(
         Mockito.eq("sourceFile4"), any(LocalResource.class));
 
-    Assert.assertEquals(3, resolved.getResolvedRsrcPaths().size());
-    Assert.assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
+    Assertions.assertEquals(3, resolved.getResolvedRsrcPaths().size());
+    Assertions.assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
         "destFile1");
   }
 
@@ -179,7 +179,7 @@ public class TestProviderUtils {
     String command = "ls  -l \" space\"";
     String expected = "ls,-l, space";
     String actual = ProviderUtils.replaceSpacesWithDelimiter(command, ",");
-    Assert.assertEquals("replaceSpaceWithDelimiter produces unexpected result.",
-        expected, actual);
+    Assertions.assertEquals(
+       expected, actual, "replaceSpaceWithDelimiter produces unexpected result.");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -38,6 +37,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -169,8 +169,8 @@ public class TestProviderUtils {
     Mockito.verify(launcher).addLocalResource(
         Mockito.eq("sourceFile4"), any(LocalResource.class));
 
-    Assertions.assertEquals(3, resolved.getResolvedRsrcPaths().size());
-    Assertions.assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
+    assertEquals(3, resolved.getResolvedRsrcPaths().size());
+    assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
         "destFile1");
   }
 
@@ -179,7 +179,7 @@ public class TestProviderUtils {
     String command = "ls  -l \" space\"";
     String expected = "ls,-l, space";
     String actual = ProviderUtils.replaceSpacesWithDelimiter(command, ",");
-    Assertions.assertEquals(
-       expected, actual, "replaceSpaceWithDelimiter produces unexpected result.");
+    assertEquals(expected, actual,
+        "replaceSpaceWithDelimiter produces unexpected result.");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.api.records.Artifact;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.provider.AbstractClientProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,21 +69,21 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "null file type");
+      Assertions.fail(EXCEPTION_PREFIX + "null file type");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setType(ConfigFile.TypeEnum.TEMPLATE);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "empty src_file for type template");
+      Assertions.fail(EXCEPTION_PREFIX + "empty src_file for type template");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setSrcFile("srcfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "empty dest file");
+      Assertions.fail(EXCEPTION_PREFIX + "empty dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -91,7 +91,7 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile = new ConfigFile();
@@ -101,7 +101,7 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
@@ -109,13 +109,13 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile.setDestFile("destfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "duplicate dest file");
+      Assertions.fail(EXCEPTION_PREFIX + "duplicate dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -127,14 +127,14 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setDestFile("/path/destfile3");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "src file should be specified");
+      Assertions.fail(EXCEPTION_PREFIX + "src file should be specified");
     } catch (IllegalArgumentException e) {
     }
 
@@ -156,7 +156,7 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "src file is a directory");
+      Assertions.fail(EXCEPTION_PREFIX + "src file is a directory");
     } catch (IllegalArgumentException e) {
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
@@ -23,13 +23,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.api.records.Artifact;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.provider.AbstractClientProvider;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -69,21 +69,21 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "null file type");
+      fail(EXCEPTION_PREFIX + "null file type");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setType(ConfigFile.TypeEnum.TEMPLATE);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "empty src_file for type template");
+      fail(EXCEPTION_PREFIX + "empty src_file for type template");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setSrcFile("srcfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "empty dest file");
+      fail(EXCEPTION_PREFIX + "empty dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -91,7 +91,7 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile = new ConfigFile();
@@ -101,7 +101,7 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
@@ -109,13 +109,13 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile.setDestFile("destfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "duplicate dest file");
+      fail(EXCEPTION_PREFIX + "duplicate dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -127,14 +127,14 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setDestFile("/path/destfile3");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "src file should be specified");
+      fail(EXCEPTION_PREFIX + "src file should be specified");
     } catch (IllegalArgumentException e) {
     }
 
@@ -156,7 +156,7 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + "src file is a directory");
+      fail(EXCEPTION_PREFIX + "src file is a directory");
     } catch (IllegalArgumentException e) {
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
 import org.apache.hadoop.yarn.service.provider.defaultImpl.DefaultClientProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestDefaultClientProvider {
   private static final String EXCEPTION_PREFIX = "Should have thrown "
@@ -48,19 +48,19 @@ public class TestDefaultClientProvider {
 
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + " dest_file must be relative");
+      Assertions.fail(EXCEPTION_PREFIX + " dest_file must be relative");
     } catch (IllegalArgumentException e) {
       String actualMsg = String.format(
           RestApiErrorMessages.ERROR_CONFIGFILE_DEST_FILE_FOR_COMP_NOT_ABSOLUTE,
           compName, "no", configFile.getDestFile());
-      Assert.assertEquals(actualMsg, e.getLocalizedMessage());
+      Assertions.assertEquals(actualMsg, e.getLocalizedMessage());
     }
 
     configFile.setDestFile("../a.txt");
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.yarn.service.providers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,7 +29,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
 import org.apache.hadoop.yarn.service.provider.defaultImpl.DefaultClientProvider;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestDefaultClientProvider {
@@ -48,19 +49,19 @@ public class TestDefaultClientProvider {
 
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
-      Assertions.fail(EXCEPTION_PREFIX + " dest_file must be relative");
+      fail(EXCEPTION_PREFIX + " dest_file must be relative");
     } catch (IllegalArgumentException e) {
       String actualMsg = String.format(
           RestApiErrorMessages.ERROR_CONFIGFILE_DEST_FILE_FOR_COMP_NOT_ABSOLUTE,
           compName, "no", configFile.getDestFile());
-      Assertions.assertEquals(actualMsg, e.getLocalizedMessage());
+      assertEquals(actualMsg, e.getLocalizedMessage());
     }
 
     configFile.setDestFile("../a.txt");
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestProviderFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestProviderFactory.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.yarn.service.provider.tarball.TarballClientProvider;
 import org.apache.hadoop.yarn.service.provider.tarball.TarballProviderFactory;
 import org.apache.hadoop.yarn.service.provider.tarball.TarballProviderService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test provider factories.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/timelineservice/TestServiceTimelinePublisher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/timelineservice/TestServiceTimelinePublisher.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.yarn.service.api.records.PlacementType;
 import org.apache.hadoop.yarn.service.api.records.Resource;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceId;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,7 +78,7 @@ public class TestServiceTimelinePublisher {
   private static String CONTAINER_BAREHOST =
       "localhost.com";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     config = new Configuration();
     config.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -90,7 +90,7 @@ public class TestServiceTimelinePublisher {
     serviceTimelinePublisher.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (serviceTimelinePublisher != null) {
       serviceTimelinePublisher.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.yarn.service.utils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link CoreFileSystem}.
@@ -40,7 +40,7 @@ public class TestCoreFileSystem {
     String version = "v1";
     Path expectedPath = new Path(rule.getFs().buildClusterDirPath(serviceName),
         YarnServiceConstants.UPGRADE_DIR + "/" + version);
-    Assert.assertEquals("incorrect upgrade path", expectedPath,
-        rule.getFs().buildClusterUpgradeDirPath(serviceName, version));
+    Assertions.assertEquals(expectedPath
+,         rule.getFs().buildClusterUpgradeDirPath(serviceName, version), "incorrect upgrade path");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestCoreFileSystem {
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
@@ -21,16 +21,17 @@ package org.apache.hadoop.yarn.service.utils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link CoreFileSystem}.
  */
 public class TestCoreFileSystem {
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -40,7 +41,7 @@ public class TestCoreFileSystem {
     String version = "v1";
     Path expectedPath = new Path(rule.getFs().buildClusterDirPath(serviceName),
         YarnServiceConstants.UPGRADE_DIR + "/" + version);
-    Assertions.assertEquals(expectedPath
-,         rule.getFs().buildClusterUpgradeDirPath(serviceName, version), "incorrect upgrade path");
+    assertEquals(expectedPath, rule.getFs().buildClusterUpgradeDirPath(serviceName, version),
+        "incorrect upgrade path");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.TestServiceManager;
 import org.apache.hadoop.yarn.service.api.records.ComponentContainers;
 import org.apache.hadoop.yarn.service.api.records.ContainerState;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -45,9 +45,9 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assert.assertEquals("num comps", 2, compContainers.size());
+    Assertions.assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assert.assertEquals("num containers", 2, item.getContainers().size());
+      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
     });
   }
 
@@ -58,12 +58,12 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assert.assertEquals("num comps", 1, compContainers.size());
-    Assert.assertEquals("comp name", "compa",
+    Assertions.assertEquals(1, compContainers.size(), "num comps");
+    Assertions.assertEquals("comp name", "compa",
         compContainers.get(0).getComponentName());
 
-    Assert.assertEquals("num containers", 2,
-        compContainers.get(0).getContainers().size());
+    Assertions.assertEquals(2
+,         compContainers.get(0).getContainers().size(), "num containers");
   }
 
   @Test
@@ -74,15 +74,15 @@ public class TestFilterUtils {
         GetCompInstancesRequestProto.newBuilder();
 
     reqBuilder.setVersion("v2");
-    Assert.assertEquals("num comps", 0,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).size());
+    Assertions.assertEquals(0
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
 
     reqBuilder.addAllComponentNames(Lists.newArrayList("compa"))
         .setVersion("v1").build();
 
-    Assert.assertEquals("num containers", 2,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
-            .getContainers().size());
+    Assertions.assertEquals(2
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
+            .getContainers().size(), "num containers");
   }
 
   @Test
@@ -96,16 +96,16 @@ public class TestFilterUtils {
         ContainerState.READY.toString()));
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(sc,
         reqBuilder.build());
-    Assert.assertEquals("num comps", 2, compContainers.size());
+    Assertions.assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assert.assertEquals("num containers", 2, item.getContainers().size());
+      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
     });
 
     reqBuilder.clearContainerStates();
     reqBuilder.addAllContainerStates(Lists.newArrayList(
         ContainerState.STOPPED.toString()));
-    Assert.assertEquals("num comps", 0,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).size());
+    Assertions.assertEquals(0
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestFilterUtils {
 
   @RegisterExtension
-  public ServiceTestUtils.ServiceFSWatcher rule =
+  private ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
@@ -26,15 +26,16 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.TestServiceManager;
 import org.apache.hadoop.yarn.service.api.records.ComponentContainers;
 import org.apache.hadoop.yarn.service.api.records.ContainerState;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TestFilterUtils {
 
-  @Rule
+  @RegisterExtension
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
@@ -45,9 +46,9 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assertions.assertEquals(2, compContainers.size(), "num comps");
+    assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
+      assertEquals(2, item.getContainers().size(), "num containers");
     });
   }
 
@@ -58,12 +59,9 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assertions.assertEquals(1, compContainers.size(), "num comps");
-    Assertions.assertEquals("comp name", "compa",
-        compContainers.get(0).getComponentName());
-
-    Assertions.assertEquals(2
-,         compContainers.get(0).getContainers().size(), "num containers");
+    assertEquals(1, compContainers.size(), "num comps");
+    assertEquals("compa", compContainers.get(0).getComponentName(), "comp name");
+    assertEquals(2, compContainers.get(0).getContainers().size(), "num containers");
   }
 
   @Test
@@ -74,15 +72,14 @@ public class TestFilterUtils {
         GetCompInstancesRequestProto.newBuilder();
 
     reqBuilder.setVersion("v2");
-    Assertions.assertEquals(0
-,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
+    assertEquals(0, FilterUtils.filterInstances(sc, reqBuilder.build()).size(),
+        "num comps");
 
     reqBuilder.addAllComponentNames(Lists.newArrayList("compa"))
         .setVersion("v1").build();
 
-    Assertions.assertEquals(2
-,         FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
-            .getContainers().size(), "num containers");
+    assertEquals(2, FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
+        .getContainers().size(), "num containers");
   }
 
   @Test
@@ -96,16 +93,16 @@ public class TestFilterUtils {
         ContainerState.READY.toString()));
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(sc,
         reqBuilder.build());
-    Assertions.assertEquals(2, compContainers.size(), "num comps");
+    assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
+      assertEquals(2, item.getContainers().size(), "num containers");
     });
 
     reqBuilder.clearContainerStates();
     reqBuilder.addAllContainerStates(Lists.newArrayList(
         ContainerState.STOPPED.toString()));
-    Assertions.assertEquals(0
-,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
+    assertEquals(0, FilterUtils.filterInstances(sc, reqBuilder.build()).size(),
+        "num comps");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.yarn.service.api.records.Resource;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +50,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.yarn.service.conf.RestApiConstants.DEFAULT_UNLIMITED_LIFETIME;
 import static org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for ServiceApiUtil helper methods.
@@ -72,12 +73,13 @@ public class TestServiceApiUtil extends ServiceTestUtils {
   private static final YarnConfiguration CONF_DNS_ENABLED = new
       YarnConfiguration();
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CONF_DNS_ENABLED.setBoolean(RegistryConstants.KEY_DNS_ENABLED, true);
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testResourceValidation() throws Exception {
     assertEquals(RegistryConstants.MAX_FQDN_LABEL_LENGTH + 1, LEN_64_STR
         .length());
@@ -89,7 +91,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no name");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no name");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_APPLICATION_NAME_INVALID, e.getMessage());
     }
@@ -98,7 +100,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no version
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + " service with no version");
+      Assertions.fail(EXCEPTION_PREFIX + " service with no version");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_APPLICATION_VERSION_INVALID,
           app.getName()), e.getMessage());
@@ -111,7 +113,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       app.setName(badName);
       try {
         ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-        Assert.fail(EXCEPTION_PREFIX + "service with bad name " + badName);
+        Assertions.fail(EXCEPTION_PREFIX + "service with bad name " + badName);
       } catch (IllegalArgumentException e) {
 
       }
@@ -123,7 +125,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.addComponent(comp);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
-      Assert.fail(EXCEPTION_PREFIX + "service with no launch command");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -134,7 +136,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
         .MAX_FQDN_LABEL_LENGTH));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no launch command");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -146,7 +148,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setResource(res);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no memory");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_RESOURCE_MEMORY_FOR_COMP_INVALID,
@@ -158,7 +160,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(-2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(
+      Assertions.fail(
           EXCEPTION_PREFIX + "service with invalid no of cpus");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
@@ -170,9 +172,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no container count");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no container count");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      Assertions.assertTrue(e.getMessage()
           .contains(ERROR_CONTAINERS_COUNT_INVALID));
     }
 
@@ -180,7 +182,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setProfile("hbase_finance_large");
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX
+      Assertions.fail(EXCEPTION_PREFIX
           + "service with resource profile along with cpus/memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
@@ -195,7 +197,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setMemory(null);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with resource profile only");
+      Assertions.fail(EXCEPTION_PREFIX + "service with resource profile only");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_RESOURCE_PROFILE_NOT_SUPPORTED_YET,
           e.getMessage());
@@ -209,9 +211,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // null number of containers
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "null number of containers");
+      Assertions.fail(EXCEPTION_PREFIX + "null number of containers");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      Assertions.assertTrue(e.getMessage()
           .startsWith(ERROR_CONTAINERS_COUNT_INVALID));
     }
   }
@@ -236,7 +238,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setComponents(Collections.singletonList(comp));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -246,7 +248,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.SERVICE);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_ARTIFACT_ID_INVALID, e.getMessage());
     }
@@ -255,7 +257,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.TARBALL);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -268,7 +270,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
       LOG.error("service attributes specified should be valid here", e);
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertThat(app.getLifetime()).isEqualTo(DEFAULT_UNLIMITED_LIFETIME);
@@ -315,7 +317,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -333,7 +335,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // duplicate component name fails
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with component collision");
+      Assertions.fail(EXCEPTION_PREFIX + "service with component collision");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name collision: " + compName, e.getMessage());
     }
@@ -350,7 +352,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     //component name same as service name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "component name matches service name");
+      Assertions.fail(EXCEPTION_PREFIX + "component name matches service name");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name test must not be same as service name test",
           e.getMessage());
@@ -372,7 +374,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -390,7 +392,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -403,7 +405,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -440,7 +442,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     c.setDependencies(Arrays.asList("e"));
     try {
       verifyDependencySorting(Arrays.asList(a, b, c, d, e));
-      Assert.fail(EXCEPTION_PREFIX + "components with dependency cycle");
+      Assertions.fail(EXCEPTION_PREFIX + "components with dependency cycle");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_CYCLE, Arrays.asList(c, d,
@@ -453,7 +455,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(service, sfs,
           CONF_DEFAULT_DNS);
-      Assert.fail(EXCEPTION_PREFIX + "components with bad dependencies");
+      Assertions.fail(EXCEPTION_PREFIX + "components with bad dependencies");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_INVALID, "b", "e"), ex
@@ -476,7 +478,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     for (String name : invalidNames) {
       try {
         ServiceApiUtil.validateNameFormat(name, new Configuration());
-        Assert.fail();
+        Assertions.fail();
       } catch (IllegalArgumentException ex) {
         ex.printStackTrace();
       }
@@ -496,7 +498,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // invalid component name fails if dns is enabled
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with invalid component name");
+      Assertions.fail(EXCEPTION_PREFIX + "service with invalid component name");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
           .ERROR_COMPONENT_NAME_INVALID, maxLen, compName), e.getMessage());
@@ -506,7 +508,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     compName = LEN_64_STR.substring(0, maxLen);
@@ -517,7 +519,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -534,7 +536,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "constraint with no type");
+      Assertions.fail(EXCEPTION_PREFIX + "constraint with no type");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_TYPE_NULL,
@@ -546,7 +548,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "constraint with no scope");
+      Assertions.fail(EXCEPTION_PREFIX + "constraint with no scope");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_SCOPE_NULL,
@@ -564,7 +566,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -581,7 +583,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     // Keytab with no URI scheme should succeed too
@@ -589,7 +591,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -602,7 +604,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
-      Assert.fail(EXCEPTION_PREFIX + "service with invalid principal name " +
+      Assertions.fail(EXCEPTION_PREFIX + "service with invalid principal name " +
           "format.");
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -616,7 +618,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     kp.setPrincipalName(null);
@@ -624,7 +626,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (NullPointerException e) {
-        Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+        Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -643,8 +645,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compb");
     expected.add("compa");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -663,8 +665,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -686,8 +688,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -703,12 +705,13 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
-  @Test(timeout = 1500)
+  @Test
+  @Timeout(value = 1)
   public void testNoServiceDependencies() {
     Service service = createExampleApplication();
     Component compa = createComponent("compa");
@@ -743,7 +746,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       Thread.sleep(1000);
     } catch (InterruptedException e) {
     }
-    Assert.assertTrue(thread.isAlive());
+    Assertions.assertTrue(thread.isAlive());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.yarn.service.api.records.Resource;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -46,12 +45,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.yarn.service.conf.RestApiConstants.DEFAULT_UNLIMITED_LIFETIME;
 import static org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -91,7 +91,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no name");
+      fail(EXCEPTION_PREFIX + "service with no name");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_APPLICATION_NAME_INVALID, e.getMessage());
     }
@@ -100,7 +100,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no version
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + " service with no version");
+      fail(EXCEPTION_PREFIX + " service with no version");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_APPLICATION_VERSION_INVALID,
           app.getName()), e.getMessage());
@@ -113,7 +113,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       app.setName(badName);
       try {
         ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-        Assertions.fail(EXCEPTION_PREFIX + "service with bad name " + badName);
+        fail(EXCEPTION_PREFIX + "service with bad name " + badName);
       } catch (IllegalArgumentException e) {
 
       }
@@ -125,7 +125,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.addComponent(comp);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
+      fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -136,7 +136,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
         .MAX_FQDN_LABEL_LENGTH));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
+      fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -148,7 +148,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setResource(res);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no memory");
+      fail(EXCEPTION_PREFIX + "service with no memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_RESOURCE_MEMORY_FOR_COMP_INVALID,
@@ -160,7 +160,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(-2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(
+      fail(
           EXCEPTION_PREFIX + "service with invalid no of cpus");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
@@ -172,9 +172,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no container count");
+      fail(EXCEPTION_PREFIX + "service with no container count");
     } catch (IllegalArgumentException e) {
-      Assertions.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains(ERROR_CONTAINERS_COUNT_INVALID));
     }
 
@@ -182,7 +182,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setProfile("hbase_finance_large");
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX
+      fail(EXCEPTION_PREFIX
           + "service with resource profile along with cpus/memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
@@ -197,7 +197,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setMemory(null);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with resource profile only");
+      fail(EXCEPTION_PREFIX + "service with resource profile only");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_RESOURCE_PROFILE_NOT_SUPPORTED_YET,
           e.getMessage());
@@ -211,9 +211,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // null number of containers
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "null number of containers");
+      fail(EXCEPTION_PREFIX + "null number of containers");
     } catch (IllegalArgumentException e) {
-      Assertions.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith(ERROR_CONTAINERS_COUNT_INVALID));
     }
   }
@@ -238,7 +238,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setComponents(Collections.singletonList(comp));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -248,7 +248,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.SERVICE);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_ARTIFACT_ID_INVALID, e.getMessage());
     }
@@ -257,7 +257,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.TARBALL);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -270,7 +270,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
       LOG.error("service attributes specified should be valid here", e);
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertThat(app.getLifetime()).isEqualTo(DEFAULT_UNLIMITED_LIFETIME);
@@ -317,7 +317,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -335,7 +335,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // duplicate component name fails
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with component collision");
+      fail(EXCEPTION_PREFIX + "service with component collision");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name collision: " + compName, e.getMessage());
     }
@@ -352,7 +352,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     //component name same as service name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "component name matches service name");
+      fail(EXCEPTION_PREFIX + "component name matches service name");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name test must not be same as service name test",
           e.getMessage());
@@ -374,7 +374,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -392,7 +392,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -405,7 +405,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -442,7 +442,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     c.setDependencies(Arrays.asList("e"));
     try {
       verifyDependencySorting(Arrays.asList(a, b, c, d, e));
-      Assertions.fail(EXCEPTION_PREFIX + "components with dependency cycle");
+      fail(EXCEPTION_PREFIX + "components with dependency cycle");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_CYCLE, Arrays.asList(c, d,
@@ -455,7 +455,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(service, sfs,
           CONF_DEFAULT_DNS);
-      Assertions.fail(EXCEPTION_PREFIX + "components with bad dependencies");
+      fail(EXCEPTION_PREFIX + "components with bad dependencies");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_INVALID, "b", "e"), ex
@@ -478,7 +478,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     for (String name : invalidNames) {
       try {
         ServiceApiUtil.validateNameFormat(name, new Configuration());
-        Assertions.fail();
+        fail();
       } catch (IllegalArgumentException ex) {
         ex.printStackTrace();
       }
@@ -498,7 +498,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // invalid component name fails if dns is enabled
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "service with invalid component name");
+      fail(EXCEPTION_PREFIX + "service with invalid component name");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
           .ERROR_COMPONENT_NAME_INVALID, maxLen, compName), e.getMessage());
@@ -508,7 +508,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     compName = LEN_64_STR.substring(0, maxLen);
@@ -519,7 +519,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -536,7 +536,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "constraint with no type");
+      fail(EXCEPTION_PREFIX + "constraint with no type");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_TYPE_NULL,
@@ -548,7 +548,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assertions.fail(EXCEPTION_PREFIX + "constraint with no scope");
+      fail(EXCEPTION_PREFIX + "constraint with no scope");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_SCOPE_NULL,
@@ -566,7 +566,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -583,7 +583,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     // Keytab with no URI scheme should succeed too
@@ -591,7 +591,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -604,7 +604,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
-      Assertions.fail(EXCEPTION_PREFIX + "service with invalid principal name " +
+      fail(EXCEPTION_PREFIX + "service with invalid principal name " +
           "format.");
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -618,7 +618,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     kp.setPrincipalName(null);
@@ -626,7 +626,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (NullPointerException e) {
-        Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+        fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -645,7 +645,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compb");
     expected.add("compa");
     for (int i = 0; i < expected.size(); i++) {
-      Assertions.assertEquals(expected.get(i)
+      assertEquals(expected.get(i)
 ,           order.get(i), "Components are not equal.");
     }
   }
@@ -665,7 +665,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assertions.assertEquals(expected.get(i)
+      assertEquals(expected.get(i)
 ,           order.get(i), "Components are not equal.");
     }
   }
@@ -688,7 +688,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assertions.assertEquals(expected.get(i)
+      assertEquals(expected.get(i)
 ,           order.get(i), "Components are not equal.");
     }
   }
@@ -705,7 +705,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assertions.assertEquals(expected.get(i)
+      assertEquals(expected.get(i)
 ,           order.get(i), "Components are not equal.");
     }
   }
@@ -746,7 +746,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       Thread.sleep(1000);
     } catch (InterruptedException e) {
     }
-    Assertions.assertTrue(thread.isAlive());
+    assertTrue(thread.isAlive());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
@@ -626,7 +626,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (NullPointerException e) {
-        fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -645,8 +645,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compb");
     expected.add("compa");
     for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i)
-,           order.get(i), "Components are not equal.");
+      assertEquals(expected.get(i),
+          order.get(i), "Components are not equal.");
     }
   }
 
@@ -665,8 +665,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i)
-,           order.get(i), "Components are not equal.");
+      assertEquals(expected.get(i),
+          order.get(i), "Components are not equal.");
     }
   }
 
@@ -688,8 +688,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i)
-,           order.get(i), "Components are not equal.");
+      assertEquals(expected.get(i),
+          order.get(i), "Components are not equal.");
     }
   }
 
@@ -705,8 +705,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i)
-,           order.get(i), "Components are not equal.");
+      assertEquals(expected.get(i),
+          order.get(i), "Components are not equal.");
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11761. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-services-core.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

