### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part1.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestListFilesInDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestListFilesInDFS.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdfs;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TestListFiles;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * This class tests the FileStatus API.
@@ -29,7 +29,7 @@ public class TestListFilesInDFS extends TestListFiles {
 
   private static MiniDFSCluster cluster;
 
-  @BeforeClass
+  @BeforeAll
   public static void testSetUp() throws Exception {
     setTestPaths(new Path("/tmp/TestListFilesInDFS"));
     cluster = new MiniDFSCluster.Builder(conf).build();
@@ -37,7 +37,7 @@ public class TestListFilesInDFS extends TestListFiles {
     fs.delete(TEST_DIR, true);
   }
   
-  @AfterClass
+  @AfterAll
   public static void testShutdown() throws Exception {
     if (cluster != null) {
       fs.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/crypto/TestHdfsCryptoStreams.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/crypto/TestHdfsCryptoStreams.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.fs.crypto.CryptoFSDataOutputStream;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestHdfsCryptoStreams extends CryptoStreamsTestBase {
   private static MiniDFSCluster dfsCluster;
@@ -43,7 +43,7 @@ public class TestHdfsCryptoStreams extends CryptoStreamsTestBase {
   private static Path path;
   private static Path file;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     Configuration conf = new HdfsConfiguration();
     dfsCluster = new MiniDFSCluster.Builder(conf).build();
@@ -52,14 +52,14 @@ public class TestHdfsCryptoStreams extends CryptoStreamsTestBase {
     codec = CryptoCodec.getInstance(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws Exception {
     if (dfsCluster != null) {
       dfsCluster.shutdown();
     }
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws IOException {
     ++pathCount;
@@ -70,7 +70,7 @@ public class TestHdfsCryptoStreams extends CryptoStreamsTestBase {
     super.setUp();
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     fs.delete(path, true);
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part1.

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

