### PR TITLE
YARN-11762. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-globalpolicygenerator.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGPGPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGPGPolicyFacade.java
@@ -45,10 +45,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
 import java.util.List;
@@ -84,7 +84,7 @@ public class TestGPGPolicyFacade {
     facade = FederationStateStoreFacade.getInstance(conf);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException {
     stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
@@ -103,7 +103,7 @@ public class TestGPGPolicyFacade {
         .newInstance(testConf));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     stateStore.close();
     stateStore = null;
@@ -114,7 +114,7 @@ public class TestGPGPolicyFacade {
     WeightedLocalityPolicyManager manager =
         (WeightedLocalityPolicyManager) policyFacade
             .getPolicyManager(TEST_QUEUE);
-    Assert.assertEquals(testConf, manager.serializeConf());
+    Assertions.assertEquals(testConf, manager.serializeConf());
   }
 
   /**
@@ -135,7 +135,7 @@ public class TestGPGPolicyFacade {
     manager =
         (WeightedLocalityPolicyManager) policyFacade
             .getPolicyManager(TEST_QUEUE + 0);
-    Assert.assertEquals(policyConf, manager.serializeConf());
+    Assertions.assertEquals(policyConf, manager.serializeConf());
   }
 
   /**
@@ -157,7 +157,7 @@ public class TestGPGPolicyFacade {
     manager =
         (WeightedLocalityPolicyManager) policyFacade
             .getPolicyManager(TEST_QUEUE);
-    Assert.assertEquals(policyConf, manager.serializeConf());
+    Assertions.assertEquals(policyConf, manager.serializeConf());
   }
 
   /**
@@ -243,28 +243,28 @@ public class TestGPGPolicyFacade {
     facade.reinitialize(stateStore, conf);
     policyFacade = new GPGPolicyFacade(facade, conf);
     FederationPolicyManager policyManager = policyFacade.getPolicyManager("root.a");
-    Assert.assertNotNull(policyManager);
-    Assert.assertTrue(policyManager.isSupportWeightedPolicyInfo());
+    Assertions.assertNotNull(policyManager);
+    Assertions.assertTrue(policyManager.isSupportWeightedPolicyInfo());
     WeightedPolicyInfo weightedPolicyInfo1 = policyManager.getWeightedPolicyInfo();
-    Assert.assertNotNull(weightedPolicyInfo1);
-    Assert.assertTrue(policyManager instanceof WeightedLocalityPolicyManager);
+    Assertions.assertNotNull(weightedPolicyInfo1);
+    Assertions.assertTrue(policyManager instanceof WeightedLocalityPolicyManager);
 
     // Step4. Confirm amrmPolicyWeight is accurate.
     Map<SubClusterIdInfo, Float> amrmPolicyWeights1 = weightedPolicyInfo1.getAMRMPolicyWeights();
-    Assert.assertNotNull(amrmPolicyWeights1);
+    Assertions.assertNotNull(amrmPolicyWeights1);
     Float sc1Float = amrmPolicyWeights1.get(new SubClusterIdInfo("SC-1"));
     Float sc2Float = amrmPolicyWeights1.get(new SubClusterIdInfo("SC-2"));
-    Assert.assertEquals(0.7, sc1Float, 0.001);
-    Assert.assertEquals(0.3, sc2Float, 0.001);
+    Assertions.assertEquals(0.7, sc1Float, 0.001);
+    Assertions.assertEquals(0.3, sc2Float, 0.001);
 
     // Step5. Confirm amrmPolicyWeight is accurate.
     Map<SubClusterIdInfo, Float> routerPolicyWeights1 =
         weightedPolicyInfo1.getRouterPolicyWeights();
-    Assert.assertNotNull(routerPolicyWeights1);
+    Assertions.assertNotNull(routerPolicyWeights1);
     Float sc1Float1 = routerPolicyWeights1.get(new SubClusterIdInfo("SC-1"));
     Float sc2Float2 = routerPolicyWeights1.get(new SubClusterIdInfo("SC-2"));
-    Assert.assertEquals(0.6, sc1Float1, 0.001);
-    Assert.assertEquals(0.4, sc2Float2, 0.001);
+    Assertions.assertEquals(0.6, sc1Float1, 0.001);
+    Assertions.assertEquals(0.4, sc2Float2, 0.001);
   }
 
   @Test
@@ -294,24 +294,24 @@ public class TestGPGPolicyFacade {
     facade.reinitialize(stateStore, conf);
     policyFacade = new GPGPolicyFacade(facade, conf);
     FederationPolicyManager policyManager = policyFacade.getPolicyManager("root.b");
-    Assert.assertNotNull(policyManager);
-    Assert.assertTrue(policyManager.isSupportWeightedPolicyInfo());
+    Assertions.assertNotNull(policyManager);
+    Assertions.assertTrue(policyManager.isSupportWeightedPolicyInfo());
     WeightedPolicyInfo weightedPolicyInfo1 = policyManager.getWeightedPolicyInfo();
-    Assert.assertNotNull(weightedPolicyInfo1);
+    Assertions.assertNotNull(weightedPolicyInfo1);
 
     // Step4. Confirm amrmPolicyWeight is accurate.
     Map<SubClusterIdInfo, Float> amrmPolicyWeights1 = weightedPolicyInfo1.getAMRMPolicyWeights();
-    Assert.assertNotNull(amrmPolicyWeights1);
-    Assert.assertEquals(0, amrmPolicyWeights1.size());
+    Assertions.assertNotNull(amrmPolicyWeights1);
+    Assertions.assertEquals(0, amrmPolicyWeights1.size());
 
     // Step5. Confirm amrmPolicyWeight is accurate.
     Map<SubClusterIdInfo, Float> routerPolicyWeights1 =
         weightedPolicyInfo1.getRouterPolicyWeights();
-    Assert.assertNotNull(routerPolicyWeights1);
+    Assertions.assertNotNull(routerPolicyWeights1);
     Float sc1Float1 = routerPolicyWeights1.get(new SubClusterIdInfo("SC-1"));
     Float sc2Float2 = routerPolicyWeights1.get(new SubClusterIdInfo("SC-2"));
-    Assert.assertEquals(0.8, sc1Float1, 0.001);
-    Assert.assertEquals(0.2, sc2Float2, 0.001);
+    Assertions.assertEquals(0.8, sc1Float1, 0.001);
+    Assertions.assertEquals(0.2, sc2Float2, 0.001);
   }
 
   @Test
@@ -343,8 +343,8 @@ public class TestGPGPolicyFacade {
       facade.reinitialize(stateStore, conf);
       policyFacade = new GPGPolicyFacade(facade, conf);
       FederationPolicyManager policyManager = policyFacade.getPolicyManager("root.c");
-      Assert.assertNotNull(policyManager);
-      Assert.assertFalse(policyManager.isSupportWeightedPolicyInfo());
+      Assertions.assertNotNull(policyManager);
+      Assertions.assertFalse(policyManager.isSupportWeightedPolicyInfo());
       String policyManagerTypeSimple = policyManagerType.replace(prefix, "");
       // Verify that PolicyManager is initialized successfully,
       // but getWeightedPolicyInfo is not supported.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/TestGlobalPolicyGenerator.java
@@ -24,21 +24,23 @@ import org.apache.hadoop.service.Service;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for GlobalPolicyGenerator.
  */
 public class TestGlobalPolicyGenerator {
 
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(value = 1)
   public void testNonFederation() {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.FEDERATION_ENABLED, false);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/applicationcleaner/TestDefaultApplicationCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/applicationcleaner/TestDefaultApplicationCleaner.java
@@ -43,10 +43,10 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationRegistryClient;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GPGContext;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GPGContextImpl;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for DefaultApplicationCleaner in GPG.
@@ -66,7 +66,7 @@ public class TestDefaultApplicationCleaner {
 
   private ApplicationId appIdToAddConcurrently;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new YarnConfiguration();
 
@@ -86,7 +86,7 @@ public class TestDefaultApplicationCleaner {
     UserGroupInformation user = UserGroupInformation.getCurrentUser();
     registryClient = new FederationRegistryClient(conf, registry, user);
     registryClient.cleanAllApplications();
-    Assert.assertEquals(0, registryClient.getAllApplications().size());
+    Assertions.assertEquals(0, registryClient.getAllApplications().size());
 
     gpgContext = new GPGContextImpl();
     gpgContext.setStateStoreFacade(facade);
@@ -113,11 +113,11 @@ public class TestDefaultApplicationCleaner {
       registryClient.writeAMRMTokenForUAM(appId, subClusterId.toString(),
           new Token<AMRMTokenIdentifier>());
     }
-    Assert.assertEquals(3, registryClient.getAllApplications().size());
+    Assertions.assertEquals(3, registryClient.getAllApplications().size());
     appIdToAddConcurrently = null;
   }
 
-  @After
+  @AfterEach
   public void breakDown() {
     if (stateStore != null) {
       stateStore.close();
@@ -146,14 +146,14 @@ public class TestDefaultApplicationCleaner {
     appCleaner.run();
 
     // Only one app should be left
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         stateStore
             .getApplicationsHomeSubCluster(
                 GetApplicationsHomeSubClusterRequest.newInstance())
             .getAppsHomeSubClusters().size());
 
     // The known app should not be cleaned in registry
-    Assert.assertEquals(1, registryClient.getAllApplications().size());
+    Assertions.assertEquals(1, registryClient.getAllApplications().size());
   }
 
   /**
@@ -192,13 +192,13 @@ public class TestDefaultApplicationCleaner {
          GetApplicationsHomeSubClusterRequest.newInstance();
     GetApplicationsHomeSubClusterResponse applicationsHomeSubCluster =
         stateStore.getApplicationsHomeSubCluster(appHomeSubClusterRequest);
-    Assert.assertNotNull(applicationsHomeSubCluster);
+    Assertions.assertNotNull(applicationsHomeSubCluster);
     List<ApplicationHomeSubCluster> appsHomeSubClusters =
         applicationsHomeSubCluster.getAppsHomeSubClusters();
-    Assert.assertNotNull(appsHomeSubClusters);
-    Assert.assertEquals(1, appsHomeSubClusters.size());
+    Assertions.assertNotNull(appsHomeSubClusters);
+    Assertions.assertEquals(1, appsHomeSubClusters.size());
 
     // The concurrently added app should be still there
-    Assert.assertEquals(1, registryClient.getAllApplications().size());
+    Assertions.assertEquals(1, registryClient.getAllApplications().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestLoadBasedGlobalPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestLoadBasedGlobalPolicy.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ClusterMetricsInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +38,8 @@ import static org.apache.hadoop.yarn.conf.YarnConfiguration.FEDERATION_GPG_LOAD_
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.FEDERATION_GPG_LOAD_BASED_MIN_WEIGHT;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.FEDERATION_GPG_LOAD_BASED_SCALING;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_FEDERATION_GPG_LOAD_BASED_SCALING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for the Load Based Global Policy.
@@ -66,7 +66,7 @@ public class TestLoadBasedGlobalPolicy {
     policyGenerator = new LoadBasedGlobalPolicy();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
 
     conf.setInt(FEDERATION_GPG_LOAD_BASED_MAX_EDIT, 2);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestPolicyGenerator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/policygenerator/TestPolicyGenerator.java
@@ -53,10 +53,10 @@ import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 import org.glassfish.jersey.jettison.JettisonConfig;
 import org.glassfish.jersey.jettison.JettisonJaxbContext;
 import org.glassfish.jersey.jettison.JettisonUnmarshaller;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import javax.xml.bind.JAXBException;
@@ -71,7 +71,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -108,7 +108,7 @@ public class TestPolicyGenerator {
     gpgContext.setStateStoreFacade(facade);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, YarnException, JAXBException {
     subClusterIds = new ArrayList<>();
     subClusterInfos = new HashMap<>();
@@ -155,7 +155,7 @@ public class TestPolicyGenerator {
     facade.reinitialize(stateStore, conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     stateStore.close();
     stateStore = null;
@@ -299,53 +299,53 @@ public class TestPolicyGenerator {
     SchedulerTypeInfo sti = GPGUtils.invokeRMWebService(webAppAddress, RMWSConsts.SCHEDULER,
         SchedulerTypeInfo.class, conf);
 
-    Assert.assertNotNull(sti);
+    Assertions.assertNotNull(sti);
     SchedulerInfo schedulerInfo = sti.getSchedulerInfo();
-    Assert.assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
+    Assertions.assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
 
     CapacitySchedulerInfo capacitySchedulerInfo = (CapacitySchedulerInfo) schedulerInfo;
-    Assert.assertNotNull(capacitySchedulerInfo);
+    Assertions.assertNotNull(capacitySchedulerInfo);
 
     CapacitySchedulerQueueInfoList queues = capacitySchedulerInfo.getQueues();
-    Assert.assertNotNull(queues);
+    Assertions.assertNotNull(queues);
     ArrayList<CapacitySchedulerQueueInfo> queueInfoList = queues.getQueueInfoList();
-    Assert.assertNotNull(queueInfoList);
-    Assert.assertEquals(2, queueInfoList.size());
+    Assertions.assertNotNull(queueInfoList);
+    Assertions.assertEquals(2, queueInfoList.size());
 
     CapacitySchedulerQueueInfo queueA = queueInfoList.get(0);
-    Assert.assertNotNull(queueA);
-    Assert.assertEquals("root.a", queueA.getQueuePath());
-    Assert.assertEquals(10.5f, queueA.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueA);
+    Assertions.assertEquals("root.a", queueA.getQueuePath());
+    Assertions.assertEquals(10.5f, queueA.getCapacity(), 0.00001);
     CapacitySchedulerQueueInfoList queueAQueues = queueA.getQueues();
-    Assert.assertNotNull(queueAQueues);
+    Assertions.assertNotNull(queueAQueues);
     ArrayList<CapacitySchedulerQueueInfo> queueInfoAList = queueAQueues.getQueueInfoList();
-    Assert.assertNotNull(queueInfoAList);
-    Assert.assertEquals(2, queueInfoAList.size());
+    Assertions.assertNotNull(queueInfoAList);
+    Assertions.assertEquals(2, queueInfoAList.size());
     CapacitySchedulerQueueInfo queueA1 = queueInfoAList.get(0);
-    Assert.assertNotNull(queueA1);
-    Assert.assertEquals(30f, queueA1.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueA1);
+    Assertions.assertEquals(30f, queueA1.getCapacity(), 0.00001);
     CapacitySchedulerQueueInfo queueA2 = queueInfoAList.get(1);
-    Assert.assertNotNull(queueA2);
-    Assert.assertEquals(70f, queueA2.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueA2);
+    Assertions.assertEquals(70f, queueA2.getCapacity(), 0.00001);
 
     CapacitySchedulerQueueInfo queueB = queueInfoList.get(1);
-    Assert.assertNotNull(queueB);
-    Assert.assertEquals("root.b", queueB.getQueuePath());
-    Assert.assertEquals(89.5f, queueB.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueB);
+    Assertions.assertEquals("root.b", queueB.getQueuePath());
+    Assertions.assertEquals(89.5f, queueB.getCapacity(), 0.00001);
     CapacitySchedulerQueueInfoList queueBQueues = queueB.getQueues();
-    Assert.assertNotNull(queueBQueues);
+    Assertions.assertNotNull(queueBQueues);
     ArrayList<CapacitySchedulerQueueInfo> queueInfoBList = queueBQueues.getQueueInfoList();
-    Assert.assertNotNull(queueInfoBList);
-    Assert.assertEquals(3, queueInfoBList.size());
+    Assertions.assertNotNull(queueInfoBList);
+    Assertions.assertEquals(3, queueInfoBList.size());
     CapacitySchedulerQueueInfo queueB1 = queueInfoBList.get(0);
-    Assert.assertNotNull(queueB1);
-    Assert.assertEquals(79.2f, queueB1.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueB1);
+    Assertions.assertEquals(79.2f, queueB1.getCapacity(), 0.00001);
     CapacitySchedulerQueueInfo queueB2 = queueInfoBList.get(1);
-    Assert.assertNotNull(queueB2);
-    Assert.assertEquals(0.8f, queueB2.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueB2);
+    Assertions.assertEquals(0.8f, queueB2.getCapacity(), 0.00001);
     CapacitySchedulerQueueInfo queueB3 = queueInfoBList.get(2);
-    Assert.assertNotNull(queueB3);
-    Assert.assertEquals(20f, queueB3.getCapacity(), 0.00001);
+    Assertions.assertNotNull(queueB3);
+    Assertions.assertEquals(20f, queueB3.getCapacity(), 0.00001);
   }
 
   private String getServiceAddress(InetSocketAddress address) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/AbstractGlobalPolicyGeneratorTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/AbstractGlobalPolicyGeneratorTest.java
@@ -28,16 +28,16 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GlobalPolicyGenerator;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Properties;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractGlobalPolicyGeneratorTest {
 
@@ -67,7 +67,7 @@ public abstract class AbstractGlobalPolicyGeneratorTest {
   private static Configuration conf;
   private GlobalPolicyGenerator gpg;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeSecureRouterTestClass() throws Exception {
     // Sets up the KDC and Principals.
     setupKDCAndPrincipals();
@@ -116,9 +116,9 @@ public abstract class AbstractGlobalPolicyGeneratorTest {
    * @throws Exception an error occurred.
    */
   public static File createKeytab(String principal, String filename) throws Exception {
-    assertTrue("empty principal", StringUtils.isNotBlank(principal));
-    assertTrue("empty host", StringUtils.isNotBlank(filename));
-    assertNotNull("null KDC", kdc);
+    assertTrue(StringUtils.isNotBlank(principal), "empty principal");
+    assertTrue(StringUtils.isNotBlank(filename), "empty host");
+    assertNotNull(kdc, "null KDC");
     File keytab = new File(kdcWorkDir, filename);
     kdc.createPrincipal(keytab,
         principal,
@@ -133,7 +133,7 @@ public abstract class AbstractGlobalPolicyGeneratorTest {
    * @throws Exception an error occurred.
    */
   public synchronized void startSecureGPG() {
-    assertNull("GPG is already running", gpg);
+    assertNull(gpg, "GPG is already running");
     MemoryFederationStateStore stateStore = new MemoryFederationStateStore();
     stateStore.init(conf);
     FederationStateStoreFacade.getInstance(conf).reinitialize(stateStore, conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/TestGpgSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/secure/TestGpgSecureLogins.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.yarn.server.globalpolicygenerator.secure;
 
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GPGContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +28,7 @@ public class TestGpgSecureLogins extends AbstractGlobalPolicyGeneratorTest {
 
   @Test
   public void testHasRealm() throws Throwable {
-    Assert.assertNotNull(getRealm());
+    Assertions.assertNotNull(getRealm());
     LOG.info("Router principal = {}", getPrincipalAndRealm(GPG_LOCALHOST));
   }
 
@@ -36,7 +36,7 @@ public class TestGpgSecureLogins extends AbstractGlobalPolicyGeneratorTest {
   public void testRouterSecureLogin() throws Exception {
     startSecureGPG();
     GPGContext gpgContext = this.getGpg().getGPGContext();
-    Assert.assertNotNull(gpgContext);
+    Assertions.assertNotNull(gpgContext);
     stopSecureRouter();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/subclustercleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/subclustercleaner/TestSubClusterCleaner.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GPGContext;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GPGContextImpl;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for Sub-cluster Cleaner in GPG.
@@ -53,7 +53,7 @@ public class TestSubClusterCleaner {
 
   private ArrayList<SubClusterId> subClusterIds;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
     conf = new YarnConfiguration();
 
@@ -89,7 +89,7 @@ public class TestSubClusterCleaner {
     }
   }
 
-  @After
+  @AfterEach
   public void breakDown() throws Exception {
     stateStore.close();
   }
@@ -97,7 +97,7 @@ public class TestSubClusterCleaner {
   @Test
   public void testSubClusterRegisterHeartBeatTime() throws YarnException {
     cleaner.run();
-    Assert.assertEquals(3, facade.getSubClusters(true, true).size());
+    Assertions.assertEquals(3, facade.getSubClusters(true, true).size());
   }
 
   /**
@@ -116,6 +116,6 @@ public class TestSubClusterCleaner {
         System.currentTimeMillis() - TWO_SECONDS);
 
     cleaner.run();
-    Assert.assertEquals(1, facade.getSubClusters(true, true).size());
+    Assertions.assertEquals(1, facade.getSubClusters(true, true).size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/TestGPGWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/TestGPGWebApp.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.globalpolicygenerator.GlobalPolicyGenerator;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/TestGPGWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/src/test/java/org/apache/hadoop/yarn/server/globalpolicygenerator/webapp/TestGPGWebServices.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -36,7 +36,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 public class TestGPGWebServices extends JerseyTestBase {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11762. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-globalpolicygenerator.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

