### PR TITLE
[HADOOP-18562]: S3A: support custom S3 and STS headers

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.s3a.impl.streams.StreamIntegration;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.io.Sizes.S_128K;
@@ -1361,6 +1362,33 @@ public final class Constants {
   @Deprecated
   public static final String AWS_SERVICE_IDENTIFIER_DDB = "DDB";
   public static final String AWS_SERVICE_IDENTIFIER_STS = "STS";
+
+  /** Prefix for S3A client-specific properties.
+   * value: {@value}
+   */
+  public static final String FS_S3A_CLIENT_PREFIX = "fs.s3a.client.";
+
+  /** Custom headers postfix.
+   * value: {@value}
+   */
+  public static final String CUSTOM_HEADERS_POSTFIX = ".custom.headers";
+
+  /**
+   * List of custom headers to be set on the service client.
+   * Multiple parameters can be used to specify custom headers.
+   * fs.s3a.client.s3.custom.headers - headers to add on all the s3 requests.
+   * fs.s3a.client.sts.custom.headers - headers to add on all the sts requests.
+   * Examples
+   * CustomHeader {@literal ->} 'Header1:Value1'
+   * CustomHeaders {@literal ->} 'Header1=Value1;Value2,Header2=Value1'
+   */
+  public static final String CUSTOM_HEADERS_STS =
+      FS_S3A_CLIENT_PREFIX + AWS_SERVICE_IDENTIFIER_STS.toLowerCase(Locale.ROOT)
+          + CUSTOM_HEADERS_POSTFIX;
+
+  public static final String CUSTOM_HEADERS_S3 =
+      FS_S3A_CLIENT_PREFIX + AWS_SERVICE_IDENTIFIER_S3.toLowerCase(Locale.ROOT)
+          + CUSTOM_HEADERS_POSTFIX;
 
   /**
    * How long to wait for the thread pool to terminate when cleaning up.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -852,6 +852,12 @@ public final class Constants {
       "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
           + ".signing-algorithm";
 
+  /** Prefix for S3A client-specific properties. */
+  public static final String FS_S3A_CLIENT_PREFIX = "fs.s3a.client.";
+
+  /** Custom headers postfix */
+  public static final String CUSTOM_HEADER_POSTFIX = ".custom.headers";
+
   /**
    * List of custom headers to be set on the service client.
    * Multiple parameters can be used to specify custom headers.
@@ -862,12 +868,12 @@ public final class Constants {
    * CustomHeaders {@literal ->} 'Header1=Value1:Value2,Header2=Value1'
    */
   public static final String CUSTOM_HEADERS_STS =
-      "fs.s3a.client." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
-          + ".custom.headers";
+      FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
+          + CUSTOM_HEADER_POSTFIX;
 
   public static final String CUSTOM_HEADERS_S3 =
-          "fs.s3a.client." + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
-                  + ".custom.headers";
+      FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
+          + CUSTOM_HEADER_POSTFIX;
 
   @Deprecated
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -855,18 +855,18 @@ public final class Constants {
   /**
    * List of custom headers to be set on the service client.
    * Multiple parameters can be used to specify custom headers.
-   * fs.s3a.s3.custom.headers - headers to add on all the s3 requests.
-   * fs.s3a.sts.custom.headers - headers to add on all the sts requests.
+   * fs.s3a.client.s3.custom.headers - headers to add on all the s3 requests.
+   * fs.s3a.client.sts.custom.headers - headers to add on all the sts requests.
    * Examples
    * CustomHeader {@literal ->} 'Header1:Value1'
    * CustomHeaders {@literal ->} 'Header1=Value1:Value2,Header2=Value1'
    */
   public static final String CUSTOM_HEADERS_STS =
-      "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
+      "fs.s3a.client." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
           + ".custom.headers";
 
   public static final String CUSTOM_HEADERS_S3 =
-          "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
+          "fs.s3a.client." + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
                   + ".custom.headers";
 
   @Deprecated

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -852,7 +852,7 @@ public final class Constants {
   public static final String SIGNING_ALGORITHM_STS =
       "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
           + ".signing-algorithm";
-  
+
   @Deprecated
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";
   public static final String FS_S3A_BLOCK_SIZE = "fs.s3a.block.size";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1376,11 +1376,15 @@ public final class Constants {
   /**
    * List of custom headers to be set on the service client.
    * Multiple parameters can be used to specify custom headers.
-   * fs.s3a.client.s3.custom.headers - headers to add on all the s3 requests.
-   * fs.s3a.client.sts.custom.headers - headers to add on all the sts requests.
-   * Examples
-   * CustomHeader {@literal ->} 'Header1:Value1'
-   * CustomHeaders {@literal ->} 'Header1=Value1;Value2,Header2=Value1'
+   * <pre>
+   * Usage:
+   * fs.s3a.client.s3.custom.headers - Headers to add on all the S3 requests.
+   * fs.s3a.client.sts.custom.headers - Headers to add on all the STS requests.
+   *
+   * Examples:
+   * CustomHeader -> 'Header1:Value1'
+   * CustomHeaders -> 'Header1=Value1;Value2,Header2=Value1'
+   * </pre>
    */
   public static final String CUSTOM_HEADERS_STS =
       FS_S3A_CLIENT_PREFIX + AWS_SERVICE_IDENTIFIER_STS.toLowerCase(Locale.ROOT)

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -855,7 +855,7 @@ public final class Constants {
   /** Prefix for S3A client-specific properties. */
   public static final String FS_S3A_CLIENT_PREFIX = "fs.s3a.client.";
 
-  /** Custom headers postfix */
+  /** Custom headers postfix. */
   public static final String CUSTOM_HEADERS_POSTFIX = ".custom.headers";
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -852,30 +852,7 @@ public final class Constants {
   public static final String SIGNING_ALGORITHM_STS =
       "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
           + ".signing-algorithm";
-
-  /** Prefix for S3A client-specific properties. */
-  public static final String FS_S3A_CLIENT_PREFIX = "fs.s3a.client.";
-
-  /** Custom headers postfix. */
-  public static final String CUSTOM_HEADERS_POSTFIX = ".custom.headers";
-
-  /**
-   * List of custom headers to be set on the service client.
-   * Multiple parameters can be used to specify custom headers.
-   * fs.s3a.client.s3.custom.headers - headers to add on all the s3 requests.
-   * fs.s3a.client.sts.custom.headers - headers to add on all the sts requests.
-   * Examples
-   * CustomHeader {@literal ->} 'Header1:Value1'
-   * CustomHeaders {@literal ->} 'Header1=Value1:Value2,Header2=Value1'
-   */
-  public static final String CUSTOM_HEADERS_STS =
-      FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
-          + CUSTOM_HEADERS_POSTFIX;
-
-  public static final String CUSTOM_HEADERS_S3 =
-      FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
-          + CUSTOM_HEADERS_POSTFIX;
-
+  
   @Deprecated
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";
   public static final String FS_S3A_BLOCK_SIZE = "fs.s3a.block.size";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -852,6 +852,23 @@ public final class Constants {
       "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
           + ".signing-algorithm";
 
+  /**
+   * List of custom headers to be set on the service client.
+   * Multiple parameters can be used to specify custom headers.
+   * fs.s3a.s3.custom.headers - headers to add on all the s3 requests.
+   * fs.s3a.sts.custom.headers - headers to add on all the sts requests.
+   * Examples
+   * CustomHeader {@literal ->} 'Header1:Value1'
+   * CustomHeaders {@literal ->} 'Header1=Value1:Value2,Header2=Value1'
+   */
+  public static final String CUSTOM_HEADERS_STS =
+      "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
+          + ".custom.headers";
+
+  public static final String CUSTOM_HEADERS_S3 =
+          "fs.s3a." + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
+                  + ".custom.headers";
+
   @Deprecated
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";
   public static final String FS_S3A_BLOCK_SIZE = "fs.s3a.block.size";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -856,7 +856,7 @@ public final class Constants {
   public static final String FS_S3A_CLIENT_PREFIX = "fs.s3a.client.";
 
   /** Custom headers postfix */
-  public static final String CUSTOM_HEADER_POSTFIX = ".custom.headers";
+  public static final String CUSTOM_HEADERS_POSTFIX = ".custom.headers";
 
   /**
    * List of custom headers to be set on the service client.
@@ -869,11 +869,11 @@ public final class Constants {
    */
   public static final String CUSTOM_HEADERS_STS =
       FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_STS.toLowerCase()
-          + CUSTOM_HEADER_POSTFIX;
+          + CUSTOM_HEADERS_POSTFIX;
 
   public static final String CUSTOM_HEADERS_S3 =
       FS_S3A_CLIENT_PREFIX + Constants.AWS_SERVICE_IDENTIFIER_S3.toLowerCase()
-          + CUSTOM_HEADER_POSTFIX;
+          + CUSTOM_HEADERS_POSTFIX;
 
   @Deprecated
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1382,8 +1382,8 @@ public final class Constants {
    * fs.s3a.client.sts.custom.headers - Headers to add on all the STS requests.
    *
    * Examples:
-   * CustomHeader -> 'Header1:Value1'
-   * CustomHeaders -> 'Header1=Value1;Value2,Header2=Value1'
+   * CustomHeader {@literal ->} 'Header1:Value1'
+   * CustomHeaders {@literal ->} 'Header1=Value1;Value2,Header2=Value1'
    * </pre>
    */
   public static final String CUSTOM_HEADERS_STS =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -420,7 +420,7 @@ public final class AWSClientConfig {
   }
 
   /**
-   *
+   * Initialize custom request headers for AWS clients.
    * @param conf hadoop configuration
    * @param clientConfig client configuration to update
    * @param awsServiceIdentifier service name
@@ -436,13 +436,13 @@ public final class AWSClientConfig {
       configKey = CUSTOM_HEADERS_STS;
       break;
     default:
-      // Nothing to do. The original signer override is already setup
+      // No known service.
     }
     if (configKey != null) {
       Map<String, String> awsClientCustomHeadersMap =
               S3AUtils.getTrimmedStringCollectionSplitByEquals(conf, configKey);
       awsClientCustomHeadersMap.forEach((header, valueString) -> {
-        List<String> headerValues = Arrays.asList(valueString.split(":"));
+        List<String> headerValues = Arrays.asList(valueString.split(";"));
         clientConfig.putHeader(header, headerValues);
       });
       LOG.debug("headers for {} client = {}", awsServiceIdentifier, clientConfig.headers());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -445,6 +445,7 @@ public final class AWSClientConfig {
         List<String> headerValues = Arrays.asList(valueString.split(":"));
         clientConfig.putHeader(header, headerValues);
       });
+      LOG.debug("headers for {} client = {}", awsServiceIdentifier, clientConfig.headers());
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -450,7 +450,8 @@ public final class AWSClientConfig {
         if (!headerValues.isEmpty()) {
           clientConfig.putHeader(header, headerValues);
         } else {
-          LOG.warn("Ignoring header '{}' for {} client because no values were provided", header, awsServiceIdentifier);
+          LOG.warn("Ignoring header '{}' for {} client because no values were provided",
+                  header, awsServiceIdentifier);
         }
       });
       LOG.debug("headers for {} client = {}", awsServiceIdentifier, clientConfig.headers());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -442,8 +443,15 @@ public final class AWSClientConfig {
       Map<String, String> awsClientCustomHeadersMap =
               S3AUtils.getTrimmedStringCollectionSplitByEquals(conf, configKey);
       awsClientCustomHeadersMap.forEach((header, valueString) -> {
-        List<String> headerValues = Arrays.asList(valueString.split(";"));
-        clientConfig.putHeader(header, headerValues);
+        List<String> headerValues = Arrays.stream(valueString.split(";"))
+                        .map(String::trim)
+                        .filter(v -> !v.isEmpty())
+                        .collect(Collectors.toList());
+        if (!headerValues.isEmpty()) {
+          clientConfig.putHeader(header, headerValues);
+        } else {
+          LOG.warn("Ignoring header '{}' for {} client because no values were provided", header, awsServiceIdentifier);
+        }
       });
       LOG.debug("headers for {} client = {}", awsServiceIdentifier, clientConfig.headers());
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -429,14 +429,14 @@ public final class AWSClientConfig {
       ClientOverrideConfiguration.Builder clientConfig, String awsServiceIdentifier) {
     String configKey = null;
     switch (awsServiceIdentifier) {
-      case AWS_SERVICE_IDENTIFIER_S3:
-        configKey = CUSTOM_HEADERS_S3;
-        break;
-      case AWS_SERVICE_IDENTIFIER_STS:
-        configKey = CUSTOM_HEADERS_STS;
-        break;
-      default:
-        // Nothing to do. The original signer override is already setup
+    case AWS_SERVICE_IDENTIFIER_S3:
+      configKey = CUSTOM_HEADERS_S3;
+      break;
+    case AWS_SERVICE_IDENTIFIER_STS:
+      configKey = CUSTOM_HEADERS_STS;
+      break;
+    default:
+      // Nothing to do. The original signer override is already setup
     }
     if (configKey != null) {
       Map<String, String> awsClientCustomHeadersMap =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -76,6 +78,8 @@ import static org.apache.hadoop.fs.s3a.Constants.SIGNING_ALGORITHM_S3;
 import static org.apache.hadoop.fs.s3a.Constants.SIGNING_ALGORITHM_STS;
 import static org.apache.hadoop.fs.s3a.Constants.SOCKET_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.USER_AGENT_PREFIX;
+import static org.apache.hadoop.fs.s3a.Constants.CUSTOM_HEADERS_S3;
+import static org.apache.hadoop.fs.s3a.Constants.CUSTOM_HEADERS_STS;
 import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.enforceMinimumDuration;
 import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.getDuration;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
@@ -119,6 +123,8 @@ public final class AWSClientConfig {
     initRequestTimeout(conf, overrideConfigBuilder);
 
     initUserAgent(conf, overrideConfigBuilder);
+
+    initRequestHeaders(conf, overrideConfigBuilder, awsServiceIdentifier);
 
     String signer = conf.getTrimmed(SIGNING_ALGORITHM, "");
     if (!signer.isEmpty()) {
@@ -408,6 +414,48 @@ public final class AWSClientConfig {
         LOG.debug("Signer override for {} = {}", awsServiceIdentifier, signerOverride);
         clientConfig.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
             SignerFactory.createSigner(signerOverride, configKey));
+      }
+    }
+  }
+
+  /**
+   *
+   * @param conf hadoop configuration
+   * @param clientConfig client configuration to update
+   * @param awsServiceIdentifier service name
+   */
+  private static void initRequestHeaders(Configuration conf,
+      ClientOverrideConfiguration.Builder clientConfig, String awsServiceIdentifier) {
+    String configKey = null;
+    switch (awsServiceIdentifier) {
+      case AWS_SERVICE_IDENTIFIER_S3:
+        configKey = CUSTOM_HEADERS_S3;
+        break;
+      case AWS_SERVICE_IDENTIFIER_STS:
+        configKey = CUSTOM_HEADERS_STS;
+        break;
+      default:
+        // Nothing to do. The original signer override is already setup
+    }
+    if (configKey != null) {
+      String[] customHeaders = conf.getTrimmedStrings(configKey);
+      if (customHeaders == null || customHeaders.length == 0) {
+        LOG.debug("No custom headers specified");
+        return;
+      }
+
+      for (String customHeader : customHeaders) {
+        String[] parts = customHeader.split("=");
+        if (parts.length != 2) {
+          String message = "Invalid format (Expected header1=value1:value2,header2=value1) for Header: ["
+                          + customHeader
+                          + "]";
+          LOG.error(message);
+          throw new IllegalArgumentException(message);
+        }
+
+        List<String> values = Arrays.asList(parts[1].split(":"));
+        clientConfig.putHeader(parts[0], values);
       }
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -438,25 +439,12 @@ public final class AWSClientConfig {
         // Nothing to do. The original signer override is already setup
     }
     if (configKey != null) {
-      String[] customHeaders = conf.getTrimmedStrings(configKey);
-      if (customHeaders == null || customHeaders.length == 0) {
-        LOG.debug("No custom headers specified");
-        return;
-      }
-
-      for (String customHeader : customHeaders) {
-        String[] parts = customHeader.split("=");
-        if (parts.length != 2) {
-          String message = "Invalid format (Expected header1=value1:value2,header2=value1) for Header: ["
-                          + customHeader
-                          + "]";
-          LOG.error(message);
-          throw new IllegalArgumentException(message);
-        }
-
-        List<String> values = Arrays.asList(parts[1].split(":"));
-        clientConfig.putHeader(parts[0], values);
-      }
+      Map<String, String> awsClientCustomHeadersMap =
+              S3AUtils.getTrimmedStringCollectionSplitByEquals(conf, configKey);
+      awsClientCustomHeadersMap.forEach((header, valueString) -> {
+        List<String> headerValues = Arrays.asList(valueString.split(":"));
+        clientConfig.putHeader(header, headerValues);
+      });
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -947,6 +947,32 @@ The switch to turn S3A auditing on or off.
 </property>
 
 ```
+
+### Configuring Custom Headers for AWS Service Clients
+
+The S3A client allows users to set custom headers for specific AWS services, such as S3 and STS.
+This feature allows you to set specific headers for S3 and STS service clients independently.
+
+**Configuration Properties:**
+- `fs.s3a.client.s3.custom.headers`: Custom headers for S3 service requests.
+- `fs.s3a.client.sts.custom.headers`: Sets custom headers for all requests to AWS STS.
+
+**Header Format:**
+Custom headers should be specified as key-value pairs, separated by `=`. Multiple values for a single header can be separated by `;`. Multiple headers can be separated by `,`.
+
+
+```xml
+<property>
+    <name>fs.s3a.client.s3.custom.headers</name>
+    <value>Header1=Value1</value>
+</property>
+
+<property>
+<name>fs.s3a.client.sts.custom.headers</name>
+<value>Header1=Value1;Value2,Header2=Value1</value>
+</property>
+```
+
 ## <a name="retry_and_recovery"></a>Retry and Recovery
 
 The S3A client makes a best-effort attempt at recovering from network failures;

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -950,8 +950,7 @@ The switch to turn S3A auditing on or off.
 
 ### Configuring Custom Headers for AWS Service Clients
 
-The S3A client allows users to set custom headers for specific AWS services, such as S3 and STS.
-This feature allows you to set specific headers for S3 and STS service clients independently.
+You can set custom headers for S3 and STS requests. These headers are set on client level, and will be sent for all requests made to these services.
 
 **Configuration Properties:**
 - `fs.s3a.client.s3.custom.headers`: Custom headers for S3 service requests.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -221,18 +221,22 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
             .describedAs("Custom client headers for s3 %s", CUSTOM_HEADERS_S3)
             .isNull();
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().size())
-            .describedAs("Count of S3 client headers")
-            .isEqualTo(0);
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().size())
-            .describedAs("Count of STS client headers")
-            .isEqualTo(2);
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().get("foo"))
-            .describedAs("STS client 'foo' header value")
-            .isEqualTo(Lists.newArrayList("bar", "baz"));
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().get("qux"))
-            .describedAs("STS client 'qux' header value")
-            .isEqualTo(Lists.newArrayList("quux"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+            .headers().size())
+        .describedAs("Count of S3 client headers")
+        .isEqualTo(0);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+            .headers().size())
+        .describedAs("Count of STS client headers")
+        .isEqualTo(2);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+            .headers().get("foo"))
+        .describedAs("STS client 'foo' header value")
+        .isEqualTo(Lists.newArrayList("bar", "baz"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+            .headers().get("qux"))
+        .describedAs("STS client 'qux' header value")
+        .isEqualTo(Lists.newArrayList("quux"));
   }
 
   /**
@@ -247,17 +251,21 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
             .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
             .isNull();
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().size())
-            .describedAs("Count of STS client headers")
-            .isEqualTo(0);
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().size())
-            .describedAs("Count of S3 client headers")
-            .isEqualTo(2);
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().get("foo"))
-            .describedAs("S3 client 'foo' header value")
-            .isEqualTo(Lists.newArrayList("bar", "baz"));
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().get("qux"))
-            .describedAs("S3 client 'qux' header value")
-            .isEqualTo(Lists.newArrayList("quux"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+            .headers().size())
+        .describedAs("Count of STS client headers")
+        .isEqualTo(0);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+            .headers().size())
+        .describedAs("Count of S3 client headers")
+        .isEqualTo(2);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+            .headers().get("foo"))
+        .describedAs("S3 client 'foo' header value")
+        .isEqualTo(Lists.newArrayList("bar", "baz"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+            .headers().get("qux"))
+        .describedAs("S3 client 'qux' header value")
+        .isEqualTo(Lists.newArrayList("quux"));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 
-import org.apache.hadoop.util.Lists;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
@@ -31,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
+import org.apache.hadoop.util.Lists;
 
 import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_STS;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.fs.s3a.impl;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 
+import org.apache.hadoop.util.Lists;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
@@ -30,10 +32,14 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 
+import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_STS;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_ACQUISITION_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_IDLE_TIME;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_KEEPALIVE;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_TTL;
+import static org.apache.hadoop.fs.s3a.Constants.CUSTOM_HEADERS_S3;
+import static org.apache.hadoop.fs.s3a.Constants.CUSTOM_HEADERS_STS;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_IDLE_TIME_DURATION;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_CONNECTION_KEEPALIVE;
@@ -48,6 +54,7 @@ import static org.apache.hadoop.fs.s3a.Constants.MINIMUM_NETWORK_OPERATION_DURAT
 import static org.apache.hadoop.fs.s3a.Constants.REQUEST_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.SOCKET_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createApiConnectionSettings;
+import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createClientConfigBuilder;
 import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.createConnectionSettings;
 import static org.apache.hadoop.fs.s3a.impl.ConfigurationHelper.enforceMinimumDuration;
 
@@ -200,5 +207,57 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
    */
   private void setOptionsToValue(String value, Configuration conf, String... keys) {
     Arrays.stream(keys).forEach(key -> conf.set(key, value));
+  }
+
+  /**
+   * if {@link org.apache.hadoop.fs.s3a.Constants#CUSTOM_HEADERS_STS} is set,
+   * verify that returned client configuration has desired headers set.
+   */
+  @Test
+  public void testInitRequestHeadersForSTS() throws IOException {
+    final Configuration conf = new Configuration();
+    conf.set(CUSTOM_HEADERS_STS, "foo=bar:baz,qux=quux");
+    Assertions.assertThat(conf.get(CUSTOM_HEADERS_S3))
+            .describedAs("Custom client headers for s3 %s", CUSTOM_HEADERS_S3)
+            .isNull();
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().size())
+            .describedAs("Count of S3 client headers")
+            .isEqualTo(0);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().size())
+            .describedAs("Count of STS client headers")
+            .isEqualTo(2);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().get("foo"))
+            .describedAs("STS client 'foo' header value")
+            .isEqualTo(Lists.newArrayList("bar", "baz"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().get("qux"))
+            .describedAs("STS client 'qux' header value")
+            .isEqualTo(Lists.newArrayList("quux"));
+  }
+
+  /**
+   * if {@link org.apache.hadoop.fs.s3a.Constants#CUSTOM_HEADERS_S3} is set,
+   * verify that returned client configuration has desired headers set.
+   */
+  @Test
+  public void testInitRequestHeadersForS3() throws IOException {
+    final Configuration conf = new Configuration();
+    conf.set(CUSTOM_HEADERS_S3, "foo=bar:baz,qux=quux");
+    Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
+            .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
+            .isNull();
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS).headers().size())
+            .describedAs("Count of STS client headers")
+            .isEqualTo(0);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().size())
+            .describedAs("Count of S3 client headers")
+            .isEqualTo(2);
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().get("foo"))
+            .describedAs("S3 client 'foo' header value")
+            .isEqualTo(Lists.newArrayList("bar", "baz"));
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3).headers().get("qux"))
+            .describedAs("S3 client 'qux' header value")
+            .isEqualTo(Lists.newArrayList("quux"));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -216,7 +216,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   @Test
   public void testInitRequestHeadersForSTS() throws IOException {
     final Configuration conf = new Configuration();
-    conf.set(CUSTOM_HEADERS_STS, "foo=bar:baz,qux=quux");
+    conf.set(CUSTOM_HEADERS_STS, "foo=bar;baz,qux=quux");
     Assertions.assertThat(conf.get(CUSTOM_HEADERS_S3))
             .describedAs("Custom client headers for s3 %s", CUSTOM_HEADERS_S3)
             .isNull();
@@ -246,7 +246,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   @Test
   public void testInitRequestHeadersForS3() throws IOException {
     final Configuration conf = new Configuration();
-    conf.set(CUSTOM_HEADERS_S3, "foo=bar:baz,qux=quux");
+    conf.set(CUSTOM_HEADERS_S3, "foo=bar;baz,qux=quux");
     Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
             .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
             .isNull();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -216,7 +216,8 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   @Test
   public void testInitRequestHeadersForSTS() throws IOException {
     final Configuration conf = new Configuration();
-    conf.set(CUSTOM_HEADERS_STS, "foo=bar;baz,qux=quux");
+    conf.set(CUSTOM_HEADERS_STS, "header1=value1;value2,header2=value3");
+
     Assertions.assertThat(conf.get(CUSTOM_HEADERS_S3))
             .describedAs("Custom client headers for s3 %s", CUSTOM_HEADERS_S3)
             .isNull();
@@ -225,18 +226,21 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
             .headers().size())
         .describedAs("Count of S3 client headers")
         .isEqualTo(0);
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
             .headers().size())
         .describedAs("Count of STS client headers")
         .isEqualTo(2);
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
-            .headers().get("foo"))
-        .describedAs("STS client 'foo' header value")
-        .isEqualTo(Lists.newArrayList("bar", "baz"));
+            .headers().get("header1"))
+        .describedAs("STS client 'header1' header value")
+        .isEqualTo(Lists.newArrayList("value1", "value2"));
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
-            .headers().get("qux"))
-        .describedAs("STS client 'qux' header value")
-        .isEqualTo(Lists.newArrayList("quux"));
+            .headers().get("header2"))
+        .describedAs("STS client 'header2' header value")
+        .isEqualTo(Lists.newArrayList("value3"));
   }
 
   /**
@@ -246,7 +250,8 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
   @Test
   public void testInitRequestHeadersForS3() throws IOException {
     final Configuration conf = new Configuration();
-    conf.set(CUSTOM_HEADERS_S3, "foo=bar;baz,qux=quux");
+    conf.set(CUSTOM_HEADERS_S3, "header1=value1;value2,header2=value3");
+
     Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
             .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
             .isNull();
@@ -255,17 +260,69 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
             .headers().size())
         .describedAs("Count of STS client headers")
         .isEqualTo(0);
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
             .headers().size())
         .describedAs("Count of S3 client headers")
         .isEqualTo(2);
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
-            .headers().get("foo"))
-        .describedAs("S3 client 'foo' header value")
-        .isEqualTo(Lists.newArrayList("bar", "baz"));
+            .headers().get("header1"))
+        .describedAs("S3 client 'header1' header value")
+        .isEqualTo(Lists.newArrayList("value1", "value2"));
+
     Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
-            .headers().get("qux"))
-        .describedAs("S3 client 'qux' header value")
-        .isEqualTo(Lists.newArrayList("quux"));
+            .headers().get("header2"))
+        .describedAs("S3 client 'header2' header value")
+        .isEqualTo(Lists.newArrayList("value3"));
+  }
+
+  /**
+   * if {@link org.apache.hadoop.fs.s3a.Constants#CUSTOM_HEADERS_S3} is set,
+   * verify that returned client configuration has desired headers set with whitespaces trimmed for headers and values.
+   */
+  @Test
+  public void testInitRequestHeadersForS3WithWhitespace() throws IOException {
+    final Configuration conf = new Configuration();
+    conf.set(CUSTOM_HEADERS_S3, "  header1 =  value1 ;  value2 ,   header2= value3  ");
+
+    Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
+            .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
+            .isNull();
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+                    .headers().size())
+            .describedAs("Count of STS client headers")
+            .isEqualTo(0);
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+                    .headers().size())
+            .describedAs("Count of S3 client headers")
+            .isEqualTo(2);
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+                    .headers().get("header1"))
+            .describedAs("S3 client 'header1' header value")
+            .isEqualTo(Lists.newArrayList("value1", "value2"));
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+                    .headers().get("header2"))
+            .describedAs("S3 client 'header2' header value")
+            .isEqualTo(Lists.newArrayList("value3"));
+  }
+
+  /**
+   * if {@link org.apache.hadoop.fs.s3a.Constants#CUSTOM_HEADERS_S3} is set with duplicate values,
+   * verify that returned client configuration has desired headers with both values.
+   */
+  @Test
+  public void testInitRequestHeadersForS3WithDuplicateValues() throws IOException {
+    Configuration conf = new Configuration();
+    conf.set(CUSTOM_HEADERS_S3, "header1=duplicate;duplicate");
+
+    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+                    .headers().get("header1"))
+            .describedAs("S3 client 'header1' header value")
+            .isEqualTo(Lists.newArrayList("duplicate", "duplicate"));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -279,7 +279,8 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
 
   /**
    * if {@link org.apache.hadoop.fs.s3a.Constants#CUSTOM_HEADERS_S3} is set,
-   * verify that returned client configuration has desired headers set with whitespaces trimmed for headers and values.
+   * verify that returned client configuration has desired headers set with
+   * whitespaces trimmed for headers and values.
    */
   @Test
   public void testInitRequestHeadersForS3WithWhitespace() throws IOException {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

- Continues work on https://github.com/apache/hadoop/pull/6550
- Addressed the review comments and added updates to the Javadoc and documentation for s3a custom headers. 

Description of original PR: 
```
Support to add custom headers to s3a s3 and sts client
Introducing new custom.headers config for each client type, Upon setting this header each s3/sts request will set these custom headers by setting overrideClientConfig on clients

"fs.s3a.client.sts.custom.headers" = "Header1:Value1:Value2,Header2:Value1"
"fs.s3a.client.s3.custom.headers" = "Header1:Value1:Value2,Header2:Value1"
```

### How was this patch tested?
Ran integ tests using `mvn -Dparallel-tests -DtestsThreadCount=8 clean verify` for a bucket in us-west-2
UTs added which succeeded as well


### For code changes:

- [ Y ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ Y ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ N/A ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

