### PR TITLE
YARN-11263. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-nodemanager Part1.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -105,13 +105,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+       <groupId>org.junit.vintage</groupId>
+       <artifactId>junit-vintage-engine</artifactId>
+       <scope>test</scope>
     </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestContainerManagerWithLCE.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestContainerManagerWithLCE.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.yarn.server.nodemanager;
 
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +31,8 @@ import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.TestContainerManager;
-import org.junit.After;
-import org.junit.Assume;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestContainerManagerWithLCE extends TestContainerManager {
 
@@ -49,10 +52,10 @@ public class TestContainerManagerWithLCE extends TestContainerManager {
         TestContainerManagerWithLCE.class.getName() + "-tmpDir");
   }
 
+  @BeforeEach
   @Override
   public void setup() throws IOException {
-    Assume.assumeTrue("LCE binary path is not passed. Not running the test",
-        shouldRunTest());
+    assumeTrue(shouldRunTest(), "LCE binary path is not passed. Not running the test");
     super.setup();
     localFS.setPermission(new Path(localDir.getCanonicalPath()),
         new FsPermission(
@@ -62,7 +65,7 @@ public class TestContainerManagerWithLCE extends TestContainerManager {
             (short) 0777));
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws IOException, InterruptedException {
     if (shouldRunTest()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/BaseAMRMProxyTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/BaseAMRMProxyTest.java
@@ -69,9 +69,8 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerIn
 import org.apache.hadoop.yarn.server.nodemanager.timelineservice.NMTimelinePublisher;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +88,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Base class for all the AMRMProxyService test cases. It provides utility
@@ -108,16 +111,16 @@ public abstract class BaseAMRMProxyTest {
   private Context nmContext;
 
   protected MockAMRMProxyService getAMRMProxyService() {
-    Assert.assertNotNull(this.amrmProxyService);
+    assertNotNull(this.amrmProxyService);
     return this.amrmProxyService;
   }
 
   protected Context getNMContext() {
-    Assert.assertNotNull(this.nmContext);
+    assertNotNull(this.nmContext);
     return this.nmContext;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.conf = createConfiguration();
     this.dispatcher = new AsyncDispatcher();
@@ -144,7 +147,7 @@ public abstract class BaseAMRMProxyTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     this.amrmProxyService.stop();
     this.amrmProxyService = null;
@@ -311,8 +314,8 @@ public abstract class BaseAMRMProxyTest {
               int index = testContexts.indexOf(testContext);
               response = new RegisterApplicationMasterResponseInfo<>(
                   registerApplicationMaster(index), testContext);
-              Assert.assertNotNull(response.getResponse());
-              Assert.assertEquals(Integer.toString(index), response.getResponse().getQueue());
+              assertNotNull(response.getResponse());
+              assertEquals(Integer.toString(index), response.getResponse().getQueue());
 
               LOG.info("Successfully registered application master with test context: {}.",
                   testContext);
@@ -325,8 +328,8 @@ public abstract class BaseAMRMProxyTest {
             return response;
           });
 
-    Assert.assertEquals("Number of responses received does not match with request",
-        testContexts.size(), responses.size());
+    assertEquals(testContexts.size(), responses.size(),
+        "Number of responses received does not match with request");
 
     Set<T> contextResponses = new TreeSet<>();
     for (RegisterApplicationMasterResponseInfo<T> item : responses) {
@@ -334,7 +337,7 @@ public abstract class BaseAMRMProxyTest {
     }
 
     for (T ep : testContexts) {
-      Assert.assertTrue(contextResponses.contains(ep));
+      assertTrue(contextResponses.contains(ep));
     }
 
     return responses;
@@ -387,7 +390,7 @@ public abstract class BaseAMRMProxyTest {
                 response = new FinishApplicationMasterResponseInfo<>(
                     finishApplicationMaster(testContexts.indexOf(testContext),
                     FinalApplicationStatus.SUCCEEDED), testContext);
-                Assert.assertNotNull(response.getResponse());
+                assertNotNull(response.getResponse());
 
                 LOG.info("Successfully finished application master with test contexts: {}.",
                     testContext);
@@ -399,18 +402,18 @@ public abstract class BaseAMRMProxyTest {
               return response;
             });
 
-    Assert.assertEquals("Number of responses received does not match with request",
-        testContexts.size(), responses.size());
+    assertEquals(testContexts.size(), responses.size(),
+        "Number of responses received does not match with request");
 
     Set<T> contextResponses = new TreeSet<>();
     for (FinishApplicationMasterResponseInfo<T> item : responses) {
-      Assert.assertNotNull(item);
-      Assert.assertNotNull(item.getResponse());
+      assertNotNull(item);
+      assertNotNull(item.getResponse());
       contextResponses.add(item.getTestContext());
     }
 
     for (T ep : testContexts) {
-      Assert.assertTrue(contextResponses.contains(ep));
+      assertTrue(contextResponses.contains(ep));
     }
 
     return responses;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyMetrics.java
@@ -22,39 +22,43 @@ import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.FinishApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestAMRMProxyMetrics extends BaseAMRMProxyTest {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestAMRMProxyMetrics.class);
   private static AMRMProxyMetrics metrics;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     metrics = AMRMProxyMetrics.getMetrics();
     LOG.info("Test: aggregate metrics are initialized correctly");
 
-    Assert.assertEquals(0, metrics.getFailedAppStartRequests());
-    Assert.assertEquals(0, metrics.getFailedRegisterAMRequests());
-    Assert.assertEquals(0, metrics.getFailedFinishAMRequests());
-    Assert.assertEquals(0, metrics.getFailedAllocateRequests());
-    Assert.assertEquals(0, metrics.getFailedAppRecoveryCount());
-    Assert.assertEquals(0, metrics.getFailedAppStopRequests());
-    Assert.assertEquals(0, metrics.getFailedUpdateAMRMTokenRequests());
-    Assert.assertEquals(0, metrics.getAllocateCount());
-    Assert.assertEquals(0, metrics.getRequestCount());
+    assertEquals(0, metrics.getFailedAppStartRequests());
+    assertEquals(0, metrics.getFailedRegisterAMRequests());
+    assertEquals(0, metrics.getFailedFinishAMRequests());
+    assertEquals(0, metrics.getFailedAllocateRequests());
+    assertEquals(0, metrics.getFailedAppRecoveryCount());
+    assertEquals(0, metrics.getFailedAppStopRequests());
+    assertEquals(0, metrics.getFailedUpdateAMRMTokenRequests());
+    assertEquals(0, metrics.getAllocateCount());
+    assertEquals(0, metrics.getRequestCount());
 
-    Assert.assertEquals(0, metrics.getNumSucceededAppStartRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededRegisterAMRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededFinishAMRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededAllocateRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededRecoverRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededAppStopRequests());
-    Assert.assertEquals(0, metrics.getNumSucceededUpdateAMRMTokenRequests());
+    assertEquals(0, metrics.getNumSucceededAppStartRequests());
+    assertEquals(0, metrics.getNumSucceededRegisterAMRequests());
+    assertEquals(0, metrics.getNumSucceededFinishAMRequests());
+    assertEquals(0, metrics.getNumSucceededAllocateRequests());
+    assertEquals(0, metrics.getNumSucceededRecoverRequests());
+    assertEquals(0, metrics.getNumSucceededAppStopRequests());
+    assertEquals(0, metrics.getNumSucceededUpdateAMRMTokenRequests());
 
     LOG.info("Test: aggregate metrics are updated correctly");
   }
@@ -76,33 +80,33 @@ public class TestAMRMProxyMetrics extends BaseAMRMProxyTest {
 
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse = registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId), registerResponse.getQueue());
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId), registerResponse.getQueue());
 
     AllocateResponse allocateResponse = allocate(testAppId);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
 
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
 
-    Assert.assertEquals(failedAppStartRequests, metrics.getFailedAppStartRequests());
-    Assert.assertEquals(failedRegisterAMRequests, metrics.getFailedRegisterAMRequests());
-    Assert.assertEquals(failedFinishAMRequests, metrics.getFailedFinishAMRequests());
-    Assert.assertEquals(failedAllocateRequests, metrics.getFailedAllocateRequests());
-    Assert.assertEquals(failedAppRecoveryRequests, metrics.getFailedAppRecoveryCount());
-    Assert.assertEquals(failedAppStopRequests, metrics.getFailedAppStopRequests());
-    Assert.assertEquals(failedUpdateAMRMTokenRequests, metrics.getFailedUpdateAMRMTokenRequests());
+    assertEquals(failedAppStartRequests, metrics.getFailedAppStartRequests());
+    assertEquals(failedRegisterAMRequests, metrics.getFailedRegisterAMRequests());
+    assertEquals(failedFinishAMRequests, metrics.getFailedFinishAMRequests());
+    assertEquals(failedAllocateRequests, metrics.getFailedAllocateRequests());
+    assertEquals(failedAppRecoveryRequests, metrics.getFailedAppRecoveryCount());
+    assertEquals(failedAppStopRequests, metrics.getFailedAppStopRequests());
+    assertEquals(failedUpdateAMRMTokenRequests, metrics.getFailedUpdateAMRMTokenRequests());
 
-    Assert.assertEquals(succeededAppStartRequests,
+    assertEquals(succeededAppStartRequests,
         metrics.getNumSucceededAppStartRequests());
-    Assert.assertEquals(1 + succeededRegisterAMRequests,
+    assertEquals(1 + succeededRegisterAMRequests,
         metrics.getNumSucceededRegisterAMRequests());
-    Assert.assertEquals(1 + succeededFinishAMRequests,
+    assertEquals(1 + succeededFinishAMRequests,
         metrics.getNumSucceededFinishAMRequests());
-    Assert.assertEquals(1 + succeededAllocateRequests,
+    assertEquals(1 + succeededAllocateRequests,
         metrics.getNumSucceededAllocateRequests());
   }
 
@@ -122,42 +126,40 @@ public class TestAMRMProxyMetrics extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
-    Assert
-        .assertEquals(Integer.toString(testAppId), registerResponse.getQueue());
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId), registerResponse.getQueue());
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId, FinalApplicationStatus.FAILED);
 
-    Assert.assertNotNull(finishResponse);
+    assertNotNull(finishResponse);
 
     try {
       // Try to finish an application master that is already finished.
       finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The request to finish application master should have failed");
+      fail("The request to finish application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("Finish registration failed as expected because it was not "
           + "registered");
     }
 
-    Assert.assertEquals(failedAppStartRequests,
+    assertEquals(failedAppStartRequests,
         metrics.getFailedAppStartRequests());
-    Assert.assertEquals(failedRegisterAMRequests,
+    assertEquals(failedRegisterAMRequests,
         metrics.getFailedRegisterAMRequests());
-    Assert.assertEquals(1 + failedFinishAMRequests,
+    assertEquals(1 + failedFinishAMRequests,
         metrics.getFailedFinishAMRequests());
-    Assert.assertEquals(failedAllocateRequests,
+    assertEquals(failedAllocateRequests,
         metrics.getFailedAllocateRequests());
 
-    Assert.assertEquals(succeededAppStartRequests,
+    assertEquals(succeededAppStartRequests,
         metrics.getNumSucceededAppStartRequests());
-    Assert.assertEquals(1 + succeededRegisterAMRequests,
+    assertEquals(1 + succeededRegisterAMRequests,
         metrics.getNumSucceededRegisterAMRequests());
-    Assert.assertEquals(1 + succeededFinishAMRequests,
+    assertEquals(1 + succeededFinishAMRequests,
         metrics.getNumSucceededFinishAMRequests());
-    Assert.assertEquals(succeededAllocateRequests,
+    assertEquals(succeededAllocateRequests,
         metrics.getNumSucceededAllocateRequests());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyService.java
@@ -88,8 +88,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       index++;
     }
 
-    assertEquals("The number of interceptors in chain does not match",
-        Integer.toString(4), Integer.toString(index));
+    assertEquals(Integer.toString(4), Integer.toString(index),
+        "The number of interceptors in chain does not match");
 
   }
 
@@ -131,8 +131,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       Map<ApplicationId, RequestInterceptorChainWrapper> pipelines =
           getAMRMProxyService().getPipelines();
       ApplicationId id = getApplicationId(testAppId);
-      assertNull(
-         pipelines.get(id), "The interceptor pipeline should be removed if initialization fails");
+      assertNull(pipelines.get(id),
+          "The interceptor pipeline should be removed if initialization fails");
     }
   }
 
@@ -397,8 +397,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
           return testAppId;
         });
 
-    assertEquals(
-       tempAppIds.size(), responses.size(), "Number of responses received does not match with request");
+    assertEquals(tempAppIds.size(), responses.size(),
+        "Number of responses received does not match with request");
 
     for (Integer testAppId : responses) {
       assertNotNull(testAppId);
@@ -452,11 +452,9 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     allocateRequest.setAskList(askList);
 
     AllocateResponse allocateResponse = allocate(appId, allocateRequest);
-    assertNotNull(
-       allocateResponse, "allocate() returned null response");
-    assertNull(
-    
-       allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
+    assertNotNull(allocateResponse, "allocate() returned null response");
+    assertNull(allocateResponse.getAMRMToken(),
+        "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
     containers.addAll(allocateResponse.getAllocatedContainers());
 
@@ -466,11 +464,9 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     while (containers.size() < askList.size() && numHeartbeat++ < 10) {
       allocateResponse =
           allocate(appId, Records.newRecord(AllocateRequest.class));
-      assertNotNull(
-         allocateResponse, "allocate() returned null response");
-      assertNull(
-      
-         allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
+      assertNotNull(allocateResponse, "allocate() returned null response");
+      assertNull(allocateResponse.getAMRMToken(),
+          "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
       containers.addAll(allocateResponse.getAllocatedContainers());
 
@@ -482,8 +478,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     // We broadcast the request, the number of containers we received will be
     // higher than we ask
-    assertTrue(
-       askList.size() <= containers.size(), "The asklist count is not same as response");
+    assertTrue(askList.size() <= containers.size(),
+        "The asklist count is not same as response");
     return containers;
   }
 
@@ -503,9 +499,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     AllocateResponse allocateResponse = allocate(appId, allocateRequest);
     assertNotNull(allocateResponse);
-    assertNull(
-    
-       allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
+    assertNull(allocateResponse.getAMRMToken(),
+        "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
     // We need to make sure all the resource managers received the
     // release list. The containers sent by the mock resource managers will be
@@ -524,9 +519,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       allocateResponse =
           allocate(appId, Records.newRecord(AllocateRequest.class));
       assertNotNull(allocateResponse);
-      assertNull(
-      
-         allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
+      assertNull(allocateResponse.getAMRMToken(),
+          "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
       newlyFinished = getCompletedContainerIds(
           allocateResponse.getCompletedContainersStatuses());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyService.java
@@ -45,8 +45,14 @@ import org.apache.hadoop.yarn.server.MockResourceManagerFacade;
 import org.apache.hadoop.yarn.server.nodemanager.amrmproxy.AMRMProxyService.RequestInterceptorChainWrapper;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredAMRMProxyState;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
@@ -70,11 +76,11 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       case 0:
       case 1:
       case 2:
-        Assert.assertEquals(PassThroughRequestInterceptor.class.getName(),
+        assertEquals(PassThroughRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockRequestInterceptor.class.getName(), root.getClass().getName());
+        assertEquals(MockRequestInterceptor.class.getName(), root.getClass().getName());
         break;
       }
 
@@ -82,7 +88,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       index++;
     }
 
-    Assert.assertEquals("The number of interceptors in chain does not match",
+    assertEquals("The number of interceptors in chain does not match",
         Integer.toString(4), Integer.toString(index));
 
   }
@@ -99,8 +105,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     // name
     int testAppId = 1;
     RegisterApplicationMasterResponse response1 = registerApplicationMaster(testAppId);
-    Assert.assertNotNull(response1);
-    Assert.assertEquals(Integer.toString(testAppId), response1.getQueue());
+    assertNotNull(response1);
+    assertEquals(Integer.toString(testAppId), response1.getQueue());
   }
 
   /**
@@ -120,13 +126,13 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     try {
       registerApplicationMaster(testAppId);
-      Assert.fail("Should not reach here. Expecting an exception thrown");
+      fail("Should not reach here. Expecting an exception thrown");
     } catch (Exception e) {
       Map<ApplicationId, RequestInterceptorChainWrapper> pipelines =
           getAMRMProxyService().getPipelines();
       ApplicationId id = getApplicationId(testAppId);
-      Assert.assertNull("The interceptor pipeline should be removed if initialization fails",
-          pipelines.get(id));
+      assertNull(
+         pipelines.get(id), "The interceptor pipeline should be removed if initialization fails");
     }
   }
 
@@ -140,8 +146,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
   public void testRegisterMultipleApplicationMasters() throws Exception {
     for (int testAppId = 0; testAppId < 3; testAppId++) {
       RegisterApplicationMasterResponse response = registerApplicationMaster(testAppId);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(Integer.toString(testAppId), response.getQueue());
+      assertNotNull(response);
+      assertEquals(Integer.toString(testAppId), response.getQueue());
     }
   }
 
@@ -174,16 +180,16 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId),
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId),
         registerResponse.getQueue());
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId,
             FinalApplicationStatus.SUCCEEDED);
 
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
   }
 
   @Test
@@ -191,20 +197,19 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId),
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId),
         registerResponse.getQueue());
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId, FinalApplicationStatus.FAILED);
 
-    Assert.assertNotNull(finishResponse);
+    assertNotNull(finishResponse);
 
     try {
       // Try to finish an application master that is already finished.
       finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The request to finish application master should have failed");
+      fail("The request to finish application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("Finish registration failed as expected because it was not registered");
@@ -216,8 +221,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     try {
       // Try to finish an application master that was not registered.
       finishApplicationMaster(4, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The request to finish application master should have failed");
+      fail("The request to finish application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("Finish registration failed as expected because it was not registered");
@@ -230,8 +234,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     for (int index = 0; index < numberOfRequests; index++) {
       RegisterApplicationMasterResponse registerResponse =
           registerApplicationMaster(index);
-      Assert.assertNotNull(registerResponse);
-      Assert.assertEquals(Integer.toString(index),
+      assertNotNull(registerResponse);
+      assertEquals(Integer.toString(index),
           registerResponse.getQueue());
     }
 
@@ -240,18 +244,17 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       FinishApplicationMasterResponse finishResponse =
           finishApplicationMaster(index, FinalApplicationStatus.SUCCEEDED);
 
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       // Assert that the application has been removed from the collection
-      Assert.assertEquals(this.getAMRMProxyService().getPipelines().size(), index);
+      assertEquals(this.getAMRMProxyService().getPipelines().size(), index);
     }
 
     try {
       // Try to finish an application master that is already finished.
       finishApplicationMaster(1, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The request to finish application master should have failed");
+      fail("The request to finish application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("Finish registration failed as expected because it was not registered");
@@ -260,8 +263,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     try {
       // Try to finish an application master that was not registered.
       finishApplicationMaster(4, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The request to finish application master should have failed");
+      fail("The request to finish application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("Finish registration failed as expected because it was not registered");
@@ -280,9 +282,8 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           registerApplicationMaster(i);
-      Assert.assertNotNull(registerResponse);
-      Assert
-          .assertEquals(Integer.toString(i), registerResponse.getQueue());
+      assertNotNull(registerResponse);
+      assertEquals(Integer.toString(i), registerResponse.getQueue());
     }
 
     finishApplicationMastersInParallel(testContexts);
@@ -293,19 +294,19 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId),
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId),
         registerResponse.getQueue());
 
     AllocateResponse allocateResponse = allocate(testAppId);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId,
             FinalApplicationStatus.SUCCEEDED);
 
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
   }
 
   @Test
@@ -314,8 +315,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     try {
       // Try to allocate an application master without registering.
       allocate(1);
-      Assert
-          .fail("The request to allocate application master should have failed");
+      fail("The request to allocate application master should have failed");
     } catch (Throwable ex) {
       // This is expected. So nothing required here.
       LOG.info("AllocateRequest failed as expected because AM was not registered");
@@ -327,7 +327,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
+    assertNotNull(registerResponse);
     getContainersAndAssert(testAppId, 1);
     finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
   }
@@ -337,7 +337,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
+    assertNotNull(registerResponse);
     getContainersAndAssert(testAppId, 10);
     finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
   }
@@ -347,7 +347,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId);
-    Assert.assertNotNull(registerResponse);
+    assertNotNull(registerResponse);
     List<Container> containers = getContainersAndAssert(testAppId, 10);
     releaseContainersAndAssert(testAppId, containers);
     finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
@@ -360,7 +360,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     for (int testAppId = 0; testAppId < numberOfApps; testAppId++) {
       RegisterApplicationMasterResponse registerResponse =
           registerApplicationMaster(testAppId);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       List<Container> containers = getContainersAndAssert(testAppId, 10);
       releaseContainersAndAssert(testAppId, containers);
     }
@@ -383,7 +383,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
           try {
             RegisterApplicationMasterResponse registerResponse =
                 registerApplicationMaster(testAppId);
-            Assert.assertNotNull("response is null", registerResponse);
+            assertNotNull(registerResponse, "response is null");
             List<Container> containers =
                 getContainersAndAssert(testAppId, 10);
             releaseContainersAndAssert(testAppId, containers);
@@ -397,11 +397,11 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
           return testAppId;
         });
 
-    Assert.assertEquals("Number of responses received does not match with request",
-        tempAppIds.size(), responses.size());
+    assertEquals(
+       tempAppIds.size(), responses.size(), "Number of responses received does not match with request");
 
     for (Integer testAppId : responses) {
-      Assert.assertNotNull(testAppId);
+      assertNotNull(testAppId);
       finishApplicationMaster(testAppId, FinalApplicationStatus.SUCCEEDED);
     }
   }
@@ -417,10 +417,10 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     RegisterApplicationMasterResponse response1 =
         registerApplicationMaster(appId.getId());
-    Assert.assertNotNull(response1);
+    assertNotNull(response1);
 
     AllocateResponse allocateResponse = allocate(appId.getId());
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     // Second Attempt
 
@@ -430,10 +430,10 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     RequestInterceptorChainWrapper chain2 =
         getAMRMProxyService().getPipelines().get(appId);
-    Assert.assertEquals(applicationAttemptId, chain2.getApplicationAttemptId());
+    assertEquals(applicationAttemptId, chain2.getApplicationAttemptId());
 
     allocateResponse = allocate(appId.getId());
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
   }
 
   private List<Container> getContainersAndAssert(int appId,
@@ -452,11 +452,11 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     allocateRequest.setAskList(askList);
 
     AllocateResponse allocateResponse = allocate(appId, allocateRequest);
-    Assert.assertNotNull("allocate() returned null response",
-        allocateResponse);
-    Assert.assertNull(
-        "new AMRMToken from RM should have been nulled by AMRMProxyService",
-        allocateResponse.getAMRMToken());
+    assertNotNull(
+       allocateResponse, "allocate() returned null response");
+    assertNull(
+    
+       allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
     containers.addAll(allocateResponse.getAllocatedContainers());
 
@@ -466,11 +466,11 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     while (containers.size() < askList.size() && numHeartbeat++ < 10) {
       allocateResponse =
           allocate(appId, Records.newRecord(AllocateRequest.class));
-      Assert.assertNotNull("allocate() returned null response",
-          allocateResponse);
-      Assert.assertNull(
-          "new AMRMToken from RM should have been nulled by AMRMProxyService",
-          allocateResponse.getAMRMToken());
+      assertNotNull(
+         allocateResponse, "allocate() returned null response");
+      assertNull(
+      
+         allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
       containers.addAll(allocateResponse.getAllocatedContainers());
 
@@ -482,14 +482,14 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     // We broadcast the request, the number of containers we received will be
     // higher than we ask
-    Assert.assertTrue("The asklist count is not same as response",
-        askList.size() <= containers.size());
+    assertTrue(
+       askList.size() <= containers.size(), "The asklist count is not same as response");
     return containers;
   }
 
   private void releaseContainersAndAssert(int appId,
       List<Container> containers) throws Exception {
-    Assert.assertTrue(containers.size() > 0);
+    assertTrue(containers.size() > 0);
     AllocateRequest allocateRequest =
         Records.newRecord(AllocateRequest.class);
     allocateRequest.setResponseId(1);
@@ -502,10 +502,10 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     allocateRequest.setReleaseList(relList);
 
     AllocateResponse allocateResponse = allocate(appId, allocateRequest);
-    Assert.assertNotNull(allocateResponse);
-    Assert.assertNull(
-        "new AMRMToken from RM should have been nulled by AMRMProxyService",
-        allocateResponse.getAMRMToken());
+    assertNotNull(allocateResponse);
+    assertNull(
+    
+       allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
     // We need to make sure all the resource managers received the
     // release list. The containers sent by the mock resource managers will be
@@ -523,10 +523,10 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
         && numHeartbeat++ < 10) {
       allocateResponse =
           allocate(appId, Records.newRecord(AllocateRequest.class));
-      Assert.assertNotNull(allocateResponse);
-      Assert.assertNull(
-          "new AMRMToken from RM should have been nulled by AMRMProxyService",
-          allocateResponse.getAMRMToken());
+      assertNotNull(allocateResponse);
+      assertNull(
+      
+         allocateResponse.getAMRMToken(), "new AMRMToken from RM should have been nulled by AMRMProxyService");
 
       newlyFinished = getCompletedContainerIds(
           allocateResponse.getCompletedContainersStatuses());
@@ -539,7 +539,7 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
       Thread.sleep(10);
     }
 
-    Assert.assertEquals(relList.size(), containersForReleasedContainerIds.size());
+    assertEquals(relList.size(), containersForReleasedContainerIds.size());
   }
 
   /**
@@ -560,47 +560,46 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
     int testAppId1 = 1;
     RegisterApplicationMasterResponse registerResponse =
         registerApplicationMaster(testAppId1);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId1),
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId1),
         registerResponse.getQueue());
 
     int testAppId2 = 2;
     registerResponse = registerApplicationMaster(testAppId2);
-    Assert.assertNotNull(registerResponse);
-    Assert.assertEquals(Integer.toString(testAppId2),
+    assertNotNull(registerResponse);
+    assertEquals(Integer.toString(testAppId2),
         registerResponse.getQueue());
 
     AllocateResponse allocateResponse = allocate(testAppId2);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     // At the time of kill, app1 just registerAM, app2 already did one allocate.
     // Both application should be recovered
     createAndStartAMRMProxyService(conf);
-    Assert.assertEquals(2, getAMRMProxyService().getPipelines().size());
+    assertEquals(2, getAMRMProxyService().getPipelines().size());
 
     allocateResponse = allocate(testAppId1);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     FinishApplicationMasterResponse finishResponse =
         finishApplicationMaster(testAppId1, FinalApplicationStatus.SUCCEEDED);
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
 
     allocateResponse = allocate(testAppId2);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
 
     finishResponse =
         finishApplicationMaster(testAppId2, FinalApplicationStatus.SUCCEEDED);
 
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
 
     int testAppId3 = 3;
     try {
       // Try to finish an application master that is not registered.
       finishApplicationMaster(testAppId3, FinalApplicationStatus.SUCCEEDED);
-      Assert
-          .fail("The Mock RM should complain about not knowing the third app");
+      fail("The Mock RM should complain about not knowing the third app");
     } catch (Throwable ex) {
     }
 
@@ -626,14 +625,14 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     RecoveredAMRMProxyState state =
         getNMContext().getNMStateStore().loadAMRMProxyState();
-    Assert.assertEquals(1, state.getAppContexts().size());
+    assertEquals(1, state.getAppContexts().size());
 
     // AMRMProxy restarts and recover
     createAndStartAMRMProxyService(conf);
 
     state = getNMContext().getNMStateStore().loadAMRMProxyState();
     // The app that failed to recover should have been removed from NMSS
-    Assert.assertEquals(0, state.getAppContexts().size());
+    assertEquals(0, state.getAppContexts().size());
   }
 
   @Test
@@ -645,14 +644,14 @@ public class TestAMRMProxyService extends BaseAMRMProxyTest {
 
     createAndStartAMRMProxyService(conf);
 
-    Assert.assertFalse(getAMRMProxyService().checkIfAppExistsInStateStore(appId));
+    assertFalse(getAMRMProxyService().checkIfAppExistsInStateStore(appId));
 
     Configuration distConf = createConfiguration();
     conf.setBoolean(YarnConfiguration.DIST_SCHEDULING_ENABLED, true);
 
     createAndStartAMRMProxyService(distConf);
 
-    Assert.assertTrue(getAMRMProxyService().checkIfAppExistsInStateStore(appId));
+    assertTrue(getAMRMProxyService().checkIfAppExistsInStateStore(appId));
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestAMRMProxyTokenSecretManager.java
@@ -29,10 +29,11 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreService;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for AMRMProxyTokenSecretManager.
@@ -43,7 +44,7 @@ public class TestAMRMProxyTokenSecretManager {
   private AMRMProxyTokenSecretManager secretManager;
   private NMMemoryStateStoreService stateStore;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.NM_RECOVERY_ENABLED, true);
@@ -57,7 +58,7 @@ public class TestAMRMProxyTokenSecretManager {
     secretManager.start();
   }
 
-  @After
+  @AfterEach
   public void breakdown() {
     if (secretManager != null) {
       secretManager.stop();
@@ -85,7 +86,7 @@ public class TestAMRMProxyTokenSecretManager {
 
     try {
       secretManager.retrievePassword(identifier);
-      Assert.fail("Expect InvalidToken exception");
+      fail("Expect InvalidToken exception");
     } catch (InvalidToken e) {
     }
   }
@@ -133,7 +134,7 @@ public class TestAMRMProxyTokenSecretManager {
 
     try {
       secretManager.retrievePassword(identifier);
-      Assert.fail("Expect InvalidToken exception because the "
+      fail("Expect InvalidToken exception because the "
           + "old master key should have expired");
     } catch (InvalidToken e) {
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -233,8 +233,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       allocateRequest = Records.newRecord(AllocateRequest.class);
       allocateRequest.setResponseId(lastResponseId);
       allocateResponse = interceptor.allocate(allocateRequest);
-      assertNotNull(
-         allocateResponse, "allocate() returned null response");
+      assertNotNull(allocateResponse, "allocate() returned null response");
       checkAMRMToken(allocateResponse.getAMRMToken());
       lastResponseId = allocateResponse.getResponseId();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -83,6 +83,8 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreServ
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.server.uam.UnmanagedAMPoolManager;
 import org.apache.hadoop.yarn.util.Records;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -117,6 +119,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
   private volatile int lastResponseId;
 
+  @BeforeEach
   @Override
   public void setUp() throws IOException {
     super.setUp();
@@ -148,6 +151,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     lastResponseId = 0;
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.cleanupRegistry();
@@ -660,8 +664,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       root = root.getNextInterceptor();
       index++;
     }
-    assertEquals("The number of interceptors in chain does not match",
-        Integer.toString(3), Integer.toString(index));
+    assertEquals(Integer.toString(3), Integer.toString(index),
+        "The number of interceptors in chain does not match");
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptor.java
@@ -83,10 +83,16 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreServ
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.server.uam.UnmanagedAMPoolManager;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Extends the TestAMRMProxyService and overrides methods in order to use the
@@ -211,7 +217,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     allocateRequest.setResponseId(lastResponseId);
     AllocateResponse allocateResponse = interceptor.allocate(allocateRequest);
-    Assert.assertNotNull("allocate() returned null response", allocateResponse);
+    assertNotNull(allocateResponse, "allocate() returned null response");
     checkAMRMToken(allocateResponse.getAMRMToken());
     lastResponseId = allocateResponse.getResponseId();
 
@@ -227,8 +233,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       allocateRequest = Records.newRecord(AllocateRequest.class);
       allocateRequest.setResponseId(lastResponseId);
       allocateResponse = interceptor.allocate(allocateRequest);
-      Assert.assertNotNull("allocate() returned null response",
-          allocateResponse);
+      assertNotNull(
+         allocateResponse, "allocate() returned null response");
       checkAMRMToken(allocateResponse.getAMRMToken());
       lastResponseId = allocateResponse.getResponseId();
 
@@ -241,13 +247,13 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       LOG.info("Total number of allocated containers: {}.", containers.size());
       Thread.sleep(10);
     }
-    Assert.assertEquals(numberOfAllocationExcepted, containers.size());
+    assertEquals(numberOfAllocationExcepted, containers.size());
     return containers;
   }
 
   private void releaseContainersAndAssert(List<Container> containers)
       throws Exception {
-    Assert.assertTrue(containers.size() > 0);
+    assertTrue(containers.size() > 0);
     AllocateRequest allocateRequest = Records.newRecord(AllocateRequest.class);
     List<ContainerId> relList = new ArrayList<>(containers.size());
     for (Container container : containers) {
@@ -258,7 +264,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     allocateRequest.setResponseId(lastResponseId);
     AllocateResponse allocateResponse = interceptor.allocate(allocateRequest);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
     checkAMRMToken(allocateResponse.getAMRMToken());
     lastResponseId = allocateResponse.getResponseId();
 
@@ -281,7 +287,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       allocateRequest = Records.newRecord(AllocateRequest.class);
       allocateRequest.setResponseId(lastResponseId);
       allocateResponse = interceptor.allocate(allocateRequest);
-      Assert.assertNotNull(allocateResponse);
+      assertNotNull(allocateResponse);
       checkAMRMToken(allocateResponse.getAMRMToken());
       lastResponseId = allocateResponse.getResponseId();
 
@@ -297,14 +303,14 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       Thread.sleep(10);
     }
 
-    Assert.assertEquals(relList.size(),
+    assertEquals(relList.size(),
         containersForReleasedContainerIds.size());
   }
 
   private void checkAMRMToken(Token amrmToken) {
     if (amrmToken != null) {
       // The token should be the one issued by home MockRM
-      Assert.assertEquals(Integer.toString(0), amrmToken.getKind());
+      assertEquals(Integer.toString(0), amrmToken.getKind());
     }
   }
 
@@ -322,10 +328,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 and sc2 active
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -334,7 +340,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
-      Assert.assertEquals(2, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(2, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the second batch of containers, with sc1 and sc3 active
       deRegisterSubCluster(SubClusterId.newInstance("SC-2"));
@@ -343,7 +349,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       numberOfContainers = 1;
       containers.addAll(
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2));
-      Assert.assertEquals(3, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(3, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the third batch of containers with only in home sub-cluster
       // active
@@ -354,7 +360,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       numberOfContainers = 2;
       containers.addAll(
           getContainersAndAssert(numberOfContainers, numberOfContainers));
-      Assert.assertEquals(3, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(3, interceptor.getUnmanagedAMPoolSize());
 
       // Release all containers
       releaseContainersAndAssert(containers);
@@ -368,8 +374,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       return null;
     });
@@ -393,10 +399,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -407,7 +413,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
       interceptor.setShouldReRegisterNext();
 
@@ -425,8 +431,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
       return null;
     });
   }
@@ -438,7 +444,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
    * RM failover and AM timeout, it will call us resulting in a second register
    * thread.
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testConcurrentRegister()
       throws InterruptedException, ExecutionException {
     ExecutorService threadpool = Executors.newCachedThreadPool();
@@ -475,10 +482,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     // Both thread should return without exception
     RegisterApplicationMasterResponse response = compSvc.take().get();
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     response = compSvc.take().get();
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     threadpool.shutdown();
   }
@@ -543,10 +550,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate one batch of containers
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -555,7 +562,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
       // Make sure all async hb threads are done
       interceptor.drainAllAsyncQueue(true);
@@ -566,11 +573,11 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       String scEntry =
           FederationInterceptor.NMSS_SECONDARY_SC_PREFIX + "SC-1";
       if (registryObj == null) {
-        Assert.assertTrue(recoveredDataMap.containsKey(scEntry));
+        assertTrue(recoveredDataMap.containsKey(scEntry));
       } else {
         // When AMRMPRoxy HA is enabled, NMSS should not have the UAM token,
         // it should be in Registry
-        Assert.assertFalse(recoveredDataMap.containsKey(scEntry));
+        assertFalse(recoveredDataMap.containsKey(scEntry));
       }
 
       // Preserve the mock RM instances
@@ -584,9 +591,9 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
           getConf(), attemptId, "test-user", null, null, null, registryObj));
       interceptor.recover(recoveredDataMap);
 
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
       // SC1 should be initialized to be timed out
-      Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
+      assertEquals(1, interceptor.getTimedOutSCs(true).size());
 
       // The first allocate call expects a fail-over exception and re-register
       try {
@@ -596,7 +603,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         AllocateResponse allocateResponse =
             interceptor.allocate(allocateRequest);
         lastResponseId = allocateResponse.getResponseId();
-        Assert.fail("Expecting an ApplicationMasterNotRegisteredException  "
+        fail("Expecting an ApplicationMasterNotRegisteredException  "
             + " after FederationInterceptor restarts and recovers");
       } catch (ApplicationMasterNotRegisteredException e) {
       }
@@ -615,18 +622,18 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       // After the application succeeds, the registry/NMSS entry should be
       // cleaned up
       if (registryObj != null) {
-        Assert.assertEquals(0,
+        assertEquals(0,
             interceptor.getRegistryClient().getAllApplications().size());
       } else {
         recoveredDataMap =
             recoverDataMapForAppAttempt(nmStateStore, attemptId);
-        Assert.assertFalse(recoveredDataMap.containsKey(scEntry));
+        assertFalse(recoveredDataMap.containsKey(scEntry));
       }
       return null;
     });
@@ -641,20 +648,20 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       switch (index) {
       case 0:
       case 1:
-        Assert.assertEquals(PassThroughRequestInterceptor.class.getName(),
+        assertEquals(PassThroughRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 2:
-        Assert.assertEquals(TestableFederationInterceptor.class.getName(),
+        assertEquals(TestableFederationInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match",
+    assertEquals("The number of interceptors in chain does not match",
         Integer.toString(3), Integer.toString(index));
   }
 
@@ -681,7 +688,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     for (int i = 0; i < 2; i++) {
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
     }
   }
@@ -697,7 +704,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     RegisterApplicationMasterResponse registerResponse =
         interceptor.registerApplicationMaster(registerReq);
-    Assert.assertNotNull(registerResponse);
+    assertNotNull(registerResponse);
     lastResponseId = 0;
 
     // Register the application second time with a different request obj
@@ -708,7 +715,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     try {
       registerResponse = interceptor.registerApplicationMaster(registerReq);
       lastResponseId = 0;
-      Assert.fail("Should throw if a different request obj is used");
+      fail("Should throw if a different request obj is used");
     } catch (YarnException e) {
     }
   }
@@ -748,15 +755,15 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     response = interceptor.allocate(allocateRequest);
 
-    Assert.assertEquals(1, response.getAllocatedContainers().size());
-    Assert.assertNotNull(response.getAvailableResources());
-    Assert.assertEquals(1, response.getCompletedContainersStatuses().size());
-    Assert.assertEquals(1, response.getUpdatedNodes().size());
-    Assert.assertNotNull(response.getPreemptionMessage());
-    Assert.assertEquals(1, response.getNMTokens().size());
-    Assert.assertEquals(1, response.getUpdatedContainers().size());
-    Assert.assertEquals(1, response.getUpdateErrors().size());
-    Assert.assertNotNull(response.getApplicationPriority());
+    assertEquals(1, response.getAllocatedContainers().size());
+    assertNotNull(response.getAvailableResources());
+    assertEquals(1, response.getCompletedContainersStatuses().size());
+    assertEquals(1, response.getUpdatedNodes().size());
+    assertNotNull(response.getPreemptionMessage());
+    assertEquals(1, response.getNMTokens().size());
+    assertEquals(1, response.getUpdatedContainers().size());
+    assertEquals(1, response.getUpdateErrors().size());
+    assertNotNull(response.getApplicationPriority());
   }
 
   @Test
@@ -772,7 +779,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       registerReq.setTrackingUrl("");
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -780,8 +787,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       getContainersAndAssert(1, 1);
 
       AllocateResponse allocateResponse = interceptor.generateBaseAllocationResponse();
-      Assert.assertEquals(2, allocateResponse.getNumClusterNodes());
-      Assert.assertEquals(0, interceptor.getTimedOutSCs(true).size());
+      assertEquals(2, allocateResponse.getNumClusterNodes());
+      assertEquals(0, interceptor.getTimedOutSCs(true).size());
 
       // Let all SC timeout (home and SC-1), without an allocate from AM
       Thread.sleep(800);
@@ -789,8 +796,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // Should not be considered timeout, because there's no recent AM
       // heartbeat
       allocateResponse = interceptor.generateBaseAllocationResponse();
-      Assert.assertEquals(2, allocateResponse.getNumClusterNodes());
-      Assert.assertEquals(0, interceptor.getTimedOutSCs(true).size());
+      assertEquals(2, allocateResponse.getNumClusterNodes());
+      assertEquals(0, interceptor.getTimedOutSCs(true).size());
 
       // Generate a duplicate heartbeat from AM, so that it won't really
       // trigger a heartbeat to all SC
@@ -802,8 +809,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       // Should be considered timeout
       allocateResponse = interceptor.generateBaseAllocationResponse();
-      Assert.assertEquals(0, allocateResponse.getNumClusterNodes());
-      Assert.assertEquals(2, interceptor.getTimedOutSCs(true).size());
+      assertEquals(0, allocateResponse.getNumClusterNodes());
+      assertEquals(2, interceptor.getTimedOutSCs(true).size());
       return null;
     });
   }
@@ -822,10 +829,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // Register the application
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate one batch of containers
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -837,7 +844,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       for (Container c : containers) {
         LOG.info("Allocated container {}.", c.getId());
       }
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
       // Make sure all async hb threads are done
       interceptor.drainAllAsyncQueue(true);
@@ -865,10 +872,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       int numberOfContainers = 3;
       // Should re-attach secondaries and get the three running containers
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
       // SC1 should be initialized to be timed out
-      Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
-      Assert.assertEquals(numberOfContainers,
+      assertEquals(1, interceptor.getTimedOutSCs(true).size());
+      assertEquals(numberOfContainers,
           registerResponse.getContainersFromPreviousAttempts().size());
 
       // Release all containers
@@ -884,12 +891,12 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       // After the application succeeds, the registry entry should be deleted
       if (interceptor.getRegistryClient() != null) {
-        Assert.assertEquals(0,
+        assertEquals(0,
             interceptor.getRegistryClient().getAllApplications().size());
       }
       return null;
@@ -933,11 +940,11 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     interceptor.mergeAllocateResponse(homeResponse,
         response, SubClusterId.newInstance("SC-1"));
 
-    Assert.assertEquals(2,
+    assertEquals(2,
         homeResponse.getPreemptionMessage().getContract().getContainers().size());
-    Assert.assertEquals(2, homeResponse.getAllocatedContainers().size());
-    Assert.assertEquals(2, homeResponse.getUpdatedNodes().size());
-    Assert.assertEquals(2, homeResponse.getCompletedContainersStatuses().size());
+    assertEquals(2, homeResponse.getAllocatedContainers().size());
+    assertEquals(2, homeResponse.getUpdatedNodes().size());
+    assertEquals(2, homeResponse.getCompletedContainersStatuses().size());
   }
 
   private PreemptionMessage createDummyPreemptionMessage(
@@ -972,10 +979,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 active
       SubClusterId subClusterId1 = SubClusterId.newInstance("SC-1");
@@ -984,8 +991,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers);
-      Assert.assertNotNull(containers);
-      Assert.assertEquals(3, containers.size());
+      assertNotNull(containers);
+      assertEquals(3, containers.size());
 
       // with sc2 active
       SubClusterId subClusterId2 = SubClusterId.newInstance("SC-2");
@@ -998,8 +1005,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       interceptor.cacheAllocatedContainersForSubClusterId(containers, subClusterId2);
       Map<ContainerId, SubClusterId> cIdToSCMap = interceptor.getContainerIdToSubClusterIdMap();
       for (SubClusterId subClusterId : cIdToSCMap.values()) {
-        Assert.assertNotNull(subClusterId);
-        Assert.assertEquals(subClusterId1, subClusterId);
+        assertNotNull(subClusterId);
+        assertEquals(subClusterId1, subClusterId);
       }
 
       // 2.Deregister SubCluster1, Register the same Containers to SubCluster2
@@ -1008,8 +1015,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       interceptor.cacheAllocatedContainersForSubClusterId(containers, subClusterId2);
       Map<ContainerId, SubClusterId> cIdToSCMap2 = interceptor.getContainerIdToSubClusterIdMap();
       for (SubClusterId subClusterId : cIdToSCMap2.values()) {
-        Assert.assertNotNull(subClusterId);
-        Assert.assertEquals(subClusterId2, subClusterId);
+        assertNotNull(subClusterId);
+        assertEquals(subClusterId2, subClusterId);
       }
 
       // 3.Deregister subClusterId2, Register the same Containers to SubCluster1
@@ -1017,7 +1024,7 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // an exception will be thrown when registering the first Container.
       deRegisterSubCluster(subClusterId2);
       Container container1 = containers.get(0);
-      Assert.assertNotNull(container1);
+      assertNotNull(container1);
       String errMsg =
           " Can't use any subCluster because an exception occurred" +
           " ContainerId: " + container1.getId() +
@@ -1043,8 +1050,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       return null;
     });
@@ -1073,10 +1080,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // Register ApplicationMaster
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq1);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 and sc2 active
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -1085,8 +1092,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
-      Assert.assertEquals(2, interceptor.getUnmanagedAMPoolSize());
-      Assert.assertEquals(numberOfContainers * 2, containers.size());
+      assertEquals(2, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(numberOfContainers * 2, containers.size());
 
       // Finish the application
       FinishApplicationMasterRequest finishReq =
@@ -1096,8 +1103,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       finishReq.setFinalApplicationStatus(FinalApplicationStatus.SUCCEEDED);
 
       FinishApplicationMasterResponse finishResp = interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResp);
-      Assert.assertTrue(finishResp.getIsUnregistered());
+      assertNotNull(finishResp);
+      assertTrue(finishResp.getIsUnregistered());
 
       return null;
     });
@@ -1127,10 +1134,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // Register ApplicationMaster
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq1);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 active
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -1138,8 +1145,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
-      Assert.assertEquals(numberOfContainers, containers.size());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(numberOfContainers, containers.size());
 
       // Finish the application
       FinishApplicationMasterRequest finishReq =
@@ -1149,13 +1156,13 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       finishReq.setFinalApplicationStatus(FinalApplicationStatus.SUCCEEDED);
 
       FinishApplicationMasterResponse finishResp = interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResp);
-      Assert.assertTrue(finishResp.getIsUnregistered());
+      assertNotNull(finishResp);
+      assertTrue(finishResp.getIsUnregistered());
 
       FederationRegistryClient client = interceptor.getRegistryClient();
       List<String> applications = client.getAllApplications();
-      Assert.assertNotNull(finishResp);
-      Assert.assertEquals(0, applications.size());
+      assertNotNull(finishResp);
+      assertEquals(0, applications.size());
       return null;
     });
   }
@@ -1185,10 +1192,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // Register ApplicationMaster
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq1);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 active
       registerSubCluster(SubClusterId.newInstance("SC-1"));
@@ -1196,8 +1203,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
-      Assert.assertEquals(numberOfContainers, containers.size());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(numberOfContainers, containers.size());
 
       // Finish the application
       FinishApplicationMasterRequest finishReq =
@@ -1210,15 +1217,15 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // At this time, the Application should not be cleaned up because the state is not SUCCESS.
       FederationRegistryClient client = interceptor.getRegistryClient();
       List<String> applications = client.getAllApplications();
-      Assert.assertNotNull(applications);
-      Assert.assertEquals(1, applications.size());
+      assertNotNull(applications);
+      assertEquals(1, applications.size());
 
       // interceptor cleanupRegistry
       ApplicationId applicationId = interceptor.getAttemptId().getApplicationId();
       client.removeAppFromRegistry(applicationId);
       applications = client.getAllApplications();
-      Assert.assertNotNull(applications);
-      Assert.assertEquals(0, applications.size());
+      assertNotNull(applications);
+      assertEquals(0, applications.size());
 
       return null;
     });
@@ -1268,9 +1275,9 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
       // SC-1 was offline, SC-2 was recovered at this time, UnmanagedAMPool.size=1 and only SC-2
       UnmanagedAMPoolManager unmanagedAMPoolManager = interceptor.getUnmanagedAMPool();
       Set<String> allUAMIds = unmanagedAMPoolManager.getAllUAMIds();
-      Assert.assertNotNull(allUAMIds);
-      Assert.assertEquals(1, allUAMIds.size());
-      Assert.assertTrue(allUAMIds.contains(sc2.getId()));
+      assertNotNull(allUAMIds);
+      assertEquals(1, allUAMIds.size());
+      assertTrue(allUAMIds.contains(sc2.getId()));
 
       // Step6. The first allocate call expects a fail-over exception and re-register.
       AllocateRequest allocateRequest = Records.newRecord(AllocateRequest.class);
@@ -1312,10 +1319,10 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     // Register HomeSC
     RegisterApplicationMasterResponse registerResponse =
         interceptor.registerApplicationMaster(registerReq);
-    Assert.assertNotNull(registerResponse);
+    assertNotNull(registerResponse);
 
     // We only registered HomeSC, so UnmanagedAMPoolSize should be empty
-    Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+    assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
     // We assign 3 Containers to each cluster
     int numberOfContainers = 3;
@@ -1323,13 +1330,13 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
         getContainersAndAssert(numberOfContainers, numberOfContainers * 3);
 
     // At this point, UnmanagedAMPoolSize should be equal to 2 and should contain SC-1, SC-2
-    Assert.assertEquals(2, interceptor.getUnmanagedAMPoolSize());
+    assertEquals(2, interceptor.getUnmanagedAMPoolSize());
     UnmanagedAMPoolManager unmanagedAMPoolManager = interceptor.getUnmanagedAMPool();
     Set<String> allUAMIds = unmanagedAMPoolManager.getAllUAMIds();
-    Assert.assertNotNull(allUAMIds);
-    Assert.assertEquals(2, allUAMIds.size());
-    Assert.assertTrue(allUAMIds.contains("SC-1"));
-    Assert.assertTrue(allUAMIds.contains("SC-2"));
+    assertNotNull(allUAMIds);
+    assertEquals(2, allUAMIds.size());
+    assertTrue(allUAMIds.contains("SC-1"));
+    assertTrue(allUAMIds.contains("SC-2"));
 
     // Make sure all async hb threads are done
     interceptor.drainAllAsyncQueue(true);
@@ -1374,9 +1381,9 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
     MockResourceManagerFacade sc1Facade = secondaries.get("SC-1");
     HashMap<ApplicationId, List<ContainerId>> appContainerMap =
         sc1Facade.getApplicationContainerIdMap();
-    Assert.assertNotNull(appContainerMap);
+    assertNotNull(appContainerMap);
     ApplicationId applicationId = attemptId.getApplicationId();
-    Assert.assertNotNull(applicationId);
+    assertNotNull(applicationId);
     List<ContainerId> sc1ContainerList = appContainerMap.get(applicationId);
 
     // Release all containers,
@@ -1397,8 +1404,8 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
     FinishApplicationMasterResponse finishResponse =
         interceptor.finishApplicationMaster(finishReq);
-    Assert.assertNotNull(finishResponse);
-    Assert.assertTrue(finishResponse.getIsUnregistered());
+    assertNotNull(finishResponse);
+    assertTrue(finishResponse.getIsUnregistered());
   }
 
   @Test
@@ -1417,17 +1424,17 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate the first batch of containers, with sc1 active
       registerSubCluster(SubClusterId.newInstance("SC-1"));
 
       int numberOfContainers = 3;
       List<Container> containers = getContainersAndAssert(numberOfContainers, numberOfContainers);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
       // Release all containers
       releaseContainersAndAssert(containers);
@@ -1441,12 +1448,12 @@ public class TestFederationInterceptor extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       return null;
     });
 
-    Assert.assertEquals(0, interceptor.getRetryCount());
+    assertEquals(0, interceptor.getRetryCount());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
@@ -73,9 +73,7 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,6 +137,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
     }
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws IOException {
     super.setUp();
@@ -184,6 +183,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
     }
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.cleanupRegistry();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/TestFederationInterceptorSecure.java
@@ -73,14 +73,18 @@ import org.apache.hadoop.yarn.server.nodemanager.NodeManager.NMContext;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
@@ -113,28 +117,25 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
   private static String serverPrincipal;
   private static File serverKeytab;
 
-  @ClassRule
-  public final static TemporaryFolder FOLDER = new TemporaryFolder();
-
-  @BeforeClass
-  public static void setUpCluster() throws Exception {
+  @BeforeAll
+  public static void setUpCluster(@TempDir java.nio.file.Path dir) throws Exception {
     miniKDC = new MiniKdc(MiniKdc.createConf(), TEST_ROOT_DIR);
     miniKDC.start();
 
-    workDir = FOLDER.getRoot();
+    workDir = dir.toFile();
     serverKeytab = new File(workDir, "yarn.keytab");
     serverPrincipal =
         serverUserName + "/" + (Path.WINDOWS ? "127.0.0.1" : "localhost") + "@EXAMPLE.COM";
     miniKDC.createPrincipal(serverKeytab, serverPrincipal);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownCluster() {
     if (miniKDC != null) {
       miniKDC.stop();
     }
-    if (FOLDER != null) {
-      FOLDER.delete();
+    if (workDir != null) {
+      workDir.delete();
     }
   }
 
@@ -257,7 +258,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
     allocateRequest.setResponseId(lastResponseId);
     AllocateResponse allocateResponse = interceptor.allocate(allocateRequest);
-    Assert.assertNotNull("allocate() returned null response", allocateResponse);
+    assertNotNull(allocateResponse, "allocate() returned null response");
     checkAMRMToken(allocateResponse.getAMRMToken());
     lastResponseId = allocateResponse.getResponseId();
 
@@ -272,7 +273,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       allocateRequest = Records.newRecord(AllocateRequest.class);
       allocateRequest.setResponseId(lastResponseId);
       allocateResponse = interceptor.allocate(allocateRequest);
-      Assert.assertNotNull("allocate() returned null response", allocateResponse);
+      assertNotNull(allocateResponse, "allocate() returned null response");
       checkAMRMToken(allocateResponse.getAMRMToken());
       lastResponseId = allocateResponse.getResponseId();
 
@@ -285,13 +286,13 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       LOG.info("Total number of allocated containers: {}.", containers.size());
       Thread.sleep(10);
     }
-    Assert.assertEquals(numberOfAllocationExcepted, containers.size());
+    assertEquals(numberOfAllocationExcepted, containers.size());
     return containers;
   }
 
   private void releaseContainersAndAssert(List<Container> containers)
       throws Exception {
-    Assert.assertTrue(containers.size() > 0);
+    assertTrue(containers.size() > 0);
     AllocateRequest allocateRequest = Records.newRecord(AllocateRequest.class);
     List<ContainerId> relList = new ArrayList<>(containers.size());
     for (Container container : containers) {
@@ -302,7 +303,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
     allocateRequest.setResponseId(lastResponseId);
     AllocateResponse allocateResponse = interceptor.allocate(allocateRequest);
-    Assert.assertNotNull(allocateResponse);
+    assertNotNull(allocateResponse);
     checkAMRMToken(allocateResponse.getAMRMToken());
     lastResponseId = allocateResponse.getResponseId();
 
@@ -322,7 +323,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       allocateRequest = Records.newRecord(AllocateRequest.class);
       allocateRequest.setResponseId(lastResponseId);
       allocateResponse = interceptor.allocate(allocateRequest);
-      Assert.assertNotNull(allocateResponse);
+      assertNotNull(allocateResponse);
       checkAMRMToken(allocateResponse.getAMRMToken());
       lastResponseId = allocateResponse.getResponseId();
 
@@ -337,13 +338,13 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       Thread.sleep(10);
     }
 
-    Assert.assertEquals(relList.size(), containersForReleasedContainerIds.size());
+    assertEquals(relList.size(), containersForReleasedContainerIds.size());
   }
 
   private void checkAMRMToken(Token amrmToken) {
     if (amrmToken != null) {
       // The token should be the one issued by home MockRM
-      Assert.assertEquals(Integer.toString(0), amrmToken.getKind());
+      assertEquals(Integer.toString(0), amrmToken.getKind());
     }
   }
 
@@ -376,10 +377,10 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
       RegisterApplicationMasterResponse registerResponse =
           interceptor.registerApplicationMaster(registerReq);
-      Assert.assertNotNull(registerResponse);
+      assertNotNull(registerResponse);
       lastResponseId = 0;
 
-      Assert.assertEquals(0, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(0, interceptor.getUnmanagedAMPoolSize());
 
       // Allocate one batch of containers
       registerSubCluster(SubClusterId.newInstance(SC_ID1));
@@ -388,7 +389,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       int numberOfContainers = 3;
       List<Container> containers =
           getContainersAndAssert(numberOfContainers, numberOfContainers * 2);
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
 
       // Make sure all async hb threads are done
       interceptor.drainAllAsyncQueue(true);
@@ -397,11 +398,11 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       Map<String, byte[]> recoveredDataMap = recoverDataMapForAppAttempt(nmStateStore, attemptId);
       String scEntry = FederationInterceptor.NMSS_SECONDARY_SC_PREFIX + "SC-1";
       if (registryObj == null) {
-        Assert.assertTrue(recoveredDataMap.containsKey(scEntry));
+        assertTrue(recoveredDataMap.containsKey(scEntry));
       } else {
         // When AMRMPRoxy HA is enabled, NMSS should not have the UAM token,
         // it should be in Registry
-        Assert.assertFalse(recoveredDataMap.containsKey(scEntry));
+        assertFalse(recoveredDataMap.containsKey(scEntry));
       }
 
       // Preserve the mock RM instances
@@ -417,9 +418,9 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
       interceptor.recover(recoveredDataMap);
       interceptor.setClientRPC(false);
 
-      Assert.assertEquals(1, interceptor.getUnmanagedAMPoolSize());
+      assertEquals(1, interceptor.getUnmanagedAMPoolSize());
       // SC-1 should be initialized to be timed out
-      Assert.assertEquals(1, interceptor.getTimedOutSCs(true).size());
+      assertEquals(1, interceptor.getTimedOutSCs(true).size());
 
       // The first allocate call expects a fail-over exception and re-register
       try {
@@ -427,7 +428,7 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
         allocateRequest.setResponseId(lastResponseId);
         AllocateResponse allocateResponse = interceptor.allocate(allocateRequest);
         lastResponseId = allocateResponse.getResponseId();
-        Assert.fail("Expecting an ApplicationMasterNotRegisteredException  "
+        fail("Expecting an ApplicationMasterNotRegisteredException  "
             + " after FederationInterceptor restarts and recovers");
       } catch (ApplicationMasterNotRegisteredException e) {
       }
@@ -446,16 +447,16 @@ public class TestFederationInterceptorSecure extends BaseAMRMProxyTest {
 
       FinishApplicationMasterResponse finishResponse =
           interceptor.finishApplicationMaster(finishReq);
-      Assert.assertNotNull(finishResponse);
-      Assert.assertTrue(finishResponse.getIsUnregistered());
+      assertNotNull(finishResponse);
+      assertTrue(finishResponse.getIsUnregistered());
 
       // After the application succeeds, the registry/NMSS entry should be
       // cleaned up
       if (registryObj != null) {
-        Assert.assertEquals(0, interceptor.getRegistryClient().getAllApplications().size());
+        assertEquals(0, interceptor.getRegistryClient().getAllApplications().size());
       } else {
         recoveredDataMap = recoverDataMapForAppAttempt(nmStateStore, attemptId);
-        Assert.assertFalse(recoveredDataMap.containsKey(scEntry));
+        assertFalse(recoveredDataMap.containsKey(scEntry));
       }
       return null;
     });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/impl/pb/TestNMProtoUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/impl/pb/TestNMProtoUtils.java
@@ -25,12 +25,12 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.DeletionTaskType;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.DockerContainerDeletionTask;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/protocolrecords/impl/pb/TestPBLocalizerRPC.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/protocolrecords/impl/pb/TestPBLocalizerRPC.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.impl.pb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
 
@@ -32,7 +32,7 @@ import org.apache.hadoop.yarn.server.nodemanager.api.LocalizationProtocol;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerAction;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerHeartbeatResponse;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestPBLocalizerRPC {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/protocolrecords/impl/pb/TestPBRecordImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/api/protocolrecords/impl/pb/TestPBRecordImpl.java
@@ -17,16 +17,15 @@
 */
 package org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.impl.pb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
 import org.apache.hadoop.yarn.api.records.URL;
-import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -49,7 +48,8 @@ import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerHe
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerStatus;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.ResourceStatusType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestPBRecordImpl {
 
@@ -118,7 +118,8 @@ public class TestPBRecordImpl {
     return ret;
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testLocalResourceStatusSerDe() throws Exception {
     LocalResourceStatus rsrcS = createLocalResourceStatus();
     assertTrue(rsrcS instanceof LocalResourceStatusPBImpl);
@@ -138,7 +139,8 @@ public class TestPBRecordImpl {
     assertEquals(createResource(), rsrcD.getResource());
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testLocalizerStatusSerDe() throws Exception {
     LocalizerStatus rsrcS = createLocalizerStatus();
     assertTrue(rsrcS instanceof LocalizerStatusPBImpl);
@@ -160,7 +162,8 @@ public class TestPBRecordImpl {
     assertEquals(createLocalResourceStatus(), rsrcD.getResourceStatus(0));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testLocalizerHeartbeatResponseSerDe() throws Exception {
     LocalizerHeartbeatResponse rsrcS = createLocalizerHeartbeatResponse();
     assertTrue(rsrcS instanceof LocalizerHeartbeatResponsePBImpl);
@@ -182,14 +185,15 @@ public class TestPBRecordImpl {
   }
 
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testSerializedExceptionDeSer() throws Exception{
     // without cause
     YarnException yarnEx = new YarnException("Yarn_Exception");
     SerializedException serEx = SerializedException.newInstance(yarnEx);
     Throwable throwable = serEx.deSerialize();
-    Assert.assertEquals(yarnEx.getClass(), throwable.getClass());
-    Assert.assertEquals(yarnEx.getMessage(), throwable.getMessage());
+    assertEquals(yarnEx.getClass(), throwable.getClass());
+    assertEquals(yarnEx.getMessage(), throwable.getMessage());
 
     // with cause
     IOException ioe = new IOException("Test_IOException");
@@ -201,13 +205,13 @@ public class TestPBRecordImpl {
     SerializedException serEx2 = SerializedException.newInstance(yarnEx2);
     Throwable throwable2 = serEx2.deSerialize();
     throwable2.printStackTrace();
-    Assert.assertEquals(yarnEx2.getClass(), throwable2.getClass());
-    Assert.assertEquals(yarnEx2.getMessage(), throwable2.getMessage());
+    assertEquals(yarnEx2.getClass(), throwable2.getClass());
+    assertEquals(yarnEx2.getMessage(), throwable2.getMessage());
 
-    Assert.assertEquals(runtimeException.getClass(), throwable2.getCause().getClass());
-    Assert.assertEquals(runtimeException.getMessage(), throwable2.getCause().getMessage());
+    assertEquals(runtimeException.getClass(), throwable2.getCause().getClass());
+    assertEquals(runtimeException.getMessage(), throwable2.getCause().getMessage());
 
-    Assert.assertEquals(ioe.getClass(), throwable2.getCause().getCause().getClass());
-    Assert.assertEquals(ioe.getMessage(), throwable2.getCause().getCause().getMessage());
+    assertEquals(ioe.getClass(), throwable2.getCause().getCause().getClass());
+    assertEquals(ioe.getMessage(), throwable2.getCause().getCause().getMessage());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
@@ -94,9 +94,10 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerIn
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class BaseContainerManagerTest {
 
@@ -179,7 +180,7 @@ public abstract class BaseContainerManagerTest {
     return spy(exec);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     localFS.delete(new Path(localDir.getAbsolutePath()), true);
     localFS.delete(new Path(tmpDir.getAbsolutePath()), true);
@@ -307,7 +308,7 @@ public abstract class BaseContainerManagerTest {
     };
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException, InterruptedException {
     if (containerManager != null) {
       containerManager.stop();
@@ -358,8 +359,8 @@ public abstract class BaseContainerManagerTest {
     } while (!fStates.contains(containerStatus.getState())
         && timeoutSecs < timeOutMax);
     LOG.info("Container state is " + containerStatus.getState());
-    Assert.assertTrue("ContainerState is not correct (timedout)",
-          fStates.contains(containerStatus.getState()));
+    assertTrue(fStates.contains(containerStatus.getState()),
+        "ContainerState is not correct (timedout)");
   }
 
   public static void waitForApplicationState(
@@ -378,8 +379,8 @@ public abstract class BaseContainerManagerTest {
       Thread.sleep(1000);
     }
   
-    Assert.assertTrue("App is not in " + finalState + " yet!! Timedout!!",
-        app.getApplicationState().equals(finalState));
+    assertTrue(app.getApplicationState().equals(finalState),
+        "App is not in " + finalState + " yet!! Timedout!!");
   }
 
   public static void waitForNMContainerState(ContainerManagerImpl
@@ -423,8 +424,8 @@ public abstract class BaseContainerManagerTest {
     } while (!finalStates.contains(currentState)
         && timeoutSecs < timeOutMax);
     LOG.info("Container state is " + currentState);
-    Assert.assertTrue("ContainerState is not correct (timedout)",
-        finalStates.contains(currentState));
+    assertTrue(finalStates.contains(currentState),
+        "ContainerState is not correct (timedout)");
   }
 
   public static Token createContainerToken(ContainerId cId, long rmIdentifier,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
@@ -97,7 +97,6 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionTask;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceFile;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -531,8 +530,7 @@ public class TestAuxServices {
       // Validate the path on reuse of localized jar
       path = aux.maybeDownloadJars("ServiceB", ServiceB.class.getName(),
           testJar.getAbsolutePath(), AuxServiceFile.TypeEnum.STATIC, conf);
-      assertFalse(
-         path.toString().endsWith("/*"), "Failed to reuse the localized jar");
+      assertFalse(path.toString().endsWith("/*"), "Failed to reuse the localized jar");
     } finally {
       if (testJar != null) {
         testJar.delete();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
@@ -142,7 +142,7 @@ public class TestAuxServices {
     rootDir.delete();
   }
 
-  public void initTestAuxServices(Boolean pUseManifest) {
+  private void initTestAuxServices(Boolean pUseManifest) {
     this.useManifest = pUseManifest;
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestAuxServices.java
@@ -21,11 +21,13 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager;
 import static org.apache.hadoop.service.Service.STATE.INITED;
 import static org.apache.hadoop.service.Service.STATE.STARTED;
 import static org.apache.hadoop.service.Service.STATE.STOPPED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -39,11 +41,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceRecord;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceRecords;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,14 +97,15 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionTask;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.records.AuxServiceFile;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test for auxiliary services. Parameter 0 tests the Configuration-based aux
  * services and parameter 1 tests manifest-based aux services.
  */
-@RunWith(value = Parameterized.class)
 public class TestAuxServices {
   private static final Logger LOG =
        LoggerFactory.getLogger(TestAuxServices.class);
@@ -118,25 +118,24 @@ public class TestAuxServices {
   private final static Context MOCK_CONTEXT = mock(Context.class);
   private final static DeletionService MOCK_DEL_SERVICE = mock(
       DeletionService.class);
-  private final Boolean useManifest;
+  private Boolean useManifest;
   private File rootDir = GenericTestUtils.getTestDir(getClass()
       .getSimpleName());
   private File manifest = new File(rootDir, "manifest.txt");
   private ObjectMapper mapper = new ObjectMapper();
 
-  @Parameterized.Parameters
   public static Collection<Boolean> getParams() {
     return Arrays.asList(false, true);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     if (!rootDir.exists()) {
       rootDir.mkdirs();
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (useManifest) {
       manifest.delete();
@@ -144,8 +143,8 @@ public class TestAuxServices {
     rootDir.delete();
   }
 
-  public TestAuxServices(Boolean useManifest) {
-    this.useManifest = useManifest;
+  public void initTestAuxServices(Boolean pUseManifest) {
+    this.useManifest = pUseManifest;
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 
@@ -269,8 +268,10 @@ public class TestAuxServices {
   }
 
   @SuppressWarnings("resource")
-  @Test
-  public void testRemoteAuxServiceClassPath() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testRemoteAuxServiceClassPath(boolean pUseManifest) throws Exception {
+    initTestAuxServices(pUseManifest);
     Configuration conf = new YarnConfiguration();
     FileSystem fs = FileSystem.get(conf);
     AuxServiceRecord serviceC =
@@ -320,11 +321,11 @@ public class TestAuxServices {
         aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
             mockContext2, mockDelService2);
         aux.init(conf);
-        Assert.fail("The permission of the jar is wrong."
+        fail("The permission of the jar is wrong."
             + "Should throw out exception.");
       } catch (YarnRuntimeException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(
-            "The remote jarfile should not be writable by group or others"));
+        assertTrue(ex.getMessage().contains(
+            "The remote jarfile should not be writable by group or others"), ex.getMessage());
       }
 
       Files.delete(Paths.get(testJar.getAbsolutePath()));
@@ -345,14 +346,14 @@ public class TestAuxServices {
       aux.start();
       Map<String, ByteBuffer> meta = aux.getMetaData();
       String auxName = "";
-      Assert.assertTrue(meta.size() == 1);
+      assertTrue(meta.size() == 1);
       for(Entry<String, ByteBuffer> i : meta.entrySet()) {
         auxName = i.getKey();
       }
-      Assert.assertEquals("ServiceC", auxName);
+      assertEquals("ServiceC", auxName);
       aux.serviceStop();
       FileStatus[] status = fs.listStatus(rootAuxServiceDirPath);
-      Assert.assertTrue(status.length == 1);
+      assertTrue(status.length == 1);
 
       // initialize the same auxservice again, and make sure that we did not
       // re-download the jar from remote directory.
@@ -361,14 +362,14 @@ public class TestAuxServices {
       aux.init(conf);
       aux.start();
       meta = aux.getMetaData();
-      Assert.assertTrue(meta.size() == 1);
+      assertTrue(meta.size() == 1);
       for(Entry<String, ByteBuffer> i : meta.entrySet()) {
         auxName = i.getKey();
       }
-      Assert.assertEquals("ServiceC", auxName);
+      assertEquals("ServiceC", auxName);
       verify(mockDelService2, times(0)).delete(any(FileDeletionTask.class));
       status = fs.listStatus(rootAuxServiceDirPath);
-      Assert.assertTrue(status.length == 1);
+      assertTrue(status.length == 1);
       aux.serviceStop();
 
       // change the last modification time for remote jar,
@@ -383,7 +384,7 @@ public class TestAuxServices {
       aux.start();
       verify(mockDelService2, times(1)).delete(any(FileDeletionTask.class));
       status = fs.listStatus(rootAuxServiceDirPath);
-      Assert.assertTrue(status.length == 2);
+      assertTrue(status.length == 2);
       aux.serviceStop();
     } finally {
       if (testJar != null) {
@@ -400,8 +401,11 @@ public class TestAuxServices {
   // including ServiceC class, and add this jar to customized directory.
   // By setting some proper configurations, we should load ServiceC class
   // from customized class path.
-  @Test (timeout = 15000)
-  public void testCustomizedAuxServiceClassPath() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  @Timeout(value = 15)
+  public void testCustomizedAuxServiceClassPath(boolean pUseManifest) throws Exception {
+    initTestAuxServices(pUseManifest);
     // verify that we can load AuxService Class from default Class path
     Configuration conf = new YarnConfiguration();
     AuxServiceRecord serviceC =
@@ -423,14 +427,14 @@ public class TestAuxServices {
     Map<String, ByteBuffer> meta = aux.getMetaData();
     String auxName = "";
     Set<String> defaultAuxClassPath = null;
-    Assert.assertTrue(meta.size() == 1);
+    assertTrue(meta.size() == 1);
     for(Entry<String, ByteBuffer> i : meta.entrySet()) {
       auxName = i.getKey();
       String auxClassPath = StandardCharsets.UTF_8.decode(i.getValue()).toString();
       defaultAuxClassPath = new HashSet<String>(Arrays.asList(StringUtils
           .getTrimmedStrings(auxClassPath)));
     }
-    Assert.assertEquals("ServiceC", auxName);
+    assertEquals("ServiceC", auxName);
     aux.serviceStop();
 
     // create a new jar file, and configure it as customized class path
@@ -474,14 +478,14 @@ public class TestAuxServices {
       aux.init(conf);
       aux.start();
       meta = aux.getMetaData();
-      Assert.assertTrue(meta.size() == 1);
+      assertTrue(meta.size() == 1);
       Set<String> customizedAuxClassPath = null;
       for(Entry<String, ByteBuffer> i : meta.entrySet()) {
-        Assert.assertTrue(auxName.equals(i.getKey()));
+        assertTrue(auxName.equals(i.getKey()));
         String classPath = StandardCharsets.UTF_8.decode(i.getValue()).toString();
         customizedAuxClassPath = new HashSet<String>(Arrays.asList(StringUtils
             .getTrimmedStrings(classPath)));
-        Assert.assertTrue(classPath.contains(testJar.getName()));
+        assertTrue(classPath.contains(testJar.getName()));
       }
       aux.stop();
 
@@ -489,7 +493,7 @@ public class TestAuxServices {
       // and the default class path.
       Set<String> mutalClassPath = Sets.intersection(defaultAuxClassPath,
           customizedAuxClassPath);
-      Assert.assertTrue(mutalClassPath.isEmpty());
+      assertTrue(mutalClassPath.isEmpty());
     } finally {
       if (testJar != null) {
         testJar.delete();
@@ -497,8 +501,11 @@ public class TestAuxServices {
     }
   }
 
-  @Test (timeout = 15000)
-  public void testReuseLocalizedAuxiliaryJar() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  @Timeout(value = 15)
+  public void testReuseLocalizedAuxiliaryJar(boolean pUseManifest) throws Exception {
+    initTestAuxServices(pUseManifest);
     File testJar = null;
     AuxServices aux = null;
     Configuration conf = new YarnConfiguration();
@@ -524,8 +531,8 @@ public class TestAuxServices {
       // Validate the path on reuse of localized jar
       path = aux.maybeDownloadJars("ServiceB", ServiceB.class.getName(),
           testJar.getAbsolutePath(), AuxServiceFile.TypeEnum.STATIC, conf);
-      assertFalse("Failed to reuse the localized jar",
-          path.toString().endsWith("/*"));
+      assertFalse(
+         path.toString().endsWith("/*"), "Failed to reuse the localized jar");
     } finally {
       if (testJar != null) {
         testJar.delete();
@@ -536,8 +543,10 @@ public class TestAuxServices {
     }
   }
 
-  @Test
-  public void testAuxEventDispatch() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxEventDispatch(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = new Configuration();
     if (useManifest) {
       AuxServiceRecord serviceA =
@@ -579,8 +588,8 @@ public class TestAuxServices {
     Collection<AuxiliaryService> servs = aux.getServices();
     for (AuxiliaryService serv: servs) {
       ArrayList<Integer> appIds = ((LightService)serv).getAppIdsStopped();
-      assertEquals("app not properly stopped", 1, appIds.size());
-      assertTrue("wrong app stopped", appIds.contains((Integer)66));
+      assertEquals(1, appIds.size(), "app not properly stopped");
+      assertTrue(appIds.contains((Integer)66), "wrong app stopped");
     }
 
     for (AuxiliaryService serv : servs) {
@@ -642,8 +651,10 @@ public class TestAuxServices {
     return conf;
   }
 
-  @Test
-  public void testAuxServices() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxServices(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = getABConf();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
         MOCK_CONTEXT, MOCK_DEL_SERVICE);
@@ -656,7 +667,7 @@ public class TestAuxServices {
       else if (s instanceof ServiceB) { latch *= 3; }
       else fail("Unexpected service type " + s.getClass());
     }
-    assertEquals("Invalid mix of services", 6, latch);
+    assertEquals(6, latch, "Invalid mix of services");
     aux.start();
     for (AuxiliaryService s : aux.getServices()) {
       assertEquals(STARTED, s.getServiceState());
@@ -670,8 +681,10 @@ public class TestAuxServices {
     }
   }
 
-  @Test
-  public void testAuxServicesMeta() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxServicesMeta(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = getABConf();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
         MOCK_CONTEXT, MOCK_DEL_SERVICE);
@@ -684,7 +697,7 @@ public class TestAuxServices {
       else if (s instanceof ServiceB) { latch *= 3; }
       else fail("Unexpected service type " + s.getClass());
     }
-    assertEquals("Invalid mix of services", 6, latch);
+    assertEquals(6, latch, "Invalid mix of services");
     aux.start();
     for (Service s : aux.getServices()) {
       assertEquals(STARTED, s.getServiceState());
@@ -701,8 +714,10 @@ public class TestAuxServices {
     }
   }
 
-  @Test
-  public void testAuxUnexpectedStop() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxUnexpectedStop(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     // AuxServices no longer expected to stop when services stop
     Configuration conf = getABConf();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
@@ -712,13 +727,15 @@ public class TestAuxServices {
 
     Service s = aux.getServices().iterator().next();
     s.stop();
-    assertEquals("Auxiliary service stop caused AuxServices stop",
-        STARTED, aux.getServiceState());
+    assertEquals(STARTED, aux.getServiceState(),
+        "Auxiliary service stop caused AuxServices stop");
     assertEquals(2, aux.getServices().size());
   }
 
-  @Test
-  public void testValidAuxServiceName() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testValidAuxServiceName(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = getABConf("Asrv1", "Bsrv_2", ServiceA.class,
         ServiceB.class);
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
@@ -726,7 +743,7 @@ public class TestAuxServices {
     try {
       aux.init(conf);
     } catch (Exception ex) {
-      Assert.fail("Should not receive the exception.");
+      fail("Should not receive the exception.");
     }
 
     //Test bad auxService Name
@@ -744,17 +761,18 @@ public class TestAuxServices {
     }
     try {
       aux1.init(conf);
-      Assert.fail("Should receive the exception.");
+      fail("Should receive the exception.");
     } catch (Exception ex) {
-      assertTrue("Wrong message: " + ex.getMessage(),
-          ex.getMessage().contains("The auxiliary service name: 1Asrv1 is " +
-              "invalid. The valid service name should only contain a-zA-Z0-9_" +
-              " and cannot start with numbers."));
+      assertTrue(ex.getMessage().contains("The auxiliary service name: 1Asrv1 is " +
+          "invalid. The valid service name should only contain a-zA-Z0-9_" +
+          " and cannot start with numbers."), "Wrong message: " + ex.getMessage());
     }
   }
 
-  @Test
-  public void testAuxServiceRecoverySetup() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxServiceRecoverySetup(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = getABConf("Asrv", "Bsrv", RecoverableServiceA.class,
         RecoverableServiceB.class);
     conf.setBoolean(YarnConfiguration.NM_RECOVERY_ENABLED, true);
@@ -763,10 +781,10 @@ public class TestAuxServices {
       final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
           MOCK_CONTEXT, MOCK_DEL_SERVICE);
       aux.init(conf);
-      Assert.assertEquals(2, aux.getServices().size());
+      assertEquals(2, aux.getServices().size());
       File auxStorageDir = new File(TEST_DIR,
           AuxServices.STATE_STORE_ROOT_NAME);
-      Assert.assertEquals(2, auxStorageDir.listFiles().length);
+      assertEquals(2, auxStorageDir.listFiles().length);
       aux.close();
     } finally {
       FileUtil.fullyDelete(TEST_DIR);
@@ -788,15 +806,14 @@ public class TestAuxServices {
     protected void serviceInit(Configuration conf) throws Exception {
       super.serviceInit(conf);
       Path storagePath = getRecoveryPath();
-      Assert.assertNotNull("Recovery path not present when aux service inits",
-          storagePath);
-      Assert.assertTrue(storagePath.toString().contains(auxName));
+      assertNotNull(storagePath,
+          "Recovery path not present when aux service inits");
+      assertTrue(storagePath.toString().contains(auxName));
       FileSystem fs = FileSystem.getLocal(conf);
-      Assert.assertTrue("Recovery path does not exist",
-          fs.exists(storagePath));
-      Assert.assertEquals("Recovery path has wrong permissions",
-          new FsPermission((short)0700),
-          fs.getFileStatus(storagePath).getPermission());
+      assertTrue(fs.exists(storagePath), "Recovery path does not exist");
+      assertEquals(new FsPermission((short)0700),
+          fs.getFileStatus(storagePath).getPermission(),
+          "Recovery path has wrong permissions");
     }
 
     @Override
@@ -854,8 +871,10 @@ public class TestAuxServices {
     }
   }
 
-  @Test
-  public void testAuxServicesConfChange() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxServicesConfChange(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = new Configuration();
     if (useManifest) {
       AuxServiceRecord service =
@@ -887,9 +906,11 @@ public class TestAuxServices {
     aux.stop();
   }
 
-  @Test
-  public void testAuxServicesManifestPermissions() throws IOException {
-    Assume.assumeTrue(useManifest);
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testAuxServicesManifestPermissions(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
+    assumeTrue(useManifest);
     Configuration conf = getABConf();
     FileSystem fs = FileSystem.get(conf);
     fs.setPermission(new Path(manifest.getAbsolutePath()), FsPermission
@@ -936,9 +957,11 @@ public class TestAuxServices {
     assertEquals(2, aux.getServices().size());
   }
 
-  @Test
-  public void testRemoveManifest() throws IOException {
-    Assume.assumeTrue(useManifest);
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testRemoveManifest(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
+    assumeTrue(useManifest);
     Configuration conf = getABConf();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
         MOCK_CONTEXT, MOCK_DEL_SERVICE);
@@ -949,20 +972,22 @@ public class TestAuxServices {
     assertEquals(0, aux.getServices().size());
   }
 
-  @Test
-  public void testManualReload() throws IOException {
-    Assume.assumeTrue(useManifest);
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testManualReload(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
+    assumeTrue(useManifest);
     Configuration conf = getABConf();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
         MOCK_CONTEXT, MOCK_DEL_SERVICE);
     aux.init(conf);
     try {
       aux.reload(null);
-      Assert.fail("Should receive the exception.");
+      fail("Should receive the exception.");
     } catch (IOException e) {
-      assertTrue("Wrong message: " + e.getMessage(),
-          e.getMessage().equals("Auxiliary services have not been started " +
-              "yet, please retry later"));
+      assertTrue(e.getMessage().equals("Auxiliary services have not been started " +
+          "yet, please retry later"),
+          "Wrong message: " + e.getMessage());
     }
     aux.start();
     assertEquals(2, aux.getServices().size());
@@ -973,27 +998,29 @@ public class TestAuxServices {
     aux.stop();
   }
 
-  @Test
-  public void testReloadWhenDisabled() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testReloadWhenDisabled(boolean pUseManifest) throws IOException {
+    initTestAuxServices(pUseManifest);
     Configuration conf = new Configuration();
     final AuxServices aux = new AuxServices(MOCK_AUX_PATH_HANDLER,
         MOCK_CONTEXT, MOCK_DEL_SERVICE);
     aux.init(conf);
     try {
       aux.reload(null);
-      Assert.fail("Should receive the exception.");
+      fail("Should receive the exception.");
     } catch (IOException e) {
-      assertTrue("Wrong message: " + e.getMessage(),
-          e.getMessage().equals("Dynamic reloading is not enabled via " +
-              YarnConfiguration.NM_AUX_SERVICES_MANIFEST_ENABLED));
+      assertTrue(e.getMessage().equals("Dynamic reloading is not enabled via " +
+          YarnConfiguration.NM_AUX_SERVICES_MANIFEST_ENABLED),
+          "Wrong message: " + e.getMessage());
     }
     try {
       aux.reloadManifest();
-      Assert.fail("Should receive the exception.");
+      fail("Should receive the exception.");
     } catch (IOException e) {
-      assertTrue("Wrong message: " + e.getMessage(),
-          e.getMessage().equals("Dynamic reloading is not enabled via " +
-              YarnConfiguration.NM_AUX_SERVICES_MANIFEST_ENABLED));
+      assertTrue(e.getMessage().equals("Dynamic reloading is not enabled via " +
+          YarnConfiguration.NM_AUX_SERVICES_MANIFEST_ENABLED),
+          "Wrong message: " + e.getMessage());
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
@@ -1200,12 +1200,12 @@ public class TestContainerManager extends BaseContainerManagerTest {
   @Test
   public void testContainerLaunchAndExitSuccess() throws IOException,
       InterruptedException, YarnException {
-	containerManager.start();
+    containerManager.start();
     int exitCode = 0;
 
-	// launch context for a command that will return exit code 0
-	// and verify exit code returned
-	testContainerLaunchAndExit(exitCode);
+    // launch context for a command that will return exit code 0
+    // and verify exit code returned
+    testContainerLaunchAndExit(exitCode);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
@@ -30,9 +30,12 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.assertGaugeGt;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -124,8 +127,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.Reso
 import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerSignalContext;
 import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerStartContext;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
@@ -229,7 +232,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     if (!localAddr.getHostAddress().equals(fqdn)) {
       // only check if fqdn is not same as ip
       // api returns ip in case of resolution failure
-      Assert.assertEquals(fqdn, context.getNodeId().getHost());
+      assertEquals(fqdn, context.getNodeId().getHost());
     }
   
     // Just do a query for a non-existing container.
@@ -248,7 +251,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch (Throwable e) {
       throwsException = true;
     }
-    Assert.assertTrue(throwsException);
+    assertTrue(throwsException);
   }
 
   @Test
@@ -318,17 +321,17 @@ public class TestContainerManager extends BaseContainerManagerTest {
     for (File f : new File[] { localDir, sysDir, userCacheDir, appDir,
         appSysDir,
         containerDir, containerSysDir }) {
-      Assert.assertTrue(f.getAbsolutePath() + " doesn't exist!!", f.exists());
-      Assert.assertTrue(f.getAbsolutePath() + " is not a directory!!",
-          f.isDirectory());
+      assertTrue(f.exists(), f.getAbsolutePath() + " doesn't exist!!");
+      assertTrue(f.isDirectory(),
+          f.getAbsolutePath() + " is not a directory!!");
     }
-    Assert.assertTrue(targetFile.getAbsolutePath() + " doesn't exist!!",
-        targetFile.exists());
+    assertTrue(targetFile.exists(),
+        targetFile.getAbsolutePath() + " doesn't exist!!");
 
     // Now verify the contents of the file
     BufferedReader reader = new BufferedReader(new FileReader(targetFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
+    assertEquals(null, reader.readLine());
 
     //
     // check the localization counter
@@ -364,7 +367,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
     assertGauge("LocalizedCacheHitFilesRatio", 50, rb);
   }
 
-  @Test (timeout = 10000L)
+  @Test
+  @Timeout(10)
   public void testAuxPathHandler() throws Exception {
     File testDir = GenericTestUtils
         .getTestDir(TestContainerManager.class.getSimpleName() + "LocDir");
@@ -391,7 +395,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
       auxiliaryLocalPathHandler.getLocalPathForRead("test");
       fail("Should not have passed!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("Could not find"));
+      assertTrue(e.getMessage().contains("Could not find"));
     } finally {
       testFile.delete();
       testDir.delete();
@@ -460,26 +464,26 @@ public class TestContainerManager extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        processStartFile.exists());
+    assertTrue(processStartFile.exists(),
+        "ProcessStartFile doesn't exist!");
     
     // Now verify the contents of the file
     BufferedReader reader =
         new BufferedReader(new FileReader(processStartFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
     // Get the pid of the process
     String pid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
     // Now test the stop functionality.
 
     // Assert that the process is alive
-    Assert.assertTrue("Process is not alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
     // Once more
-    Assert.assertTrue("Process is not alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
 
     List<ContainerId> containerIds = new ArrayList<>();
     containerIds.add(cId);
@@ -494,11 +498,11 @@ public class TestContainerManager extends BaseContainerManagerTest {
     ContainerStatus containerStatus = 
         containerManager.getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
     int expectedExitCode = ContainerExitStatus.KILLED_BY_APPMASTER;
-    Assert.assertEquals(expectedExitCode, containerStatus.getExitStatus());
+    assertEquals(expectedExitCode, containerStatus.getExitStatus());
 
     // Assert that the process is not alive anymore
-    Assert.assertFalse("Process is still alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is still alive!");
   }
 
   @Test
@@ -523,9 +527,9 @@ public class TestContainerManager extends BaseContainerManagerTest {
     int beforeRestart = metrics.getRunningContainers();
     Container container =
         containerManager.getContext().getContainers().get(cId);
-    Assert.assertFalse(container.isReInitializing());
+    assertFalse(container.isReInitializing());
     containerManager.restartContainer(cId);
-    Assert.assertTrue(container.isReInitializing());
+    assertTrue(container.isReInitializing());
 
     // Wait for original process to die and the new process to restart
     int timeoutSecs = 0;
@@ -538,8 +542,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
           "and new process to start!!");
     }
 
-    Assert.assertFalse("Old Process Still alive!!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Old Process Still alive!!");
 
     String newPid = null;
     timeoutSecs = 0;
@@ -548,11 +552,11 @@ public class TestContainerManager extends BaseContainerManagerTest {
       // Now verify the contents of the file
       BufferedReader reader =
           new BufferedReader(new FileReader(oldStartFile));
-      Assert.assertEquals(testString, reader.readLine());
+      assertEquals(testString, reader.readLine());
       // Get the pid of the process
       newPid = reader.readLine().trim();
       // No more lines
-      Assert.assertEquals(null, reader.readLine());
+      assertEquals(null, reader.readLine());
       reader.close();
       if (!newPid.equals(pid)) {
         break;
@@ -561,10 +565,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
     }
 
     // Assert both pids are different
-    Assert.assertNotEquals(pid, newPid);
+    assertNotEquals(pid, newPid);
 
     // Container cannot rollback from a restart
-    Assert.assertEquals(canRollback, container.canRollback());
+    assertEquals(canRollback, container.canRollback());
 
     return newPid;
   }
@@ -587,33 +591,33 @@ public class TestContainerManager extends BaseContainerManagerTest {
     ResourceUtilization afterUpgrade =
         ResourceUtilization.newInstance(
             containerManager.getContainerScheduler().getCurrentUtilization());
-    Assert.assertEquals("Possible resource leak detected !!",
-        beforeUpgrade, afterUpgrade);
+    assertEquals(beforeUpgrade, afterUpgrade,
+        "Possible resource leak detected !!");
 
     // Assert that the First process is not alive anymore
-    Assert.assertFalse("Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is still alive!");
 
     BufferedReader reader =
         new BufferedReader(new FileReader(newStartFile));
-    Assert.assertEquals("Upgrade World!", reader.readLine());
+    assertEquals("Upgrade World!", reader.readLine());
 
     // Get the pid of the process
     String newPid = reader.readLine().trim();
-    Assert.assertNotEquals("Old and New Pids must be different !", pid, newPid);
+    assertNotEquals(pid, newPid, "Old and New Pids must be different !");
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
     reader.close();
 
     // Verify old file still exists and is accessible by
     // the new process...
     reader = new BufferedReader(new FileReader(oldStartFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
 
     // Assert that the New process is alive
-    Assert.assertTrue("New Process is not alive!",
-        DefaultContainerExecutor.containerIsAlive(newPid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(newPid),
+        "New Process is not alive!");
     return new String[]{pid, newPid};
   }
 
@@ -627,15 +631,15 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // Should not be able to Commit (since already auto committed)
     try {
       containerManager.commitLastReInitialization(createContainerId(0));
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Nothing to Commit"));
+      assertTrue(e.getMessage().contains("Nothing to Commit"));
     }
 
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.states.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -657,7 +661,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     List<ContainerEventType> containerEventTypes =
         listener.events.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         ContainerEventType.INIT_CONTAINER,
         ContainerEventType.RESOURCE_LOCALIZED,
         ContainerEventType.CONTAINER_LAUNCHED,
@@ -677,9 +681,9 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // Should not be able to Rollback once committed
     try {
       containerManager.rollbackLastReInitialization(cId);
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Nothing to rollback to"));
+      assertTrue(e.getMessage().contains("Nothing to rollback to"));
     }
   }
 
@@ -709,10 +713,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     Container container =
         containerManager.getContext().getContainers().get(cId);
-    Assert.assertTrue(container.isReInitializing());
+    assertTrue(container.isReInitializing());
     // Original should be dead anyway
-    Assert.assertFalse("Original Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(pids[0]));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pids[0]),
+        "Original Process is still alive!");
 
     // Wait for new container to startup
     int timeoutSecs = 0;
@@ -720,7 +724,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for ReInitialization to complete..");
     }
-    Assert.assertFalse(container.isReInitializing());
+    assertFalse(container.isReInitializing());
 
     timeoutSecs = 0;
     // Wait for new processStartfile to be created
@@ -732,19 +736,19 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // Now verify the contents of the file
     BufferedReader reader =
         new BufferedReader(new FileReader(oldStartFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
     // Get the pid of the process
     String rolledBackPid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
-    Assert.assertNotEquals("The Rolled-back process should be a different pid",
-        pids[0], rolledBackPid);
+    assertNotEquals(pids[0], rolledBackPid,
+        "The Rolled-back process should be a different pid");
 
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.states.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -784,7 +788,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     List<ContainerEventType> containerEventTypes =
         listener.events.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         ContainerEventType.INIT_CONTAINER,
         ContainerEventType.RESOURCE_LOCALIZED,
         ContainerEventType.CONTAINER_LAUNCHED,
@@ -825,13 +829,13 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     // Assert that the First process is STILL alive
     // since upgrade was terminated..
-    Assert.assertTrue("Process is NOT alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is NOT alive!");
 
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.states.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -847,7 +851,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     List<ContainerEventType> containerEventTypes =
         listener.events.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         ContainerEventType.INIT_CONTAINER,
         ContainerEventType.RESOURCE_LOCALIZED,
         ContainerEventType.CONTAINER_LAUNCHED,
@@ -876,8 +880,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
     prepareContainerUpgrade(true, true, false, cId, newStartFile);
 
     // Assert that the First process is not alive anymore
-    Assert.assertFalse("Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is still alive!");
   }
 
   @Test
@@ -901,8 +905,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
     prepareContainerUpgrade(false, true, false, cId, newStartFile);
 
     // Assert that the First process is not alive anymore
-    Assert.assertFalse("Original Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Original Process is still alive!");
 
     int timeoutSecs = 0;
     // Wait for oldStartFile to be created
@@ -916,19 +920,19 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // Now verify the contents of the file
     BufferedReader reader =
         new BufferedReader(new FileReader(oldStartFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
     // Get the pid of the process
     String rolledBackPid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
-    Assert.assertNotEquals("The Rolled-back process should be a different pid",
-        pid, rolledBackPid);
+    assertNotEquals(pid, rolledBackPid,
+        "The Rolled-back process should be a different pid");
 
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.states.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -956,7 +960,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     List<ContainerEventType> containerEventTypes =
         listener.events.get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         ContainerEventType.INIT_CONTAINER,
         ContainerEventType.RESOURCE_LOCALIZED,
         ContainerEventType.CONTAINER_LAUNCHED,
@@ -996,7 +1000,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
       containerManager.reInitializeContainer(cId, containerLaunchContext,
           autoCommit);
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot perform RE_INIT"));
+      assertTrue(e.getMessage().contains("Cannot perform RE_INIT"));
     }
     int timeoutSecs = 0;
     int maxTimeToWait = failLoc ? 10 : 20;
@@ -1038,24 +1042,23 @@ public class TestContainerManager extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        startFile.exists());
+    assertTrue(startFile.exists(), "ProcessStartFile doesn't exist!");
 
     // Now verify the contents of the file
     BufferedReader reader =
         new BufferedReader(new FileReader(startFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
     // Get the pid of the process
     String pid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
     // Assert that the process is alive
-    Assert.assertTrue("Process is not alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
     // Once more
-    Assert.assertTrue("Process is not alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
     return pid;
   }
 
@@ -1191,7 +1194,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
         getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
 
 	  // Verify exit status matches exit state of script
-	  Assert.assertEquals(exitCode,
+	  assertEquals(exitCode,
 			  containerStatus.getExitStatus());	    
   }
   
@@ -1306,9 +1309,9 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // Verify container cannot localize resources while at non-running state.
     try{
       containerManager.localize(request);
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains("Cannot perform LOCALIZE"));
     }
   }
@@ -1333,19 +1336,16 @@ public class TestContainerManager extends BaseContainerManagerTest {
     // localDir/nmPrivate/application_0_0000/container_0_0000_01_000000
     File containerSysDir = new File(appSysDir, containerId.toString());
 
-    Assert.assertTrue("AppDir " + appDir.getAbsolutePath() + " doesn't exist!!",
-        appDir.exists());
-    Assert.assertTrue(
-        "AppSysDir " + appSysDir.getAbsolutePath() + " doesn't exist!!",
-        appSysDir.exists());
-    Assert.assertTrue(
-        "containerDir " + containerDir.getAbsolutePath() + " doesn't exist !",
-        containerDir.exists());
-    Assert.assertTrue("containerSysDir " + containerSysDir.getAbsolutePath()
-        + " doesn't exist !", containerDir.exists());
-    Assert.assertTrue(
-        "targetFile " + targetFile.getAbsolutePath() + " doesn't exist !!",
-        targetFile.exists());
+    assertTrue(appDir.exists(), "AppDir " + appDir.getAbsolutePath() + " doesn't exist!!");
+    assertTrue(appSysDir.exists(), "AppSysDir "
+        + appSysDir.getAbsolutePath() + " doesn't exist!!");
+    assertTrue(containerDir.exists(), "containerDir "
+        + containerDir.getAbsolutePath() + " doesn't exist !");
+    assertTrue(containerDir.exists(), "containerSysDir "
+        + containerSysDir.getAbsolutePath()
+        + " doesn't exist !");
+    assertTrue(targetFile.exists(),
+        "targetFile " + targetFile.getAbsolutePath() + " doesn't exist !!");
   }
 
   @Test
@@ -1423,15 +1423,15 @@ public class TestContainerManager extends BaseContainerManagerTest {
     File appSysDir = new File(sysDir, appIDStr);
     File containerSysDir = new File(appSysDir, containerIDStr);
     // AppDir should still exist
-    Assert.assertTrue("AppDir " + appDir.getAbsolutePath()
-        + " doesn't exist!!", appDir.exists());
-    Assert.assertTrue("AppSysDir " + appSysDir.getAbsolutePath()
-        + " doesn't exist!!", appSysDir.exists());
+    assertTrue(appDir.exists(), "AppDir " + appDir.getAbsolutePath()
+        + " doesn't exist!!");
+    assertTrue(appSysDir.exists(), "AppSysDir " + appSysDir.getAbsolutePath()
+        + " doesn't exist!!");
     for (File f : new File[] { containerDir, containerSysDir }) {
-      Assert.assertFalse(f.getAbsolutePath() + " exists!!", f.exists());
+      assertFalse(f.exists(), f.getAbsolutePath() + " exists!!");
     }
-    Assert.assertFalse(targetFile.getAbsolutePath() + " exists!!",
-        targetFile.exists());
+    assertFalse(targetFile.exists(),
+        targetFile.getAbsolutePath() + " exists!!");
 
     // Simulate RM sending an AppFinish event.
     containerManager.handle(new CMgrCompletedAppsEvent(Arrays
@@ -1450,15 +1450,15 @@ public class TestContainerManager extends BaseContainerManagerTest {
       while (f.exists() && timeout++ < 15) {
         Thread.sleep(1000);
       }
-      Assert.assertFalse(f.getAbsolutePath() + " exists!!", f.exists());
+      assertFalse(f.exists(), f.getAbsolutePath() + " exists!!");
     }
     // Wait for deletion
     int timeout = 0;
     while (targetFile.exists() && timeout++ < 15) {
       Thread.sleep(1000);
     }
-    Assert.assertFalse(targetFile.getAbsolutePath() + " exists!!",
-        targetFile.exists());
+    assertFalse(targetFile.exists(),
+        targetFile.getAbsolutePath() + " exists!!");
   }
 
   @Test
@@ -1495,14 +1495,14 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch (Throwable e) {
       e.printStackTrace();
       catchException = true;
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
         "Container " + cId1 + " rejected as it is allocated by a previous RM"));
-      Assert.assertTrue(e.getClass().getName()
+      assertTrue(e.getClass().getName()
         .equalsIgnoreCase(InvalidContainerException.class.getName()));
     }
 
     // Verify that startContainer fail because of invalid container request
-    Assert.assertTrue(catchException);
+    assertTrue(catchException);
 
     // Construct the Container with a RMIdentifier within current RM
     StartContainerRequest startRequest2 =
@@ -1523,7 +1523,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
       noException = false;
     }
     // Verify that startContainer get no YarnException
-    Assert.assertTrue(noException);
+    assertTrue(noException);
   }
 
   @Test
@@ -1555,17 +1555,17 @@ public class TestContainerManager extends BaseContainerManagerTest {
         containerManager.startContainers(requestList);
     Thread.sleep(5000);
 
-    Assert.assertEquals(5, response.getSuccessfullyStartedContainers().size());
+    assertEquals(5, response.getSuccessfullyStartedContainers().size());
     for (ContainerId id : response.getSuccessfullyStartedContainers()) {
       // Containers with odd id should succeed.
-      Assert.assertEquals(1, id.getContainerId() & 1);
+      assertEquals(1, id.getContainerId() & 1);
     }
-    Assert.assertEquals(5, response.getFailedRequests().size());
+    assertEquals(5, response.getFailedRequests().size());
     for (Map.Entry<ContainerId, SerializedException> entry : response
       .getFailedRequests().entrySet()) {
       // Containers with even id should fail.
-      Assert.assertEquals(0, entry.getKey().getContainerId() & 1);
-      Assert.assertTrue(entry.getValue().getMessage()
+      assertEquals(0, entry.getKey().getContainerId() & 1);
+      assertTrue(entry.getValue().getMessage()
         .contains(
           "Container " + entry.getKey() + " rejected as it is allocated by a previous RM"));
     }
@@ -1605,17 +1605,17 @@ public class TestContainerManager extends BaseContainerManagerTest {
         GetContainerStatusesRequest.newInstance(containerIds);
     GetContainerStatusesResponse statusResponse =
         containerManager.getContainerStatuses(statusRequest);
-    Assert.assertEquals(5, statusResponse.getContainerStatuses().size());
+    assertEquals(5, statusResponse.getContainerStatuses().size());
     for (ContainerStatus status : statusResponse.getContainerStatuses()) {
       // Containers with odd id should succeed
-      Assert.assertEquals(1, status.getContainerId().getContainerId() & 1);
+      assertEquals(1, status.getContainerId().getContainerId() & 1);
     }
-    Assert.assertEquals(5, statusResponse.getFailedRequests().size());
+    assertEquals(5, statusResponse.getFailedRequests().size());
     for (Map.Entry<ContainerId, SerializedException> entry : statusResponse
       .getFailedRequests().entrySet()) {
       // Containers with even id should fail.
-      Assert.assertEquals(0, entry.getKey().getContainerId() & 1);
-      Assert.assertTrue(entry.getValue().getMessage()
+      assertEquals(0, entry.getKey().getContainerId() & 1);
+      assertTrue(entry.getValue().getMessage()
           .contains("attempted to get status for non-application container"));
     }
 
@@ -1624,18 +1624,18 @@ public class TestContainerManager extends BaseContainerManagerTest {
         StopContainersRequest.newInstance(containerIds);
     StopContainersResponse stopResponse =
         containerManager.stopContainers(stopRequest);
-    Assert.assertEquals(5, stopResponse.getSuccessfullyStoppedContainers()
+    assertEquals(5, stopResponse.getSuccessfullyStoppedContainers()
       .size());
     for (ContainerId id : stopResponse.getSuccessfullyStoppedContainers()) {
       // Containers with odd id should succeed.
-      Assert.assertEquals(1, id.getContainerId() & 1);
+      assertEquals(1, id.getContainerId() & 1);
     }
-    Assert.assertEquals(5, stopResponse.getFailedRequests().size());
+    assertEquals(5, stopResponse.getFailedRequests().size());
     for (Map.Entry<ContainerId, SerializedException> entry : stopResponse
       .getFailedRequests().entrySet()) {
       // Containers with even id should fail.
-      Assert.assertEquals(0, entry.getKey().getContainerId() & 1);
-      Assert.assertTrue(entry.getValue().getMessage()
+      assertEquals(0, entry.getKey().getContainerId() & 1);
+      assertTrue(entry.getValue().getMessage()
           .contains("attempted to stop non-application container"));
     }
   }
@@ -1661,10 +1661,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
     StartContainersResponse startResponse =
         containerManager.startContainers(allRequests);
 
-    Assert.assertFalse("Should not be authorized to start container",
-        startResponse.getSuccessfullyStartedContainers().contains(cId));
-    Assert.assertTrue("Start container request should fail",
-        startResponse.getFailedRequests().containsKey(cId));
+    assertFalse(startResponse.getSuccessfullyStartedContainers().contains(cId),
+        "Should not be authorized to start container");
+    assertTrue(startResponse.getFailedRequests().containsKey(cId),
+        "Start container request should fail");
 
     // Insert the containerId into context, make it as if it is running
     ContainerTokenIdentifier containerTokenIdentifier =
@@ -1681,10 +1681,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
     StopContainersResponse stopResponse =
         containerManager.stopContainers(stopRequest);
 
-    Assert.assertFalse("Should not be authorized to stop container",
-        stopResponse.getSuccessfullyStoppedContainers().contains(cId));
-    Assert.assertTrue("Stop container request should fail",
-        stopResponse.getFailedRequests().containsKey(cId));
+    assertFalse(stopResponse.getSuccessfullyStoppedContainers().contains(cId),
+        "Should not be authorized to stop container");
+    assertTrue(stopResponse.getFailedRequests().containsKey(cId),
+        "Stop container request should fail");
 
     // getContainerStatuses()
     containerIds = new ArrayList<>();
@@ -1694,10 +1694,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
     GetContainerStatusesResponse response =
         containerManager.getContainerStatuses(request);
 
-    Assert.assertEquals("Should not be authorized to get container status",
-        response.getContainerStatuses().size(), 0);
-    Assert.assertTrue("Get status request should fail",
-        response.getFailedRequests().containsKey(cId));
+    assertEquals(response.getContainerStatuses().size(), 0,
+        "Should not be authorized to get container status");
+    assertTrue(response.getFailedRequests().containsKey(cId),
+        "Get status request should fail");
   }
 
   @Test
@@ -1734,10 +1734,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     StartContainersResponse response =
         containerManager.startContainers(requestList);
-    Assert.assertEquals(1, response.getFailedRequests().size());
-    Assert.assertEquals(0, response.getSuccessfullyStartedContainers().size());
-    Assert.assertTrue(response.getFailedRequests().containsKey(cId));
-    Assert.assertTrue(response.getFailedRequests().get(cId).getMessage()
+    assertEquals(1, response.getFailedRequests().size());
+    assertEquals(0, response.getSuccessfullyStartedContainers().size());
+    assertTrue(response.getFailedRequests().containsKey(cId));
+    assertTrue(response.getFailedRequests().get(cId).getMessage()
         .contains("The auxService:" + serviceName + " does not exist"));
   }
 
@@ -1754,7 +1754,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_NMTOKEN_MSG);
 
     strExceptionMsg = "";
@@ -1764,7 +1764,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_CONTAINERTOKEN_MSG);
 
     strExceptionMsg = "";
@@ -1774,7 +1774,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_NMTOKEN_MSG);
 
     strExceptionMsg = "";
@@ -1783,7 +1783,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_NMTOKEN_MSG);
 
     ContainerManagerImpl spyContainerMgr = spy(cMgrImpl);
@@ -1798,7 +1798,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_NMTOKEN_MSG);
 
     strExceptionMsg = "";
@@ -1808,7 +1808,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_NMTOKEN_MSG);
 
     Mockito.doNothing().when(spyContainerMgr).authorizeUser(ugInfo, null);
@@ -1822,7 +1822,7 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } catch(YarnException ye) {
       strExceptionMsg = ye.getCause().getMessage();
     }
-    Assert.assertEquals(strExceptionMsg,
+    assertEquals(strExceptionMsg,
         ContainerManagerImpl.INVALID_CONTAINERTOKEN_MSG);
   }
 
@@ -1846,10 +1846,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
     StartContainersResponse response = containerManager
         .startContainers(requestList);
 
-    Assert.assertEquals(4, response.getSuccessfullyStartedContainers().size());
+    assertEquals(4, response.getSuccessfullyStartedContainers().size());
     int i = 0;
     for (ContainerId id : response.getSuccessfullyStartedContainers()) {
-      Assert.assertEquals(i, id.getContainerId());
+      assertEquals(i, id.getContainerId());
       i++;
     }
 
@@ -1880,14 +1880,14 @@ public class TestContainerManager extends BaseContainerManagerTest {
     ContainerUpdateResponse updateResponse =
         containerManager.updateContainer(updateRequest);
     // Check response
-    Assert.assertEquals(
+    assertEquals(
         1, updateResponse.getSuccessfullyUpdatedContainers().size());
-    Assert.assertEquals(1, updateResponse.getFailedRequests().size());
+    assertEquals(1, updateResponse.getFailedRequests().size());
     for (Map.Entry<ContainerId, SerializedException> entry : updateResponse
         .getFailedRequests().entrySet()) {
-      Assert.assertNotNull("Failed message", entry.getValue().getMessage());
+      assertNotNull(entry.getValue().getMessage(), "Failed message");
       if (cId7.equals(entry.getKey())) {
-        Assert.assertTrue(entry.getValue().getMessage()
+        assertTrue(entry.getValue().getMessage()
             .contains("Container " + cId7.toString()
                 + " is not handled by this NodeManager"));
       } else {
@@ -1958,9 +1958,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
         ContainerUpdateRequest.newInstance(increaseTokens);
     ContainerUpdateResponse updateResponse =
         containerManager.updateContainer(updateRequest);
-    Assert.assertEquals(
-        1, updateResponse.getSuccessfullyUpdatedContainers().size());
-    Assert.assertTrue(updateResponse.getFailedRequests().isEmpty());
+    assertEquals(1, updateResponse.getSuccessfullyUpdatedContainers().size());
+    assertTrue(updateResponse.getFailedRequests().isEmpty());
     // Check status
     List<ContainerId> containerIds = new ArrayList<>();
     containerIds.add(cId);
@@ -1980,9 +1979,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
     updateRequest = ContainerUpdateRequest.newInstance(decreaseTokens);
     updateResponse = containerManager.updateContainer(updateRequest);
 
-    Assert.assertEquals(
-        1, updateResponse.getSuccessfullyUpdatedContainers().size());
-    Assert.assertTrue(updateResponse.getFailedRequests().isEmpty());
+    assertEquals(1, updateResponse.getSuccessfullyUpdatedContainers().size());
+    assertTrue(updateResponse.getFailedRequests().isEmpty());
 
     // Check status with retry
     containerStatus = containerManager
@@ -2069,8 +2067,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        processStartFile.exists());
+    assertTrue(processStartFile.exists(),
+        "ProcessStartFile doesn't exist!");
 
     // Simulate NodeStatusUpdaterImpl sending CMgrSignalContainersEvent
     SignalContainerRequest signalReq =
@@ -2086,8 +2084,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
     } else {
       verify(exec, timeout(10000).atLeastOnce()).signalContainer(signalContextCaptor.capture());
       ContainerSignalContext signalContext = signalContextCaptor.getAllValues().get(0);
-      Assert.assertEquals(cId, signalContext.getContainer().getContainerId());
-      Assert.assertEquals(signal, signalContext.getSignal());
+      assertEquals(cId, signalContext.getContainer().getContainerId());
+      assertEquals(signal, signalContext.getSignal());
     }
   }
 
@@ -2129,10 +2127,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     StartContainersResponse response =
         containerManager.startContainers(requestList);
-    Assert.assertTrue(response.getFailedRequests().size() == 1);
-    Assert.assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
-    Assert.assertTrue(response.getFailedRequests().containsKey(cId));
-    Assert.assertTrue(response.getFailedRequests().get(cId).getMessage()
+    assertTrue(response.getFailedRequests().size() == 1);
+    assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
+    assertTrue(response.getFailedRequests().containsKey(cId));
+    assertTrue(response.getFailedRequests().get(cId).getMessage()
         .contains("Null resource URL for local resource"));
   }
 
@@ -2174,10 +2172,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     StartContainersResponse response =
         containerManager.startContainers(requestList);
-    Assert.assertTrue(response.getFailedRequests().size() == 1);
-    Assert.assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
-    Assert.assertTrue(response.getFailedRequests().containsKey(cId));
-    Assert.assertTrue(response.getFailedRequests().get(cId).getMessage()
+    assertTrue(response.getFailedRequests().size() == 1);
+    assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
+    assertTrue(response.getFailedRequests().containsKey(cId));
+    assertTrue(response.getFailedRequests().get(cId).getMessage()
         .contains("Null resource type for local resource"));
   }
 
@@ -2219,10 +2217,10 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     StartContainersResponse response =
         containerManager.startContainers(requestList);
-    Assert.assertTrue(response.getFailedRequests().size() == 1);
-    Assert.assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
-    Assert.assertTrue(response.getFailedRequests().containsKey(cId));
-    Assert.assertTrue(response.getFailedRequests().get(cId).getMessage()
+    assertTrue(response.getFailedRequests().size() == 1);
+    assertTrue(response.getSuccessfullyStartedContainers().size() == 0);
+    assertTrue(response.getFailedRequests().containsKey(cId));
+    assertTrue(response.getFailedRequests().get(cId).getMessage()
         .contains("Null resource visibility for local resource"));
   }
 
@@ -2264,16 +2262,16 @@ public class TestContainerManager extends BaseContainerManagerTest {
     GetLocalizationStatusesResponse statusResponse =
         containerManager.getLocalizationStatuses(statusRequest);
 
-    Assert.assertEquals(1, statusResponse.getLocalizationStatuses()
+    assertEquals(1, statusResponse.getLocalizationStatuses()
         .get(containerId).size());
     LocalizationStatus status = statusResponse.getLocalizationStatuses()
         .get(containerId).iterator().next();
-    Assert.assertEquals("resource key", "dest_file1",
+    assertEquals("resource key", "dest_file1",
         status.getResourceKey());
-    Assert.assertEquals("resource status", LocalizationState.COMPLETED,
-        status.getLocalizationState());
+    assertEquals(LocalizationState.COMPLETED,
+        status.getLocalizationState(), "resource status");
 
-    Assert.assertEquals(0, statusResponse.getFailedRequests().size());
+    assertEquals(0, statusResponse.getFailedRequests().size());
 
     // stop containers
     StopContainersRequest stopRequest =
@@ -2326,21 +2324,21 @@ public class TestContainerManager extends BaseContainerManagerTest {
 
     GetLocalizationStatusesResponse statusResponse =
         containerManager.getLocalizationStatuses(statusRequest);
-    Assert.assertEquals(2, statusResponse.getLocalizationStatuses().size());
+    assertEquals(2, statusResponse.getLocalizationStatuses().size());
 
     ContainerId[] containerIds = {container1, container2};
     Arrays.stream(containerIds).forEach(cntnId -> {
       List<LocalizationStatus> statuses = statusResponse
           .getLocalizationStatuses().get(container1);
-      Assert.assertEquals(1, statuses.size());
+      assertEquals(1, statuses.size());
       LocalizationStatus status = statuses.get(0);
-      Assert.assertEquals("resource key", "dest_file1",
+      assertEquals("resource key", "dest_file1",
           status.getResourceKey());
-      Assert.assertEquals("resource status", LocalizationState.COMPLETED,
-          status.getLocalizationState());
+      assertEquals(LocalizationState.COMPLETED,
+          status.getLocalizationState(), "resource status");
     });
 
-    Assert.assertEquals(0, statusResponse.getFailedRequests().size());
+    assertEquals(0, statusResponse.getFailedRequests().size());
 
     // stop containers
     StopContainersRequest stopRequest =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
@@ -1193,16 +1193,15 @@ public class TestContainerManager extends BaseContainerManagerTest {
     ContainerStatus containerStatus = containerManager.
         getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
 
-	  // Verify exit status matches exit state of script
-	  assertEquals(exitCode,
-			  containerStatus.getExitStatus());	    
+	 // Verify exit status matches exit state of script
+     assertEquals(exitCode, containerStatus.getExitStatus());
   }
   
   @Test
   public void testContainerLaunchAndExitSuccess() throws IOException,
       InterruptedException, YarnException {
 	  containerManager.start();
-	  int exitCode = 0; 
+	  int exitCode = 0;
 
 	  // launch context for a command that will return exit code 0 
 	  // and verify exit code returned 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManager.java
@@ -1193,19 +1193,19 @@ public class TestContainerManager extends BaseContainerManagerTest {
     ContainerStatus containerStatus = containerManager.
         getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
 
-	 // Verify exit status matches exit state of script
-     assertEquals(exitCode, containerStatus.getExitStatus());
+    // Verify exit status matches exit state of script
+    assertEquals(exitCode, containerStatus.getExitStatus());
   }
   
   @Test
   public void testContainerLaunchAndExitSuccess() throws IOException,
       InterruptedException, YarnException {
-	  containerManager.start();
-	  int exitCode = 0;
+	containerManager.start();
+    int exitCode = 0;
 
-	  // launch context for a command that will return exit code 0 
-	  // and verify exit code returned 
-	  testContainerLaunchAndExit(exitCode);	  
+	// launch context for a command that will return exit code 0
+	// and verify exit code returned
+	testContainerLaunchAndExit(exitCode);
   }
 
   @Test
@@ -2265,8 +2265,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
         .get(containerId).size());
     LocalizationStatus status = statusResponse.getLocalizationStatuses()
         .get(containerId).iterator().next();
-    assertEquals("resource key", "dest_file1",
-        status.getResourceKey());
+    assertEquals("dest_file1",
+        status.getResourceKey(), "resource key");
     assertEquals(LocalizationState.COMPLETED,
         status.getLocalizationState(), "resource status");
 
@@ -2331,8 +2331,8 @@ public class TestContainerManager extends BaseContainerManagerTest {
           .getLocalizationStatuses().get(container1);
       assertEquals(1, statuses.size());
       LocalizationStatus status = statuses.get(0);
-      assertEquals("resource key", "dest_file1",
-          status.getResourceKey());
+      assertEquals("dest_file1",
+          status.getResourceKey(), "resource key");
       assertEquals(LocalizationState.COMPLETED,
           status.getLocalizationState(), "resource status");
     });

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestContainerManagerRecovery.java
@@ -19,11 +19,11 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -117,9 +117,8 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerIn
 import org.apache.hadoop.yarn.server.nodemanager.timelineservice.NMTimelinePublisher;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestContainerManagerRecovery extends BaseContainerManagerTest {
 
@@ -128,7 +127,7 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     localFS.delete(new Path(localDir.getAbsolutePath()), true);
     localFS.delete(new Path(tmpDir.getAbsolutePath()), true);
@@ -600,14 +599,14 @@ public class TestContainerManagerRecovery extends BaseContainerManagerTest {
     app = context.getApplications().get(appId);
     assertNotNull(app);
 
-    Assert.assertNotNull(nmContainer);
+    assertNotNull(nmContainer);
     ResourceMappings resourceMappings = nmContainer.getResourceMappings();
     List<Serializable> assignedResource = resourceMappings
         .getAssignedResources("gpu");
-    Assert.assertTrue(assignedResource.equals(gpuResources));
-    Assert.assertTrue(
+    assertTrue(assignedResource.equals(gpuResources));
+    assertTrue(
         resourceMappings.getAssignedResources("numa").equals(numaResources));
-    Assert.assertTrue(
+    assertTrue(
         resourceMappings.getAssignedResources("fpga").equals(fpgaResources));
     cm.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestNMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestNMProxy.java
@@ -47,9 +47,12 @@ import org.apache.hadoop.yarn.security.NMTokenIdentifier;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestNMProxy extends BaseContainerManagerTest {
 
@@ -59,7 +62,7 @@ public class TestNMProxy extends BaseContainerManagerTest {
 
   int retryCount = 0;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     containerManager.start();
   }
@@ -114,8 +117,9 @@ public class TestNMProxy extends BaseContainerManagerTest {
     };
   }
 
-  @Test(timeout = 20000)
-   public void testNMProxyRetry() throws Exception {
+  @Test
+  @Timeout(value = 20)
+  public void testNMProxyRetry() throws Exception {
      conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_MAX_WAIT_MS, 10000);
      conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_RETRY_INTERVAL_MS, 100);
      StartContainersRequest allRequests =
@@ -124,32 +128,36 @@ public class TestNMProxy extends BaseContainerManagerTest {
     ContainerManagementProtocol proxy = getNMProxy(conf);
 
     proxy.startContainers(allRequests);
-    Assert.assertEquals(5, retryCount);
+    assertEquals(5, retryCount);
 
     retryCount = 0;
     proxy.stopContainers(Records.newRecord(StopContainersRequest.class));
-    Assert.assertEquals(5, retryCount);
+    assertEquals(5, retryCount);
 
     retryCount = 0;
     proxy.getContainerStatuses(Records
       .newRecord(GetContainerStatusesRequest.class));
-    Assert.assertEquals(5, retryCount);
+    assertEquals(5, retryCount);
   }
 
-  @Test(timeout = 20000, expected = IOException.class)
+  @Test
+  @Timeout(value = 20)
   public void testShouldNotRetryForeverForNonNetworkExceptionsOnNMConnections()
       throws Exception {
-    conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_MAX_WAIT_MS, -1);
-    StartContainersRequest allRequests =
-        Records.newRecord(StartContainersRequest.class);
+    assertThrows(IOException.class, ()->{
+      conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_MAX_WAIT_MS, -1);
+      StartContainersRequest allRequests =
+         Records.newRecord(StartContainersRequest.class);
 
-    ContainerManagementProtocol proxy = getNMProxy(conf);
+      ContainerManagementProtocol proxy = getNMProxy(conf);
 
-    retryCount = 0;
-    proxy.startContainers(allRequests);
+      retryCount = 0;
+      proxy.startContainers(allRequests);
+    });
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testNMProxyRPCRetry() throws Exception {
     conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_MAX_WAIT_MS, 1000);
     conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_RETRY_INTERVAL_MS, 100);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestNMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/TestNMProxy.java
@@ -147,7 +147,7 @@ public class TestNMProxy extends BaseContainerManagerTest {
     assertThrows(IOException.class, ()->{
       conf.setLong(YarnConfiguration.CLIENT_NM_CONNECT_MAX_WAIT_MS, -1);
       StartContainersRequest allRequests =
-         Records.newRecord(StartContainersRequest.class);
+          Records.newRecord(StartContainersRequest.class);
 
       ContainerManagementProtocol proxy = getNMProxy(conf);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/application/TestApplication.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/application/TestApplication.java
@@ -17,8 +17,17 @@
  */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.refEq;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -64,8 +73,7 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecret
 import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerInNM;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 
@@ -273,7 +281,7 @@ public class TestApplication {
         ContainerTokenIdentifier identifier =
             wa.getContainerTokenIdentifier(container.getContainerId());
         waitForContainerTokenToExpire(identifier);
-        Assert.assertTrue(wa.context.getContainerTokenSecretManager()
+        assertTrue(wa.context.getContainerTokenSecretManager()
           .isValidStartContainerRequest(identifier));
       }
       assertEquals(ApplicationState.FINISHED, wa.app.getApplicationState());
@@ -349,7 +357,7 @@ public class TestApplication {
         ContainerTokenIdentifier identifier =
             wa.getContainerTokenIdentifier(container.getContainerId());
         waitForContainerTokenToExpire(identifier);
-        Assert.assertTrue(wa.context.getContainerTokenSecretManager()
+        assertTrue(wa.context.getContainerTokenSecretManager()
           .isValidStartContainerRequest(identifier));
       }
       assertEquals(ApplicationState.FINISHED, wa.app.getApplicationState());
@@ -602,7 +610,7 @@ public class TestApplication {
           .put(identifier.getContainerID(), identifier);
         context.getContainerTokenSecretManager().startContainerSuccessful(
           identifier);
-        Assert.assertFalse(context.getContainerTokenSecretManager()
+        assertFalse(context.getContainerTokenSecretManager()
           .isValidStartContainerRequest(identifier));
       }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestContainer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestContainer.java
@@ -17,10 +17,10 @@
 */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.refEq;
@@ -107,8 +107,7 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreServic
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
@@ -358,17 +357,17 @@ public class TestContainer {
       ContainerEventType e5 = wc.initStateToEvent.get(s5);
       ContainerState s6 = wc.eventToFinalState.get(e5);
 
-      Assert.assertEquals(ContainerState.LOCALIZING, s2);
-      Assert.assertEquals(ContainerState.SCHEDULED, s3);
-      Assert.assertEquals(ContainerState.RUNNING, s4);
-      Assert.assertEquals(ContainerState.EXITED_WITH_SUCCESS, s5);
-      Assert.assertEquals(ContainerState.DONE, s6);
+      assertEquals(ContainerState.LOCALIZING, s2);
+      assertEquals(ContainerState.SCHEDULED, s3);
+      assertEquals(ContainerState.RUNNING, s4);
+      assertEquals(ContainerState.EXITED_WITH_SUCCESS, s5);
+      assertEquals(ContainerState.DONE, s6);
 
-      Assert.assertEquals(ContainerEventType.INIT_CONTAINER, e1);
-      Assert.assertEquals(ContainerEventType.RESOURCE_LOCALIZED, e2);
-      Assert.assertEquals(ContainerEventType.CONTAINER_LAUNCHED, e3);
-      Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_SUCCESS, e4);
-      Assert.assertEquals(ContainerEventType.CONTAINER_RESOURCES_CLEANEDUP, e5);
+      assertEquals(ContainerEventType.INIT_CONTAINER, e1);
+      assertEquals(ContainerEventType.RESOURCE_LOCALIZED, e2);
+      assertEquals(ContainerEventType.CONTAINER_LAUNCHED, e3);
+      assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_SUCCESS, e4);
+      assertEquals(ContainerEventType.CONTAINER_RESOURCES_CLEANEDUP, e5);
     }
     finally {
       if (wc != null) {
@@ -586,14 +585,14 @@ public class TestContainer {
       // check container metrics is generated.
       ContainerMetrics containerMetrics =
           ContainerMetrics.forContainer(wc.cId, 1, 5000);
-      Assert.assertEquals(ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
+      assertEquals(ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
           containerMetrics.exitCode.value());
-      Assert.assertTrue(containerMetrics.startTime.value() > 0);
-      Assert.assertTrue(containerMetrics.finishTime.value() >=
+      assertTrue(containerMetrics.startTime.value() > 0);
+      assertTrue(containerMetrics.finishTime.value() >=
               containerMetrics.startTime.value());
-      Assert.assertEquals(ContainerEventType.KILL_CONTAINER,
+      assertEquals(ContainerEventType.KILL_CONTAINER,
           wc.initStateToEvent.get(ContainerState.NEW));
-      Assert.assertEquals(ContainerState.DONE,
+      assertEquals(ContainerState.DONE,
           wc.eventToFinalState.get(ContainerEventType.KILL_CONTAINER));
     } finally {
       if (wc != null) {
@@ -879,7 +878,7 @@ public class TestContainer {
       assertEquals(ContainerState.LOCALIZATION_FAILED, wc.c.getContainerState());
       assertNull(wc.c.getLocalizedResources());
       verifyCleanupCall(wc);
-      Assert.assertTrue(wc.getDiagnostics().contains(FAKE_LOCALIZATION_ERROR));
+      assertTrue(wc.getDiagnostics().contains(FAKE_LOCALIZATION_ERROR));
     } finally {
       if (wc != null) {
         wc.finished();
@@ -1065,7 +1064,7 @@ public class TestContainer {
           break;
         }
       }
-      Assert.assertEquals(expectedRetries, retryTimes);
+      assertEquals(expectedRetries, retryTimes);
     } finally {
       if (wc != null) {
         wc.finished();
@@ -1097,7 +1096,7 @@ public class TestContainer {
     try {
       wc = new WrappedContainer(25, 314159265358980L, 4345,
           "yak", containerRetryContext);
-      Assert.assertEquals(
+      assertEquals(
           ((ContainerImpl)wc.c).getContainerRetryContext().getRetryInterval(),
           expectedRestartInterval);
     } finally {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestResourceMappings.java
@@ -19,9 +19,8 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,12 +28,15 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 public class TestResourceMappings {
 
   private static final ResourceMappings.AssignedResources testResources =
       new ResourceMappings.AssignedResources();
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     testResources.updateAssignedResources(ImmutableList.of(
         Device.Builder.newInstance()
@@ -64,12 +66,12 @@ public class TestResourceMappings {
       ResourceMappings.AssignedResources deserialized =
           ResourceMappings.AssignedResources.fromBytes(serializedString);
 
-      Assert.assertEquals(testResources.getAssignedResources(),
+      assertEquals(testResources.getAssignedResources(),
           deserialized.getAssignedResources());
 
     } catch (IOException e) {
       e.printStackTrace();
-      Assert.fail(String.format("Serialization of test AssignedResources " +
+      fail(String.format("Serialization of test AssignedResources " +
           "failed with %s", e.getMessage()));
     }
   }
@@ -82,12 +84,12 @@ public class TestResourceMappings {
       ResourceMappings.AssignedResources deserialized =
           ResourceMappings.AssignedResources.fromBytes(serializedString);
 
-      Assert.assertEquals(testResources.getAssignedResources(),
+      assertEquals(testResources.getAssignedResources(),
           deserialized.getAssignedResources());
 
     } catch (IOException e) {
       e.printStackTrace();
-      Assert.fail(String.format("Deserialization of test AssignedResources " +
+      fail(String.format("Deserialization of test AssignedResources " +
           "failed with %s", e.getMessage()));
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestSlidingWindowRetryPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/TestSlidingWindowRetryPolicy.java
@@ -21,9 +21,12 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.container;
 import org.apache.hadoop.yarn.api.records.ContainerRetryContext;
 import org.apache.hadoop.yarn.api.records.ContainerRetryPolicy;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link SlidingWindowRetryPolicy}.
@@ -33,7 +36,7 @@ public class TestSlidingWindowRetryPolicy {
   private ControlledClock clock;
   private SlidingWindowRetryPolicy retryPolicy;
 
-  @Before
+  @BeforeEach
   public void setup() {
     clock = new ControlledClock();
     retryPolicy = new SlidingWindowRetryPolicy(clock);
@@ -45,10 +48,9 @@ public class TestSlidingWindowRetryPolicy {
         ContainerRetryContext.NEVER_RETRY_CONTEXT;
     SlidingWindowRetryPolicy.RetryContext windowContext = new
         SlidingWindowRetryPolicy.RetryContext(retryContext);
-    Assert.assertFalse("never retry", retryPolicy.shouldRetry(windowContext,
-        12));
-    Assert.assertEquals("remaining retries", 0,
-        windowContext.getRemainingRetries());
+    assertFalse(retryPolicy.shouldRetry(windowContext,
+        12), "never retry");
+    assertEquals(0, windowContext.getRemainingRetries(), "remaining retries");
   }
 
   @Test
@@ -58,11 +60,10 @@ public class TestSlidingWindowRetryPolicy {
         0, 10);
     SlidingWindowRetryPolicy.RetryContext windowContext = new
         SlidingWindowRetryPolicy.RetryContext(retryContext);
-    Assert.assertTrue("always retry", retryPolicy.shouldRetry(windowContext,
-        12));
-    Assert.assertEquals("remaining retries",
-        ContainerRetryContext.RETRY_FOREVER,
-        windowContext.getRemainingRetries());
+    assertTrue(retryPolicy.shouldRetry(windowContext,
+        12), "always retry");
+    assertEquals(ContainerRetryContext.RETRY_FOREVER,
+        windowContext.getRemainingRetries(), "remaining retries");
   }
 
   @Test
@@ -71,31 +72,31 @@ public class TestSlidingWindowRetryPolicy {
         .newInstance(ContainerRetryPolicy.RETRY_ON_ALL_ERRORS, null, 1, 0, 10);
     SlidingWindowRetryPolicy.RetryContext windowRetryContext =
         new SlidingWindowRetryPolicy.RetryContext(retryContext);
-    Assert.assertTrue("retry 1",
-        retryPolicy.shouldRetry(windowRetryContext, 12));
+    assertTrue(
+        retryPolicy.shouldRetry(windowRetryContext, 12), "retry 1");
     retryPolicy.updateRetryContext(windowRetryContext);
-    Assert.assertEquals("remaining retries", 1,
-        windowRetryContext.getRemainingRetries());
+    assertEquals(1,
+        windowRetryContext.getRemainingRetries(), "remaining retries");
 
     clock.setTime(20);
-    Assert.assertTrue("retry 2",
-        retryPolicy.shouldRetry(windowRetryContext, 12));
+    assertTrue(
+        retryPolicy.shouldRetry(windowRetryContext, 12), "retry 2");
     retryPolicy.updateRetryContext(windowRetryContext);
-    Assert.assertEquals("remaining retries", 1,
-        windowRetryContext.getRemainingRetries());
+    assertEquals(1,
+        windowRetryContext.getRemainingRetries(), "remaining retries");
 
     clock.setTime(40);
-    Assert.assertTrue("retry 3",
-        retryPolicy.shouldRetry(windowRetryContext, 12));
+    assertTrue(
+        retryPolicy.shouldRetry(windowRetryContext, 12), "retry 3");
     retryPolicy.updateRetryContext(windowRetryContext);
-    Assert.assertEquals("remaining retries", 1,
-        windowRetryContext.getRemainingRetries());
+    assertEquals(1,
+        windowRetryContext.getRemainingRetries(), "remaining retries");
 
     clock.setTime(45);
-    Assert.assertFalse("retry failed",
-        retryPolicy.shouldRetry(windowRetryContext, 12));
+    assertFalse(
+        retryPolicy.shouldRetry(windowRetryContext, 12), "retry failed");
     retryPolicy.updateRetryContext(windowRetryContext);
-    Assert.assertEquals("remaining retries", 0,
-        windowRetryContext.getRemainingRetries());
+    assertEquals(0,
+        windowRetryContext.getRemainingRetries(), "remaining retries");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestDockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestDockerContainerDeletionTask.java
@@ -18,10 +18,10 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task
 
 import org.apache.hadoop.yarn.proto.YarnServerNodemanagerRecoveryProtos;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -36,7 +36,7 @@ public class TestDockerContainerDeletionTask {
   private DeletionService deletionService;
   private DockerContainerDeletionTask deletionTask;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     deletionService = mock(DeletionService.class);
     deletionTask = new DockerContainerDeletionTask(ID, deletionService, USER,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestFileDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/TestFileDeletionTask.java
@@ -19,14 +19,14 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.proto.YarnServerNodemanagerRecoveryProtos.DeletionServiceDeleteTaskProto;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -43,7 +43,7 @@ public class TestFileDeletionTask {
   private DeletionService deletionService;
   private FileDeletionTask deletionTask;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     deletionService = mock(DeletionService.class);
     baseDirs.add(BASEDIR);
@@ -51,7 +51,7 @@ public class TestFileDeletionTask {
         baseDirs);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     baseDirs.clear();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerCleanup.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerCleanup.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerSignalContext;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -41,6 +40,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_SLEEP_DELAY_BEFORE_SIGKILL_MS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,7 +56,7 @@ public class TestContainerCleanup {
   private ContainerLaunch launch;
   private ContainerCleanup cleanup;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new YarnConfiguration();
     conf.setLong(NM_SLEEP_DELAY_BEFORE_SIGKILL_MS, 60000);
@@ -103,8 +103,8 @@ public class TestContainerCleanup {
         ArgumentCaptor.forClass(ContainerSignalContext.class);
 
     verify(executor, Mockito.times(1)).signalContainer(captor.capture());
-    Assert.assertEquals("signal", ContainerExecutor.Signal.TERM,
-        captor.getValue().getSignal());
+    assertEquals(ContainerExecutor.Signal.TERM,
+        captor.getValue().getSignal(), "signal");
   }
 
   @Test
@@ -115,7 +115,7 @@ public class TestContainerCleanup {
         ArgumentCaptor.forClass(ContainerSignalContext.class);
 
     verify(executor, Mockito.times(1)).signalContainer(captor.capture());
-    Assert.assertEquals("signal", ContainerExecutor.Signal.TERM,
-        captor.getValue().getSignal());
+    assertEquals(ContainerExecutor.Signal.TERM,
+        captor.getValue().getSignal(), "signal");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -740,8 +740,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       getJarManifestClasspath(userSetEnv.get(Environment.CLASSPATH.name()));
 
     assertTrue(result.size() > 1);
-    assertTrue(
-      result.get(result.size() - 1).endsWith("userjarlink.jar"));
+    assertTrue(result.get(result.size() - 1).endsWith("userjarlink.jar"));
 
     //Then, with user classpath first
     userSetEnv.put(Environment.CLASSPATH_PREPEND_DISTCACHE.name(), "true");
@@ -759,8 +758,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       getJarManifestClasspath(userSetEnv.get(Environment.CLASSPATH.name()));
 
     assertTrue(result.size() > 1);
-    assertTrue(
-      result.get(0).endsWith("userjarlink.jar"));
+    assertTrue(result.get(0).endsWith("userjarlink.jar"));
 
   }
 
@@ -1042,11 +1040,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
           assertTrue(exitEvent.getDiagnosticInfo().contains("Error files: "),
               "Should contain the Multi file information");
         }
-        assertTrue(exitEvent.getDiagnosticInfo()
-            .contains("Last "
+        assertTrue(exitEvent.getDiagnosticInfo().contains("Last "
             + YarnConfiguration.DEFAULT_NM_CONTAINER_STDERR_BYTES
-            + " bytes of"),
-            "Should contain the error Log message with tail size info");
+            + " bytes of"), "Should contain the error Log message with tail size info");
         assertTrue(exitEvent.getDiagnosticInfo()
             .contains(INVALID_JAVA_HOME + "/bin/java"),
             "Should contain contents of error Log");
@@ -1074,6 +1070,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
    */
   @Test
   @Timeout(value = 60)
+  @SuppressWarnings("checkstyle:methodlength")
   public void testContainerEnvVariables() throws Exception {
     containerManager.start();
 
@@ -1323,8 +1320,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     assertEquals(expectedExitCode, containerStatus.getExitStatus());
 
     // Assert that the process is not alive anymore
-    assertFalse(
-     DefaultContainerExecutor.containerIsAlive(pid), "Process is still alive!");
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid), "Process is still alive!");
   }
 
   @Test
@@ -1413,8 +1409,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    assertTrue(processStartFile.exists(),
-        "ProcessStartFile doesn't exist!");
+    assertTrue(processStartFile.exists(), "ProcessStartFile doesn't exist!");
 
     NMContainerStatus nmContainerStatus =
         containerManager.getContext().getContainers().get(cId)
@@ -1854,8 +1849,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
           new File(localLogDir, ContainerExecutor.DIRECTORY_CONTENTS);
         File scriptCopy = new File(localLogDir, tempFile.getName());
 
-        assertEquals(debugLogsExist,
-            directorInfo.exists(), "Directory info file missing");
+        assertEquals(debugLogsExist, directorInfo.exists(), "Directory info file missing");
         assertEquals(debugLogsExist,
             scriptCopy.exists(), "Copy of launch script missing");
         if (debugLogsExist) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -21,10 +21,24 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.launcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeWindows;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -126,10 +140,9 @@ import org.apache.hadoop.yarn.util.AuxiliaryServiceHelper;
 import org.apache.hadoop.yarn.util.LinuxResourceCalculatorPlugin;
 import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -154,7 +167,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     super();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf.setClass(
         YarnConfiguration.NM_MON_RESOURCE_CALCULATOR,
@@ -240,7 +253,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
   }
 
   // test the diagnostics are generated
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testInvalidSymlinkDiagnostics() throws IOException  {
 
     File shellFile = null;
@@ -290,12 +304,12 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       String diagnostics = null;
       try {
         shexc.execute();
-        Assert.fail("Should catch exception");
+        fail("Should catch exception");
       } catch(ExitCodeException e){
         diagnostics = e.getMessage();
       }
-      Assert.assertNotNull(diagnostics);
-      Assert.assertTrue(shexc.getExitCode() != 0);
+      assertNotNull(diagnostics);
+      assertTrue(shexc.getExitCode() != 0);
       symLinkFile = new File(tmpDir, symLink);
     }
     finally {
@@ -315,7 +329,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testWriteEnvExport() throws Exception {
     // Valid only for unix
     assumeNotWindows();
@@ -348,22 +363,23 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     String shellContent =
         new String(Files.readAllBytes(Paths.get(shellFile.getAbsolutePath())),
             StandardCharsets.UTF_8);
-    Assert.assertTrue(shellContent
+    assertTrue(shellContent
         .contains("export HADOOP_COMMON_HOME=\"/opt/hadoopcommon\""));
     // Whitelisted variable overridden by container
-    Assert.assertTrue(shellContent.contains(
+    assertTrue(shellContent.contains(
         "export HADOOP_MAPRED_HOME=\"/opt/hadoopbuild\""));
     // Available in env but not in whitelist
-    Assert.assertFalse(shellContent.contains("HADOOP_HDFS_HOME"));
+    assertFalse(shellContent.contains("HADOOP_HDFS_HOME"));
     // Available in env and in whitelist
-    Assert.assertTrue(shellContent.contains(
+    assertTrue(shellContent.contains(
         "export HADOOP_YARN_HOME=${HADOOP_YARN_HOME:-\"nodemanager_yarn_home\"}"
       ));
     fos.flush();
     fos.close();
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testWriteEnvExportDocker() throws Exception {
     // Valid only for unix
     assumeNotWindows();
@@ -399,22 +415,23 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     String shellContent =
         new String(Files.readAllBytes(Paths.get(shellFile.getAbsolutePath())),
             StandardCharsets.UTF_8);
-    Assert.assertTrue(shellContent
+    assertTrue(shellContent
         .contains("export HADOOP_COMMON_HOME=\"/opt/hadoopcommon\""));
     // Whitelisted variable overridden by container
-    Assert.assertTrue(shellContent.contains(
+    assertTrue(shellContent.contains(
         "export HADOOP_MAPRED_HOME=\"/opt/hadoopbuild\""));
     // Available in env but not in whitelist
-    Assert.assertFalse(shellContent.contains("HADOOP_HDFS_HOME"));
+    assertFalse(shellContent.contains("HADOOP_HDFS_HOME"));
     // Available in env and in whitelist
-    Assert.assertTrue(shellContent.contains(
+    assertTrue(shellContent.contains(
         "export HADOOP_YARN_HOME=${HADOOP_YARN_HOME:-\"nodemanager_yarn_home\"}"
     ));
     fos.flush();
     fos.close();
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testWriteEnvOrder() throws Exception {
     // Valid only for unix
     assumeNotWindows();
@@ -475,18 +492,18 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
             StandardCharsets.UTF_8);
     // First make sure everything is there that's supposed to be
     for (String envVar : env.keySet()) {
-      Assert.assertTrue(shellContent.contains(envVar + "="));
+      assertTrue(shellContent.contains(envVar + "="));
     }
     // The whitelist vars should not have been added to env
     // They should only be in the launch script
     for (String wlVar : whitelistVars) {
-      Assert.assertFalse(env.containsKey(wlVar));
-      Assert.assertTrue(shellContent.contains(wlVar + "="));
+      assertFalse(env.containsKey(wlVar));
+      assertTrue(shellContent.contains(wlVar + "="));
     }
     // Non-whitelist nm vars should be in neither env nor in launch script
     for (String nwlVar : nonWhiteListEnv) {
-      Assert.assertFalse(env.containsKey(nwlVar));
-      Assert.assertFalse(shellContent.contains(nwlVar + "="));
+      assertFalse(env.containsKey(nwlVar));
+      assertFalse(shellContent.contains(nwlVar + "="));
     }
     // Explicitly Set NM vars should be before user vars
     for (String nmVar : trackedNmVars) {
@@ -494,7 +511,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         // Need to skip nm vars and whitelist vars
         if (!trackedNmVars.contains(userVar) &&
             !whitelistVars.contains(userVar)) {
-          Assert.assertTrue(shellContent.indexOf(nmVar + "=") <
+          assertTrue(shellContent.indexOf(nmVar + "=") <
               shellContent.indexOf(userVar + "="));
         }
       }
@@ -502,13 +519,14 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     // Whitelisted vars should be before explicitly set NM vars
     for (String wlVar : whitelistVars) {
       for (String nmVar : trackedNmVars) {
-        Assert.assertTrue(shellContent.indexOf(wlVar + "=") <
+        assertTrue(shellContent.indexOf(wlVar + "=") <
             shellContent.indexOf(nmVar + "="));
       }
     }
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testInvalidEnvSyntaxDiagnostics() throws IOException  {
 
     File shellFile = null;
@@ -544,17 +562,17 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       String diagnostics = null;
       try {
         shexc.execute();
-        Assert.fail("Should catch exception");
+        fail("Should catch exception");
       } catch(ExitCodeException e){
         //Capture diagnostics from prelaunch.stderr
         List<String> error = Files.readAllLines(Paths.get(localLogDir.getAbsolutePath(), ContainerLaunch.CONTAINER_PRE_LAUNCH_STDERR),
             StandardCharsets.UTF_8);
         diagnostics = StringUtils.join("\n", error);
       }
-      Assert.assertTrue(diagnostics.contains(Shell.WINDOWS ?
+      assertTrue(diagnostics.contains(Shell.WINDOWS ?
           "is not recognized as an internal or external command" :
           "command not found"));
-      Assert.assertTrue(shexc.getExitCode() != 0);
+      assertTrue(shexc.getExitCode() != 0);
     }
     finally {
       // cleanup
@@ -565,7 +583,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testEnvExpansion() throws IOException {
     Path logPath = new Path("/nm/container/logs");
     String input =
@@ -586,18 +605,19 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     String expectedAddOpens = Shell.isJavaVersionAtLeast(17) ? additionalJdk17PlusOptions : "";
 
     if (Shell.WINDOWS) {
-      Assert.assertEquals("%HADOOP_HOME%/share/hadoop/common/*;"
+      assertEquals("%HADOOP_HOME%/share/hadoop/common/*;"
           + "%HADOOP_HOME%/share/hadoop/common/lib/*;"
           + "%HADOOP_LOG_HOME%/nm/container/logs" + " " + expectedAddOpens, res);
     } else {
-      Assert.assertEquals("$HADOOP_HOME/share/hadoop/common/*:"
+      assertEquals("$HADOOP_HOME/share/hadoop/common/*:"
           + "$HADOOP_HOME/share/hadoop/common/lib/*:"
           + "$HADOOP_LOG_HOME/nm/container/logs" + " " + expectedAddOpens, res);
     }
     System.out.println(res);
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testContainerLaunchStdoutAndStderrDiagnostics() throws IOException {
 
     File shellFile = null;
@@ -631,15 +651,15 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       String diagnostics = null;
       try {
         shexc.execute();
-        Assert.fail("Should catch exception");
+        fail("Should catch exception");
       } catch(ExitCodeException e){
         diagnostics = e.getMessage();
       }
       // test stderr
-      Assert.assertTrue(diagnostics.contains("error"));
+      assertTrue(diagnostics.contains("error"));
       // test stdout
-      Assert.assertTrue(shexc.getOutput().contains("hello"));
-      Assert.assertTrue(shexc.getExitCode() == 2);
+      assertTrue(shexc.getOutput().contains("hello"));
+      assertTrue(shexc.getExitCode() == 2);
     }
     finally {
       // cleanup
@@ -684,9 +704,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     Dispatcher dispatcher = mock(Dispatcher.class);
     EventHandler<Event> eventHandler = new EventHandler<Event>() {
       public void handle(Event event) {
-        Assert.assertTrue(event instanceof ContainerExitEvent);
+        assertTrue(event instanceof ContainerExitEvent);
         ContainerExitEvent exitEvent = (ContainerExitEvent) event;
-        Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
+        assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
             exitEvent.getType());
       }
     };
@@ -719,8 +739,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     List<String> result =
       getJarManifestClasspath(userSetEnv.get(Environment.CLASSPATH.name()));
 
-    Assert.assertTrue(result.size() > 1);
-    Assert.assertTrue(
+    assertTrue(result.size() > 1);
+    assertTrue(
       result.get(result.size() - 1).endsWith("userjarlink.jar"));
 
     //Then, with user classpath first
@@ -738,8 +758,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     result =
       getJarManifestClasspath(userSetEnv.get(Environment.CLASSPATH.name()));
 
-    Assert.assertTrue(result.size() > 1);
-    Assert.assertTrue(
+    assertTrue(result.size() > 1);
+    assertTrue(
       result.get(0).endsWith("userjarlink.jar"));
 
   }
@@ -778,9 +798,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     Dispatcher dispatcher = mock(Dispatcher.class);
     EventHandler<Event> eventHandler = new EventHandler<Event>() {
       public void handle(Event event) {
-        Assert.assertTrue(event instanceof ContainerExitEvent);
+        assertTrue(event instanceof ContainerExitEvent);
         ContainerExitEvent exitEvent = (ContainerExitEvent) event;
-        Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
+        assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
             exitEvent.getType());
       }
     };
@@ -818,15 +838,15 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     launch.addConfigsToEnv(userSetEnv);
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
-    Assert.assertTrue(userSetEnv.containsKey("MALLOC_ARENA_MAX"));
-    Assert.assertTrue(userSetEnv.containsKey(testKey1));
-    Assert.assertTrue(userSetEnv.containsKey(testKey2));
-    Assert.assertTrue(userSetEnv.containsKey(testKey3));
-    Assert.assertEquals(userMallocArenaMaxVal + File.pathSeparator
+    assertTrue(userSetEnv.containsKey("MALLOC_ARENA_MAX"));
+    assertTrue(userSetEnv.containsKey(testKey1));
+    assertTrue(userSetEnv.containsKey(testKey2));
+    assertTrue(userSetEnv.containsKey(testKey3));
+    assertEquals(userMallocArenaMaxVal + File.pathSeparator
         + mallocArenaMaxVal, userSetEnv.get("MALLOC_ARENA_MAX"));
-    Assert.assertEquals(testVal1, userSetEnv.get(testKey1));
-    Assert.assertEquals(testVal2, userSetEnv.get(testKey2));
-    Assert.assertEquals(testVal3, userSetEnv.get(testKey3));
+    assertEquals(testVal1, userSetEnv.get(testKey1));
+    assertEquals(testVal2, userSetEnv.get(testKey2));
+    assertEquals(testVal3, userSetEnv.get(testKey3));
   }
 
   @Test
@@ -849,9 +869,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     Dispatcher dispatcher = mock(Dispatcher.class);
     EventHandler<Event> eventHandler = new EventHandler<Event>() {
       public void handle(Event event) {
-        Assert.assertTrue(event instanceof ContainerExitEvent);
+        assertTrue(event instanceof ContainerExitEvent);
         ContainerExitEvent exitEvent = (ContainerExitEvent) event;
-        Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
+        assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
             exitEvent.getType());
       }
     };
@@ -876,8 +896,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
 
-    Assert.assertTrue(userSetEnv.containsKey(Environment.PATH.name()));
-    Assert.assertEquals(forcePath + ":$PATH",
+    assertTrue(userSetEnv.containsKey(Environment.PATH.name()));
+    assertEquals(forcePath + ":$PATH",
         userSetEnv.get(Environment.PATH.name()));
 
     String userPath = "/usr/bin:/usr/local/bin";
@@ -889,8 +909,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     launch.sanitizeEnv(userSetEnv, pwd, appDirs, userLocalDirs, containerLogs,
         resources, nmp, nmEnvTrack);
 
-    Assert.assertTrue(userSetEnv.containsKey(Environment.PATH.name()));
-    Assert.assertEquals(forcePath + ":" + userPath,
+    assertTrue(userSetEnv.containsKey(Environment.PATH.name()));
+    assertEquals(forcePath + ":" + userPath,
         userSetEnv.get(Environment.PATH.name()));
   }
 
@@ -994,8 +1014,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     ContainerLaunch launch = new ContainerLaunch(context, conf, dispatcher,
         exec, app, container, dirsHandler, containerManager);
     launch.call();
-    Assert.assertTrue("ContainerExitEvent should have occurred",
-        eventHandler.isContainerExitEventOccurred());
+    assertTrue(eventHandler.isContainerExitEventOccurred(),
+        "ContainerExitEvent should have occurred");
   }
 
   private static class ContainerExitHandler implements EventHandler<Event> {
@@ -1015,22 +1035,21 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       if (event instanceof ContainerExitEvent) {
         containerExitEventOccurred = true;
         ContainerExitEvent exitEvent = (ContainerExitEvent) event;
-        Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
+        assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
             exitEvent.getType());
         LOG.info("Diagnostic Info : " + exitEvent.getDiagnosticInfo());
         if (testForMultiFile) {
-          Assert.assertTrue("Should contain the Multi file information",
-              exitEvent.getDiagnosticInfo().contains("Error files: "));
+          assertTrue(exitEvent.getDiagnosticInfo().contains("Error files: "),
+              "Should contain the Multi file information");
         }
-        Assert.assertTrue(
-            "Should contain the error Log message with tail size info",
-            exitEvent.getDiagnosticInfo()
-                .contains("Last "
-                    + YarnConfiguration.DEFAULT_NM_CONTAINER_STDERR_BYTES
-                    + " bytes of"));
-        Assert.assertTrue("Should contain contents of error Log",
-            exitEvent.getDiagnosticInfo().contains(
-                INVALID_JAVA_HOME + "/bin/java"));
+        assertTrue(exitEvent.getDiagnosticInfo()
+            .contains("Last "
+            + YarnConfiguration.DEFAULT_NM_CONTAINER_STDERR_BYTES
+            + " bytes of"),
+            "Should contain the error Log message with tail size info");
+        assertTrue(exitEvent.getDiagnosticInfo()
+            .contains(INVALID_JAVA_HOME + "/bin/java"),
+            "Should contain contents of error Log");
       }
     }
   }
@@ -1053,7 +1072,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
    * See if environment variable is forwarded using sanitizeEnv.
    * @throws Exception
    */
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testContainerEnvVariables() throws Exception {
     containerManager.start();
 
@@ -1207,14 +1227,14 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
     BufferedReader reader =
         new BufferedReader(new FileReader(processFinalFile));
-    Assert.assertEquals(cId.toString(), reader.readLine());
-    Assert.assertEquals(context.getNodeId().getHost(), reader.readLine());
-    Assert.assertEquals(String.valueOf(context.getNodeId().getPort()),
+    assertEquals(cId.toString(), reader.readLine());
+    assertEquals(context.getNodeId().getHost(), reader.readLine());
+    assertEquals(String.valueOf(context.getNodeId().getPort()),
       reader.readLine());
-    Assert.assertEquals(String.valueOf(HTTP_PORT), reader.readLine());
-    Assert.assertEquals(StringUtils.join(",", appDirs), reader.readLine());
-    Assert.assertEquals(user, reader.readLine());
-    Assert.assertEquals(user, reader.readLine());
+    assertEquals(String.valueOf(HTTP_PORT), reader.readLine());
+    assertEquals(StringUtils.join(",", appDirs), reader.readLine());
+    assertEquals(user, reader.readLine());
+    assertEquals(user, reader.readLine());
     String obtainedPWD = reader.readLine();
     boolean found = false;
     for (Path localDir : appDirs) {
@@ -1223,34 +1243,34 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         break;
       }
     }
-    Assert.assertTrue("Wrong local-dir found : " + obtainedPWD, found);
-    Assert.assertEquals(
+    assertTrue(found, "Wrong local-dir found : " + obtainedPWD);
+    assertEquals(
         conf.get(
               YarnConfiguration.NM_USER_HOME_DIR, 
               YarnConfiguration.DEFAULT_NM_USER_HOME_DIR),
         reader.readLine());
-    Assert.assertEquals(userConfDir, reader.readLine());
+    assertEquals(userConfDir, reader.readLine());
     for (String serviceName : containerManager.getAuxServiceMetaData().keySet()) {
-      Assert.assertEquals(
+      assertEquals(
           containerManager.getAuxServiceMetaData().get(serviceName),
           ByteBuffer.wrap(Base64.decodeBase64(reader.readLine().getBytes())));
     }
 
-    Assert.assertEquals(cId.toString(), containerLaunchContext
+    assertEquals(cId.toString(), containerLaunchContext
         .getEnvironment().get(Environment.CONTAINER_ID.name()));
-    Assert.assertEquals(context.getNodeId().getHost(), containerLaunchContext
+    assertEquals(context.getNodeId().getHost(), containerLaunchContext
       .getEnvironment().get(Environment.NM_HOST.name()));
-    Assert.assertEquals(String.valueOf(context.getNodeId().getPort()),
+    assertEquals(String.valueOf(context.getNodeId().getPort()),
       containerLaunchContext.getEnvironment().get(Environment.NM_PORT.name()));
-    Assert.assertEquals(String.valueOf(HTTP_PORT), containerLaunchContext
+    assertEquals(String.valueOf(HTTP_PORT), containerLaunchContext
       .getEnvironment().get(Environment.NM_HTTP_PORT.name()));
-    Assert.assertEquals(StringUtils.join(",", appDirs), containerLaunchContext
+    assertEquals(StringUtils.join(",", appDirs), containerLaunchContext
         .getEnvironment().get(Environment.LOCAL_DIRS.name()));
-    Assert.assertEquals(StringUtils.join(",", containerLogDirs),
+    assertEquals(StringUtils.join(",", containerLogDirs),
       containerLaunchContext.getEnvironment().get(Environment.LOG_DIRS.name()));
-    Assert.assertEquals(user, containerLaunchContext.getEnvironment()
+    assertEquals(user, containerLaunchContext.getEnvironment()
     	.get(Environment.USER.name()));
-    Assert.assertEquals(user, containerLaunchContext.getEnvironment()
+    assertEquals(user, containerLaunchContext.getEnvironment()
     	.get(Environment.LOGNAME.name()));
     found = false;
     obtainedPWD =
@@ -1261,29 +1281,29 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         break;
       }
     }
-    Assert.assertTrue("Wrong local-dir found : " + obtainedPWD, found);
-    Assert.assertEquals(
+    assertTrue(found, "Wrong local-dir found : " + obtainedPWD);
+    assertEquals(
         conf.get(
     	        YarnConfiguration.NM_USER_HOME_DIR, 
     	        YarnConfiguration.DEFAULT_NM_USER_HOME_DIR),
     	containerLaunchContext.getEnvironment()
     		.get(Environment.HOME.name()));
-    Assert.assertEquals(userConfDir, containerLaunchContext.getEnvironment()
+    assertEquals(userConfDir, containerLaunchContext.getEnvironment()
         .get(Environment.HADOOP_CONF_DIR.name()));
 
     // Get the pid of the process
     String pid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
     // Now test the stop functionality.
 
     // Assert that the process is alive
-    Assert.assertTrue("Process is not alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
     // Once more
-    Assert.assertTrue("Process is not alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertTrue(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is not alive!");
 
     // Now test the stop functionality.
     List<ContainerId> containerIds = new ArrayList<ContainerId>();
@@ -1300,20 +1320,21 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     ContainerStatus containerStatus = 
         containerManager.getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
     int expectedExitCode = ContainerExitStatus.KILLED_BY_APPMASTER;
-    Assert.assertEquals(expectedExitCode, containerStatus.getExitStatus());
+    assertEquals(expectedExitCode, containerStatus.getExitStatus());
 
     // Assert that the process is not alive anymore
-    Assert.assertFalse("Process is still alive!",
-      DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(
+     DefaultContainerExecutor.containerIsAlive(pid), "Process is still alive!");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testAuxiliaryServiceHelper() throws Exception {
     Map<String, String> env = new HashMap<String, String>();
     String serviceName = "testAuxiliaryService";
     ByteBuffer bb = ByteBuffer.wrap("testAuxiliaryService".getBytes());
     AuxiliaryServiceHelper.setServiceDataIntoEnv(serviceName, bb, env);
-    Assert.assertEquals(bb,
+    assertEquals(bb,
         AuxiliaryServiceHelper.getServiceDataFromEnv(serviceName, env));
   }
 
@@ -1392,13 +1413,13 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        processStartFile.exists());
+    assertTrue(processStartFile.exists(),
+        "ProcessStartFile doesn't exist!");
 
     NMContainerStatus nmContainerStatus =
         containerManager.getContext().getContainers().get(cId)
           .getNMContainerStatus();
-    Assert.assertEquals(priority, nmContainerStatus.getPriority());
+    assertEquals(priority, nmContainerStatus.getPriority());
 
     // Now test the stop functionality.
     List<ContainerId> containerIds = new ArrayList<ContainerId>();
@@ -1418,7 +1439,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     ContainerStatus containerStatus = 
         containerManager.getContainerStatuses(gcsRequest)
           .getContainerStatuses().get(0);
-    Assert.assertEquals(ContainerExitStatus.KILLED_BY_APPMASTER,
+    assertEquals(ContainerExitStatus.KILLED_BY_APPMASTER,
         containerStatus.getExitStatus());
 
     // Now verify the contents of the file.  Script generates a message when it
@@ -1427,8 +1448,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     // There is no way for the process to trap and respond.  Instead, we can
     // verify that the job object with ID matching container ID no longer exists.
     if (Shell.WINDOWS || !delayed) {
-      Assert.assertFalse("Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(cId.toString()));
+      assertFalse(DefaultContainerExecutor.containerIsAlive(cId.toString()),
+          "Process is still alive!");
     } else {
       BufferedReader reader =
           new BufferedReader(new FileReader(processStartFile));
@@ -1444,23 +1465,26 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
           break;
         }
       }
-      Assert.assertTrue("Did not find sigterm message", foundSigTermMessage);
+      assertTrue(foundSigTermMessage, "Did not find sigterm message");
       reader.close();
     }
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testDelayedKill() throws Exception {
     internalKillTest(true);
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testImmediateKill() throws Exception {
     internalKillTest(false);
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCallFailureWithNullLocalizedResources() {
     Container container = mock(Container.class);
     when(container.getContainerId()).thenReturn(ContainerId.newContainerId(
@@ -1474,9 +1498,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     EventHandler<Event> eventHandler = new EventHandler<Event>() {
       @Override
       public void handle(Event event) {
-        Assert.assertTrue(event instanceof ContainerExitEvent);
+        assertTrue(event instanceof ContainerExitEvent);
         ContainerExitEvent exitEvent = (ContainerExitEvent) event;
-        Assert.assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
+        assertEquals(ContainerEventType.CONTAINER_EXITED_WITH_FAILURE,
             exitEvent.getType());
       }
     };
@@ -1505,7 +1529,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
    * Test that script exists with non-zero exit code when command fails.
    * @throws IOException
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testShellScriptBuilderNonZeroExitCode() throws IOException {
     ShellScriptBuilder builder = ShellScriptBuilder.create();
     builder.command(Arrays.asList(new String[] {"unknownCommand"}));
@@ -1534,7 +1559,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
 
   private static final String expectedMessage = "The command line has a length of";
   
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWindowsShellScriptBuilderCommand() throws IOException {
     String callCmd = "@call ";
     
@@ -1584,7 +1610,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
   
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWindowsShellScriptBuilderEnv() throws IOException {
     // Test is only relevant on Windows
     assumeWindows();
@@ -1607,7 +1634,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
     
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWindowsShellScriptBuilderMkdir() throws IOException {
     String mkDirCmd = "@if not exist \"\" mkdir \"\"";
 
@@ -1632,7 +1660,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWindowsShellScriptBuilderLink() throws IOException {
     // Test is only relevant on Windows
     assumeWindows();
@@ -1665,7 +1694,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
 
   @Test
   public void testKillProcessGroup() throws Exception {
-    Assume.assumeTrue(Shell.isSetsidAvailable);
+    assumeTrue(Shell.isSetsidAvailable);
     containerManager.start();
 
     // Construct the Container-id
@@ -1732,15 +1761,15 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        processStartFile.exists());
+    assertTrue(processStartFile.exists(),
+        "ProcessStartFile doesn't exist!");
 
     BufferedReader reader =
           new BufferedReader(new FileReader(processStartFile));
     // Get the pid of the process
     String pid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
     reader.close();
 
     reader =
@@ -1748,7 +1777,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     // Get the pid of the child process
     String child = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
     reader.close();
 
     LOG.info("Manually killing pid " + pid + ", but not child pid " + child);
@@ -1757,8 +1786,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     BaseContainerManagerTest.waitForContainerState(containerManager, cId,
         ContainerState.COMPLETE);
 
-    Assert.assertFalse("Process is still alive!",
-        DefaultContainerExecutor.containerIsAlive(pid));
+    assertFalse(DefaultContainerExecutor.containerIsAlive(pid),
+        "Process is still alive!");
 
     List<ContainerId> containerIds = new ArrayList<ContainerId>();
     containerIds.add(cId);
@@ -1769,7 +1798,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     ContainerStatus containerStatus =
         containerManager.getContainerStatuses(gcsRequest)
             .getContainerStatuses().get(0);
-    Assert.assertEquals(ExitCode.FORCE_KILLED.getExitCode(),
+    assertEquals(ExitCode.FORCE_KILLED.getExitCode(),
         containerStatus.getExitStatus());
   }
 
@@ -1825,15 +1854,14 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
           new File(localLogDir, ContainerExecutor.DIRECTORY_CONTENTS);
         File scriptCopy = new File(localLogDir, tempFile.getName());
 
-        Assert.assertEquals("Directory info file missing", debugLogsExist,
-          directorInfo.exists());
-        Assert.assertEquals("Copy of launch script missing", debugLogsExist,
-          scriptCopy.exists());
+        assertEquals(debugLogsExist,
+            directorInfo.exists(), "Directory info file missing");
+        assertEquals(debugLogsExist,
+            scriptCopy.exists(), "Copy of launch script missing");
         if (debugLogsExist) {
-          Assert.assertTrue("Directory info file size is 0",
-            directorInfo.length() > 0);
-          Assert.assertTrue("Size of copy of launch script is 0",
-            scriptCopy.length() > 0);
+          assertTrue(directorInfo.length() > 0, "Directory info file size is 0");
+          assertTrue(scriptCopy.length() > 0,
+              "Size of copy of launch script is 0");
         }
       }
     } finally {
@@ -1889,10 +1917,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       File directorInfo =
           new File(localLogDir, ContainerExecutor.DIRECTORY_CONTENTS);
       File scriptCopy = new File(localLogDir, tempFile.getName());
-      Assert.assertFalse("Directory info file missing",
-          directorInfo.exists());
-      Assert.assertFalse("Copy of launch script missing",
-          scriptCopy.exists());
+      assertFalse(directorInfo.exists(), "Directory info file missing");
+      assertFalse(scriptCopy.exists(), "Copy of launch script missing");
     } finally {
       // cleanup
       if (shellFile != null && shellFile.exists()) {
@@ -1995,17 +2021,17 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         // expected
         System.out.println("Received an expected exception: " + e.getMessage());
 
-        Assert.assertEquals(true, stdout.exists());
+        assertEquals(true, stdout.exists());
         BufferedReader stdoutReader = new BufferedReader(new FileReader(stdout));
         // Get the pid of the process
         String line = stdoutReader.readLine().trim();
-        Assert.assertEquals(TEST_STDOUT_ECHO, line);
+        assertEquals(TEST_STDOUT_ECHO, line);
         // No more lines
-        Assert.assertEquals(null, stdoutReader.readLine());
+        assertEquals(null, stdoutReader.readLine());
         stdoutReader.close();
 
-        Assert.assertEquals(true, stderr.exists());
-        Assert.assertTrue(stderr.length() > 0);
+        assertEquals(true, stderr.exists());
+        assertTrue(stderr.length() > 0);
       }
     }
     finally {
@@ -2051,8 +2077,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         // expected
         System.out.println("Received an expected exception: " + e.getMessage());
 
-        Assert.assertEquals(false, stdout.exists());
-        Assert.assertEquals(false, stderr.exists());
+        assertEquals(false, stdout.exists());
+        assertEquals(false, stderr.exists());
       }
     } finally {
       FileUtil.fullyDelete(shellFile);
@@ -2113,9 +2139,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
           new String[] { shellFile.getAbsolutePath() }, tmpDir, cmdEnv);
       try {
         shexc.execute();
-        Assert.fail("Should catch exception");
+        fail("Should catch exception");
       } catch (ExitCodeException e) {
-        Assert.assertTrue(shexc.getExitCode() != 0);
+        assertTrue(shexc.getExitCode() != 0);
       }
     } finally {
       // cleanup
@@ -2161,9 +2187,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       try {
         shexc.execute();
       } catch(ExitCodeException e){
-        Assert.fail("Should not catch exception");
+        fail("Should not catch exception");
       }
-      Assert.assertTrue(shexc.getExitCode() == 0);
+      assertTrue(shexc.getExitCode() == 0);
     }
     finally {
       // cleanup
@@ -2182,32 +2208,28 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     copy.putAll(env);
     Map<String, String> ordered = sb.orderEnvByDependencies(env);
     // 1st, check that env and copy are the same
-    Assert.assertEquals(
-        "Input env map has been altered because its size changed",
-        copy.size(), env.size()
-    );
+    assertEquals(copy.size(), env.size(),
+        "Input env map has been altered because its size changed");
     final Iterator<Map.Entry<String, String>> ai = env.entrySet().iterator();
     for (Map.Entry<String, String> e : copy.entrySet()) {
       Map.Entry<String, String> a = ai.next();
-      Assert.assertTrue(
-          "Keys have been reordered in input env map",
+      assertTrue(
           // env must not be altered at all, so we don't use String.equals
           // copy and env must use the same String refs
-          e.getKey() == a.getKey()
+          e.getKey() == a.getKey(), "Keys have been reordered in input env map"
       );
-      Assert.assertTrue(
-          "Key "+e.getKey()+" does not longer points to its "
-              +"original value have been reordered in input env map",
+      assertTrue(
           // env must be altered at all, so we don't use String.equals
           // copy and env must use the same String refs
-          e.getValue() == a.getValue()
+          e.getValue() == a.getValue(), "Key "+e.getKey()+" does not longer points to its "
+          +"original value have been reordered in input env map"
       );
     }
     // 2nd, check the ordered version as the expected ordering
     // and did not altered values
-    Assert.assertEquals(
+    assertEquals(env.size(), ordered.size(),
         "Input env map and ordered env map must have the same size, env="+env+
-            ", ordered="+ordered, env.size(), ordered.size()
+        ", ordered="+ordered
     );
     int iA = -1;
     int iB = -1;
@@ -2233,7 +2255,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
       } else if ("cyclic_C".equals(e.getKey())) {
         icC = i++;
       } else {
-        Assert.fail("Test need to ne fixed, got an unexpected env entry "+
+        fail("Test need to ne fixed, got an unexpected env entry "+
             e.getKey());
       }
     }
@@ -2241,31 +2263,31 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     // B depends on A, C depends on B so there are assertion on B>A and C>B
     // but there is no assertion about C>A because B might be missing in some
     // broken envs
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", B should be after A", iA<0 || iB<0 || iA<iB);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", C should be after B", iB<0 || iC<0 || iB<iC);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", D should be after A", iA<0 || iD<0 || iA<iD);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", D should be after B", iB<0 || iD<0 || iB<iD);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_A should be after C", iC<0 || icA<0 || icB<0 || icC<0 ||
-        iC<icA);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_B should be after C", iC<0 || icB<0 || icC<0 ||
-        iC<icB);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_C should be after C", iC<0 || icC<0 || iC<icC);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_A should be after cyclic_B if no cyclic_C", icC>=0 ||
-        icA<0 || icB<0 || icB<icA);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_B should be after cyclic_C if no cyclic_A", icA>=0 ||
-        icB<0 || icC<0 || icC<icB);
-    Assert.assertTrue("when reordering "+env+" into "+ordered+
-        ", cyclic_C should be after cyclic_A if no cyclic_B", icA>=0 ||
-        icC<0 || icA<0 || icA<icC);
+    assertTrue(iA<0 || iB<0 || iA<iB, "when reordering "+env+" into "+ordered+
+        ", B should be after A");
+    assertTrue(iB<0 || iC<0 || iB<iC, "when reordering "+env+" into "+ordered+
+        ", C should be after B");
+    assertTrue(iA<0 || iD<0 || iA<iD, "when reordering "+env+" into "+ordered+
+        ", D should be after A");
+    assertTrue(iB<0 || iD<0 || iB<iD, "when reordering "+env+" into "+ordered+
+        ", D should be after B");
+    assertTrue(iC<0 || icA<0 || icB<0 || icC<0 ||
+        iC<icA, "when reordering "+env+" into "+ordered+
+        ", cyclic_A should be after C");
+    assertTrue(iC<0 || icB<0 || icC<0 ||
+        iC<icB, "when reordering "+env+" into "+ordered+
+        ", cyclic_B should be after C");
+    assertTrue(iC<0 || icC<0 || iC<icC, "when reordering "+env+" into "+ordered+
+        ", cyclic_C should be after C");
+    assertTrue(icC>=0 ||
+        icA<0 || icB<0 || icB<icA, "when reordering "+env+" into "+ordered+
+        ", cyclic_A should be after cyclic_B if no cyclic_C");
+    assertTrue(icA>=0 ||
+        icB<0 || icC<0 || icC<icB, "when reordering "+env+" into "+ordered+
+        ", cyclic_B should be after cyclic_C if no cyclic_A");
+    assertTrue(icA>=0 ||
+        icC<0 || icA<0 || icA<icC, "when reordering "+env+" into "+ordered+
+        ", cyclic_C should be after cyclic_A if no cyclic_B");
   }
 
   private Set<String> asSet(String...str) {
@@ -2274,7 +2296,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     return set;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testOrderEnvByDependencies() {
     final Map<String, Set<String>> fakeDeps = new HashMap<>();
     fakeDeps.put("Aval", Collections.emptySet()); // A has no dependencies
@@ -2312,19 +2335,17 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         };
 
     try {
-      Assert.assertNull("Ordering a null env map must return a null value.",
-          sb.orderEnvByDependencies(null));
+      assertNull(sb.orderEnvByDependencies(null),
+          "Ordering a null env map must return a null value.");
     } catch (Exception e) {
-      Assert.fail("null value is to be supported");
+      fail("null value is to be supported");
     }
 
     try {
-      Assert.assertEquals(
-          "Ordering an empty env map must return an empty map.",
-          0, sb.orderEnvByDependencies(Collections.emptyMap()).size()
-      );
+      assertEquals(0, sb.orderEnvByDependencies(Collections.emptyMap()).size(),
+          "Ordering an empty env map must return an empty map.");
     } catch (Exception e) {
-      Assert.fail("Empty map is to be supported");
+      fail("Empty map is to be supported");
     }
 
     final Map<String, String> combination = new LinkedHashMap<>();
@@ -2442,20 +2463,22 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     verify(mockExecutor, times(1)).launchContainer(ctxCaptor.capture());
     ContainerStartContext ctx = ctxCaptor.getValue();
 
-    Assert.assertEquals(StringUtils.join(",",
+    assertEquals(StringUtils.join(",",
         launch.getNMFilecacheDirs(localDirsForRead)),
         StringUtils.join(",", ctx.getFilecacheDirs()));
-    Assert.assertEquals(StringUtils.join(",",
+    assertEquals(StringUtils.join(",",
         launch.getUserFilecacheDirs(localDirsForRead)),
         StringUtils.join(",", ctx.getUserFilecacheDirs()));
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testFilesAndEnvWithoutHTTPS() throws Exception {
     testFilesAndEnv(false);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testFilesAndEnvWithHTTPS() throws Exception {
     testFilesAndEnv(true);
   }
@@ -2529,27 +2552,27 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     Path nmPrivate = dirsHandler.getLocalPathForWrite(
         ResourceLocalizationService.NM_PRIVATE_DIR + Path.SEPARATOR +
             appId.toString() + Path.SEPARATOR + id.toString());
-    Assert.assertEquals(new Path(nmPrivate, ContainerLaunch.CONTAINER_SCRIPT),
+    assertEquals(new Path(nmPrivate, ContainerLaunch.CONTAINER_SCRIPT),
         csc.getNmPrivateContainerScriptPath());
-    Assert.assertEquals(new Path(nmPrivate,
+    assertEquals(new Path(nmPrivate,
         String.format(ContainerExecutor.TOKEN_FILE_NAME_FMT,
             id.toString())), csc.getNmPrivateTokensPath());
-    Assert.assertEquals("script",
+    assertEquals("script",
         readStringFromPath(csc.getNmPrivateContainerScriptPath()));
-    Assert.assertEquals("credentials",
+    assertEquals("credentials",
         readStringFromPath(csc.getNmPrivateTokensPath()));
     if (https) {
-      Assert.assertEquals(new Path(nmPrivate, ContainerLaunch.KEYSTORE_FILE),
+      assertEquals(new Path(nmPrivate, ContainerLaunch.KEYSTORE_FILE),
           csc.getNmPrivateKeystorePath());
-      Assert.assertEquals(new Path(nmPrivate, ContainerLaunch.TRUSTSTORE_FILE),
+      assertEquals(new Path(nmPrivate, ContainerLaunch.TRUSTSTORE_FILE),
           csc.getNmPrivateTruststorePath());
-      Assert.assertEquals("keystore",
+      assertEquals("keystore",
           readStringFromPath(csc.getNmPrivateKeystorePath()));
-      Assert.assertEquals("truststore",
+      assertEquals("truststore",
           readStringFromPath(csc.getNmPrivateTruststorePath()));
     } else {
-      Assert.assertNull(csc.getNmPrivateKeystorePath());
-      Assert.assertNull(csc.getNmPrivateTruststorePath());
+      assertNull(csc.getNmPrivateKeystorePath());
+      assertNull(csc.getNmPrivateTruststorePath());
     }
 
     // verify env
@@ -2562,25 +2585,25 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
             Path.SEPARATOR + ContainerLocalizer.APPCACHE + Path.SEPARATOR +
             app.getAppId().toString() + Path.SEPARATOR +
             container.getContainerId().toString());
-    Assert.assertEquals(new Path(workDir,
+    assertEquals(new Path(workDir,
             ContainerLaunch.FINAL_CONTAINER_TOKENS_FILE).toUri().getPath(),
         env.get(ApplicationConstants.CONTAINER_TOKEN_FILE_ENV_NAME));
     if (https) {
-      Assert.assertEquals(new Path(workDir,
+      assertEquals(new Path(workDir,
               ContainerLaunch.KEYSTORE_FILE).toUri().getPath(),
           env.get(ApplicationConstants.KEYSTORE_FILE_LOCATION_ENV_NAME));
-      Assert.assertEquals("keystore_password",
+      assertEquals("keystore_password",
           env.get(ApplicationConstants.KEYSTORE_PASSWORD_ENV_NAME));
-      Assert.assertEquals(new Path(workDir,
+      assertEquals(new Path(workDir,
               ContainerLaunch.TRUSTSTORE_FILE).toUri().getPath(),
           env.get(ApplicationConstants.TRUSTSTORE_FILE_LOCATION_ENV_NAME));
-      Assert.assertEquals("truststore_password",
+      assertEquals("truststore_password",
           env.get(ApplicationConstants.TRUSTSTORE_PASSWORD_ENV_NAME));
     } else {
-      Assert.assertNull(env.get("KEYSTORE_FILE_LOCATION"));
-      Assert.assertNull(env.get("KEYSTORE_PASSWORD"));
-      Assert.assertNull(env.get("TRUSTSTORE_FILE_LOCATION"));
-      Assert.assertNull(env.get("TRUSTSTORE_PASSWORD"));
+      assertNull(env.get("KEYSTORE_FILE_LOCATION"));
+      assertNull(env.get("KEYSTORE_PASSWORD"));
+      assertNull(env.get("TRUSTSTORE_FILE_LOCATION"));
+      assertNull(env.get("TRUSTSTORE_PASSWORD"));
     }
   }
 
@@ -2592,7 +2615,8 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testExpandNmAdmEnv() throws Exception {
     // setup mocks
     Dispatcher dispatcher = mock(Dispatcher.class);
@@ -2668,7 +2692,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
         ArgumentCaptor.forClass(ContainerStartContext.class);
     verify(containerExecutor, times(1)).launchContainer(cscArgument.capture());
     ContainerStartContext csc = cscArgument.getValue();
-    Assert.assertEquals("script",
+    assertEquals("script",
         readStringFromPath(csc.getNmPrivateContainerScriptPath()));
 
     // verify env
@@ -2676,9 +2700,9 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     verify(containerExecutor, times(1)).writeLaunchEnv(any(),
         envArgument.capture(), any(), any(), any(), any(), any());
     Map env = envArgument.getValue();
-    Assert.assertEquals(userVarVal, env.get(userVar));
-    Assert.assertEquals(testVal1Expanded, env.get(testKey1));
-    Assert.assertEquals(testVal2Expanded, env.get(testKey2));
+    assertEquals(userVarVal, env.get(userVar));
+    assertEquals(testVal1Expanded, env.get(testKey1));
+    assertEquals(testVal2Expanded, env.get(testKey2));
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunchParameterized.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunchParameterized.java
@@ -20,13 +20,14 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.launcher;
 
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.Shell;
-import org.junit.Assert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Set;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestContainerLaunchParameterized {
   private static Stream<Arguments> inputForGetEnvDependenciesLinux() {
@@ -104,8 +105,8 @@ public class TestContainerLaunchParameterized {
                                    Set<String> expected) {
     ContainerLaunch.ShellScriptBuilder bash =
         ContainerLaunch.ShellScriptBuilder.create(Shell.OSType.OS_TYPE_LINUX);
-    Assert.assertEquals("Failed to parse " + input, expected,
-        bash.getEnvDependencies(input));
+    assertEquals(expected,
+        bash.getEnvDependencies(input), "Failed to parse " + input);
   }
 
   private static Stream<Arguments> inputForGetEnvDependenciesWin() {
@@ -141,8 +142,8 @@ public class TestContainerLaunchParameterized {
                                  Set<String> expected) {
     ContainerLaunch.ShellScriptBuilder win =
         ContainerLaunch.ShellScriptBuilder.create(Shell.OSType.OS_TYPE_WIN);
-    Assert.assertEquals("Failed to parse " + input, expected,
-        win.getEnvDependencies(input));
+    assertEquals(expected,
+        win.getEnvDependencies(input), "Failed to parse " + input);
   }
 
   private static Set<String> asSet(String... str) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerRelaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerRelaunch.java
@@ -34,12 +34,12 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerStartContext;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.security.AMSecretKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -98,32 +98,32 @@ public class TestContainerRelaunch {
     ContainerRelaunch cr = new ContainerRelaunch(mockContext, conf, dispatcher,
         mockExecutor, mockApp, mockContainer, mockDirsHandler, null);
     int result = cr.call();
-    assertEquals("relaunch failed", 0, result);
+    assertEquals(0, result, "relaunch failed");
     ArgumentCaptor<ContainerStartContext> captor =
         ArgumentCaptor.forClass(ContainerStartContext.class);
     verify(mockExecutor).relaunchContainer(captor.capture());
     ContainerStartContext csc = captor.getValue();
-    assertNotNull("app ID null", csc.getAppId());
-    assertNotNull("container null", csc.getContainer());
-    assertNotNull("container local dirs null", csc.getContainerLocalDirs());
-    assertNotNull("container log dirs null", csc.getContainerLogDirs());
-    assertNotNull("work dir null", csc.getContainerWorkDir());
-    assertNotNull("filecache dirs null", csc.getFilecacheDirs());
-    assertNotNull("local dirs null", csc.getLocalDirs());
-    assertNotNull("localized resources null", csc.getLocalizedResources());
-    assertNotNull("log dirs null", csc.getLogDirs());
-    assertNotNull("script path null", csc.getNmPrivateContainerScriptPath());
-    assertNotNull("tokens path null", csc.getNmPrivateTokensPath());
+    assertNotNull(csc.getAppId(), "app ID null");
+    assertNotNull(csc.getContainer(), "container null");
+    assertNotNull(csc.getContainerLocalDirs(), "container local dirs null");
+    assertNotNull(csc.getContainerLogDirs(), "container log dirs null");
+    assertNotNull(csc.getContainerWorkDir(), "work dir null");
+    assertNotNull(csc.getFilecacheDirs(), "filecache dirs null");
+    assertNotNull(csc.getLocalDirs(), "local dirs null");
+    assertNotNull(csc.getLocalizedResources(), "localized resources null");
+    assertNotNull(csc.getLogDirs(), "log dirs null");
+    assertNotNull(csc.getNmPrivateContainerScriptPath(), "script path null");
+    assertNotNull(csc.getNmPrivateTokensPath(), "tokens path null");
     if (https) {
-      assertNotNull("keystore path null", csc.getNmPrivateKeystorePath());
-      assertNotNull("truststore path null", csc.getNmPrivateTruststorePath());
+      assertNotNull(csc.getNmPrivateKeystorePath(), "keystore path null");
+      assertNotNull(csc.getNmPrivateTruststorePath(), "truststore path null");
     } else {
-      assertNull("keystore path not null", csc.getNmPrivateKeystorePath());
-      assertNull("truststore path not null", csc.getNmPrivateTruststorePath());
+      assertNull(csc.getNmPrivateKeystorePath(), "keystore path not null");
+      assertNull(csc.getNmPrivateTruststorePath(), "truststore path not null");
     }
-    assertNotNull("user null", csc.getUser());
-    assertNotNull("user local dirs null", csc.getUserLocalDirs());
-    assertNotNull("user filecache dirs null", csc.getUserFilecacheDirs());
-    assertNotNull("application local dirs null", csc.getApplicationLocalDirs());
+    assertNotNull(csc.getUser(), "user null");
+    assertNotNull(csc.getUserLocalDirs(), "user local dirs null");
+    assertNotNull(csc.getUserFilecacheDirs(), "user filecache dirs null");
+    assertNotNull(csc.getApplicationLocalDirs(), "application local dirs null");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainersLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainersLauncher.java
@@ -30,9 +30,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.ContainerManag
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.Application;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.ApplicationImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerImpl;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -45,8 +44,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests to verify all the Container's Launcher Events in
@@ -98,7 +104,7 @@ public class TestContainersLauncher {
 
   private ContainersLauncher spy;
 
-  @Before
+  @BeforeEach
   public void setup() throws IllegalArgumentException, IllegalAccessException {
     MockitoAnnotations.initMocks(this);
     ContainersLauncher tempContainersLauncher = new ContainersLauncher(
@@ -206,8 +212,8 @@ public class TestContainersLauncher {
       return null;
     }).when(spy).cleanup(any(), any(), anyBoolean());
     spy.handle(event);
-    Assert.assertEquals("container not cleaned", containerId,
-        cleanedContainers.get(0));
+    assertEquals(containerId
+,         cleanedContainers.get(0), "container not cleaned");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainersLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainersLauncher.java
@@ -212,8 +212,7 @@ public class TestContainersLauncher {
       return null;
     }).when(spy).cleanup(any(), any(), anyBoolean());
     spy.handle(event);
-    assertEquals(containerId
-,         cleanedContainers.get(0), "container not cleaned");
+    assertEquals(containerId, cleanedContainers.get(0), "container not cleaned");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/TestPrivilegedOperationExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/privileged/TestPrivilegedOperationExecutor.java
@@ -22,9 +22,8 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privile
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +31,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestPrivilegedOperationExecutor {
   private static final Logger LOG =
@@ -54,7 +56,7 @@ public class TestPrivilegedOperationExecutor {
   private PrivilegedOperation opTasks2;
   private PrivilegedOperation opTasks3;
 
-  @Before
+  @BeforeEach
   public void setup() {
     localDataDir = System.getProperty("test.build.data");
     customExecutorPath = localDataDir + "/bin/container-executor";
@@ -100,17 +102,17 @@ public class TestPrivilegedOperationExecutor {
         : new File("").getAbsolutePath();
     String expectedPath = yarnHome + "/bin/container-executor";
 
-    Assert.assertEquals(expectedPath, containerExePath);
+    assertEquals(expectedPath, containerExePath);
 
     containerExePath = PrivilegedOperationExecutor
         .getContainerExecutorExecutablePath(emptyConf);
-    Assert.assertEquals(expectedPath, containerExePath);
+    assertEquals(expectedPath, containerExePath);
 
     //if NM_LINUX_CONTAINER_EXECUTOR_PATH is set, this must be returned
     expectedPath = customExecutorPath;
     containerExePath = PrivilegedOperationExecutor
         .getContainerExecutorExecutablePath(confWithExecutorPath);
-    Assert.assertEquals(expectedPath, containerExePath);
+    assertEquals(expectedPath, containerExePath);
   }
 
   @Test
@@ -123,9 +125,9 @@ public class TestPrivilegedOperationExecutor {
 
     //No arguments added - so the resulting array should consist of
     //1)full path to executor 2) cli switch
-    Assert.assertEquals(2, cmdArray.length);
-    Assert.assertEquals(customExecutorPath, cmdArray[0]);
-    Assert.assertEquals(op.getOperationType().getOption(), cmdArray[1]);
+    assertEquals(2, cmdArray.length);
+    assertEquals(customExecutorPath, cmdArray[0]);
+    assertEquals(op.getOperationType().getOption(), cmdArray[1]);
 
     //other (dummy) arguments to tc modify state
     String[] additionalArgs = { "cmd_file_1", "cmd_file_2", "cmd_file_3"};
@@ -136,13 +138,13 @@ public class TestPrivilegedOperationExecutor {
     //Resulting array should be of length 2 greater than the number of
     //additional arguments added.
 
-    Assert.assertEquals(2 + additionalArgs.length, cmdArray.length);
-    Assert.assertEquals(customExecutorPath, cmdArray[0]);
-    Assert.assertEquals(op.getOperationType().getOption(), cmdArray[1]);
+    assertEquals(2 + additionalArgs.length, cmdArray.length);
+    assertEquals(customExecutorPath, cmdArray[0]);
+    assertEquals(op.getOperationType().getOption(), cmdArray[1]);
 
     //Rest of args should be same as additional args.
     for (int i = 0; i < additionalArgs.length; ++i) {
-      Assert.assertEquals(additionalArgs[i], cmdArray[2 + i]);
+      assertEquals(additionalArgs[i], cmdArray[2 + i]);
     }
 
     //Now test prefix commands
@@ -151,23 +153,23 @@ public class TestPrivilegedOperationExecutor {
     int prefixLength = prefixCommands.size();
     //Resulting array should be of length of prefix command args + 2 (exec
     // path + switch) + length of additional args.
-    Assert.assertEquals(prefixLength + 2 + additionalArgs.length,
+    assertEquals(prefixLength + 2 + additionalArgs.length,
         cmdArray.length);
 
     //Prefix command array comes first
     for (int i = 0; i < prefixLength; ++i) {
-      Assert.assertEquals(prefixCommands.get(i), cmdArray[i]);
+      assertEquals(prefixCommands.get(i), cmdArray[i]);
     }
 
     //Followed by the container executor path and the cli switch
-    Assert.assertEquals(customExecutorPath, cmdArray[prefixLength]);
-    Assert.assertEquals(op.getOperationType().getOption(),
+    assertEquals(customExecutorPath, cmdArray[prefixLength]);
+    assertEquals(op.getOperationType().getOption(),
         cmdArray[prefixLength + 1]);
 
     //Followed by the rest of the args
     //Rest of args should be same as additional args.
     for (int i = 0; i < additionalArgs.length; ++i) {
-      Assert.assertEquals(additionalArgs[i], cmdArray[prefixLength + 2 + i]);
+      assertEquals(additionalArgs[i], cmdArray[prefixLength + 2 + i]);
     }
   }
 
@@ -181,7 +183,7 @@ public class TestPrivilegedOperationExecutor {
 
     try {
       PrivilegedOperationExecutor.squashCGroupOperations(ops);
-      Assert.fail("Expected squash operation to fail with an exception!");
+      fail("Expected squash operation to fail with an exception!");
     } catch (PrivilegedOperationException e) {
       LOG.info("Caught expected exception : " + e);
     }
@@ -193,7 +195,7 @@ public class TestPrivilegedOperationExecutor {
 
     try {
       PrivilegedOperationExecutor.squashCGroupOperations(ops);
-      Assert.fail("Expected squash operation to fail with an exception!");
+      fail("Expected squash operation to fail with an exception!");
     } catch (PrivilegedOperationException e) {
       LOG.info("Caught expected exception : " + e);
     }
@@ -222,12 +224,12 @@ public class TestPrivilegedOperationExecutor {
           .append(cGroupTasks3).toString();
 
       //We expect axactly one argument
-      Assert.assertEquals(1, op.getArguments().size());
+      assertEquals(1, op.getArguments().size());
       //Squashed list of tasks files
-      Assert.assertEquals(expected, op.getArguments().get(0));
+      assertEquals(expected, op.getArguments().get(0));
     } catch (PrivilegedOperationException e) {
       LOG.info("Caught unexpected exception : " + e);
-      Assert.fail("Caught unexpected exception: " + e);
+      fail("Caught unexpected exception: " + e);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
@@ -59,14 +59,14 @@ public class TestCGroupElasticMemoryController {
   public void testConstructorOff()
       throws YarnException {
     assertThrows(YarnException.class, () -> {
-        new CGroupElasticMemoryController(
+      new CGroupElasticMemoryController(
           conf,
           null,
           null,
           false,
           false,
           10000
-        );
+      );
     });
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
@@ -23,14 +23,16 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -53,17 +55,19 @@ public class TestCGroupElasticMemoryController {
    * Test that at least one memory type is requested.
    * @throws YarnException on exception
    */
-  @Test(expected = YarnException.class)
+  @Test
   public void testConstructorOff()
       throws YarnException {
-    new CGroupElasticMemoryController(
-        conf,
-        null,
-        null,
-        false,
-        false,
-        10000
-    );
+    assertThrows(YarnException.class, () -> {
+      new CGroupElasticMemoryController(
+              conf,
+              null,
+              null,
+              false,
+              false,
+              10000
+      );
+    });
   }
 
   /**
@@ -91,15 +95,15 @@ public class TestCGroupElasticMemoryController {
    * Test that the handler is notified about multiple OOM events.
    * @throws Exception on exception
    */
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testMultipleOOMEvents() throws Exception {
     conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
         script.getAbsolutePath());
     try {
       FileUtils.writeStringToFile(script,
           "#!/bin/bash\nprintf oomevent;printf oomevent;\n", StandardCharsets.UTF_8, false);
-      assertTrue("Could not set executable",
-          script.setExecutable(true));
+      assertTrue(script.setExecutable(true), "Could not set executable");
 
       CGroupsHandler cgroups = mock(CGroupsHandler.class);
       when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
@@ -122,8 +126,9 @@ public class TestCGroupElasticMemoryController {
       controller.run();
       verify(handler, times(2)).run();
     } finally {
-      assertTrue(String.format("Could not clean up script %s",
-          script.getAbsolutePath()), script.delete());
+      assertTrue(script.delete(),
+          String.format("Could not clean up script %s",
+          script.getAbsolutePath()));
     }
   }
 
@@ -132,15 +137,15 @@ public class TestCGroupElasticMemoryController {
    * the child process starts
    * @throws Exception one exception
    */
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testStopBeforeStart() throws Exception {
     conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
         script.getAbsolutePath());
     try {
       FileUtils.writeStringToFile(script, "#!/bin/bash\nprintf oomevent;printf oomevent;\n",
           StandardCharsets.UTF_8, false);
-      assertTrue("Could not set executable",
-          script.setExecutable(true));
+      assertTrue(script.setExecutable(true), "Could not set executable");
 
       CGroupsHandler cgroups = mock(CGroupsHandler.class);
       when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
@@ -164,8 +169,8 @@ public class TestCGroupElasticMemoryController {
       controller.run();
       verify(handler, times(0)).run();
     } finally {
-      assertTrue(String.format("Could not clean up script %s",
-          script.getAbsolutePath()), script.delete());
+      assertTrue(script.delete(), String.format("Could not clean up script %s",
+          script.getAbsolutePath()));
     }
   }
 
@@ -173,40 +178,42 @@ public class TestCGroupElasticMemoryController {
    * Test the edge case that OOM is never resolved.
    * @throws Exception on exception
    */
-  @Test(timeout = 20000, expected = YarnRuntimeException.class)
+  @Test
+  @Timeout(value = 20)
   public void testInfiniteOOM() throws Exception {
-    conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
-        script.getAbsolutePath());
-    Runnable handler = mock(Runnable.class);
-    try {
-      FileUtils.writeStringToFile(script, "#!/bin/bash\nprintf oomevent;sleep 1000;\n",
-          StandardCharsets.UTF_8, false);
-      assertTrue("Could not set executable",
-          script.setExecutable(true));
+    assertThrows(YarnRuntimeException.class, () -> {
+      conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
+              script.getAbsolutePath());
+      Runnable handler = mock(Runnable.class);
+      try {
+        FileUtils.writeStringToFile(script, "#!/bin/bash\nprintf oomevent;sleep 1000;\n",
+            StandardCharsets.UTF_8, false);
+        assertTrue(script.setExecutable(true), "Could not set executable");
 
-      CGroupsHandler cgroups = mock(CGroupsHandler.class);
-      when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
-      when(cgroups.getCGroupParam(any(), any(), any()))
-          .thenReturn("under_oom 1");
+        CGroupsHandler cgroups = mock(CGroupsHandler.class);
+        when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
+        when(cgroups.getCGroupParam(any(), any(), any()))
+            .thenReturn("under_oom 1");
 
-      doNothing().when(handler).run();
+        doNothing().when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
-              conf,
-              null,
-              cgroups,
-              true,
-              false,
-              10000,
-              handler
-          );
-      controller.run();
-    } finally {
-      verify(handler, times(1)).run();
-      assertTrue(String.format("Could not clean up script %s",
-          script.getAbsolutePath()), script.delete());
-    }
+        CGroupElasticMemoryController controller =
+             new CGroupElasticMemoryController(
+                 conf,
+                 null,
+                 cgroups,
+                 true,
+                 false,
+                 10000,
+                 handler
+              );
+        controller.run();
+      } finally {
+        verify(handler, times(1)).run();
+        assertTrue(script.delete(), String.format("Could not clean up script %s",
+            script.getAbsolutePath()));
+      }
+    });
   }
 
   /**
@@ -214,40 +221,43 @@ public class TestCGroupElasticMemoryController {
    * containers.
    * @throws Exception on exception
    */
-  @Test(timeout = 20000, expected = YarnRuntimeException.class)
+  @Test
+  @Timeout(value = 20)
   public void testNothingToKill() throws Exception {
-    conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
-        script.getAbsolutePath());
-    Runnable handler = mock(Runnable.class);
-    try {
-      FileUtils.writeStringToFile(script, "#!/bin/bash\nprintf oomevent;sleep 1000;\n",
-          StandardCharsets.UTF_8, false);
-      assertTrue("Could not set executable",
-          script.setExecutable(true));
+    assertThrows(YarnRuntimeException.class, () -> {
+      conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
+              script.getAbsolutePath());
+      Runnable handler = mock(Runnable.class);
+      try {
+        FileUtils.writeStringToFile(script, "#!/bin/bash\nprintf oomevent;sleep 1000;\n",
+            StandardCharsets.UTF_8, false);
+        assertTrue(
+            script.setExecutable(true), "Could not set executable");
 
-      CGroupsHandler cgroups = mock(CGroupsHandler.class);
-      when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
-      when(cgroups.getCGroupParam(any(), any(), any()))
-          .thenReturn("under_oom 1");
+        CGroupsHandler cgroups = mock(CGroupsHandler.class);
+        when(cgroups.getPathForCGroup(any(), any())).thenReturn("");
+        when(cgroups.getCGroupParam(any(), any(), any()))
+            .thenReturn("under_oom 1");
 
-      doThrow(new YarnRuntimeException("Expected")).when(handler).run();
+        doThrow(new YarnRuntimeException("Expected")).when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
-              conf,
-              null,
-              cgroups,
-              true,
-              false,
-              10000,
-              handler
-          );
-      controller.run();
-    } finally {
-      verify(handler, times(1)).run();
-      assertTrue(String.format("Could not clean up script %s",
-          script.getAbsolutePath()), script.delete());
-    }
+        CGroupElasticMemoryController controller =
+             new CGroupElasticMemoryController(
+                 conf,
+                 null,
+                 cgroups,
+                 true,
+                 false,
+                 10000,
+                 handler
+             );
+        controller.run();
+      } finally {
+        verify(handler, times(1)).run();
+        assertTrue(script.delete(), String.format("Could not clean up script %s",
+            script.getAbsolutePath()));
+      }
+    });
   }
 
   /**
@@ -257,7 +267,8 @@ public class TestCGroupElasticMemoryController {
    * We do not use a script this time to avoid leaking the child process.
    * @throws Exception exception occurred
    */
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testNormalExit() throws Exception {
     conf.set(YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_LISTENER_PATH,
         "sleep");
@@ -287,7 +298,7 @@ public class TestCGroupElasticMemoryController {
         try {
           Thread.sleep(2000);
         } catch (InterruptedException ex) {
-          assertTrue("Wait interrupted.", false);
+          assertTrue(false, "Wait interrupted.");
         }
         LOG.info(String.format("Calling process destroy in %d ms",
             System.currentTimeMillis() - start));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
@@ -59,14 +59,14 @@ public class TestCGroupElasticMemoryController {
   public void testConstructorOff()
       throws YarnException {
     assertThrows(YarnException.class, () -> {
-      new CGroupElasticMemoryController(
-              conf,
-              null,
-              null,
-              false,
-              false,
-              10000
-      );
+        new CGroupElasticMemoryController(
+          conf,
+          null,
+          null,
+          false,
+          false,
+          10000
+        );
     });
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsBlkioResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsBlkioResourceHandlerImpl.java
@@ -23,16 +23,18 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the cgroups disk handler implementation.
@@ -42,7 +44,7 @@ public class TestCGroupsBlkioResourceHandlerImpl {
   private CGroupsHandler mockCGroupsHandler;
   private CGroupsBlkioResourceHandlerImpl cGroupsBlkioResourceHandlerImpl;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockCGroupsHandler = mock(CGroupsHandler.class);
     cGroupsBlkioResourceHandlerImpl =
@@ -56,7 +58,7 @@ public class TestCGroupsBlkioResourceHandlerImpl {
         cGroupsBlkioResourceHandlerImpl.bootstrap(conf);
     verify(mockCGroupsHandler, times(1)).initializeCGroupController(
         CGroupsHandler.CGroupController.BLKIO);
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -79,21 +81,21 @@ public class TestCGroupsBlkioResourceHandlerImpl {
         CGroupsHandler.CGroupController.BLKIO, id,
         CGroupsHandler.CGROUP_PARAM_WEIGHT,
         CGroupsBlkioResourceHandlerImpl.DEFAULT_WEIGHT);
-    Assert.assertNotNull(ret);
-    Assert.assertEquals(1, ret.size());
+    assertNotNull(ret);
+    assertEquals(1, ret.size());
     PrivilegedOperation op = ret.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 
   @Test
   public void testReacquireContainer() throws Exception {
     ContainerId containerIdMock = mock(ContainerId.class);
-    Assert.assertNull(cGroupsBlkioResourceHandlerImpl
+    assertNull(cGroupsBlkioResourceHandlerImpl
         .reacquireContainer(containerIdMock));
   }
 
@@ -102,7 +104,7 @@ public class TestCGroupsBlkioResourceHandlerImpl {
     String id = "container_01_01";
     ContainerId mockContainerId = mock(ContainerId.class);
     when(mockContainerId.toString()).thenReturn(id);
-    Assert.assertNull(cGroupsBlkioResourceHandlerImpl
+    assertNull(cGroupsBlkioResourceHandlerImpl
         .postComplete(mockContainerId));
     verify(mockCGroupsHandler, times(1)).deleteCGroup(
         CGroupsHandler.CGroupController.BLKIO, id);
@@ -110,7 +112,7 @@ public class TestCGroupsBlkioResourceHandlerImpl {
 
   @Test
   public void testTeardown() throws Exception {
-    Assert.assertNull(cGroupsBlkioResourceHandlerImpl.teardown());
+    assertNull(cGroupsBlkioResourceHandlerImpl.teardown());
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
@@ -28,17 +28,26 @@ import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestCGroupsCpuResourceHandlerImpl {
 
@@ -47,7 +56,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
   private ResourceCalculatorPlugin plugin;
   final int numProcessors = 4;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockCGroupsHandler = mock(CGroupsHandler.class);
     when(mockCGroupsHandler.getPathForCGroup(any(), any())).thenReturn(".");
@@ -73,7 +82,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
     verify(mockCGroupsHandler, times(0))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_QUOTA_US, "");
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -96,7 +105,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_QUOTA_US,
             String.valueOf(CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US));
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -117,7 +126,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
       verify(mockCGroupsHandler, times(1))
           .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
               CGroupsHandler.CGROUP_CPU_QUOTA_US, "-1");
-      Assert.assertNull(ret);
+      assertNull(ret);
     } finally {
       FileUtils.deleteQuietly(existingLimit);
     }
@@ -152,14 +161,14 @@ public class TestCGroupsCpuResourceHandlerImpl {
     verify(mockCGroupsHandler, never())
         .updateCGroupParam(eq(CGroupsHandler.CGroupController.CPU), eq(id),
             eq(CGroupsHandler.CGROUP_CPU_QUOTA_US), anyString());
-    Assert.assertNotNull(ret);
-    Assert.assertEquals(1, ret.size());
+    assertNotNull(ret);
+    assertEquals(1, ret.size());
     PrivilegedOperation op = ret.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 
@@ -200,14 +209,14 @@ public class TestCGroupsCpuResourceHandlerImpl {
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
             CGroupsHandler.CGROUP_CPU_QUOTA_US, String.valueOf(
                 (int) (CGroupsCpuResourceHandlerImpl.MAX_QUOTA_US * share)));
-    Assert.assertNotNull(ret);
-    Assert.assertEquals(1, ret.size());
+    assertNotNull(ret);
+    assertEquals(1, ret.size());
     PrivilegedOperation op = ret.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 
@@ -277,7 +286,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
   @Test
   public void testReacquireContainer() throws Exception {
     ContainerId containerIdMock = mock(ContainerId.class);
-    Assert.assertNull(
+    assertNull(
         cGroupsCpuResourceHandler.reacquireContainer(containerIdMock));
   }
 
@@ -286,19 +295,19 @@ public class TestCGroupsCpuResourceHandlerImpl {
     String id = "container_01_01";
     ContainerId mockContainerId = mock(ContainerId.class);
     when(mockContainerId.toString()).thenReturn(id);
-    Assert.assertNull(cGroupsCpuResourceHandler.postComplete(mockContainerId));
+    assertNull(cGroupsCpuResourceHandler.postComplete(mockContainerId));
     verify(mockCGroupsHandler, times(1))
         .deleteCGroup(CGroupsHandler.CGroupController.CPU, id);
   }
 
   @Test
   public void testTeardown() throws Exception {
-    Assert.assertNull(cGroupsCpuResourceHandler.teardown());
+    assertNull(cGroupsCpuResourceHandler.teardown());
   }
 
   @Test
   public void testStrictResourceUsage() throws Exception {
-    Assert.assertNull(cGroupsCpuResourceHandler.teardown());
+    assertNull(cGroupsCpuResourceHandler.teardown());
   }
 
   @Test
@@ -318,7 +327,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
     cGroupsCpuResourceHandler.preStart(container);
     verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
-            CGroupsHandler.CGROUP_CPU_SHARES, "2");
+        CGroupsHandler.CGROUP_CPU_SHARES, "2");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsCpuResourceHandlerImpl.java
@@ -327,7 +327,7 @@ public class TestCGroupsCpuResourceHandlerImpl {
     cGroupsCpuResourceHandler.preStart(container);
     verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, id,
-        CGroupsHandler.CGROUP_CPU_SHARES, "2");
+          CGroupsHandler.CGROUP_CPU_SHARES, "2");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerBase.java
@@ -25,15 +25,15 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.security.Permission;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -46,7 +46,7 @@ public abstract class TestCGroupsHandlerBase {
   protected CGroupsHandler.CGroupController controller;
   protected String controllerPath;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
 
@@ -64,7 +64,7 @@ public abstract class TestCGroupsHandlerBase {
     controllerPath = getControllerFilePath(controller.getName());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     FileUtil.fullyDelete(new File(tmpPath));
   }
@@ -116,7 +116,7 @@ public abstract class TestCGroupsHandlerBase {
    */
   protected File createEmptyMtabFile() throws IOException {
     File emptyMtab = new File(tmpPath, "mtab");
-    assertTrue("New file should have been created", emptyMtab.createNewFile());
+    assertTrue(emptyMtab.createNewFile(), "New file should have been created");
     return emptyMtab;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
@@ -28,8 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
@@ -43,9 +42,10 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -82,13 +82,13 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
                     + " cgroup rw,relatime,cpu"
                     + (cpuAcct ? ",cpuacct" :"")
                     + " 0 0\n";
-    assertTrue("Directory should be created", cpuCgroup.mkdirs());
+    assertTrue(cpuCgroup.mkdirs(), "Directory should be created");
 
     File blkioCgroup = new File(parentDir, "blkio");
     String blkioMtabContent =
             "none " + blkioCgroup.getAbsolutePath()
                     + " cgroup rw,relatime,blkio 0 0\n";
-    assertTrue("Directory should be created", blkioCgroup.mkdirs());
+    assertTrue(blkioCgroup.mkdirs(), "Directory should be created");
 
     File mockMtab = new File(parentDir, UUID.randomUUID().toString());
     if (!mockMtab.exists()) {
@@ -111,7 +111,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
   public void testMountController() throws IOException {
     File parentDir = new File(tmpPath);
     File cgroup = new File(parentDir, controller.getName());
-    assertTrue("cgroup dir should be cerated", cgroup.mkdirs());
+    assertTrue(cgroup.mkdirs(), "cgroup dir should be cerated");
     //Since we enabled (deferred) cgroup controller mounting, no interactions
     //should have occurred, with this mock
     verifyZeroInteractions(privilegedOperationExecutorMock);
@@ -139,7 +139,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
 
         //we'll explicitly capture and assert that the
         //captured op and the expected op are identical.
-        Assert.assertEquals(expectedOp, opCaptor.getValue());
+        assertEquals(expectedOp, opCaptor.getValue());
         verifyNoMoreInteractions(privilegedOperationExecutorMock);
 
         //Try mounting the same controller again - this should be a no-op
@@ -166,8 +166,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
     // Let's manually create a path to (partially) simulate a controller mounted
     // later in the test. This is required because the handler uses a mocked
     // privileged operation executor
-    assertTrue("Sample subsystem should be created",
-        new File(controllerPath).mkdirs());
+    assertTrue(new File(controllerPath).mkdirs(),
+        "Sample subsystem should be created");
 
     try {
       cGroupsHandler = new CGroupsHandlerImpl(createMountConfiguration(),
@@ -182,18 +182,18 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
     String expectedPath =
         controllerPath + Path.SEPARATOR + testCGroup;
     String path = cGroupsHandler.getPathForCGroup(controller, testCGroup);
-    Assert.assertEquals(expectedPath, path);
+    assertEquals(expectedPath, path);
 
     String expectedPathTasks = expectedPath + Path.SEPARATOR
         + CGroupsHandler.CGROUP_PROCS_FILE;
     path = cGroupsHandler.getPathForCGroupTasks(controller, testCGroup);
-    Assert.assertEquals(expectedPathTasks, path);
+    assertEquals(expectedPathTasks, path);
 
     String param = CGroupsHandler.CGROUP_PARAM_CLASSID;
     String expectedPathParam = expectedPath + Path.SEPARATOR
         + controller.getName() + "." + param;
     path = cGroupsHandler.getPathForCGroupParam(controller, testCGroup, param);
-    Assert.assertEquals(expectedPathParam, path);
+    assertEquals(expectedPathParam, path);
   }
 
   @Test
@@ -207,8 +207,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
     // Lets manually create a path to (partially) simulate a controller mounted
     // later in the test. This is required because the handler uses a mocked
     // privileged operation executor
-    assertTrue("Sample subsystem should be created",
-        new File(controllerPath).mkdirs());
+    assertTrue(new File(controllerPath).mkdirs(),
+        "Sample subsystem should be created");
 
     try {
       cGroupsHandler = new CGroupsHandlerImpl(createMountConfiguration(),
@@ -216,9 +216,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       cGroupsHandler.initializeCGroupController(controller);
     } catch (ResourceHandlerException e) {
       LOG.error("Caught exception: " + e);
-      assertTrue(
-          "Unexpected ResourceHandlerException when mounting controller!",
-          false);
+      assertTrue(false,
+          "Unexpected ResourceHandlerException when mounting controller!");
     }
 
     String testCGroup = "container_01";
@@ -228,7 +227,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       String path = cGroupsHandler.createCGroup(controller, testCGroup);
 
       assertTrue(new File(expectedPath).exists());
-      Assert.assertEquals(expectedPath, path);
+      assertEquals(expectedPath, path);
 
       //update param and read param tests.
       //We don't use net_cls.classid because as a test param here because
@@ -247,14 +246,14 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
 
       assertTrue(paramFile.exists());
       try {
-        Assert.assertEquals(paramValue, new String(Files.readAllBytes(
+        assertEquals(paramValue, new String(Files.readAllBytes(
             paramFile.toPath())));
       } catch (IOException e) {
         LOG.error("Caught exception: " + e);
-        Assert.fail("Unexpected IOException trying to read cgroup param!");
+        fail("Unexpected IOException trying to read cgroup param!");
       }
 
-      Assert.assertEquals(paramValue,
+      assertEquals(paramValue,
           cGroupsHandler.getCGroupParam(controller, testCGroup, param));
 
       //We can't really do a delete test here. Linux cgroups
@@ -267,8 +266,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       //deletion is not possible with a regular non-empty directory.
     } catch (ResourceHandlerException e) {
       LOG.error("Caught exception: " + e);
-      Assert
-        .fail("Unexpected ResourceHandlerException during cgroup operations!");
+      fail("Unexpected ResourceHandlerException during cgroup operations!");
     }
   }
 
@@ -295,7 +293,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
             newMtab);
 
     // Verify
-    Assert.assertEquals(2, controllerPaths.size());
+    assertEquals(2, controllerPaths.size());
     assertTrue(controllerPaths
         .containsKey(CGroupsHandler.CGroupController.CPU));
     assertTrue(controllerPaths
@@ -303,8 +301,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
     String cpuDir = controllerPaths.get(CGroupsHandler.CGroupController.CPU);
     String blkioDir =
         controllerPaths.get(CGroupsHandler.CGroupController.BLKIO);
-    Assert.assertEquals(parentDir.getAbsolutePath() + "/cpu", cpuDir);
-    Assert.assertEquals(parentDir.getAbsolutePath() + "/blkio", blkioDir);
+    assertEquals(parentDir.getAbsolutePath() + "/cpu", cpuDir);
+    assertEquals(parentDir.getAbsolutePath() + "/blkio", blkioDir);
   }
 
   /**
@@ -329,59 +327,58 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
             ""));
     // Test that a missing yarn hierarchy will be created automatically
     if (!cpuCgroupMountDir.equals(mountPoint)) {
-      assertFalse("Directory should be deleted", cpuCgroupMountDir.exists());
+      assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
     }
     cGroupsHandler.initializeCGroupController(
         CGroupsHandler.CGroupController.CPU);
-    assertTrue("Cgroups not writable", cpuCgroupMountDir.exists() &&
-        cpuCgroupMountDir.canWrite());
+    assertTrue(cpuCgroupMountDir.exists() &&
+        cpuCgroupMountDir.canWrite(), "Cgroups not writable");
 
     // Test that an inaccessible yarn hierarchy results in an exception
     assertTrue(cpuCgroupMountDir.setWritable(false));
     try {
       cGroupsHandler.initializeCGroupController(
           CGroupsHandler.CGroupController.CPU);
-      Assert.fail("An inaccessible path should result in an exception");
+      fail("An inaccessible path should result in an exception");
     } catch (Exception e) {
-      assertTrue("Unexpected exception " + e.getClass().toString(),
-          e instanceof ResourceHandlerException);
+      assertTrue(e instanceof ResourceHandlerException,
+          "Unexpected exception " + e.getClass().toString());
     } finally {
-      assertTrue("Could not revert writable permission",
-          cpuCgroupMountDir.setWritable(true));
+      assertTrue(cpuCgroupMountDir.setWritable(true),
+          "Could not revert writable permission");
     }
 
     // Test that a non-accessible mount directory results in an exception
     if (!cpuCgroupMountDir.equals(mountPoint)) {
-      assertTrue("Could not delete cgroups", cpuCgroupMountDir.delete());
-      assertFalse("Directory should be deleted", cpuCgroupMountDir.exists());
+      assertTrue(cpuCgroupMountDir.delete(), "Could not delete cgroups");
+      assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
     }
     assertTrue(mountPoint.setWritable(false));
     try {
       cGroupsHandler.initializeCGroupController(
           CGroupsHandler.CGroupController.CPU);
-      Assert.fail("An inaccessible path should result in an exception");
+      fail("An inaccessible path should result in an exception");
     } catch (Exception e) {
-      assertTrue("Unexpected exception " + e.getClass().toString(),
-          e instanceof ResourceHandlerException);
+      assertTrue(e instanceof ResourceHandlerException,
+          "Unexpected exception " + e.getClass().toString());
     } finally {
-      assertTrue("Could not revert writable permission",
-          mountPoint.setWritable(true));
+      assertTrue(mountPoint.setWritable(true),
+          "Could not revert writable permission");
     }
 
     // Test that a SecurityException results in an exception
     if (!cpuCgroupMountDir.equals(mountPoint)) {
-      Assert.assertFalse("Could not delete cgroups",
-          cpuCgroupMountDir.delete());
-      assertFalse("Directory should be deleted", cpuCgroupMountDir.exists());
+      assertFalse(cpuCgroupMountDir.delete(), "Could not delete cgroups");
+      assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
       SecurityManager manager = System.getSecurityManager();
       System.setSecurityManager(new MockSecurityManagerDenyWrite());
       try {
         cGroupsHandler.initializeCGroupController(
             CGroupsHandler.CGroupController.CPU);
-        Assert.fail("An inaccessible path should result in an exception");
+        fail("An inaccessible path should result in an exception");
       } catch (Exception e) {
-        assertTrue("Unexpected exception " + e.getClass().toString(),
-            e instanceof ResourceHandlerException);
+        assertTrue(e instanceof ResourceHandlerException,
+            "Unexpected exception " + e.getClass().toString());
       } finally {
         System.setSecurityManager(manager);
       }
@@ -389,19 +386,18 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
 
     // Test that a non-existing mount directory results in an exception
     if (!cpuCgroupMountDir.equals(mountPoint)) {
-      Assert.assertFalse("Could not delete cgroups",
-          cpuCgroupMountDir.delete());
-      assertFalse("Directory should be deleted", cpuCgroupMountDir.exists());
+      assertFalse(cpuCgroupMountDir.delete(), "Could not delete cgroups");
+      assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
     }
     FileUtils.deleteQuietly(mountPoint);
-    assertFalse("cgroups mount point should be deleted", mountPoint.exists());
+    assertFalse(mountPoint.exists(), "cgroups mount point should be deleted");
     try {
       cGroupsHandler.initializeCGroupController(
           CGroupsHandler.CGroupController.CPU);
-      Assert.fail("An inaccessible path should result in an exception");
+      fail("An inaccessible path should result in an exception");
     } catch (Exception e) {
-      assertTrue("Unexpected exception " + e.getClass().toString(),
-          e instanceof ResourceHandlerException);
+      assertTrue(e instanceof ResourceHandlerException,
+          "Unexpected exception " + e.getClass().toString());
     }
   }
 
@@ -416,9 +412,9 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
           privilegedOperationExecutorMock);
       Map<String, Set<String>> cgroups = new LinkedHashMap<>();
 
-      Assert.assertTrue("temp dir should be created", cpu.mkdirs());
-      Assert.assertTrue("temp dir should be created", memory.mkdirs());
-      Assert.assertFalse("temp dir should not be created", cpuNoExist.exists());
+      assertTrue(cpu.mkdirs(), "temp dir should be created");
+      assertTrue(memory.mkdirs(), "temp dir should be created");
+      assertFalse(cpuNoExist.exists(), "temp dir should not be created");
 
       cgroups.put(
           memory.getAbsolutePath(), Collections.singleton("memory"));
@@ -426,8 +422,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
           cpuNoExist.getAbsolutePath(), Collections.singleton("cpu"));
       cgroups.put(cpu.getAbsolutePath(), Collections.singleton("cpu"));
       String selectedCPU = handler.findControllerInMtab("cpu", cgroups);
-      Assert.assertEquals("Wrong CPU mount point selected",
-          cpu.getAbsolutePath(), selectedCPU);
+      assertEquals(cpu.getAbsolutePath(), selectedCPU,
+          "Wrong CPU mount point selected");
     } finally {
       FileUtils.deleteQuietly(cpu);
       FileUtils.deleteQuietly(memory);
@@ -470,8 +466,8 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
         oldMountPoint, true);
 
     File newMountPoint = new File(parentDir, newMountPointDir);
-    assertTrue("Could not create dirs",
-        new File(newMountPoint, "cpu").mkdirs());
+    assertTrue(new File(newMountPoint, "cpu").mkdirs(),
+        "Could not create dirs");
 
     // Initialize YARN classes
     Configuration confMount = createMountConfiguration();
@@ -489,7 +485,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
         .executePrivilegedOperation(opCaptor.capture(), eq(false));
     File hierarchyFile =
         new File(new File(newMountPoint, "cpu"), this.hierarchy);
-    assertTrue("Yarn cgroup should exist", hierarchyFile.exists());
+    assertTrue(hierarchyFile.exists(), "Yarn cgroup should exist");
   }
 
 
@@ -502,15 +498,16 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
     File cpu = new File(new File(tmpPath, "cpuacct,cpu"), "/hadoop-yarn");
 
     try {
-      Assert.assertTrue("temp dir should be created", cpu.mkdirs());
+      assertTrue(cpu.mkdirs(), "temp dir should be created");
 
       CGroupsHandlerImpl cGroupsHandler = new CGroupsHandlerImpl(conf, null);
       cGroupsHandler.initializeCGroupController(
               CGroupsHandler.CGroupController.CPU);
 
-      Assert.assertEquals("CPU CGRoup path was not set", cpu.getAbsolutePath(),
-              new File(cGroupsHandler.getPathForCGroup(
-                  CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath());
+      assertEquals(cpu.getAbsolutePath(),
+          new File(cGroupsHandler.getPathForCGroup(
+          CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath(),
+          "CPU CGRoup path was not set");
 
     } finally {
       FileUtils.deleteQuietly(cpu);
@@ -526,32 +523,32 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
         "/hadoop-yarn");
     CGroupsHandlerImpl cGroupsHandler = new CGroupsHandlerImpl(conf, null);
     String expectedRelativePath = "hadoop-yarn/c1";
-    Assert.assertEquals(expectedRelativePath,
+    assertEquals(expectedRelativePath,
         cGroupsHandler.getRelativePathForCGroup("c1"));
 
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "hadoop-yarn");
     cGroupsHandler = new CGroupsHandlerImpl(conf, null);
-    Assert.assertEquals(expectedRelativePath,
+    assertEquals(expectedRelativePath,
         cGroupsHandler.getRelativePathForCGroup("c1"));
 
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "hadoop-yarn/");
     cGroupsHandler = new CGroupsHandlerImpl(conf, null);
-    Assert.assertEquals(expectedRelativePath,
+    assertEquals(expectedRelativePath,
         cGroupsHandler.getRelativePathForCGroup("c1"));
 
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "//hadoop-yarn//");
     cGroupsHandler = new CGroupsHandlerImpl(conf, null);
-    Assert.assertEquals(expectedRelativePath,
+    assertEquals(expectedRelativePath,
         cGroupsHandler.getRelativePathForCGroup("c1"));
 
     expectedRelativePath = "hadoop-yarn/root/c1";
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         "//hadoop-yarn/root//");
     cGroupsHandler = new CGroupsHandlerImpl(conf, null);
-    Assert.assertEquals(expectedRelativePath,
+    assertEquals(expectedRelativePath,
         cGroupsHandler.getRelativePathForCGroup("c1"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsResourceCalculator.java
@@ -25,14 +25,14 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.util.CpuTimeTracker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,12 +44,12 @@ public class TestCGroupsResourceCalculator {
 
   private Path root;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     root = Files.createTempDirectory("TestCGroupsResourceCalculator");
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     FileUtils.deleteDirectory(root.toFile());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2CpuResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2CpuResourceHandlerImpl.java
@@ -29,13 +29,15 @@ import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,7 +54,7 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
   private ResourceCalculatorPlugin plugin;
   final int numProcessors = 4;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockCGroupsHandler = mock(CGroupsHandler.class);
     when(mockCGroupsHandler.getPathForCGroup(any(), any())).thenReturn(".");
@@ -75,7 +77,7 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
     verify(mockCGroupsHandler, times(0))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_MAX, "");
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -95,7 +97,7 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
     verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_MAX, cpuMaxValue);
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -117,7 +119,7 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
     verify(mockCGroupsHandler, times(1))
         .updateCGroupParam(CGroupsHandler.CGroupController.CPU, "",
             CGroupsHandler.CGROUP_CPU_MAX, "max 100000");
-    Assert.assertNull(ret);
+    assertNull(ret);
   }
 
   @Test
@@ -257,7 +259,7 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
   @Test
   public void testReacquireContainer() throws Exception {
     ContainerId containerIdMock = mock(ContainerId.class);
-    Assert.assertNull(
+    assertNull(
         cGroupsCpuResourceHandler.reacquireContainer(containerIdMock));
   }
 
@@ -266,14 +268,14 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
     String id = "container_01_01";
     ContainerId mockContainerId = mock(ContainerId.class);
     when(mockContainerId.toString()).thenReturn(id);
-    Assert.assertNull(cGroupsCpuResourceHandler.postComplete(mockContainerId));
+    assertNull(cGroupsCpuResourceHandler.postComplete(mockContainerId));
     verify(mockCGroupsHandler, times(1))
         .deleteCGroup(CGroupsHandler.CGroupController.CPU, id);
   }
 
   @Test
   public void testTeardown() throws Exception {
-    Assert.assertNull(cGroupsCpuResourceHandler.teardown());
+    assertNull(cGroupsCpuResourceHandler.teardown());
   }
 
   @Test
@@ -300,14 +302,14 @@ public class TestCGroupsV2CpuResourceHandlerImpl {
   }
 
   private void validatePrivilegedOperationList(List<PrivilegedOperation> ops, String path) {
-    Assert.assertNotNull(ops);
-    Assert.assertEquals(1, ops.size());
+    assertNotNull(ops);
+    assertEquals(1, ops.size());
     PrivilegedOperation op = ops.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2HandlerImpl.java
@@ -24,8 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +37,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the CGroups handler implementation.
@@ -75,8 +76,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
         enabledControllers);
 
     File subtreeControlFile = new File(parentDir, CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE);
-    Assert.assertTrue("empty subtree_control file should be created",
-        subtreeControlFile.createNewFile());
+    assertTrue(subtreeControlFile.createNewFile(),
+        "empty subtree_control file should be created");
 
     File hierarchyDir = new File(parentDir, hierarchy);
     if (!hierarchyDir.mkdirs()) {
@@ -98,8 +99,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     verifyZeroInteractions(privilegedOperationExecutorMock);
     File parentDir = new File(tmpPath);
     File mtab = createPremountedCgroups(parentDir);
-    assertTrue("Sample subsystem should be created",
-        new File(controllerPath).exists());
+    assertTrue(new File(controllerPath).exists(),
+        "Sample subsystem should be created");
 
     CGroupsHandler cGroupsHandler = new CGroupsV2HandlerImpl(createNoMountConfiguration(hierarchy),
         privilegedOperationExecutorMock, mtab.getAbsolutePath());
@@ -109,34 +110,36 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     String expectedPath =
         controllerPath + Path.SEPARATOR + testCGroup;
     String path = cGroupsHandler.getPathForCGroup(controller, testCGroup);
-    Assert.assertEquals(expectedPath, path);
+    assertEquals(expectedPath, path);
 
     String expectedPathTasks = expectedPath + Path.SEPARATOR
         + CGroupsHandler.CGROUP_PROCS_FILE;
     path = cGroupsHandler.getPathForCGroupTasks(controller, testCGroup);
-    Assert.assertEquals(expectedPathTasks, path);
+    assertEquals(expectedPathTasks, path);
 
     String param = CGroupsHandler.CGROUP_PARAM_CLASSID;
     String expectedPathParam = expectedPath + Path.SEPARATOR
         + controller.getName() + "." + param;
     path = cGroupsHandler.getPathForCGroupParam(controller, testCGroup, param);
-    Assert.assertEquals(expectedPathParam, path);
+    assertEquals(expectedPathParam, path);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testUnsupportedMountConfiguration() throws Exception {
-    //As per junit behavior, we expect a new mock object to be available
-    //in this test.
-    verifyZeroInteractions(privilegedOperationExecutorMock);
-    CGroupsHandler cGroupsHandler;
-    File mtab = createEmptyMtabFile();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      //As per junit behavior, we expect a new mock object to be available
+      //in this test.
+      verifyZeroInteractions(privilegedOperationExecutorMock);
+      CGroupsHandler cGroupsHandler;
+      File mtab = createEmptyMtabFile();
 
-    assertTrue("Sample subsystem should be created",
-            new File(controllerPath).mkdirs());
+      assertTrue(new File(controllerPath).mkdirs(),
+          "Sample subsystem should be created");
 
-    cGroupsHandler = new CGroupsV2HandlerImpl(createMountConfiguration(),
-            privilegedOperationExecutorMock, mtab.getAbsolutePath());
-    cGroupsHandler.initializeCGroupController(controller);
+      cGroupsHandler = new CGroupsV2HandlerImpl(createMountConfiguration(),
+          privilegedOperationExecutorMock, mtab.getAbsolutePath());
+      cGroupsHandler.initializeCGroupController(controller);
+    });
   }
 
   @Test
@@ -144,8 +147,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     verifyZeroInteractions(privilegedOperationExecutorMock);
     File parentDir = new File(tmpPath);
     File mtab = createPremountedCgroups(parentDir);
-    assertTrue("Sample subsystem should be created",
-            new File(controllerPath).exists());
+    assertTrue(new File(controllerPath).exists(),
+        "Sample subsystem should be created");
 
     CGroupsHandler cGroupsHandler = new CGroupsV2HandlerImpl(createNoMountConfiguration(hierarchy),
         privilegedOperationExecutorMock, mtab.getAbsolutePath());
@@ -157,7 +160,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     String path = cGroupsHandler.createCGroup(controller, testCGroup);
 
     assertTrue(new File(expectedPath).exists());
-    Assert.assertEquals(expectedPath, path);
+    assertEquals(expectedPath, path);
 
     String param = "test_param";
     String paramValue = "test_param_value";
@@ -169,9 +172,9 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     File paramFile = new File(paramPath);
 
     assertTrue(paramFile.exists());
-    Assert.assertEquals(paramValue, new String(Files.readAllBytes(
+    assertEquals(paramValue, new String(Files.readAllBytes(
         paramFile.toPath())));
-    Assert.assertEquals(paramValue,
+    assertEquals(paramValue,
         cGroupsHandler.getCGroupParam(controller, testCGroup, param));
   }
 
@@ -198,7 +201,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
             newMtab);
 
     // Verify
-    Assert.assertEquals(4, controllerPaths.size());
+    assertEquals(4, controllerPaths.size());
     assertTrue(controllerPaths
         .containsKey(CGroupsHandler.CGroupController.CPU));
     assertTrue(controllerPaths
@@ -206,8 +209,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     String cpuDir = controllerPaths.get(CGroupsHandler.CGroupController.CPU);
     String memoryDir =
         controllerPaths.get(CGroupsHandler.CGroupController.MEMORY);
-    Assert.assertEquals(parentDir.getAbsolutePath(), cpuDir);
-    Assert.assertEquals(parentDir.getAbsolutePath(), memoryDir);
+    assertEquals(parentDir.getAbsolutePath(), cpuDir);
+    assertEquals(parentDir.getAbsolutePath(), memoryDir);
   }
 
   /*
@@ -245,8 +248,8 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
         CGroupsHandler.CGROUP_CONTROLLERS_FILE, enabledV2Controllers);
 
     File subtreeControlFile = new File(v2ParentDir, CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE);
-    Assert.assertTrue("empty subtree_control file should be created",
-        subtreeControlFile.createNewFile());
+    assertTrue(subtreeControlFile.createNewFile(),
+        "empty subtree_control file should be created");
 
     File hierarchyDir = new File(v2ParentDir, hierarchy);
     if (!hierarchyDir.mkdirs()) {
@@ -269,7 +272,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
     File v1ParentDir = new File(tmpPath);
 
     File v2ParentDir = new File(v1ParentDir, "unified");
-    Assert.assertTrue("temp dir should be created", v2ParentDir.mkdirs());
+    assertTrue(v2ParentDir.mkdirs(), "temp dir should be created");
     v2ParentDir.deleteOnExit();
 
     // create mock cgroup
@@ -277,7 +280,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
 
     // create memory cgroup for v1
     File memoryCgroup = new File(v1ParentDir, "memory");
-    assertTrue("Directory should be created", memoryCgroup.mkdirs());
+    assertTrue(memoryCgroup.mkdirs(), "Directory should be created");
 
     // init v1 and v2 handlers
     CGroupsHandlerImpl cGroupsHandler = new CGroupsHandlerImpl(
@@ -294,12 +297,12 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
         cGroupsHandler.initializeControllerPathsFromMtab(
             newMtab);
 
-    Assert.assertEquals(1, controllerv1Paths.size());
+    assertEquals(1, controllerv1Paths.size());
     assertTrue(controllerv1Paths
         .containsKey(CGroupsHandler.CGroupController.MEMORY));
     String memoryDir =
         controllerv1Paths.get(CGroupsHandler.CGroupController.MEMORY);
-    Assert.assertEquals(memoryCgroup.getAbsolutePath(), memoryDir);
+    assertEquals(memoryCgroup.getAbsolutePath(), memoryDir);
 
     // Verify resource handlers that are enabled in v2
     newMtab =
@@ -308,11 +311,11 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
         cGroupsV2Handler.initializeControllerPathsFromMtab(
             newMtab);
 
-    Assert.assertEquals(3, controllerPaths.size());
+    assertEquals(3, controllerPaths.size());
     assertTrue(controllerPaths
         .containsKey(CGroupsHandler.CGroupController.CPU));
     String cpuDir = controllerPaths.get(CGroupsHandler.CGroupController.CPU);
-    Assert.assertEquals(v2ParentDir.getAbsolutePath(), cpuDir);
+    assertEquals(v2ParentDir.getAbsolutePath(), cpuDir);
   }
 
   @Test
@@ -343,7 +346,7 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
       throws Exception {
     File baseCgroup = new File(mountPath);
     File subCgroup = new File(mountPath, "/hadoop-yarn");
-    Assert.assertTrue("temp dir should be created", subCgroup.mkdirs());
+    assertTrue(subCgroup.mkdirs(), "temp dir should be created");
     subCgroup.deleteOnExit();
 
     String enabledControllers = "cpuset cpu io memory hugetlb pids rdma misc\n";
@@ -352,36 +355,37 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
 
     File subtreeControlFile = new File(subCgroup.getAbsolutePath(),
         CGroupsHandler.CGROUP_SUBTREE_CONTROL_FILE);
-    Assert.assertTrue("empty subtree_control file should be created",
-        subtreeControlFile.createNewFile());
+    assertTrue(subtreeControlFile.createNewFile(),
+        "empty subtree_control file should be created");
 
     CGroupsV2HandlerImpl cGroupsHandler = new CGroupsV2HandlerImpl(conf, null);
     cGroupsHandler.initializeCGroupController(CGroupsHandler.CGroupController.CPU);
 
-    Assert.assertEquals("CPU cgroup path was not set", subCgroup.getAbsolutePath(),
+    assertEquals(subCgroup.getAbsolutePath(),
         new File(cGroupsHandler.getPathForCGroup(
-            CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath());
+        CGroupsHandler.CGroupController.CPU, "")).getAbsolutePath(),
+        "CPU cgroup path was not set");
 
     // Verify that the subtree control file was updated
     String subtreeControllersEnabledString = FileUtils.readFileToString(subtreeControlFile,
         StandardCharsets.UTF_8);
-    Assert.assertEquals("The newly added controller doesn't contain + sign",
-        1, StringUtils.countMatches(subtreeControllersEnabledString, "+"));
-    Assert.assertEquals("Controller is not enabled in subtree control file",
-        controller.getName(), subtreeControllersEnabledString.replace("+", "").trim());
+    assertEquals(1, StringUtils.countMatches(subtreeControllersEnabledString, "+"),
+        "The newly added controller doesn't contain + sign");
+    assertEquals(controller.getName(), subtreeControllersEnabledString.replace("+", "").trim(),
+        "Controller is not enabled in subtree control file");
 
     cGroupsHandler.initializeCGroupController(CGroupsHandler.CGroupController.MEMORY);
 
     subtreeControllersEnabledString = FileUtils.readFileToString(subtreeControlFile,
         StandardCharsets.UTF_8);
-    Assert.assertEquals("The newly added controllers doesn't contain + signs",
-        2, StringUtils.countMatches(subtreeControllersEnabledString, "+"));
+    assertEquals(2, StringUtils.countMatches(subtreeControllersEnabledString, "+"),
+        "The newly added controllers doesn't contain + signs");
 
     Set<String> subtreeControllersEnabled = new HashSet<>(Arrays.asList(
         subtreeControllersEnabledString.replace("+", " ").trim().split(" ")));
-    Assert.assertEquals(2, subtreeControllersEnabled.size());
-    Assert.assertTrue("Controller is not enabled in subtree control file",
-        cGroupsHandler.getValidCGroups().containsAll(subtreeControllersEnabled));
+    assertEquals(2, subtreeControllersEnabled.size());
+    assertTrue(cGroupsHandler.getValidCGroups().containsAll(subtreeControllersEnabled),
+        "Controller is not enabled in subtree control file");
 
     // Test that the subtree control file is appended correctly
     // even if some controllers are present
@@ -391,29 +395,30 @@ public class TestCGroupsV2HandlerImpl extends TestCGroupsHandlerBase {
 
     subtreeControllersEnabledString = FileUtils.readFileToString(subtreeControlFile,
         StandardCharsets.UTF_8);
-    Assert.assertEquals("The newly added controller doesn't contain + sign",
-        1, StringUtils.countMatches(subtreeControllersEnabledString, "+"));
+    assertEquals(1, StringUtils.countMatches(subtreeControllersEnabledString, "+"),
+        "The newly added controller doesn't contain + sign");
 
     subtreeControllersEnabled = new HashSet<>(Arrays.asList(
         subtreeControllersEnabledString.replace("+", " ").split(" ")));
-    Assert.assertEquals(3, subtreeControllersEnabled.size());
-    Assert.assertTrue("Controllers not enabled in subtree control file",
-        cGroupsHandler.getValidCGroups().containsAll(subtreeControllersEnabled));
+    assertEquals(3, subtreeControllersEnabled.size());
+    assertTrue(cGroupsHandler.getValidCGroups().containsAll(subtreeControllersEnabled),
+        "Controllers not enabled in subtree control file");
   }
 
   private void validateCgroupV1Controllers(YarnConfiguration conf, String mountPath)
       throws ResourceHandlerException {
     File blkio = new File(new File(mountPath, "blkio"), "/hadoop-yarn");
 
-    Assert.assertTrue("temp dir should be created", blkio.mkdirs());
+    assertTrue(blkio.mkdirs(), "temp dir should be created");
 
     CGroupsHandlerImpl cGroupsv1Handler = new CGroupsHandlerImpl(conf, null);
     cGroupsv1Handler.initializeCGroupController(
         CGroupsHandler.CGroupController.BLKIO);
 
-    Assert.assertEquals("BLKIO CGRoup path was not set", blkio.getAbsolutePath(),
+    assertEquals(blkio.getAbsolutePath(),
         new File(cGroupsv1Handler.getPathForCGroup(
-            CGroupsHandler.CGroupController.BLKIO, "")).getAbsolutePath());
+        CGroupsHandler.CGroupController.BLKIO, "")).getAbsolutePath(),
+        "BLKIO CGRoup path was not set");
 
     FileUtils.deleteQuietly(blkio);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2ResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsV2ResourceCalculator.java
@@ -25,14 +25,14 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.util.CpuTimeTracker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,12 +44,12 @@ public class TestCGroupsV2ResourceCalculator {
 
   private Path root;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     root = Files.createTempDirectory("TestCGroupsV2ResourceCalculator");
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     FileUtils.deleteDirectory(root.toFile());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCgroupsV2MemoryResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCgroupsV2MemoryResourceHandlerImpl.java
@@ -26,12 +26,15 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -43,7 +46,7 @@ public class TestCgroupsV2MemoryResourceHandlerImpl {
   private CGroupsHandler mockCGroupsHandler;
   private CGroupsV2MemoryResourceHandlerImpl cGroupsMemoryResourceHandler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockCGroupsHandler = mock(CGroupsHandler.class);
     when(mockCGroupsHandler.getPathForCGroup(any(), any())).thenReturn(".");
@@ -60,19 +63,19 @@ public class TestCgroupsV2MemoryResourceHandlerImpl {
         cGroupsMemoryResourceHandler.bootstrap(conf);
     verify(mockCGroupsHandler, times(1))
         .initializeCGroupController(CGroupsHandler.CGroupController.MEMORY);
-    Assert.assertNull(ret);
+    assertNull(ret);
     conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, true);
     try {
       cGroupsMemoryResourceHandler.bootstrap(conf);
     } catch (ResourceHandlerException re) {
-      Assert.fail("Pmem check should be allowed to run with cgroups");
+      fail("Pmem check should be allowed to run with cgroups");
     }
     conf.setBoolean(YarnConfiguration.NM_PMEM_CHECK_ENABLED, false);
     conf.setBoolean(YarnConfiguration.NM_VMEM_CHECK_ENABLED, true);
     try {
       cGroupsMemoryResourceHandler.bootstrap(conf);
     } catch (ResourceHandlerException re) {
-      Assert.fail("Vmem check should be allowed to run with cgroups");
+      fail("Vmem check should be allowed to run with cgroups");
     }
   }
 
@@ -106,14 +109,14 @@ public class TestCgroupsV2MemoryResourceHandlerImpl {
         .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
             CGroupsHandler.CGROUP_MEMORY_LOW,
             String.valueOf((int) (memory * 0.9)) + "M");
-    Assert.assertNotNull(ret);
-    Assert.assertEquals(1, ret.size());
+    assertNotNull(ret);
+    assertEquals(1, ret.size());
     PrivilegedOperation op = ret.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 
@@ -148,21 +151,21 @@ public class TestCgroupsV2MemoryResourceHandlerImpl {
         .updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, id,
             CGroupsHandler.CGROUP_MEMORY_LOW,
             String.valueOf((int) (memory * 0.9)) + "M");
-    Assert.assertNotNull(ret);
-    Assert.assertEquals(1, ret.size());
+    assertNotNull(ret);
+    assertEquals(1, ret.size());
     PrivilegedOperation op = ret.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         op.getOperationType());
     List<String> args = op.getArguments();
-    Assert.assertEquals(1, args.size());
-    Assert.assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
+    assertEquals(1, args.size());
+    assertEquals(PrivilegedOperation.CGROUP_ARG_PREFIX + path,
         args.get(0));
   }
 
   @Test
   public void testReacquireContainer() throws Exception {
     ContainerId containerIdMock = mock(ContainerId.class);
-    Assert.assertNull(
+    assertNull(
         cGroupsMemoryResourceHandler.reacquireContainer(containerIdMock));
   }
 
@@ -171,15 +174,14 @@ public class TestCgroupsV2MemoryResourceHandlerImpl {
     String id = "container_01_01";
     ContainerId mockContainerId = mock(ContainerId.class);
     when(mockContainerId.toString()).thenReturn(id);
-    Assert
-        .assertNull(cGroupsMemoryResourceHandler.postComplete(mockContainerId));
+    assertNull(cGroupsMemoryResourceHandler.postComplete(mockContainerId));
     verify(mockCGroupsHandler, times(1))
         .deleteCGroup(CGroupsHandler.CGroupController.MEMORY, id);
   }
 
   @Test
   public void testTeardown() throws Exception {
-    Assert.assertNull(cGroupsMemoryResourceHandler.teardown());
+    assertNull(cGroupsMemoryResourceHandler.teardown());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestDefaultOOMHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestDefaultOOMHandler.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.yarn.server.nodemanager.ContainerExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerSignalContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +37,7 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_OOM_CONTROL;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_USAGE_BYTES;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -51,59 +52,63 @@ public class TestDefaultOOMHandler {
   /**
    * Test an OOM situation where there are no containers that can be killed.
    */
-  @Test(expected = YarnRuntimeException.class)
+  @Test
   public void testExceptionThrownWithNoContainersToKill() throws Exception {
-    Context context = mock(Context.class);
+    assertThrows(YarnRuntimeException.class, () -> {
+      Context context = mock(Context.class);
 
-    when(context.getContainers()).thenReturn(new ConcurrentHashMap<>(0));
+      when(context.getContainers()).thenReturn(new ConcurrentHashMap<>(0));
 
-    CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
-    when(cGroupsHandler.getCGroupParam(
-        CGroupsHandler.CGroupController.MEMORY,
-        "",
-        CGROUP_PARAM_MEMORY_OOM_CONTROL))
-        .thenReturn("under_oom 1").thenReturn("under_oom 0");
+      CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
+      when(cGroupsHandler.getCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY,
+          "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL))
+          .thenReturn("under_oom 1").thenReturn("under_oom 0");
 
-    DefaultOOMHandler handler = new DefaultOOMHandler(context, false) {
-      @Override
-      protected CGroupsHandler getCGroupsHandler() {
-        return cGroupsHandler;
-      }
-    };
+      DefaultOOMHandler handler = new DefaultOOMHandler(context, false) {
+        @Override
+        protected CGroupsHandler getCGroupsHandler() {
+          return cGroupsHandler;
+        }
+      };
 
-    handler.run();
+      handler.run();
+    });
   }
 
   /**
    * Test an OOM situation where there are no running containers that
    * can be killed.
    */
-  @Test(expected = YarnRuntimeException.class)
+  @Test
   public void testExceptionThrownWithNoRunningContainersToKill()
       throws Exception {
-    ConcurrentHashMap<ContainerId, Container> containers =
-        new ConcurrentHashMap<>();
-    Container c1 = createContainer(1, true, 1L, false);
-    containers.put(c1.getContainerId(), c1);
+    assertThrows(YarnRuntimeException.class, () -> {
+      ConcurrentHashMap<ContainerId, Container> containers =
+          new ConcurrentHashMap<>();
+      Container c1 = createContainer(1, true, 1L, false);
+      containers.put(c1.getContainerId(), c1);
 
-    Context context = mock(Context.class);
-    when(context.getContainers()).thenReturn(containers);
+      Context context = mock(Context.class);
+      when(context.getContainers()).thenReturn(containers);
 
-    CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
-    when(cGroupsHandler.getCGroupParam(
-        CGroupsHandler.CGroupController.MEMORY,
-        "",
-        CGROUP_PARAM_MEMORY_OOM_CONTROL))
-        .thenReturn("under_oom 1").thenReturn("under_oom 0");
+      CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
+      when(cGroupsHandler.getCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY,
+          "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL))
+          .thenReturn("under_oom 1").thenReturn("under_oom 0");
 
-    DefaultOOMHandler handler = new DefaultOOMHandler(context, false) {
-      @Override
-      protected CGroupsHandler getCGroupsHandler() {
-        return cGroupsHandler;
-      }
-    };
+      DefaultOOMHandler handler = new DefaultOOMHandler(context, false) {
+        @Override
+        protected CGroupsHandler getCGroupsHandler() {
+          return cGroupsHandler;
+        }
+      };
 
-    handler.run();
+      handler.run();
+    });
   }
 
   /**
@@ -489,46 +494,46 @@ public class TestDefaultOOMHandler {
    * running as processes. Their cgroup.procs file is not available,
    * so kill them won't succeed.
    */
-  @Test(expected = YarnRuntimeException.class)
+  @Test
   public void testExceptionThrownWhenNoContainersKilledSuccessfully()
       throws Exception {
-    ConcurrentHashMap<ContainerId, Container> containers =
-        new ConcurrentHashMap<>();
-    Container c1 = createContainer(1, false, 1L, true);
-    containers.put(c1.getContainerId(), c1);
-    Container c2 = createContainer(2, false, 2L, true);
-    containers.put(c2.getContainerId(), c2);
+    assertThrows(YarnRuntimeException.class, () -> {
+      ConcurrentHashMap<ContainerId, Container> containers =
+          new ConcurrentHashMap<>();
+      Container c1 = createContainer(1, false, 1L, true);
+      containers.put(c1.getContainerId(), c1);
+      Container c2 = createContainer(2, false, 2L, true);
+      containers.put(c2.getContainerId(), c2);
 
-    ContainerExecutor ex = createContainerExecutor(containers);
-    Context context = mock(Context.class);
-    when(context.getContainers()).thenReturn(containers);
-    when(context.getContainerExecutor()).thenReturn(ex);
+      ContainerExecutor ex = createContainerExecutor(containers);
+      Context context = mock(Context.class);
+      when(context.getContainers()).thenReturn(containers);
+      when(context.getContainerExecutor()).thenReturn(ex);
 
-    CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
-    when(cGroupsHandler.getCGroupParam(
-        CGroupsHandler.CGroupController.MEMORY,
-        "",
-        CGROUP_PARAM_MEMORY_OOM_CONTROL))
-        .thenReturn("under_oom 1").thenReturn("under_oom 0");
-    // c1 process has not started, hence no cgroup.procs file yet
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c1.getContainerId().toString(), CGROUP_PROCS_FILE))
-        .thenThrow(
-            new ResourceHandlerException(CGROUP_PROCS_FILE + " not found"));
-    // c2 process has not started, hence no cgroup.procs file yet
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c2.getContainerId().toString(), CGROUP_PROCS_FILE))
-        .thenThrow(
-            new ResourceHandlerException(CGROUP_PROCS_FILE + " not found"));
+      CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
+      when(cGroupsHandler.getCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY,
+          "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL))
+          .thenReturn("under_oom 1").thenReturn("under_oom 0");
+      // c1 process has not started, hence no cgroup.procs file yet
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c1.getContainerId().toString(), CGROUP_PROCS_FILE))
+          .thenThrow(new ResourceHandlerException(CGROUP_PROCS_FILE + " not found"));
+      // c2 process has not started, hence no cgroup.procs file yet
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c2.getContainerId().toString(), CGROUP_PROCS_FILE))
+          .thenThrow(new ResourceHandlerException(CGROUP_PROCS_FILE + " not found"));
 
-    DefaultOOMHandler handler =
-        new DefaultOOMHandler(context, false) {
-          @Override
-          protected CGroupsHandler getCGroupsHandler() {
-            return cGroupsHandler;
-          }
-        };
-    handler.run();
+      DefaultOOMHandler handler =
+          new DefaultOOMHandler(context, false) {
+            @Override
+            protected CGroupsHandler getCGroupsHandler() {
+              return cGroupsHandler;
+            }
+          };
+      handler.run();
+    });
   }
 
   /**
@@ -1160,69 +1165,70 @@ public class TestDefaultOOMHandler {
    * OOM is not resolved even after killing all running containers.
    * A YarnRuntimeException is excepted to be thrown.
    */
-  @Test(expected = YarnRuntimeException.class)
+  @Test
   public void testOOMUnresolvedAfterKillingAllContainers() throws Exception {
-    int currentContainerId = 0;
+    assertThrows(YarnRuntimeException.class, () -> {
+      int currentContainerId = 0;
 
-    ConcurrentHashMap<ContainerId, Container> containers =
-        new ConcurrentHashMap<>();
-    Container c1 = createContainer(currentContainerId++, false, 1, true);
-    containers.put(c1.getContainerId(), c1);
-    Container c2 = createContainer(currentContainerId++, false, 2, true);
-    containers.put(c2.getContainerId(), c2);
-    Container c3 = createContainer(currentContainerId++, true, 3, true);
-    containers.put(c3.getContainerId(), c3);
+      ConcurrentHashMap<ContainerId, Container> containers =
+          new ConcurrentHashMap<>();
+      Container c1 = createContainer(currentContainerId++, false, 1, true);
+      containers.put(c1.getContainerId(), c1);
+      Container c2 = createContainer(currentContainerId++, false, 2, true);
+      containers.put(c2.getContainerId(), c2);
+      Container c3 = createContainer(currentContainerId++, true, 3, true);
+      containers.put(c3.getContainerId(), c3);
 
-    ContainerExecutor ex = createContainerExecutor(containers);
-    Context context = mock(Context.class);
-    when(context.getContainers()).thenReturn(containers);
-    when(context.getContainerExecutor()).thenReturn(ex);
+      ContainerExecutor ex = createContainerExecutor(containers);
+      Context context = mock(Context.class);
+      when(context.getContainers()).thenReturn(containers);
+      when(context.getContainerExecutor()).thenReturn(ex);
 
-    CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
-    when(cGroupsHandler.getCGroupParam(
-        CGroupsHandler.CGroupController.MEMORY,
-        "",
-        CGROUP_PARAM_MEMORY_OOM_CONTROL))
-        .thenReturn("under_oom 1")
-        .thenReturn("under_oom 1")
-        .thenReturn("under_oom 1")
-        .thenReturn("under_oom 1");
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c1.getContainerId().toString(), CGROUP_PROCS_FILE))
-        .thenReturn("1234").thenReturn("");
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c1.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
-        .thenReturn(getMB(9));
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c1.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
-        .thenReturn(getMB(9));
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c2.getContainerId().toString(), CGROUP_PROCS_FILE))
-        .thenReturn("1235").thenReturn("");
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c2.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
-        .thenReturn(getMB(9));
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c2.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
-        .thenReturn(getMB(9));
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c3.getContainerId().toString(), CGROUP_PROCS_FILE))
-        .thenReturn("1236").thenReturn("");
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c3.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
-        .thenReturn(getMB(9));
-    when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
-        c3.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
-        .thenReturn(getMB(9));
+      CGroupsHandler cGroupsHandler = mock(CGroupsHandler.class);
+      when(cGroupsHandler.getCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY,
+          "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL))
+          .thenReturn("under_oom 1")
+          .thenReturn("under_oom 1")
+          .thenReturn("under_oom 1")
+          .thenReturn("under_oom 1");
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c1.getContainerId().toString(), CGROUP_PROCS_FILE))
+          .thenReturn("1234").thenReturn("");
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c1.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
+          .thenReturn(getMB(9));
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c1.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
+          .thenReturn(getMB(9));
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c2.getContainerId().toString(), CGROUP_PROCS_FILE))
+          .thenReturn("1235").thenReturn("");
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c2.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
+          .thenReturn(getMB(9));
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c2.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
+          .thenReturn(getMB(9));
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c3.getContainerId().toString(), CGROUP_PROCS_FILE))
+          .thenReturn("1236").thenReturn("");
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c3.getContainerId().toString(), CGROUP_PARAM_MEMORY_USAGE_BYTES))
+          .thenReturn(getMB(9));
+      when(cGroupsHandler.getCGroupParam(CGroupsHandler.CGroupController.MEMORY,
+          c3.getContainerId().toString(), CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES))
+          .thenReturn(getMB(9));
 
-    DefaultOOMHandler handler =
-        new DefaultOOMHandler(context, false) {
+      DefaultOOMHandler handler = new DefaultOOMHandler(context, false) {
           @Override
           protected CGroupsHandler getCGroupsHandler() {
             return cGroupsHandler;
           }
-        };
-    handler.run();
+       };
+      handler.run();
+    });
   }
 
   private static ContainerId createContainerId(int id) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestDefaultOOMHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestDefaultOOMHandler.java
@@ -1226,7 +1226,7 @@ public class TestDefaultOOMHandler {
           protected CGroupsHandler getCGroupsHandler() {
             return cGroupsHandler;
           }
-       };
+      };
       handler.run();
     });
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestNetworkPacketTaggingHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestNetworkPacketTaggingHandlerImpl.java
@@ -20,6 +20,9 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -39,10 +42,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +67,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
   private ContainerId containerIdMock;
   private Container containerMock;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
     cGroupsHandlerMock = mock(CGroupsHandler.class);
@@ -99,7 +101,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
       verifyNoMoreInteractions(cGroupsHandlerMock);
     } catch (ResourceHandlerException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected ResourceHandlerException!");
+      fail("Caught unexpected ResourceHandlerException!");
     }
   }
 
@@ -113,7 +115,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
       testPostComplete(handlerImpl);
     } catch (ResourceHandlerException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected ResourceHandlerException!");
+      fail("Caught unexpected ResourceHandlerException!");
     }
   }
 
@@ -136,7 +138,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
 
     //Now check the privileged operations being returned
     //We expect one operations - for adding pid to tasks file
-    Assert.assertEquals(1, ops.size());
+    assertEquals(1, ops.size());
 
     //Verify that the add pid op is correct
     PrivilegedOperation addPidOp = ops.get(0);
@@ -144,10 +146,10 @@ public class TestNetworkPacketTaggingHandlerImpl {
         TEST_TASKS_FILE;
     List<String> addPidOpArgs = addPidOp.getArguments();
 
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         addPidOp.getOperationType());
-    Assert.assertEquals(1, addPidOpArgs.size());
-    Assert.assertEquals(expectedAddPidOpArg, addPidOpArgs.get(0));
+    assertEquals(1, addPidOpArgs.size());
+    assertEquals(expectedAddPidOpArg, addPidOpArgs.get(0));
   }
 
   private void testPostComplete(NetworkPacketTaggingHandlerImpl handlerImpl)
@@ -160,7 +162,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
         eq(CGroupsHandler.CGroupController.NET_CLS), eq(TEST_CONTAINER_ID_STR));
 
     //We don't expect any operations to be returned here
-    Assert.assertNull(ops);
+    assertNull(ops);
   }
 
   private NetworkPacketTaggingHandlerImpl
@@ -175,7 +177,7 @@ public class TestNetworkPacketTaggingHandlerImpl {
     };
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     FileUtil.fullyDelete(new File(tmpPath));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestResourceHandlerModule.java
@@ -21,13 +21,16 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +44,7 @@ public class TestResourceHandlerModule {
   private Configuration emptyConf;
   private Configuration networkEnabledConf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     emptyConf = new YarnConfiguration();
     networkEnabledConf = new YarnConfiguration();
@@ -58,12 +61,12 @@ public class TestResourceHandlerModule {
       //is explicitly enabled
       OutboundBandwidthResourceHandler resourceHandler = ResourceHandlerModule
           .initOutboundBandwidthResourceHandler(emptyConf);
-      Assert.assertNull(resourceHandler);
+      assertNull(resourceHandler);
 
       //When network as a resource is enabled this should be non-null
       resourceHandler = ResourceHandlerModule
           .initOutboundBandwidthResourceHandler(networkEnabledConf);
-      Assert.assertNotNull(resourceHandler);
+      assertNotNull(resourceHandler);
 
       //Ensure that outbound bandwidth resource handler is present in the chain
       ResourceHandlerChain resourceHandlerChain = ResourceHandlerModule
@@ -75,12 +78,12 @@ public class TestResourceHandlerModule {
         //Exactly one resource handler in chain
         assertThat(resourceHandlers).hasSize(1);
         //Same instance is expected to be in the chain.
-        Assert.assertTrue(resourceHandlers.get(0) == resourceHandler);
+        assertTrue(resourceHandlers.get(0) == resourceHandler);
       } else {
-        Assert.fail("Null returned");
+        fail("Null returned");
       }
     } catch (ResourceHandlerException e) {
-      Assert.fail("Unexpected ResourceHandlerException: " + e);
+      fail("Unexpected ResourceHandlerException: " + e);
     }
   }
 
@@ -89,13 +92,13 @@ public class TestResourceHandlerModule {
 
     DiskResourceHandler handler =
         ResourceHandlerModule.initDiskResourceHandler(emptyConf);
-    Assert.assertNull(handler);
+    assertNull(handler);
 
     Configuration diskConf = new YarnConfiguration();
     diskConf.setBoolean(YarnConfiguration.NM_DISK_RESOURCE_ENABLED, true);
 
     handler = ResourceHandlerModule.initDiskResourceHandler(diskConf);
-    Assert.assertNotNull(handler);
+    assertNotNull(handler);
 
     ResourceHandlerChain resourceHandlerChain =
         ResourceHandlerModule.getConfiguredResourceHandlerChain(diskConf,
@@ -106,9 +109,9 @@ public class TestResourceHandlerModule {
       // Exactly one resource handler in chain
       assertThat(resourceHandlers).hasSize(1);
       // Same instance is expected to be in the chain.
-      Assert.assertTrue(resourceHandlers.get(0) == handler);
+      assertTrue(resourceHandlers.get(0) == handler);
     } else {
-      Assert.fail("Null returned");
+      fail("Null returned");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficControlBandwidthHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficControlBandwidthHandlerImpl.java
@@ -28,10 +28,9 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationException;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +38,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -67,7 +70,7 @@ public class TestTrafficControlBandwidthHandlerImpl {
   ContainerId containerIdMock;
   Container containerMock;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
     cGroupsHandlerMock = mock(CGroupsHandler.class);
@@ -108,7 +111,7 @@ public class TestTrafficControlBandwidthHandlerImpl {
       verifyNoMoreInteractions(trafficControllerMock);
     } catch (ResourceHandlerException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected ResourceHandlerException!");
+      fail("Caught unexpected ResourceHandlerException!");
     }
   }
 
@@ -126,7 +129,7 @@ public class TestTrafficControlBandwidthHandlerImpl {
       testPostComplete(trafficControllerSpy, handlerImpl);
     } catch (ResourceHandlerException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected ResourceHandlerException!");
+      fail("Caught unexpected ResourceHandlerException!");
     }
   }
 
@@ -159,7 +162,7 @@ public class TestTrafficControlBandwidthHandlerImpl {
     //Now check the privileged operations being returned
     //We expect two operations - one for adding pid to tasks file and another
     //for a tc modify operation
-    Assert.assertEquals(2, ops.size());
+    assertEquals(2, ops.size());
 
     //Verify that the add pid op is correct
     PrivilegedOperation addPidOp = ops.get(0);
@@ -167,20 +170,20 @@ public class TestTrafficControlBandwidthHandlerImpl {
         TEST_TASKS_FILE;
     List<String> addPidOpArgs = addPidOp.getArguments();
 
-    Assert.assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
+    assertEquals(PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP,
         addPidOp.getOperationType());
-    Assert.assertEquals(1, addPidOpArgs.size());
-    Assert.assertEquals(expectedAddPidOpArg, addPidOpArgs.get(0));
+    assertEquals(1, addPidOpArgs.size());
+    assertEquals(expectedAddPidOpArg, addPidOpArgs.get(0));
 
     //Verify that that tc modify op is correct
     PrivilegedOperation tcModifyOp = ops.get(1);
     List<String> tcModifyOpArgs = tcModifyOp.getArguments();
 
-    Assert.assertEquals(PrivilegedOperation.OperationType.TC_MODIFY_STATE,
+    assertEquals(PrivilegedOperation.OperationType.TC_MODIFY_STATE,
         tcModifyOp.getOperationType());
-    Assert.assertEquals(1, tcModifyOpArgs.size());
+    assertEquals(1, tcModifyOpArgs.size());
     //verify that the tc command file exists
-    Assert.assertTrue(new File(tcModifyOpArgs.get(0)).exists());
+    assertTrue(new File(tcModifyOpArgs.get(0)).exists());
   }
 
   private void testPostComplete(TrafficController trafficControllerSpy,
@@ -208,23 +211,23 @@ public class TestTrafficControlBandwidthHandlerImpl {
 
       List<String> args = opCaptor.getValue().getArguments();
 
-      Assert.assertEquals(PrivilegedOperation.OperationType.TC_MODIFY_STATE,
+      assertEquals(PrivilegedOperation.OperationType.TC_MODIFY_STATE,
           opCaptor.getValue().getOperationType());
-      Assert.assertEquals(1, args.size());
+      assertEquals(1, args.size());
       //ensure that tc command file exists
-      Assert.assertTrue(new File(args.get(0)).exists());
+      assertTrue(new File(args.get(0)).exists());
 
       verify(trafficControllerSpy).releaseClassId(TEST_CLASSID);
     } catch (PrivilegedOperationException e) {
       LOG.error("Caught exception: " + e);
-      Assert.fail("Unexpected PrivilegedOperationException from mock!");
+      fail("Unexpected PrivilegedOperationException from mock!");
     }
 
     //We don't expect any operations to be returned here
-    Assert.assertNull(ops);
+    assertNull(ops);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     FileUtil.fullyDelete(new File(tmpPath));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestTrafficController.java
@@ -26,10 +26,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationException;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +40,9 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -92,7 +94,7 @@ public class TestTrafficController {
 
   private PrivilegedOperationExecutor privilegedOperationExecutorMock;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privilegedOperationExecutorMock = mock(PrivilegedOperationExecutor.class);
     conf = new YarnConfiguration();
@@ -107,26 +109,26 @@ public class TestTrafficController {
       List<String> expectedTcCmds)
       throws IOException {
     //Verify that the optype matches
-    Assert.assertEquals(expectedOpType, op.getOperationType());
+    assertEquals(expectedOpType, op.getOperationType());
 
     List<String> args = op.getArguments();
 
     //Verify that arg count is always 1 (tc command file) for a tc operation
-    Assert.assertEquals(1, args.size());
+    assertEquals(1, args.size());
 
     File tcCmdsFile = new File(args.get(0));
 
     //Verify that command file exists
-    Assert.assertTrue(tcCmdsFile.exists());
+    assertTrue(tcCmdsFile.exists());
 
     List<String> tcCmds = Files.readAllLines(tcCmdsFile.toPath(),
         StandardCharsets.UTF_8);
 
     //Verify that the number of commands is the same as expected and verify
     //that each command is the same, in sequence
-    Assert.assertEquals(expectedTcCmds.size(), tcCmds.size());
+    assertEquals(expectedTcCmds.size(), tcCmds.size());
     for (int i = 0; i < tcCmds.size(); ++i) {
-      Assert.assertEquals(expectedTcCmds.get(i), tcCmds.get(i));
+      assertEquals(expectedTcCmds.get(i), tcCmds.get(i));
     }
   }
 
@@ -163,7 +165,7 @@ public class TestTrafficController {
     } catch (ResourceHandlerException | PrivilegedOperationException |
         IOException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected exception: "
+      fail("Caught unexpected exception: "
           + e.getClass().getSimpleName());
     }
   }
@@ -215,7 +217,7 @@ public class TestTrafficController {
     } catch (ResourceHandlerException | PrivilegedOperationException |
         IOException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected exception: "
+      fail("Caught unexpected exception: "
           + e.getClass().getSimpleName());
     }
   }
@@ -235,13 +237,13 @@ public class TestTrafficController {
         TrafficController.BatchBuilder invalidBuilder = trafficController.
             new BatchBuilder(
             PrivilegedOperation.OperationType.ADD_PID_TO_CGROUP);
-        Assert.fail("Invalid builder check failed!");
+        fail("Invalid builder check failed!");
       } catch (ResourceHandlerException e) {
         //expected
       }
     } catch (ResourceHandlerException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected exception: "
+      fail("Caught unexpected exception: "
           + e.getClass().getSimpleName());
     }
   }
@@ -259,7 +261,7 @@ public class TestTrafficController {
     int parsedClassId = trafficController.getClassIdFromFileContents
         (TEST_CLASS_ID_DECIMAL_STR);
 
-    Assert.assertEquals(TEST_CLASS_ID, parsedClassId);
+    assertEquals(TEST_CLASS_ID, parsedClassId);
   }
 
   @Test
@@ -274,8 +276,8 @@ public class TestTrafficController {
 
       int classId = trafficController.getNextClassId();
 
-      Assert.assertTrue(classId >= MIN_CONTAINER_CLASS_ID);
-      Assert.assertEquals(String.format(FORMAT_CONTAINER_CLASS_STR, classId),
+      assertTrue(classId >= MIN_CONTAINER_CLASS_ID);
+      assertEquals(String.format(FORMAT_CONTAINER_CLASS_STR, classId),
           trafficController.getStringForNetClsClassId(classId));
 
       //Verify that the operation is setup correctly with strictMode = false
@@ -316,12 +318,12 @@ public class TestTrafficController {
           Arrays.asList(expectedDeleteClassCmd));
     } catch (ResourceHandlerException | IOException e) {
       LOG.error("Unexpected exception: " + e);
-      Assert.fail("Caught unexpected exception: "
+      fail("Caught unexpected exception: "
           + e.getClass().getSimpleName());
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     FileUtil.fullyDelete(new File(tmpPath));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
@@ -506,10 +506,10 @@ public class TestFpgaResourceHandlerImpl {
   @Test
   public void testSha256CalculationFails() throws ResourceHandlerException {
     ResourceHandlerException exception =
-      assertThrows(ResourceHandlerException.class, () -> {
-        dummyAocx.delete();
-        fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
-      });
+        assertThrows(ResourceHandlerException.class, () -> {
+          dummyAocx.delete();
+          fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
+        });
     assertEquals("Could not calculate SHA-256", exception.getMessage());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.fpga;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -254,7 +257,7 @@ public class TestFpgaResourceHandlerImpl {
     List<FpgaDevice> list = fpgaResourceHandler.getFpgaAllocator()
         .getUsedFpga().get(getContainerId(0).toString());
     for (FpgaDevice device : list) {
-      assertEquals("IP should be updated to GEMM", "GEMM", device.getIPID());
+      assertEquals("GEMM", device.getIPID(), "IP should be updated to GEMM");
     }
     // Case 2. The id-1 container request 3 FPGA of IntelOpenCL and GEMM IP. this should fail
     boolean flag = false;
@@ -294,7 +297,7 @@ public class TestFpgaResourceHandlerImpl {
     list = fpgaResourceHandler.getFpgaAllocator()
         .getUsedFpga().get(getContainerId(3).toString());
     for (FpgaDevice device : list) {
-      assertEquals("IPID should be GEMM", "GEMM", device.getIPID());
+      assertEquals("GEMM", device.getIPID(), "IPID should be GEMM");
     }
     assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
@@ -340,8 +343,8 @@ public class TestFpgaResourceHandlerImpl {
             .get(getContainerId(0).toString());
     fpgaResourceHandler.postComplete(getContainerId(0));
     for (FpgaDevice device : list) {
-      assertEquals("IP should be updated to GEMM", "GEMM",
-          device.getIPID());
+      assertEquals("GEMM", device.getIPID(),
+          "IP should be updated to GEMM");
     }
 
     // Case 1. id-1 container request preStart, with no plugin.configureIP called
@@ -445,8 +448,7 @@ public class TestFpgaResourceHandlerImpl {
         count++;
       }
     }
-    assertEquals(
-       1, count, "Unexpected available minor number in allocator");
+    assertEquals(1, count, "Unexpected available minor number in allocator");
 
 
     // Case 2. Recover a not allowed device with minor number 5
@@ -505,9 +507,9 @@ public class TestFpgaResourceHandlerImpl {
   public void testSha256CalculationFails() throws ResourceHandlerException {
     ResourceHandlerException exception =
       assertThrows(ResourceHandlerException.class, () -> {
-      dummyAocx.delete();
-      fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
-    });
+        dummyAocx.delete();
+        fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
+      });
     assertEquals("Could not calculate SHA-256", exception.getMessage());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/fpga/TestFpgaResourceHandlerImpl.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.fpga;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -66,19 +66,14 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.fpga.FpgaDevice;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.io.FileWriteMode;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
 public class TestFpgaResourceHandlerImpl {
-  @Rule
-  public ExpectedException expected = ExpectedException.none();
 
   private static final String HASHABLE_STRING = "abcdef";
   private static final String EXPECTED_HASH =
@@ -103,7 +98,7 @@ public class TestFpgaResourceHandlerImpl {
     return f.getAbsolutePath();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, YarnException {
     CustomResourceTypesConfigurationProvider.
         initResourceTypes(ResourceInformation.FPGA_URI);
@@ -138,7 +133,7 @@ public class TestFpgaResourceHandlerImpl {
         .write(HASHABLE_STRING);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (dummyAocx != null) {
       dummyAocx.delete();
@@ -155,9 +150,9 @@ public class TestFpgaResourceHandlerImpl {
     verify(mockVendorPlugin, times(2)).initPlugin(configuration);
     verify(mockCGroupsHandler, times(1)).initializeCGroupController(
         CGroupsHandler.CGroupController.DEVICES);
-    Assert.assertEquals(5, fpgaResourceHandler.getFpgaAllocator()
+    assertEquals(5, fpgaResourceHandler.getFpgaAllocator()
         .getAvailableFpgaCount());
-    Assert.assertEquals(5, fpgaResourceHandler.getFpgaAllocator()
+    assertEquals(5, fpgaResourceHandler.getFpgaAllocator()
         .getAllowedFpga().size());
     // Case 2. subset of devices
     fpgaResourceHandler = new FpgaResourceHandlerImpl(mockContext,
@@ -166,7 +161,7 @@ public class TestFpgaResourceHandlerImpl {
     allowed = "0,1,2";
     configuration.set(YarnConfiguration.NM_FPGA_ALLOWED_DEVICES, allowed);
     fpgaResourceHandler.bootstrap(configuration);
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAllowedFpga().size());
     List<FpgaDevice> allowedDevices =
         fpgaResourceHandler.getFpgaAllocator().getAllowedFpga();
@@ -177,9 +172,9 @@ public class TestFpgaResourceHandlerImpl {
           check = true;
         }
       }
-      Assert.assertTrue("Minor:" + s +" found", check);
+      assertTrue(check, "Minor:" + s +" found");
     }
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     // Case 3. User configuration contains invalid minor device number
@@ -189,9 +184,9 @@ public class TestFpgaResourceHandlerImpl {
     allowed = "0,1,7";
     configuration.set(YarnConfiguration.NM_FPGA_ALLOWED_DEVICES, allowed);
     fpgaResourceHandler.bootstrap(configuration);
-    Assert.assertEquals(2,
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
-    Assert.assertEquals(2,
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getAllowedFpga().size());
   }
 
@@ -202,9 +197,9 @@ public class TestFpgaResourceHandlerImpl {
     String allowed = "0,1,7";
     configuration.set(YarnConfiguration.NM_FPGA_ALLOWED_DEVICES, allowed);
     fpgaResourceHandler.bootstrap(configuration);
-    Assert.assertEquals(2,
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getAllowedFpga().size());
-    Assert.assertEquals(2,
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     String[] invalidAllowedStrings = {"a,1,2,", "a,1,2", "0,1,2,#", "a", "1,"};
@@ -216,7 +211,7 @@ public class TestFpgaResourceHandlerImpl {
       } catch (ResourceHandlerException e) {
         invalidConfiguration = true;
       }
-      Assert.assertTrue(invalidConfiguration);
+      assertTrue(invalidConfiguration);
     }
 
     String[] allowedStrings = {"1,2", "1"};
@@ -228,7 +223,7 @@ public class TestFpgaResourceHandlerImpl {
       } catch (ResourceHandlerException e) {
         invalidConfiguration = true;
       }
-      Assert.assertFalse(invalidConfiguration);
+      assertFalse(invalidConfiguration);
     }
   }
 
@@ -244,7 +239,7 @@ public class TestFpgaResourceHandlerImpl {
     } catch (ResourceHandlerException e) {
       invalidConfiguration = true;
     }
-    Assert.assertTrue(invalidConfiguration);
+    assertTrue(invalidConfiguration);
   }
 
   @Test
@@ -254,12 +249,12 @@ public class TestFpgaResourceHandlerImpl {
     fpgaResourceHandler.bootstrap(configuration);
     // Case 1. The id-0 container request 1 FPGA of IntelOpenCL type and GEMM IP
     fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
-    Assert.assertEquals(1, fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
+    assertEquals(1, fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
     verifyDeniedDevices(getContainerId(0), Arrays.asList(1, 2));
     List<FpgaDevice> list = fpgaResourceHandler.getFpgaAllocator()
         .getUsedFpga().get(getContainerId(0).toString());
     for (FpgaDevice device : list) {
-      Assert.assertEquals("IP should be updated to GEMM", "GEMM", device.getIPID());
+      assertEquals("IP should be updated to GEMM", "GEMM", device.getIPID());
     }
     // Case 2. The id-1 container request 3 FPGA of IntelOpenCL and GEMM IP. this should fail
     boolean flag = false;
@@ -268,26 +263,26 @@ public class TestFpgaResourceHandlerImpl {
     } catch (ResourceHandlerException e) {
       flag = true;
     }
-    Assert.assertTrue(flag);
+    assertTrue(flag);
     // Case 3. Release the id-0 container
     fpgaResourceHandler.postComplete(getContainerId(0));
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
     // Now we have enough devices, re-allocate for the id-1 container
     fpgaResourceHandler.preStart(mockContainer(1, 3, "GEMM"));
     // Id-1 container should have 0 denied devices
     verifyDeniedDevices(getContainerId(1), new ArrayList<>());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
     // Release container id-1
     fpgaResourceHandler.postComplete(getContainerId(1));
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
     // Case 4. Now all 3 devices should have IPID GEMM
     // Try container id-2 and id-3
@@ -299,32 +294,32 @@ public class TestFpgaResourceHandlerImpl {
     list = fpgaResourceHandler.getFpgaAllocator()
         .getUsedFpga().get(getContainerId(3).toString());
     for (FpgaDevice device : list) {
-      Assert.assertEquals("IPID should be GEMM", "GEMM", device.getIPID());
+      assertEquals("IPID should be GEMM", "GEMM", device.getIPID());
     }
-    Assert.assertEquals(2,
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(1,
+    assertEquals(1,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
     fpgaResourceHandler.postComplete(getContainerId(3));
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     // Case 5. id-4 request 0 FPGA device
     fpgaResourceHandler.preStart(mockContainer(4, 0, ""));
     // Deny all devices for id-4
     verifyDeniedDevices(getContainerId(4), Arrays.asList(0, 1, 2));
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     // Case 6. id-5 with invalid FPGA device
     try {
       fpgaResourceHandler.preStart(mockContainer(5, -2, ""));
     } catch (ResourceHandlerException e) {
-      Assert.assertTrue(true);
+      assertTrue(true);
     }
   }
 
@@ -336,7 +331,7 @@ public class TestFpgaResourceHandlerImpl {
     fpgaResourceHandler.bootstrap(configuration);
     // The id-0 container request 3 FPGA of IntelOpenCL type and GEMM IP
     fpgaResourceHandler.preStart(mockContainer(0, 3, "GEMM"));
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
     List<FpgaDevice> list =
         fpgaResourceHandler
@@ -345,7 +340,7 @@ public class TestFpgaResourceHandlerImpl {
             .get(getContainerId(0).toString());
     fpgaResourceHandler.postComplete(getContainerId(0));
     for (FpgaDevice device : list) {
-      Assert.assertEquals("IP should be updated to GEMM", "GEMM",
+      assertEquals("IP should be updated to GEMM", "GEMM",
           device.getIPID());
     }
 
@@ -419,9 +414,9 @@ public class TestFpgaResourceHandlerImpl {
     // NM start
     configuration.set(YarnConfiguration.NM_FPGA_ALLOWED_DEVICES, "0,1,2");
     fpgaResourceHandler.bootstrap(configuration);
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
     // Case 1. try recover state for id-0 container
     fpgaResourceHandler.reacquireContainer(getContainerId(0));
@@ -438,7 +433,7 @@ public class TestFpgaResourceHandlerImpl {
         count++;
       }
     }
-    Assert.assertEquals("Unexpected used minor number in allocator",2, count);
+    assertEquals(2, count, "Unexpected used minor number in allocator");
     List<FpgaDevice> available =
         fpgaResourceHandler
             .getFpgaAllocator()
@@ -450,8 +445,8 @@ public class TestFpgaResourceHandlerImpl {
         count++;
       }
     }
-    Assert.assertEquals("Unexpected available minor number in allocator",
-        1, count);
+    assertEquals(
+       1, count, "Unexpected available minor number in allocator");
 
 
     // Case 2. Recover a not allowed device with minor number 5
@@ -467,10 +462,10 @@ public class TestFpgaResourceHandlerImpl {
     } catch (ResourceHandlerException e) {
       flag = true;
     }
-    Assert.assertTrue(flag);
-    Assert.assertEquals(2,
+    assertTrue(flag);
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(1,
+    assertEquals(1,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     // Case 3. recover a already used device by other container
@@ -486,10 +481,10 @@ public class TestFpgaResourceHandlerImpl {
     } catch (ResourceHandlerException e) {
       flag = true;
     }
-    Assert.assertTrue(flag);
-    Assert.assertEquals(2,
+    assertTrue(flag);
+    assertEquals(2,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(1,
+    assertEquals(1,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
 
     // Case 4. recover a normal container c3 with remaining minor device number 2
@@ -500,19 +495,20 @@ public class TestFpgaResourceHandlerImpl {
     // Mock we've stored the c2 states
     mockStateStoreForContainer(c3, assigned);
     fpgaResourceHandler.reacquireContainer(getContainerId(3));
-    Assert.assertEquals(3,
+    assertEquals(3,
         fpgaResourceHandler.getFpgaAllocator().getUsedFpgaCount());
-    Assert.assertEquals(0,
+    assertEquals(0,
         fpgaResourceHandler.getFpgaAllocator().getAvailableFpgaCount());
   }
 
   @Test
   public void testSha256CalculationFails() throws ResourceHandlerException {
-    expected.expect(ResourceHandlerException.class);
-    expected.expectMessage("Could not calculate SHA-256");
-
-    dummyAocx.delete();
-    fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
+    ResourceHandlerException exception =
+      assertThrows(ResourceHandlerException.class, () -> {
+      dummyAocx.delete();
+      fpgaResourceHandler.preStart(mockContainer(0, 1, "GEMM"));
+    });
+    assertEquals("Could not calculate SHA-256", exception.getMessage());
   }
 
   @Test
@@ -531,7 +527,7 @@ public class TestFpgaResourceHandlerImpl {
     List<FpgaDevice> devices =
         fpgaResourceHandler.getFpgaAllocator().getAllowedFpga();
     FpgaDevice device = devices.get(0);
-    assertEquals("Hash value", EXPECTED_HASH, device.getAocxHash());
+    assertEquals(EXPECTED_HASH, device.getAocxHash(), "Hash value");
   }
 
   private void verifyDeniedDevices(ContainerId containerId,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
@@ -365,7 +365,7 @@ public class TestGpuResourceAllocator {
           assertEquals(1, testSubject.getAvailableGpus());
 
           testSubject.assignGpus(container3);
-      });
+        });
 
     assertThat(exception.getMessage()).contains("Failed to find enough GPUs");
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
@@ -342,30 +342,30 @@ public class TestGpuResourceAllocator {
   public void testThreeContainersJustTwoOfThemSatisfied()
       throws ResourceHandlerException, IOException {
     ResourceHandlerException exception =
-      assertThrows(ResourceHandlerException.class, () -> {
-      addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
-              new GpuDevice(1, 3), new GpuDevice(1, 4),
-              new GpuDevice(1, 5), new GpuDevice(1, 6));
-      Container container = createMockContainer(3, 5L);
-      Container container2 = createMockContainer(2, 6L);
-      Container container3 = createMockContainer(2, 6L);
+        assertThrows(ResourceHandlerException.class, () -> {
+        addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
+            new GpuDevice(1, 3), new GpuDevice(1, 4),
+            new GpuDevice(1, 5), new GpuDevice(1, 6));
+        Container container = createMockContainer(3, 5L);
+        Container container2 = createMockContainer(2, 6L);
+        Container container3 = createMockContainer(2, 6L);
 
-      GpuAllocation allocation = testSubject.assignGpus(container);
-      assertAllocatedGpus(3, 3, container, allocation);
-      assertEquals(3, testSubject.getDeviceAllocationMapping().size());
-      assertEquals(3, testSubject.getAssignedGpus().size());
-      assertEquals(6, testSubject.getAllowedGpus().size());
-      assertEquals(3, testSubject.getAvailableGpus());
+        GpuAllocation allocation = testSubject.assignGpus(container);
+        assertAllocatedGpus(3, 3, container, allocation);
+        assertEquals(3, testSubject.getDeviceAllocationMapping().size());
+        assertEquals(3, testSubject.getAssignedGpus().size());
+        assertEquals(6, testSubject.getAllowedGpus().size());
+        assertEquals(3, testSubject.getAvailableGpus());
 
-      GpuAllocation allocation2 = testSubject.assignGpus(container2);
-      assertAllocatedGpus(2, 4, container2, allocation2);
-      assertEquals(5, testSubject.getDeviceAllocationMapping().size());
-      assertEquals(5, testSubject.getAssignedGpus().size());
-      assertEquals(6, testSubject.getAllowedGpus().size());
-      assertEquals(1, testSubject.getAvailableGpus());
+        GpuAllocation allocation2 = testSubject.assignGpus(container2);
+        assertAllocatedGpus(2, 4, container2, allocation2);
+        assertEquals(5, testSubject.getDeviceAllocationMapping().size());
+        assertEquals(5, testSubject.getAssignedGpus().size());
+        assertEquals(6, testSubject.getAllowedGpus().size());
+        assertEquals(1, testSubject.getAvailableGpus());
 
-      testSubject.assignGpus(container3);
-    });
+        testSubject.assignGpus(container3);
+      });
 
     assertThat(exception.getMessage()).contains("Failed to find enough GPUs");
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resourc
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
 import static org.apache.hadoop.yarn.api.records.ResourceInformation.GPU_URI;
 import static org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider.initResourceTypes;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,10 +51,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resource
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.gpu.GpuResourceAllocator.GpuAllocation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu.GpuDevice;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
@@ -90,12 +90,9 @@ public class TestGpuResourceAllocator {
   @Mock
   private NMStateStoreService nmStateStore;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   private GpuResourceAllocator testSubject;
 
-  @Before
+  @BeforeEach
   public void setup() {
     initResourceTypes(ResourceInformation.GPU_URI);
     MockitoAnnotations.initMocks(this);
@@ -309,64 +306,68 @@ public class TestGpuResourceAllocator {
   @Test
   public void testRequestMoreThanAvailableGpu()
       throws ResourceHandlerException {
-    addGpus(new GpuDevice(1, 1));
-    Container container = createMockContainer(2, 5L);
-
-    exception.expect(ResourceHandlerException.class);
-    exception.expectMessage("Failed to find enough GPUs");
-    testSubject.assignGpus(container);
+    ResourceHandlerException exception = assertThrows(ResourceHandlerException.class, () -> {
+      addGpus(new GpuDevice(1, 1));
+      Container container = createMockContainer(2, 5L);
+      testSubject.assignGpus(container);
+    });
+    assertThat(exception.getMessage()).contains("Failed to find enough GPUs");
   }
 
   @Test
   public void testRequestMoreThanAvailableGpuAndOneContainerIsReleasingGpus()
       throws ResourceHandlerException, IOException {
-    addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2), new GpuDevice(1, 3));
-    Container container = createMockContainer(2, 5L);
-    GpuAllocation allocation = testSubject.assignGpus(container);
-    assertAllocatedGpus(2, 1, container, allocation);
+    ResourceHandlerException exception = assertThrows(ResourceHandlerException.class, () -> {
+      addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2), new GpuDevice(1, 3));
+      Container container = createMockContainer(2, 5L);
+      GpuAllocation allocation = testSubject.assignGpus(container);
+      assertAllocatedGpus(2, 1, container, allocation);
 
-    assertEquals(2, testSubject.getDeviceAllocationMapping().size());
-    assertEquals(2, testSubject.getAssignedGpus().size());
-    assertEquals(3, testSubject.getAllowedGpus().size());
-    assertEquals(1, testSubject.getAvailableGpus());
+      assertEquals(2, testSubject.getDeviceAllocationMapping().size());
+      assertEquals(2, testSubject.getAssignedGpus().size());
+      assertEquals(3, testSubject.getAllowedGpus().size());
+      assertEquals(1, testSubject.getAvailableGpus());
 
-    setupContainerAsReleasingGpus(container);
-    Container container2 = createMockContainer(2, 6L);
+      setupContainerAsReleasingGpus(container);
+      Container container2 = createMockContainer(2, 6L);
+      GpuAllocation allocation2 = testSubject.assignGpus(container2);
+      assertAllocatedGpus(2, 1, container, allocation2);
+    });
 
-    exception.expect(ResourceHandlerException.class);
-    exception.expectMessage("as some other containers might not " +
-        "releasing GPUs");
-    GpuAllocation allocation2 = testSubject.assignGpus(container2);
-    assertAllocatedGpus(2, 1, container, allocation2);
+    assertThat(exception.getMessage()).
+        contains("as some other containers might not releasing GPUs");
   }
 
   @Test
   public void testThreeContainersJustTwoOfThemSatisfied()
       throws ResourceHandlerException, IOException {
-    addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
-            new GpuDevice(1, 3), new GpuDevice(1, 4),
-            new GpuDevice(1, 5), new GpuDevice(1, 6));
-    Container container = createMockContainer(3, 5L);
-    Container container2 = createMockContainer(2, 6L);
-    Container container3 = createMockContainer(2, 6L);
+    ResourceHandlerException exception =
+      assertThrows(ResourceHandlerException.class, () -> {
+      addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
+              new GpuDevice(1, 3), new GpuDevice(1, 4),
+              new GpuDevice(1, 5), new GpuDevice(1, 6));
+      Container container = createMockContainer(3, 5L);
+      Container container2 = createMockContainer(2, 6L);
+      Container container3 = createMockContainer(2, 6L);
 
-    GpuAllocation allocation = testSubject.assignGpus(container);
-    assertAllocatedGpus(3, 3, container, allocation);
-    assertEquals(3, testSubject.getDeviceAllocationMapping().size());
-    assertEquals(3, testSubject.getAssignedGpus().size());
-    assertEquals(6, testSubject.getAllowedGpus().size());
-    assertEquals(3, testSubject.getAvailableGpus());
+      GpuAllocation allocation = testSubject.assignGpus(container);
+      assertAllocatedGpus(3, 3, container, allocation);
+      assertEquals(3, testSubject.getDeviceAllocationMapping().size());
+      assertEquals(3, testSubject.getAssignedGpus().size());
+      assertEquals(6, testSubject.getAllowedGpus().size());
+      assertEquals(3, testSubject.getAvailableGpus());
 
-    GpuAllocation allocation2 = testSubject.assignGpus(container2);
-    assertAllocatedGpus(2, 4, container2, allocation2);
-    assertEquals(5, testSubject.getDeviceAllocationMapping().size());
-    assertEquals(5, testSubject.getAssignedGpus().size());
-    assertEquals(6, testSubject.getAllowedGpus().size());
-    assertEquals(1, testSubject.getAvailableGpus());
+      GpuAllocation allocation2 = testSubject.assignGpus(container2);
+      assertAllocatedGpus(2, 4, container2, allocation2);
+      assertEquals(5, testSubject.getDeviceAllocationMapping().size());
+      assertEquals(5, testSubject.getAssignedGpus().size());
+      assertEquals(6, testSubject.getAllowedGpus().size());
+      assertEquals(1, testSubject.getAvailableGpus());
 
-    exception.expect(ResourceHandlerException.class);
-    exception.expectMessage("Failed to find enough GPUs");
-    testSubject.assignGpus(container3);
+      testSubject.assignGpus(container3);
+    });
+
+    assertThat(exception.getMessage()).contains("Failed to find enough GPUs");
   }
 
   @Test
@@ -425,17 +426,15 @@ public class TestGpuResourceAllocator {
   @Test
   public void testGpuGetsUnassignedWhenStateStoreThrowsException()
       throws ResourceHandlerException, IOException {
-    doThrow(new IOException("Failed to save container mappings " +
-        "to NM state store!"))
-        .when(nmStateStore).storeAssignedResources(any(Container.class),
-        anyString(), anyList());
+    assertThrows(ResourceHandlerException.class, () -> {
+      doThrow(new IOException("Failed to save container mappings " +
+          "to NM state store!"))
+          .when(nmStateStore).storeAssignedResources(any(Container.class),
+          anyString(), anyList());
 
-    createAndAddGpus(1);
-
-    exception.expect(ResourceHandlerException.class);
-    exception.expectMessage("Failed to save container mappings " +
-        "to NM state store");
-    Container container = createMockContainer(1, 5L);
-    testSubject.assignGpus(container);
+      createAndAddGpus(1);
+      Container container = createMockContainer(1, 5L);
+      testSubject.assignGpus(container);
+    });
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/gpu/TestGpuResourceAllocator.java
@@ -343,28 +343,28 @@ public class TestGpuResourceAllocator {
       throws ResourceHandlerException, IOException {
     ResourceHandlerException exception =
         assertThrows(ResourceHandlerException.class, () -> {
-        addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
-            new GpuDevice(1, 3), new GpuDevice(1, 4),
-            new GpuDevice(1, 5), new GpuDevice(1, 6));
-        Container container = createMockContainer(3, 5L);
-        Container container2 = createMockContainer(2, 6L);
-        Container container3 = createMockContainer(2, 6L);
+          addGpus(new GpuDevice(1, 1), new GpuDevice(1, 2),
+              new GpuDevice(1, 3), new GpuDevice(1, 4),
+              new GpuDevice(1, 5), new GpuDevice(1, 6));
+          Container container = createMockContainer(3, 5L);
+          Container container2 = createMockContainer(2, 6L);
+          Container container3 = createMockContainer(2, 6L);
 
-        GpuAllocation allocation = testSubject.assignGpus(container);
-        assertAllocatedGpus(3, 3, container, allocation);
-        assertEquals(3, testSubject.getDeviceAllocationMapping().size());
-        assertEquals(3, testSubject.getAssignedGpus().size());
-        assertEquals(6, testSubject.getAllowedGpus().size());
-        assertEquals(3, testSubject.getAvailableGpus());
+          GpuAllocation allocation = testSubject.assignGpus(container);
+          assertAllocatedGpus(3, 3, container, allocation);
+          assertEquals(3, testSubject.getDeviceAllocationMapping().size());
+          assertEquals(3, testSubject.getAssignedGpus().size());
+          assertEquals(6, testSubject.getAllowedGpus().size());
+          assertEquals(3, testSubject.getAvailableGpus());
 
-        GpuAllocation allocation2 = testSubject.assignGpus(container2);
-        assertAllocatedGpus(2, 4, container2, allocation2);
-        assertEquals(5, testSubject.getDeviceAllocationMapping().size());
-        assertEquals(5, testSubject.getAssignedGpus().size());
-        assertEquals(6, testSubject.getAllowedGpus().size());
-        assertEquals(1, testSubject.getAvailableGpus());
+          GpuAllocation allocation2 = testSubject.assignGpus(container2);
+          assertAllocatedGpus(2, 4, container2, allocation2);
+          assertEquals(5, testSubject.getDeviceAllocationMapping().size());
+          assertEquals(5, testSubject.getAssignedGpus().size());
+          assertEquals(6, testSubject.getAllowedGpus().size());
+          assertEquals(1, testSubject.getAvailableGpus());
 
-        testSubject.assignGpus(container3);
+          testSubject.assignGpus(container3);
       });
 
     assertThat(exception.getMessage()).contains("Failed to find enough GPUs");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/TestNumaResourceAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/TestNumaResourceAllocator.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.numa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,9 +40,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ResourceMappings;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ResourceMappings.AssignedResources;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for NumaResourceAllocator.
@@ -52,7 +51,7 @@ public class TestNumaResourceAllocator {
   private Configuration conf;
   private NumaResourceAllocator numaResourceAllocator;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, YarnException {
     conf = new YarnConfiguration();
     Context mockContext = mock(Context.class);
@@ -76,7 +75,7 @@ public class TestNumaResourceAllocator {
     Collection<NumaNodeResource> nodesList = numaResourceAllocator
         .getNumaNodesList();
     Collection<NumaNodeResource> expectedNodesList = getExpectedNumaNodesList();
-    Assert.assertEquals(expectedNodesList, nodesList);
+    assertEquals(expectedNodesList, nodesList);
   }
 
   @Test
@@ -104,7 +103,7 @@ public class TestNumaResourceAllocator {
     Collection<NumaNodeResource> nodesList = numaResourceAllocator
         .getNumaNodesList();
     Collection<NumaNodeResource> expectedNodesList = getExpectedNumaNodesList();
-    Assert.assertEquals(expectedNodesList, nodesList);
+    assertEquals(expectedNodesList, nodesList);
   }
 
   @Test
@@ -113,8 +112,8 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048, 2)));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
   }
 
   @Test
@@ -124,29 +123,29 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048, 2)));
-    Assert.assertEquals("0", String.join(",", nodeInfo1.getMemNodes()));
-    Assert.assertEquals("0", String.join(",", nodeInfo1.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo1.getMemNodes()));
+    assertEquals("0", String.join(",", nodeInfo1.getCpuNodes()));
 
     NumaResourceAllocation nodeInfo2 = numaResourceAllocator
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000002"),
             Resource.newInstance(2048, 2)));
-    Assert.assertEquals("1", String.join(",", nodeInfo2.getMemNodes()));
-    Assert.assertEquals("1", String.join(",", nodeInfo2.getCpuNodes()));
+    assertEquals("1", String.join(",", nodeInfo2.getMemNodes()));
+    assertEquals("1", String.join(",", nodeInfo2.getCpuNodes()));
 
     NumaResourceAllocation nodeInfo3 = numaResourceAllocator
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000003"),
             Resource.newInstance(2048, 2)));
-    Assert.assertEquals("0", String.join(",", nodeInfo3.getMemNodes()));
-    Assert.assertEquals("0", String.join(",", nodeInfo3.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo3.getMemNodes()));
+    assertEquals("0", String.join(",", nodeInfo3.getCpuNodes()));
 
     NumaResourceAllocation nodeInfo4 = numaResourceAllocator
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000003"),
             Resource.newInstance(2048, 2)));
-    Assert.assertEquals("1", String.join(",", nodeInfo4.getMemNodes()));
-    Assert.assertEquals("1", String.join(",", nodeInfo4.getCpuNodes()));
+    assertEquals("1", String.join(",", nodeInfo4.getMemNodes()));
+    assertEquals("1", String.join(",", nodeInfo4.getCpuNodes()));
   }
 
   @Test
@@ -156,8 +155,8 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(102400, 2)));
-    Assert.assertEquals("0,1", String.join(",", nodeInfo.getMemNodes()));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
+    assertEquals("0,1", String.join(",", nodeInfo.getMemNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
   }
 
   @Test
@@ -166,8 +165,8 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048, 6)));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
-    Assert.assertEquals("0,1", String.join(",", nodeInfo.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
+    assertEquals("0,1", String.join(",", nodeInfo.getCpuNodes()));
   }
 
   @Test
@@ -177,8 +176,8 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048000, 6)));
-    Assert.assertNull("Should not assign numa nodes when there"
-        + " are no sufficient memory resources available.", nodeInfo);
+    assertNull(nodeInfo, "Should not assign numa nodes when there"
+        + " are no sufficient memory resources available.");
   }
 
   @Test
@@ -188,8 +187,8 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048, 600)));
-    Assert.assertNull("Should not assign numa nodes when there"
-        + " are no sufficient cpu resources available.", nodeInfo);
+    assertNull(nodeInfo, "Should not assign numa nodes when there"
+        + " are no sufficient cpu resources available.");
   }
 
   @Test
@@ -198,15 +197,15 @@ public class TestNumaResourceAllocator {
         .allocateNumaNodes(getContainer(
             ContainerId.fromString("container_1481156246874_0001_01_000001"),
             Resource.newInstance(2048, 8)));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
-    Assert.assertEquals("0,1", String.join(",", nodeInfo.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
+    assertEquals("0,1", String.join(",", nodeInfo.getCpuNodes()));
 
     // Request the resource when all cpu nodes occupied
     nodeInfo = numaResourceAllocator.allocateNumaNodes(getContainer(
         ContainerId.fromString("container_1481156246874_0001_01_000002"),
         Resource.newInstance(2048, 4)));
-    Assert.assertNull("Should not assign numa nodes when there"
-        + " are no sufficient cpu resources available.", nodeInfo);
+    assertNull(nodeInfo, "Should not assign numa nodes when there"
+        + " are no sufficient cpu resources available.");
 
     // Release the resources
     numaResourceAllocator.releaseNumaResource(
@@ -215,8 +214,8 @@ public class TestNumaResourceAllocator {
     nodeInfo = numaResourceAllocator.allocateNumaNodes(getContainer(
         ContainerId.fromString("container_1481156246874_0001_01_000003"),
         Resource.newInstance(1024, 2)));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
-    Assert.assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getMemNodes()));
+    assertEquals("0", String.join(",", nodeInfo.getCpuNodes()));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/TestNumaResourceHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/numa/TestNumaResourceHandlerImpl.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.numa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -38,8 +38,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Reso
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerException;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for NumaResourceHandlerImpl.
@@ -51,7 +51,7 @@ public class TestNumaResourceHandlerImpl {
   private NumaResourceHandlerImpl numaResourceHandler;
   private Container mockContainer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, ResourceHandlerException {
     conf = new YarnConfiguration();
     setNumaTopologyConfigs();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDelegatingLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDelegatingLinuxContainerRuntime.java
@@ -21,13 +21,15 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerExecutionException;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntime;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test container runtime delegation.
@@ -38,7 +40,7 @@ public class TestDelegatingLinuxContainerRuntime {
   private Configuration conf;
   private Map<String, String> env = new HashMap<>();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     delegatingLinuxContainerRuntime = new DelegatingLinuxContainerRuntime();
     conf = new Configuration();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -57,14 +57,10 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.Reso
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerExecutionException;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeConstants;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeContext;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -122,6 +118,10 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.CONTAINER_PID_NAMESPACE_SUFFIX;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.RUN_PRIVILEGED_CONTAINER_SUFFIX;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.OCIContainerRuntime.formatOciEnvKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -132,7 +132,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
 public class TestDockerContainerRuntime {
   private static final Logger LOG =
        LoggerFactory.getLogger(TestDockerContainerRuntime.class);
@@ -183,20 +182,20 @@ public class TestDockerContainerRuntime {
   private final static String ENV_OCI_CONTAINER_RUN_PRIVILEGED_CONTAINER =
       formatOciEnvKey(RUNTIME_TYPE, RUN_PRIVILEGED_CONTAINER_SUFFIX);
 
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
-
-  @Parameterized.Parameters(name = "https={0}")
+  // @Parameterized.Parameters(name = "https={0}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {true}, {false}
     });
   }
 
-  @Parameterized.Parameter
   public boolean https;
 
-  @Before
+  public void initHttps(boolean pHttps) {
+    this.https = pHttps;
+    setup();
+  }
+
   public void setup() {
 
     conf = new Configuration();
@@ -323,7 +322,7 @@ public class TestDockerContainerRuntime {
         .setExecutionAttribute(RESOURCES_OPTIONS, resourcesOptions);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     File tmpDir = new File(tmpPath);
     FileUtils.deleteDirectory(tmpDir);
@@ -368,8 +367,10 @@ public class TestDockerContainerRuntime {
     return mockNMContext;
   }
 
-  @Test
-  public void testSelectDockerContainerType() {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testSelectDockerContainerType(boolean pHttps) {
+    initHttps(pHttps);
     Map<String, String> envDockerType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -377,16 +378,18 @@ public class TestDockerContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_DOCKER);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertEquals(false, DockerLinuxContainerRuntime
+    assertEquals(false, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, null));
-    Assert.assertEquals(true, DockerLinuxContainerRuntime
+    assertEquals(true, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envDockerType));
-    Assert.assertEquals(false, DockerLinuxContainerRuntime
+    assertEquals(false, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envOtherType));
   }
 
-  @Test
-  public void testSelectDockerContainerTypeWithDockerAsDefault() {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testSelectDockerContainerTypeWithDockerAsDefault(boolean pHttps) {
+    initHttps(pHttps);
     Map<String, String> envDockerType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -396,16 +399,18 @@ public class TestDockerContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_DOCKER);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertEquals(true, DockerLinuxContainerRuntime
+    assertEquals(true, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, null));
-    Assert.assertEquals(true, DockerLinuxContainerRuntime
+    assertEquals(true, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envDockerType));
-    Assert.assertEquals(false, DockerLinuxContainerRuntime
+    assertEquals(false, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envOtherType));
   }
 
-  @Test
-  public void testSelectDockerContainerTypeWithDefaultSet() {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testSelectDockerContainerTypeWithDefaultSet(boolean pHttps) {
+    initHttps(pHttps);
     Map<String, String> envDockerType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -414,11 +419,11 @@ public class TestDockerContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_DOCKER);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertEquals(false, DockerLinuxContainerRuntime
+    assertEquals(false, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, null));
-    Assert.assertEquals(true, DockerLinuxContainerRuntime
+    assertEquals(true, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envDockerType));
-    Assert.assertEquals(false, DockerLinuxContainerRuntime
+    assertEquals(false, DockerLinuxContainerRuntime
         .isDockerContainerRequested(conf, envOtherType));
   }
 
@@ -443,13 +448,13 @@ public class TestDockerContainerRuntime {
     return opCaptor.getValue();
   }
 
-    @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked")
   private PrivilegedOperation capturePrivilegedOperationAndVerifyArgs()
       throws PrivilegedOperationException {
 
     PrivilegedOperation op = capturePrivilegedOperation();
 
-    Assert.assertEquals(PrivilegedOperation.OperationType
+    assertEquals(PrivilegedOperation.OperationType
         .LAUNCH_DOCKER_CONTAINER, op.getOperationType());
 
     List<String> args = op.getArguments();
@@ -458,37 +463,39 @@ public class TestDockerContainerRuntime {
     // specific order
     int expected = (https) ? 15 : 13;
     int counter = 1;
-    Assert.assertEquals(expected, args.size());
-    Assert.assertEquals(user, args.get(counter++));
-    Assert.assertEquals(Integer.toString(PrivilegedOperation.RunAsUserCommand
+    assertEquals(expected, args.size());
+    assertEquals(user, args.get(counter++));
+    assertEquals(Integer.toString(PrivilegedOperation.RunAsUserCommand
         .LAUNCH_DOCKER_CONTAINER.getValue()), args.get(counter++));
-    Assert.assertEquals(appId, args.get(counter++));
-    Assert.assertEquals(containerId, args.get(counter++));
-    Assert.assertEquals(containerWorkDir.toString(), args.get(counter++));
-    Assert.assertEquals(nmPrivateContainerScriptPath.toUri().toString(),
+    assertEquals(appId, args.get(counter++));
+    assertEquals(containerId, args.get(counter++));
+    assertEquals(containerWorkDir.toString(), args.get(counter++));
+    assertEquals(nmPrivateContainerScriptPath.toUri().toString(),
         args.get(counter++));
-    Assert.assertEquals(nmPrivateTokensPath.toUri().getPath(),
+    assertEquals(nmPrivateTokensPath.toUri().getPath(),
         args.get(counter++));
     if (https) {
-      Assert.assertEquals("--https", args.get(counter++));
-      Assert.assertEquals(nmPrivateKeystorePath.toUri().toString(),
+      assertEquals("--https", args.get(counter++));
+      assertEquals(nmPrivateKeystorePath.toUri().toString(),
           args.get(counter++));
-      Assert.assertEquals(nmPrivateTruststorePath.toUri().toString(),
+      assertEquals(nmPrivateTruststorePath.toUri().toString(),
           args.get(counter++));
     } else {
-      Assert.assertEquals("--http", args.get(counter++));
+      assertEquals("--http", args.get(counter++));
     }
-    Assert.assertEquals(pidFilePath.toString(), args.get(counter++));
-    Assert.assertEquals(localDirs.get(0), args.get(counter++));
-    Assert.assertEquals(logDirs.get(0), args.get(counter++));
+    assertEquals(pidFilePath.toString(), args.get(counter++));
+    assertEquals(localDirs.get(0), args.get(counter++));
+    assertEquals(logDirs.get(0), args.get(counter++));
 
     return op;
   }
 
-  @Test
-  public void testDockerContainerLaunch()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerContainerLaunch(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -497,40 +504,41 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
+    assertEquals("  mounts="
             + "/test_container_log_dir:/test_container_log_dir:rw,"
             + "/test_application_local_dir:/test_application_local_dir:rw,"
             + "/test_filecache_dir:/test_filecache_dir:ro,"
             + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDockerContainerLaunchWithDefaultImage()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerContainerLaunchWithDefaultImage(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.set(YarnConfiguration.NM_DOCKER_IMAGE_NAME, "busybox:1.2.3");
     env.remove(DockerLinuxContainerRuntime.ENV_DOCKER_CONTAINER_IMAGE);
 
@@ -543,40 +551,41 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:1.2.3", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:1.2.3", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDockerContainerLaunchWithoutDefaultImageUpdate()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerContainerLaunchWithoutDefaultImageUpdate(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     conf.setBoolean(YarnConfiguration.NM_DOCKER_IMAGE_UPDATE, false);
@@ -584,45 +593,46 @@ public class TestDockerContainerRuntime {
     runtime.initialize(conf, nmContext);
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
-    Assert.assertEquals(false,
+    assertEquals(false,
         conf.getBoolean(YarnConfiguration.NM_DOCKER_IMAGE_UPDATE, false));
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDockerContainerLaunchWithDefaultImageUpdate()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerContainerLaunchWithDefaultImageUpdate(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     conf.setBoolean(YarnConfiguration.NM_DOCKER_IMAGE_UPDATE, true);
@@ -642,13 +652,13 @@ public class TestDockerContainerRuntime {
 
     // pull image from remote hub firstly
     PrivilegedOperation op = allCaptures.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType
+    assertEquals(PrivilegedOperation.OperationType
         .RUN_DOCKER_CMD, op.getOperationType());
 
     File commandFile = new File(StringUtils.join(",", op.getArguments()));
     FileInputStream fileInputStream = new FileInputStream(commandFile);
     String fileContent = new String(IOUtils.toByteArray(fileInputStream));
-    Assert.assertEquals("[docker-command-execution]\n"
+    assertEquals("[docker-command-execution]\n"
         + "  docker-command=pull\n"
         + "  image=busybox:latest\n", fileContent);
     fileInputStream.close();
@@ -658,40 +668,41 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testContainerLaunchWithUserRemapping()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testContainerLaunchWithUserRemapping(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ENABLE_USER_REMAPPING,
         true);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -700,41 +711,41 @@ public class TestDockerContainerRuntime {
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
 
-    Assert.assertEquals(13, dockerCommands.size());
+    assertEquals(13, dockerCommands.size());
     int counter = 0;
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testAllowedNetworksConfiguration() throws
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testAllowedNetworksConfiguration(boolean pHttps) throws
       ContainerExecutionException {
+    initHttps(pHttps);
     //the default network configuration should cause
     // no exception should be thrown.
 
@@ -757,7 +768,7 @@ public class TestDockerContainerRuntime {
       runtime =
           new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
       runtime.initialize(conf, nmContext);
-      Assert.fail("Invalid default network configuration should did not "
+      fail("Invalid default network configuration should did not "
           + "trigger initialization failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
@@ -775,11 +786,13 @@ public class TestDockerContainerRuntime {
     runtime.initialize(conf, nmContext);
   }
 
-  @Test
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
   @SuppressWarnings("unchecked")
-  public void testContainerLaunchWithNetworkingDefaults()
+  public void testContainerLaunchWithNetworkingDefaults(boolean pHttps)
       throws ContainerExecutionException, IOException,
       PrivilegedOperationException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime =
         new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -791,7 +804,7 @@ public class TestDockerContainerRuntime {
       env.put(DockerLinuxContainerRuntime.ENV_DOCKER_CONTAINER_NETWORK,
           disallowedNetwork);
       runtime.launchContainer(builder.build());
-      Assert.fail("Network was expected to be disallowed: " +
+      fail("Network was expected to be disallowed: " +
           disallowedNetwork);
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception: " + e);
@@ -812,44 +825,44 @@ public class TestDockerContainerRuntime {
     //This is the expected docker invocation for this case
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  hostname=test.hostname",
+    assertEquals("  hostname=test.hostname",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  net=" + allowedNetwork, dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=" + allowedNetwork, dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
   @SuppressWarnings("unchecked")
-  public void testContainerLaunchWithHostDnsNetwork()
+  public void testContainerLaunchWithHostDnsNetwork(boolean pHttps)
       throws ContainerExecutionException, IOException,
       PrivilegedOperationException {
+    initHttps(pHttps);
     // Make it look like Registry DNS is enabled so we can test whether
     // hostname goes through
     conf.setBoolean(RegistryConstants.KEY_DNS_ENABLED, true);
@@ -867,44 +880,44 @@ public class TestDockerContainerRuntime {
     //This is the expected docker invocation for this case
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  hostname=test.hostname",
+    assertEquals("  hostname=test.hostname",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
   @SuppressWarnings("unchecked")
-  public void testContainerLaunchWithCustomNetworks()
+  public void testContainerLaunchWithCustomNetworks(boolean pHttps)
       throws ContainerExecutionException, IOException,
       PrivilegedOperationException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime =
         new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
 
@@ -931,37 +944,36 @@ public class TestDockerContainerRuntime {
     // ("sdn1") is the expected network to be used in this case
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  hostname=ctr-e11-1518975676334-14532816-01-000001",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=sdn1", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=sdn1", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
 
     //now set an explicit (non-default) allowedNetwork and ensure that it is
@@ -975,36 +987,35 @@ public class TestDockerContainerRuntime {
     //This is the expected docker invocation for this case. customNetwork2
     // ("sdn2") is the expected network to be used in this case
     counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  hostname=ctr-e11-1518975676334-14532816-01-000001",
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=sdn2", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=sdn2", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
 
 
@@ -1014,17 +1025,19 @@ public class TestDockerContainerRuntime {
         customNetwork3);
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Disallowed network : " + customNetwork3
+      fail("Disallowed network : " + customNetwork3
           + "did not trigger launch failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testLaunchPidNamespaceContainersInvalidEnvVar()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPidNamespaceContainersInvalidEnvVar(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1034,18 +1047,20 @@ public class TestDockerContainerRuntime {
     List<String> dockerCommands = readDockerCommands();
 
     int expected = 13;
-    Assert.assertEquals(expected, dockerCommands.size());
+    assertEquals(expected, dockerCommands.size());
 
     String command = dockerCommands.get(0);
 
     //ensure --pid isn't in the invocation
-    Assert.assertTrue("Unexpected --pid in docker run args : " + command,
-        !command.contains("--pid"));
+    assertTrue(!command.contains("--pid"),
+        "Unexpected --pid in docker run args : " + command);
   }
 
-  @Test
-  public void testLaunchPidNamespaceContainersWithDisabledSetting()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPidNamespaceContainersWithDisabledSetting(boolean pHttps)
       throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1054,16 +1069,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a pid host disabled container failure.");
+      fail("Expected a pid host disabled container failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testLaunchPidNamespaceContainersEnabled()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPidNamespaceContainersEnabled(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     //Enable host pid namespace containers.
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ALLOW_HOST_PID_NAMESPACE,
         true);
@@ -1079,41 +1096,42 @@ public class TestDockerContainerRuntime {
 
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  pid=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  pid=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testLaunchPrivilegedContainersInvalidEnvVar()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPrivilegedContainersInvalidEnvVar(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1123,18 +1141,20 @@ public class TestDockerContainerRuntime {
     List<String> dockerCommands = readDockerCommands();
 
     int expected = 13;
-    Assert.assertEquals(expected, dockerCommands.size());
+    assertEquals(expected, dockerCommands.size());
 
     String command = dockerCommands.get(0);
 
     //ensure --privileged isn't in the invocation
-    Assert.assertTrue("Unexpected --privileged in docker run args : " + command,
-        !command.contains("--privileged"));
+    assertTrue(!command.contains("--privileged"),
+        "Unexpected --privileged in docker run args : " + command);
   }
 
-  @Test
-  public void testLaunchPrivilegedContainersWithDisabledSetting()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPrivilegedContainersWithDisabledSetting(boolean pHttps)
       throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS,
         false);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -1145,15 +1165,17 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a privileged launch container failure.");
+      fail("Expected a privileged launch container failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testLaunchPrivilegedContainersWithEnabledSettingAndDefaultACL()
-      throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPrivilegedContainersWithEnabledSettingAndDefaultACL(
+      boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     //Enable privileged containers.
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS,
         true);
@@ -1170,16 +1192,17 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a privileged launch container failure.");
+      fail("Expected a privileged launch container failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void
-  testLaunchPrivilegedContainersEnabledAndUserNotInWhitelist()
-      throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPrivilegedContainersEnabledAndUserNotInWhitelist(
+      boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     //Enable privileged containers.
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS,
         true);
@@ -1195,17 +1218,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a privileged launch container failure.");
+      fail("Expected a privileged launch container failure.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void
-  testLaunchPrivilegedContainersEnabledAndUserInWhitelist()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchPrivilegedContainersEnabledAndUserInWhitelist(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     //Enable privileged containers.
     conf.setBoolean(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS,
         true);
@@ -1224,38 +1248,39 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  privileged=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + submittingUser,
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  privileged=true", dockerCommands.get(counter++));
+    assertEquals("  user=" + submittingUser,
         dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testCGroupParent() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testCGroupParent(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     String hierarchy = "hadoop-yarn-test";
     conf.set(YarnConfiguration.NM_LINUX_CONTAINER_CGROUPS_HIERARCHY,
         hierarchy);
@@ -1305,8 +1330,10 @@ public class TestDockerContainerRuntime {
     Mockito.verifyNoMoreInteractions(command);
   }
 
-  @Test
-  public void testMountSourceOnly() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testMountSourceOnly(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1317,16 +1344,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testMountSourceTarget()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testMountSourceTarget(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1340,41 +1369,43 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/test_local_dir/test_resource_file:test_mount:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/test_local_dir/test_resource_file:test_mount:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testMountMultiple()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testMountMultiple(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1389,42 +1420,44 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/test_local_dir/test_resource_file:test_mount1:ro,"
-            + "/test_local_dir/test_resource_file:test_mount2:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/test_local_dir/test_resource_file:test_mount1:ro,"
+        + "/test_local_dir/test_resource_file:test_mount2:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testUserMounts()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testUserMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1439,41 +1472,43 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/tmp/foo:/tmp/foo:ro,"
-            + "/tmp/bar:/tmp/bar:rw,/tmp/baz:/tmp/baz:rw,/a:/a:rw+shared,"
-            + "/b:/b:ro+shared,/c:/c:rw+rshared,/d:/d:rw+private",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/tmp/foo:/tmp/foo:ro,"
+        + "/tmp/bar:/tmp/bar:rw,/tmp/baz:/tmp/baz:rw,/a:/a:rw+shared,"
+        + "/b:/b:ro+shared,/c:/c:rw+rshared,/d:/d:rw+private",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testUserMountInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testUserMountInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1484,14 +1519,16 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testUserMountModeInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testUserMountModeInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1502,14 +1539,16 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mode.");
+      fail("Expected a launch container failure due to invalid mode.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testUserMountModeNulInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testUserMountModeNulInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1520,16 +1559,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to NUL in mount.");
+      fail("Expected a launch container failure due to NUL in mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testTmpfsMount()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testTmpfsMount(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1541,13 +1582,15 @@ public class TestDockerContainerRuntime {
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
 
-    Assert.assertTrue(dockerCommands.contains("  tmpfs=/run"));
+    assertTrue(dockerCommands.contains("  tmpfs=/run"));
   }
 
-  @Test
-  public void testTmpfsMountMulti()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testTmpfsMountMulti(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1559,13 +1602,15 @@ public class TestDockerContainerRuntime {
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
 
-    Assert.assertTrue(dockerCommands.contains("  tmpfs=/run,/tmp"));
+    assertTrue(dockerCommands.contains("  tmpfs=/run,/tmp"));
   }
 
-  @Test
-  public void testDefaultTmpfsMounts()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultTmpfsMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_TMPFS_MOUNTS, "/run,/var/run");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
@@ -1578,12 +1623,14 @@ public class TestDockerContainerRuntime {
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
 
-    Assert.assertTrue(dockerCommands.contains("  tmpfs=/tmpfs,/run,/var/run"));
+    assertTrue(dockerCommands.contains("  tmpfs=/tmpfs,/run,/var/run"));
   }
 
-  @Test
-  public void testDefaultTmpfsMountsInvalid()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultTmpfsMountsInvalid(boolean pHttps)
       throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_TMPFS_MOUNTS, "run,var/run");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
@@ -1595,15 +1642,17 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail(
-          "Expected a launch container failure due to non-absolute path.");
+      fail("Expected a launch container failure due to non-absolute path.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testTmpfsRelativeInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testTmpfsRelativeInvalid(boolean pHttps)
+      throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1614,15 +1663,16 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail(
-          "Expected a launch container failure due to non-absolute path.");
+      fail("Expected a launch container failure due to non-absolute path.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testTmpfsColonInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testTmpfsColonInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1633,15 +1683,16 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail(
-          "Expected a launch container failure due to invalid character.");
+      fail("Expected a launch container failure due to invalid character.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testTmpfsNulInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testTmpfsNulInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
             mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1652,17 +1703,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail(
-          "Expected a launch container failure due to NUL in tmpfs mount.");
+      fail("Expected a launch container failure due to NUL in tmpfs mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testDefaultROMounts()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultROMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_RO_MOUNTS,
         "/tmp/foo:/tmp/foo,/tmp/bar:/tmp/bar");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -1674,39 +1726,41 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/tmp/foo:/tmp/foo:ro,/tmp/bar:/tmp/bar:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/tmp/foo:/tmp/foo:ro,/tmp/bar:/tmp/bar:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDefaultROMountsInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultROMountsInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_RO_MOUNTS,
         "source,target");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -1715,16 +1769,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testDefaultRWMounts()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultRWMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_RW_MOUNTS,
         "/tmp/foo:/tmp/foo,/tmp/bar:/tmp/bar");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -1736,39 +1792,41 @@ public class TestDockerContainerRuntime {
 
     int expected = 13;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/tmp/foo:/tmp/foo:rw,/tmp/bar:/tmp/bar:rw",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/tmp/foo:/tmp/foo:rw,/tmp/bar:/tmp/bar:rw",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDefaultRWMountsInvalid() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDefaultRWMountsInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setStrings(NM_DOCKER_DEFAULT_RW_MOUNTS,
         "source,target");
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
@@ -1777,15 +1835,18 @@ public class TestDockerContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testContainerLivelinessFileExistsNoException() throws Exception {
-    File testTempDir = tempDir.newFolder();
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testContainerLivelinessFileExistsNoException(boolean pHttps,
+      @TempDir java.nio.file.Path path) throws Exception {
+    initHttps(pHttps);
+    File testTempDir = Files.createDirectory(path).toFile();
     File procPidPath = new File(testTempDir + File.separator + signalPid);
     procPidPath.createNewFile();
     procPidPath.deleteOnExit();
@@ -1800,8 +1861,10 @@ public class TestDockerContainerRuntime {
     runtime.signalContainer(builder.build());
   }
 
-  @Test
-  public void testContainerLivelinessNoFileException() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testContainerLivelinessNoFileException(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     builder.setExecutionAttribute(RUN_AS_USER, runAsUser)
@@ -1812,16 +1875,18 @@ public class TestDockerContainerRuntime {
     try {
       runtime.signalContainer(builder.build());
     } catch (ContainerExecutionException e) {
-      Assert.assertEquals(
+      assertEquals(
           PrivilegedOperation.ResultCode.INVALID_CONTAINER_PID.getValue(),
           e.getExitCode());
     }
   }
 
-  @Test
-  public void testDockerStopOnTermSignalWhenRunning()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerStopOnTermSignalWhenRunning(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     when(mockExecutor
         .executePrivilegedOperation(any(), any(PrivilegedOperation.class),
         any(), any(), anyBoolean(), anyBoolean())).thenReturn(
@@ -1831,11 +1896,13 @@ public class TestDockerContainerRuntime {
     verifyStopCommand(dockerCommands, ContainerExecutor.Signal.TERM.toString());
   }
 
-  @Test
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
   @SuppressWarnings("unchecked")
-  public void testDockerStopWithQuitSignalWhenRunning()
+  public void testDockerStopWithQuitSignalWhenRunning(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     when(mockExecutor
         .executePrivilegedOperation(any(), any(PrivilegedOperation.class),
             any(), any(), anyBoolean(), anyBoolean())).thenReturn(
@@ -1847,46 +1914,52 @@ public class TestDockerContainerRuntime {
     verifyStopCommand(dockerCommands, "SIGQUIT");
   }
 
-  @Test
-  public void testDockerStopOnKillSignalWhenRunning()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerStopOnKillSignalWhenRunning(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException {
+    initHttps(pHttps);
     List<String> dockerCommands = getDockerCommandsForSignal(
         ContainerExecutor.Signal.KILL);
-    Assert.assertEquals(5, dockerCommands.size());
-    Assert.assertEquals(runAsUser, dockerCommands.get(0));
-    Assert.assertEquals(user, dockerCommands.get(1));
-    Assert.assertEquals(
+    assertEquals(5, dockerCommands.size());
+    assertEquals(runAsUser, dockerCommands.get(0));
+    assertEquals(user, dockerCommands.get(1));
+    assertEquals(
         Integer.toString(PrivilegedOperation.RunAsUserCommand
         .SIGNAL_CONTAINER.getValue()),
         dockerCommands.get(2));
-    Assert.assertEquals(signalPid, dockerCommands.get(3));
-    Assert.assertEquals(
+    assertEquals(signalPid, dockerCommands.get(3));
+    assertEquals(
         Integer.toString(ContainerExecutor.Signal.KILL.getValue()),
         dockerCommands.get(4));
   }
 
-  @Test
-  public void testDockerKillOnQuitSignalWhenRunning() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerKillOnQuitSignalWhenRunning(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     List<String> dockerCommands = getDockerCommandsForSignal(
         ContainerExecutor.Signal.QUIT);
 
-    Assert.assertEquals(5, dockerCommands.size());
-    Assert.assertEquals(runAsUser, dockerCommands.get(0));
-    Assert.assertEquals(user, dockerCommands.get(1));
-    Assert.assertEquals(
+    assertEquals(5, dockerCommands.size());
+    assertEquals(runAsUser, dockerCommands.get(0));
+    assertEquals(user, dockerCommands.get(1));
+    assertEquals(
         Integer.toString(PrivilegedOperation.RunAsUserCommand
         .SIGNAL_CONTAINER.getValue()),
         dockerCommands.get(2));
-    Assert.assertEquals(signalPid, dockerCommands.get(3));
-    Assert.assertEquals(
+    assertEquals(signalPid, dockerCommands.get(3));
+    assertEquals(
         Integer.toString(ContainerExecutor.Signal.QUIT.getValue()),
         dockerCommands.get(4));
   }
 
-  @Test
-  public void testDockerStopOnTermSignalWhenRunningPrivileged()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerStopOnTermSignalWhenRunningPrivileged(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.set(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS, "true");
     conf.set(YarnConfiguration.NM_DOCKER_PRIVILEGED_CONTAINERS_ACL,
         submittingUser);
@@ -1900,10 +1973,12 @@ public class TestDockerContainerRuntime {
     verifyStopCommand(dockerCommands, ContainerExecutor.Signal.TERM.toString());
   }
 
-  @Test
-  public void testDockerStopOnKillSignalWhenRunningPrivileged()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerStopOnKillSignalWhenRunningPrivileged(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     conf.set(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS, "true");
     conf.set(YarnConfiguration.NM_DOCKER_PRIVILEGED_CONTAINERS_ACL,
         submittingUser);
@@ -1914,18 +1989,20 @@ public class TestDockerContainerRuntime {
         DockerCommandExecutor.DockerContainerStatus.RUNNING.getName());
     List<String> dockerCommands = getDockerCommandsForDockerStop(
         ContainerExecutor.Signal.KILL);
-    Assert.assertEquals(4, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]", dockerCommands.get(0));
-    Assert.assertEquals("  docker-command=kill", dockerCommands.get(1));
-    Assert.assertEquals(
+    assertEquals(4, dockerCommands.size());
+    assertEquals("[docker-command-execution]", dockerCommands.get(0));
+    assertEquals("  docker-command=kill", dockerCommands.get(1));
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(2));
-    Assert.assertEquals("  signal=KILL", dockerCommands.get(3));
+    assertEquals("  signal=KILL", dockerCommands.get(3));
   }
 
-  @Test
-  public void testDockerKillOnQuitSignalWhenRunningPrivileged()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerKillOnQuitSignalWhenRunningPrivileged(boolean pHttps)
       throws Exception {
+    initHttps(pHttps);
     conf.set(YarnConfiguration.NM_DOCKER_ALLOW_PRIVILEGED_CONTAINERS, "true");
     conf.set(YarnConfiguration.NM_DOCKER_PRIVILEGED_CONTAINERS_ACL,
         submittingUser);
@@ -1937,17 +2014,19 @@ public class TestDockerContainerRuntime {
     List<String> dockerCommands = getDockerCommandsForDockerStop(
         ContainerExecutor.Signal.QUIT);
 
-    Assert.assertEquals(4, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]", dockerCommands.get(0));
-    Assert.assertEquals("  docker-command=kill", dockerCommands.get(1));
-    Assert.assertEquals(
+    assertEquals(4, dockerCommands.size());
+    assertEquals("[docker-command-execution]", dockerCommands.get(0));
+    assertEquals("  docker-command=kill", dockerCommands.get(1));
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(2));
-    Assert.assertEquals("  signal=QUIT", dockerCommands.get(3));
+    assertEquals("  signal=QUIT", dockerCommands.get(3));
   }
 
-  @Test
-  public void testDockerRmOnWhenExited() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerRmOnWhenExited(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     env.put(DockerLinuxContainerRuntime.ENV_DOCKER_CONTAINER_DELAYED_REMOVAL,
         "false");
     conf.set(YarnConfiguration.NM_DOCKER_ALLOW_DELAYED_REMOVAL, "true");
@@ -1962,9 +2041,11 @@ public class TestDockerContainerRuntime {
             any(), anyBoolean(), anyBoolean());
   }
 
-  @Test
-  public void testNoDockerRmWhenDelayedDeletionEnabled()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testNoDockerRmWhenDelayedDeletionEnabled(boolean pHttps)
       throws Exception {
+    initHttps(pHttps);
     env.put(DockerLinuxContainerRuntime.ENV_DOCKER_CONTAINER_DELAYED_REMOVAL,
         "true");
     conf.set(YarnConfiguration.NM_DOCKER_ALLOW_DELAYED_REMOVAL, "true");
@@ -1994,7 +2075,7 @@ public class TestDockerContainerRuntime {
     runtime.signalContainer(builder.build());
 
     PrivilegedOperation op = capturePrivilegedOperation(2);
-    Assert.assertEquals(op.getOperationType(),
+    assertEquals(op.getOperationType(),
         PrivilegedOperation.OperationType.RUN_DOCKER_CMD);
     String dockerCommandFile = op.getArguments().get(0);
     return Files.readAllLines(Paths.get(dockerCommandFile),
@@ -2015,7 +2096,7 @@ public class TestDockerContainerRuntime {
     runtime.signalContainer(builder.build());
 
     PrivilegedOperation op = capturePrivilegedOperation();
-    Assert.assertEquals(op.getOperationType(),
+    assertEquals(op.getOperationType(),
         PrivilegedOperation.OperationType.SIGNAL_CONTAINER);
     return op.getArguments();
   }
@@ -2037,8 +2118,10 @@ public class TestDockerContainerRuntime {
     return conf;
   }
 
-  @Test
-  public void testDockerImageNamePattern() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerImageNamePattern(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     String[] validNames = {"ubuntu", "fedora/httpd:version1.0", "fedora/httpd:version1.0.test",
         "fedora/httpd:version1.0.TEST", "myregistryhost:5000/ubuntu",
         "myregistryhost:5000/fedora/httpd:version1.0",
@@ -2068,15 +2151,17 @@ public class TestDockerContainerRuntime {
     for (String name : invalidNames) {
       try {
         DockerLinuxContainerRuntime.validateImageName(name);
-        Assert.fail(name + " is an invalid name and should fail the regex");
+        fail(name + " is an invalid name and should fail the regex");
       } catch (ContainerExecutionException ce) {
         continue;
       }
     }
   }
 
-  @Test
-  public void testDockerHostnamePattern() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerHostnamePattern(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     String[] validNames = {"ab", "a.b.c.d", "a1-b.cd.ef", "0AB.", "C_D-"};
 
     String[] invalidNames = {"a", "a#.b.c", "-a.b.c", "a@b.c", "a/b/c"};
@@ -2088,24 +2173,30 @@ public class TestDockerContainerRuntime {
     for (String name : invalidNames) {
       try {
         DockerLinuxContainerRuntime.validateHostname(name);
-        Assert.fail(name + " is an invalid hostname and should fail the regex");
+        fail(name + " is an invalid hostname and should fail the regex");
       } catch (ContainerExecutionException ce) {
         continue;
       }
     }
   }
 
-  @Test
-  public void testValidDockerHostnameLength() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testValidDockerHostnameLength(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     String validLength = "example.test.site";
     DockerLinuxContainerRuntime.validateHostname(validLength);
   }
 
-  @Test(expected = ContainerExecutionException.class)
-  public void testInvalidDockerHostnameLength() throws Exception {
-    String invalidLength =
-        "exampleexampleexampleexampleexampleexampleexampleexample.test.site";
-    DockerLinuxContainerRuntime.validateHostname(invalidLength);
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testInvalidDockerHostnameLength(boolean pHttps) throws Exception {
+    initHttps(pHttps);
+    assertThrows(ContainerExecutionException.class, () -> {
+      String invalidLength =
+          "exampleexampleexampleexampleexampleexampleexampleexample.test.site";
+      DockerLinuxContainerRuntime.validateHostname(invalidLength);
+    });
   }
 
   @SuppressWarnings("unchecked")
@@ -2128,25 +2219,25 @@ public class TestDockerContainerRuntime {
     List<PrivilegedOperation> allCaptures = opCaptor.getAllValues();
 
     PrivilegedOperation op = allCaptures.get(0);
-    Assert.assertEquals(PrivilegedOperation.OperationType
+    assertEquals(PrivilegedOperation.OperationType
         .RUN_DOCKER_CMD, op.getOperationType());
 
     File commandFile = new File(StringUtils.join(",", op.getArguments()));
     FileInputStream fileInputStream = new FileInputStream(commandFile);
     String fileContent = new String(IOUtils.toByteArray(fileInputStream));
-    Assert.assertEquals("[docker-command-execution]\n"
+    assertEquals("[docker-command-execution]\n"
         + "  docker-command=volume\n" + "  driver=local\n"
         + "  sub-command=create\n" + "  volume=volume1\n", fileContent);
     fileInputStream.close();
 
     op = allCaptures.get(1);
-    Assert.assertEquals(PrivilegedOperation.OperationType
+    assertEquals(PrivilegedOperation.OperationType
         .RUN_DOCKER_CMD, op.getOperationType());
 
     commandFile = new File(StringUtils.join(",", op.getArguments()));
     fileInputStream = new FileInputStream(commandFile);
     fileContent = new String(IOUtils.toByteArray(fileInputStream));
-    Assert.assertEquals(
+    assertEquals(
         "[docker-command-execution]\n" + "  docker-command=volume\n"
             + "  sub-command=ls\n", fileContent);
     fileInputStream.close();
@@ -2229,18 +2320,19 @@ public class TestDockerContainerRuntime {
         // Expected
         return;
       } else{
-        Assert.fail("Should successfully prepareContainers" + e);
+        fail("Should successfully prepareContainers" + e);
       }
     }
     if (expectFail) {
-      Assert.fail(
-          "Should fail because output is illegal");
+      fail("Should fail because output is illegal");
     }
   }
 
-  @Test
-  public void testDockerCommandPluginCheckVolumeAfterCreation()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerCommandPluginCheckVolumeAfterCreation(boolean pHttps)
       throws Exception {
+    initHttps(pHttps);
     // For following tests, we expect to have volume1,local in output
 
     // Failure cases
@@ -2279,8 +2371,10 @@ public class TestDockerContainerRuntime {
   }
 
 
-  @Test
-  public void testDockerCommandPlugin() throws Exception {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerCommandPlugin(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime =
         new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
     when(mockExecutor
@@ -2320,50 +2414,51 @@ public class TestDockerContainerRuntime {
 
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert
-        .assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals("  image=busybox:latest", dockerCommands.get(counter++));
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
-            + "/source/path:/destination/path:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro,"
+        + "/source/path:/destination/path:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
 
     // Verify volume-driver is set to expected value.
-    Assert.assertEquals("  volume-driver=driver-1",
+    assertEquals("  volume-driver=driver-1",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testDockerCapabilities() throws ContainerExecutionException {
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerCapabilities(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     try {
       conf.setStrings(YarnConfiguration.NM_DOCKER_CONTAINER_CAPABILITIES,
           "none", "CHOWN", "DAC_OVERRIDE");
       runtime.initialize(conf, nmContext);
-      Assert.fail("Initialize didn't fail with invalid capabilities " +
+      fail("Initialize didn't fail with invalid capabilities " +
           "'none', 'CHOWN', 'DAC_OVERRIDE'");
     } catch (ContainerExecutionException e) {
     }
@@ -2372,7 +2467,7 @@ public class TestDockerContainerRuntime {
       conf.setStrings(YarnConfiguration.NM_DOCKER_CONTAINER_CAPABILITIES,
           "CHOWN", "DAC_OVERRIDE", "NONE");
       runtime.initialize(conf, nmContext);
-      Assert.fail("Initialize didn't fail with invalid capabilities " +
+      fail("Initialize didn't fail with invalid capabilities " +
           "'CHOWN', 'DAC_OVERRIDE', 'NONE'");
     } catch (ContainerExecutionException e) {
     }
@@ -2380,25 +2475,26 @@ public class TestDockerContainerRuntime {
     conf.setStrings(YarnConfiguration.NM_DOCKER_CONTAINER_CAPABILITIES,
         "NONE");
     runtime.initialize(conf, nmContext);
-    Assert.assertEquals(0, runtime.getCapabilities().size());
+    assertEquals(0, runtime.getCapabilities().size());
 
     conf.setStrings(YarnConfiguration.NM_DOCKER_CONTAINER_CAPABILITIES,
         "none");
     runtime.initialize(conf, nmContext);
-    Assert.assertEquals(0, runtime.getCapabilities().size());
+    assertEquals(0, runtime.getCapabilities().size());
 
     conf.setStrings(YarnConfiguration.NM_DOCKER_CONTAINER_CAPABILITIES,
         "CHOWN", "DAC_OVERRIDE");
     runtime.initialize(conf, nmContext);
     Iterator<String> it = runtime.getCapabilities().iterator();
-    Assert.assertEquals("CHOWN", it.next());
-    Assert.assertEquals("DAC_OVERRIDE", it.next());
+    assertEquals("CHOWN", it.next());
+    assertEquals("DAC_OVERRIDE", it.next());
   }
 
-  @Test
-  public void testLaunchContainerWithDockerTokens()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainerWithDockerTokens(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException, IOException {
-
+    initHttps(pHttps);
     // Get the credentials object with the Tokens.
     Credentials credentials = DockerClientConfigHandler.readCredentialsFromConfigFile(
         new Path(getDockerClientConfigFile().toURI()), conf, appId);
@@ -2409,9 +2505,11 @@ public class TestDockerContainerRuntime {
     testLaunchContainer(tokens, null);
   }
 
-  @Test
-  public void testLaunchContainerWithAdditionalDockerClientConfig()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainerWithAdditionalDockerClientConfig(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException, IOException {
+    initHttps(pHttps);
     testLaunchContainer(null, getDockerClientConfigFile());
   }
 
@@ -2442,7 +2540,7 @@ public class TestDockerContainerRuntime {
     builder.setExecutionAttribute(NM_PRIVATE_CONTAINER_SCRIPT_PATH, outDir);
     runtime.launchContainer(builder.build());
     PrivilegedOperation op = capturePrivilegedOperation();
-    Assert.assertEquals(
+    assertEquals(
         PrivilegedOperation.OperationType.LAUNCH_DOCKER_CONTAINER,
             op.getOperationType());
 
@@ -2450,30 +2548,30 @@ public class TestDockerContainerRuntime {
 
     int expectedArgs = (https) ? 15 : 13;
     int argsCounter = 0;
-    Assert.assertEquals(expectedArgs, args.size());
-    Assert.assertEquals(runAsUser, args.get(argsCounter++));
-    Assert.assertEquals(user, args.get(argsCounter++));
-    Assert.assertEquals(Integer.toString(
+    assertEquals(expectedArgs, args.size());
+    assertEquals(runAsUser, args.get(argsCounter++));
+    assertEquals(user, args.get(argsCounter++));
+    assertEquals(Integer.toString(
         PrivilegedOperation.RunAsUserCommand.LAUNCH_DOCKER_CONTAINER
             .getValue()), args.get(argsCounter++));
-    Assert.assertEquals(appId, args.get(argsCounter++));
-    Assert.assertEquals(containerId, args.get(argsCounter++));
-    Assert.assertEquals(containerWorkDir.toString(), args.get(argsCounter++));
-    Assert.assertEquals(outDir.toUri().getPath(), args.get(argsCounter++));
-    Assert.assertEquals(nmPrivateTokensPath.toUri().getPath(),
+    assertEquals(appId, args.get(argsCounter++));
+    assertEquals(containerId, args.get(argsCounter++));
+    assertEquals(containerWorkDir.toString(), args.get(argsCounter++));
+    assertEquals(outDir.toUri().getPath(), args.get(argsCounter++));
+    assertEquals(nmPrivateTokensPath.toUri().getPath(),
         args.get(argsCounter++));
     if (https) {
-      Assert.assertEquals("--https", args.get(argsCounter++));
-      Assert.assertEquals(nmPrivateKeystorePath.toUri().toString(),
+      assertEquals("--https", args.get(argsCounter++));
+      assertEquals(nmPrivateKeystorePath.toUri().toString(),
           args.get(argsCounter++));
-      Assert.assertEquals(nmPrivateTruststorePath.toUri().toString(),
+      assertEquals(nmPrivateTruststorePath.toUri().toString(),
           args.get(argsCounter++));
     } else {
-      Assert.assertEquals("--http", args.get(argsCounter++));
+      assertEquals("--http", args.get(argsCounter++));
     }
-    Assert.assertEquals(pidFilePath.toString(), args.get(argsCounter++));
-    Assert.assertEquals(localDirs.get(0), args.get(argsCounter++));
-    Assert.assertEquals(logDirs.get(0), args.get(argsCounter++));
+    assertEquals(pidFilePath.toString(), args.get(argsCounter++));
+    assertEquals(localDirs.get(0), args.get(argsCounter++));
+    assertEquals(logDirs.get(0), args.get(argsCounter++));
     String dockerCommandFile = args.get(argsCounter++);
 
     List<String> dockerCommands = Files
@@ -2481,35 +2579,35 @@ public class TestDockerContainerRuntime {
 
     int expected = 14;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
+    assertEquals("  cap-add=SYS_CHROOT,NET_BIND_SERVICE",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
-    Assert.assertEquals("  detach=true", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=run", dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-config=" + outDir.getParent(),
+    assertEquals("  cap-drop=ALL", dockerCommands.get(counter++));
+    assertEquals("  detach=true", dockerCommands.get(counter++));
+    assertEquals("  docker-command=run", dockerCommands.get(counter++));
+    assertEquals("  docker-config=" + outDir.getParent(),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  group-add=" + String.join(",", groups),
+    assertEquals("  group-add=" + String.join(",", groups),
         dockerCommands.get(counter++));
-    Assert.assertEquals("  image=busybox:latest",
+    assertEquals("  image=busybox:latest",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  launch-command=bash,/test_container_work_dir/launch_container.sh",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  mounts="
-            + "/test_container_log_dir:/test_container_log_dir:rw,"
-            + "/test_application_local_dir:/test_application_local_dir:rw,"
-            + "/test_filecache_dir:/test_filecache_dir:ro,"
-            + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
+    assertEquals("  mounts="
+        + "/test_container_log_dir:/test_container_log_dir:rw,"
+        + "/test_application_local_dir:/test_application_local_dir:rw,"
+        + "/test_filecache_dir:/test_filecache_dir:ro,"
+        + "/test_user_filecache_dir:/test_user_filecache_dir:ro",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  net=host", dockerCommands.get(counter++));
-    Assert.assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
-    Assert.assertEquals("  workdir=/test_container_work_dir",
+    assertEquals("  net=host", dockerCommands.get(counter++));
+    assertEquals("  user=" + uidGidPair, dockerCommands.get(counter++));
+    assertEquals("  workdir=/test_container_work_dir",
         dockerCommands.get(counter++));
   }
 
@@ -2523,10 +2621,12 @@ public class TestDockerContainerRuntime {
     return file;
   }
 
-  @Test
-  public void testDockerContainerRelaunch()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testDockerContainerRelaunch(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime =
         new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
     when(mockExecutor
@@ -2539,20 +2639,22 @@ public class TestDockerContainerRuntime {
 
     int expected = 3;
     int counter = 0;
-    Assert.assertEquals(expected, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]",
+    assertEquals(expected, dockerCommands.size());
+    assertEquals("[docker-command-execution]",
         dockerCommands.get(counter++));
-    Assert.assertEquals("  docker-command=start",
+    assertEquals("  docker-command=start",
         dockerCommands.get(counter++));
-    Assert.assertEquals(
+    assertEquals(
         "  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(counter));
   }
 
-  @Test
-  public void testLaunchContainersWithSpecificDockerRuntime()
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
+  public void testLaunchContainersWithSpecificDockerRuntime(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime = new DockerLinuxContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -2561,15 +2663,17 @@ public class TestDockerContainerRuntime {
             .ENV_DOCKER_CONTAINER_DOCKER_RUNTIME, "runc");
     runtime.launchContainer(builder.build());
     List<String> dockerCommands = readDockerCommands();
-    Assert.assertEquals(14, dockerCommands.size());
-    Assert.assertEquals("  runtime=runc", dockerCommands.get(11));
+    assertEquals(14, dockerCommands.size());
+    assertEquals("  runtime=runc", dockerCommands.get(11));
   }
 
-  @Test
+  @ParameterizedTest(name = "https={0}")
+  @MethodSource("data")
   @SuppressWarnings("unchecked")
-  public void testContainerLaunchWithAllowedRuntimes()
+  public void testContainerLaunchWithAllowedRuntimes(boolean pHttps)
       throws ContainerExecutionException, IOException,
       PrivilegedOperationException {
+    initHttps(pHttps);
     DockerLinuxContainerRuntime runtime =
         new DockerLinuxContainerRuntime(mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -2580,7 +2684,7 @@ public class TestDockerContainerRuntime {
       env.put(DockerLinuxContainerRuntime.ENV_DOCKER_CONTAINER_DOCKER_RUNTIME,
           disallowedRuntime);
       runtime.launchContainer(builder.build());
-      Assert.fail("Runtime was expected to be disallowed: " +
+      fail("Runtime was expected to be disallowed: " +
           disallowedRuntime);
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception: " + e);
@@ -2595,18 +2699,18 @@ public class TestDockerContainerRuntime {
     List<String> dockerCommands = readDockerCommands();
 
     //This is the expected docker invocation for this case
-    Assert.assertEquals(14, dockerCommands.size());
-    Assert.assertEquals("  runtime=runc", dockerCommands.get(11));
+    assertEquals(14, dockerCommands.size());
+    assertEquals("  runtime=runc", dockerCommands.get(11));
   }
 
   private static void verifyStopCommand(List<String> dockerCommands,
       String signal) {
-    Assert.assertEquals(4, dockerCommands.size());
-    Assert.assertEquals("[docker-command-execution]", dockerCommands.get(0));
-    Assert.assertEquals("  docker-command=kill", dockerCommands.get(1));
-    Assert.assertEquals("  name=container_e11_1518975676334_14532816_01_000001",
+    assertEquals(4, dockerCommands.size());
+    assertEquals("[docker-command-execution]", dockerCommands.get(0));
+    assertEquals("  docker-command=kill", dockerCommands.get(1));
+    assertEquals("  name=container_e11_1518975676334_14532816_01_000001",
         dockerCommands.get(2));
-    Assert.assertEquals("  signal=" + signal, dockerCommands.get(3));
+    assertEquals("  signal=" + signal, dockerCommands.get(3));
   }
 
   private List<String> readDockerCommands() throws IOException,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -190,7 +190,7 @@ public class TestDockerContainerRuntime {
 
   public boolean https;
 
-  public void initHttps(boolean pHttps) {
+  private void initHttps(boolean pHttps) {
     this.https = pHttps;
     setup();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestDockerContainerRuntime.java
@@ -182,7 +182,6 @@ public class TestDockerContainerRuntime {
   private final static String ENV_OCI_CONTAINER_RUN_PRIVILEGED_CONTAINER =
       formatOciEnvKey(RUNTIME_TYPE, RUN_PRIVILEGED_CONTAINER_SUFFIX);
 
-  // @Parameterized.Parameters(name = "https={0}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {true}, {false}
@@ -1846,7 +1845,7 @@ public class TestDockerContainerRuntime {
   public void testContainerLivelinessFileExistsNoException(boolean pHttps,
       @TempDir java.nio.file.Path path) throws Exception {
     initHttps(pHttps);
-    File testTempDir = Files.createDirectory(path).toFile();
+    File testTempDir = path.toFile();
     File procPidPath = new File(testTempDir + File.separator + signalPid);
     procPidPath.createNewFile();
     procPidPath.deleteOnExit();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestHdfsManifestToResourcesPlugin.java
@@ -30,10 +30,9 @@ import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.HdfsManifestToResourcesPlugin;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageManifest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,14 +62,14 @@ public class TestHdfsManifestToResourcesPlugin {
   private static final String CONFIG_MEDIA_TYPE =
       "application/vnd.docker.container.image.v1+json";
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
     File tmpDir = new File(tmpPath);
     tmpDir.mkdirs();
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     File tmpDir = new File(tmpPath);
     FileUtils.deleteDirectory(tmpDir);
@@ -134,8 +134,8 @@ public class TestHdfsManifestToResourcesPlugin {
         LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
         size2, modTime);
 
-    Assert.assertEquals(rsrc1, returnedLayers.get(0));
-    Assert.assertEquals(rsrc2, returnedLayers.get(1));
+    assertEquals(rsrc1, returnedLayers.get(0));
+    assertEquals(rsrc2, returnedLayers.get(1));
 
   }
 
@@ -177,6 +177,6 @@ public class TestHdfsManifestToResourcesPlugin {
         LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
         size, modTime);
 
-    Assert.assertEquals(rsrc, returnedLayer);
+    assertEquals(rsrc, returnedLayer);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestImageTagToManifestPlugin.java
@@ -26,10 +26,9 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.runc.ImageTagToManifestPlugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +40,7 @@ import java.io.PrintWriter;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_HDFS_RUNC_IMAGE_TAG_TO_HASH_FILE;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_LOCAL_RUNC_IMAGE_TAG_TO_HASH_FILE;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_IMAGE_TOPLEVEL_DIR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -81,7 +81,7 @@ public class TestImageTagToManifestPlugin {
       "   ]\n" +
       "}";
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
     mapper = new ObjectMapper();
@@ -89,7 +89,7 @@ public class TestImageTagToManifestPlugin {
     tmpDir.mkdirs();
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     File tmpDir = new File(tmpPath);
     FileUtils.deleteDirectory(tmpDir);
@@ -159,11 +159,11 @@ public class TestImageTagToManifestPlugin {
     String returnedCommentHash = mockImageTagToManifestPlugin
         .getHashFromImageTag(commentImage);
 
-    Assert.assertEquals(fakeImageHash, returnedFakeImageHash);
-    Assert.assertEquals(busyboxHash, returnedBusyboxHash);
+    assertEquals(fakeImageHash, returnedFakeImageHash);
+    assertEquals(busyboxHash, returnedBusyboxHash);
 
     //Image hash should not be found, so returned hash should be the tag
-    Assert.assertEquals(commentImage, returnedCommentHash);
+    assertEquals(commentImage, returnedCommentHash);
   }
 
   @Test
@@ -203,11 +203,11 @@ public class TestImageTagToManifestPlugin {
     String returnedCommentHash = mockImageTagToManifestPlugin
         .getHashFromImageTag(commentImage);
 
-    Assert.assertEquals(fakeImageHash, returnedFakeImageHash);
-    Assert.assertEquals(busyboxHash, returnedBusyboxHash);
+    assertEquals(fakeImageHash, returnedFakeImageHash);
+    assertEquals(busyboxHash, returnedBusyboxHash);
 
     //Image hash should not be found, so returned hash should be the tag
-    Assert.assertEquals(commentImage, returnedCommentHash);
+    assertEquals(commentImage, returnedCommentHash);
   }
 
   @Test
@@ -243,6 +243,6 @@ public class TestImageTagToManifestPlugin {
         .getManifestFromImageTag("image");
     ImageManifest expectedManifest =
         mapper.readValue(manifestJson, ImageManifest.class);
-    Assert.assertEquals(expectedManifest.toString(), manifest.toString());
+    assertEquals(expectedManifest.toString(), manifest.toString());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
@@ -88,7 +88,7 @@ public class TestJavaSandboxLinuxContainerRuntime {
   private final static String HADOOP_HOME = "hadoop.home.dir";
   private final static String HADOOP_HOME_DIR = System.getProperty(HADOOP_HOME);
   private final Properties baseProps = new Properties(System.getProperties());
-  
+
   private static File grantFile, denyFile, policyFile,
           grantDir, denyDir, containerDir;
   private static java.nio.file.Path policyFilePath;
@@ -275,7 +275,7 @@ public class TestJavaSandboxLinuxContainerRuntime {
   public void testDeny() throws Exception {
     assertThrows(java.security.AccessControlException.class, () -> {
       FilePermission denyPermission =
-         new FilePermission(denyFile.getAbsolutePath(), "read");
+          new FilePermission(denyFile.getAbsolutePath(), "read");
       securityManager.checkPermission(denyPermission);
     });
   }
@@ -290,8 +290,8 @@ public class TestJavaSandboxLinuxContainerRuntime {
     List<String> commands = Arrays.asList(nonJavaCommands);
     assertThrows(ContainerExecutionException.class, () -> {
       JavaSandboxLinuxContainerRuntime.NMContainerPolicyUtils
-      .appendSecurityFlags(commands, env, policyFilePath,
-      JavaSandboxLinuxContainerRuntime.SandboxMode.enforcing);
+          .appendSecurityFlags(commands, env, policyFilePath,
+          JavaSandboxLinuxContainerRuntime.SandboxMode.enforcing);
     });
   }
 
@@ -324,9 +324,8 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    assertTrue(
-       inputCommand[0].equals(commands.get(0)), "Command should not be modified when user is " +
-            "member of whitelisted group");
+    assertTrue(inputCommand[0].equals(commands.get(0)),
+        "Command should not be modified when user is member of whitelisted group");
   }
 
   @Test
@@ -344,10 +343,9 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    assertTrue(
-       commands.get(0).contains(SECURITY_FLAG)
+    assertTrue(commands.get(0).contains(SECURITY_FLAG)
         && commands.get(0).contains(POLICY_FLAG), "Command should be modified to include " +
-            "policy file in whitelisted Sandbox mode");
+        "policy file in whitelisted Sandbox mode");
   }
 
   @Test
@@ -365,9 +363,9 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    assertTrue(
-       commands.get(0).contains(SECURITY_FLAG), "Java security manager must be enabled for "
-            + "unauthorized users");
+    assertTrue(commands.get(0).contains(SECURITY_FLAG),
+        "Java security manager must be enabled for "
+        + "unauthorized users");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
@@ -27,12 +27,9 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerExecutionException;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeContext;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -75,6 +72,10 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.RUN_AS_USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER_LOCAL_DIRS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,10 +88,7 @@ public class TestJavaSandboxLinuxContainerRuntime {
   private final static String HADOOP_HOME = "hadoop.home.dir";
   private final static String HADOOP_HOME_DIR = System.getProperty(HADOOP_HOME);
   private final Properties baseProps = new Properties(System.getProperties());
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
+  
   private static File grantFile, denyFile, policyFile,
           grantDir, denyDir, containerDir;
   private static java.nio.file.Path policyFilePath;
@@ -112,7 +110,7 @@ public class TestJavaSandboxLinuxContainerRuntime {
   private final static String APPLICATION_ID = "application_1234567890";
   private File baseTestDirectory;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
 
     baseTestDirectory = new File(System.getProperty("test.build.data",
@@ -258,10 +256,10 @@ public class TestJavaSandboxLinuxContainerRuntime {
     String generatedPolicy = policyMatches.group(1);
 
     //Test that generated policy file has included both policies
-    Assert.assertTrue(
+    assertTrue(
         Files.readAllLines(Paths.get(generatedPolicy)).contains(
             classLoaderPermString.toString().split("\n")[1]));
-    Assert.assertTrue(
+    assertTrue(
         Files.readAllLines(Paths.get(generatedPolicy)).contains(
             socketPermString.toString().split("\n")[1]));
   }
@@ -275,10 +273,11 @@ public class TestJavaSandboxLinuxContainerRuntime {
 
   @Test
   public void testDeny() throws Exception {
-    FilePermission denyPermission =
-        new FilePermission(denyFile.getAbsolutePath(), "read");
-    exception.expect(java.security.AccessControlException.class);
-    securityManager.checkPermission(denyPermission);
+    assertThrows(java.security.AccessControlException.class, () -> {
+      FilePermission denyPermission =
+         new FilePermission(denyFile.getAbsolutePath(), "read");
+      securityManager.checkPermission(denyPermission);
+    });
   }
 
   @Test
@@ -289,11 +288,11 @@ public class TestJavaSandboxLinuxContainerRuntime {
     };
 
     List<String> commands = Arrays.asList(nonJavaCommands);
-    exception.expect(ContainerExecutionException.class);
-    JavaSandboxLinuxContainerRuntime.NMContainerPolicyUtils
-        .appendSecurityFlags(commands, env, policyFilePath,
-            JavaSandboxLinuxContainerRuntime.SandboxMode.enforcing);
-
+    assertThrows(ContainerExecutionException.class, () -> {
+      JavaSandboxLinuxContainerRuntime.NMContainerPolicyUtils
+      .appendSecurityFlags(commands, env, policyFilePath,
+      JavaSandboxLinuxContainerRuntime.SandboxMode.enforcing);
+    });
   }
 
   @Test
@@ -325,9 +324,9 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    Assert.assertTrue("Command should not be modified when user is " +
-            "member of whitelisted group",
-        inputCommand[0].equals(commands.get(0)));
+    assertTrue(
+       inputCommand[0].equals(commands.get(0)), "Command should not be modified when user is " +
+            "member of whitelisted group");
   }
 
   @Test
@@ -345,10 +344,10 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    Assert.assertTrue("Command should be modified to include " +
-            "policy file in whitelisted Sandbox mode",
-        commands.get(0).contains(SECURITY_FLAG)
-        && commands.get(0).contains(POLICY_FLAG));
+    assertTrue(
+       commands.get(0).contains(SECURITY_FLAG)
+        && commands.get(0).contains(POLICY_FLAG), "Command should be modified to include " +
+            "policy file in whitelisted Sandbox mode");
   }
 
   @Test
@@ -366,9 +365,9 @@ public class TestJavaSandboxLinuxContainerRuntime {
     runtimeContextBuilder.setExecutionAttribute(CONTAINER_RUN_CMDS, commands);
     runtime.prepareContainer(runtimeContextBuilder.build());
 
-    Assert.assertTrue("Java security manager must be enabled for "
-            + "unauthorized users",
-        commands.get(0).contains(SECURITY_FLAG));
+    assertTrue(
+       commands.get(0).contains(SECURITY_FLAG), "Java security manager must be enabled for "
+            + "unauthorized users");
   }
 
   @Test
@@ -386,8 +385,8 @@ public class TestJavaSandboxLinuxContainerRuntime {
     };
 
     Arrays.stream(multiCmds)
-        .forEach(cmd -> Assert.assertTrue(cmd.matches(MULTI_COMMAND_REGEX)));
-    Assert.assertFalse("cmd1 &> logfile".matches(MULTI_COMMAND_REGEX));
+        .forEach(cmd -> assertTrue(cmd.matches(MULTI_COMMAND_REGEX)));
+    assertFalse("cmd1 &> logfile".matches(MULTI_COMMAND_REGEX));
   }
 
   @Test
@@ -401,10 +400,10 @@ public class TestJavaSandboxLinuxContainerRuntime {
         "/nm/app/container/usercache/badjava -cp Bad.jar ChaosClass"
     };
     for(String javaCmd : javaCmds) {
-      Assert.assertTrue(javaCmd.matches(CONTAINS_JAVA_CMD));
+      assertTrue(javaCmd.matches(CONTAINS_JAVA_CMD));
     }
     for(String nonJavaCmd : nonJavaCmds) {
-      Assert.assertFalse(nonJavaCmd.matches(CONTAINS_JAVA_CMD));
+      assertFalse(nonJavaCmd.matches(CONTAINS_JAVA_CMD));
     }
   }
 
@@ -419,7 +418,7 @@ public class TestJavaSandboxLinuxContainerRuntime {
         "keepThis"
     };
     for(int i = 0; i < securityManagerCmds.length; i++){
-      Assert.assertEquals(
+      assertEquals(
           securityManagerCmds[i].replaceAll(CLEAN_CMD_REGEX, "").trim(),
           cleanedCmdsResult[i]);
     }
@@ -446,11 +445,11 @@ public class TestJavaSandboxLinuxContainerRuntime {
             JavaSandboxLinuxContainerRuntime.SandboxMode.enforcing);
 
     for(int i = 0; i < commands.size(); i++) {
-      Assert.assertTrue(commands.get(i).trim().equals(cleanCommands[i].trim()));
+      assertTrue(commands.get(i).trim().equals(cleanCommands[i].trim()));
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup(){
     System.setProperties(baseProps);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
@@ -61,11 +61,9 @@ import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -89,6 +87,12 @@ import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_DEFAULT_RW_M
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_RUNC_LAYER_MOUNTS_TO_KEEP;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.*;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.RuncContainerRuntime.ENV_RUNC_CONTAINER_MOUNTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -100,7 +104,6 @@ import static org.mockito.Mockito.when;
 /**
  * This class tests the {@link RuncContainerRuntime}.
  */
-@RunWith(Parameterized.class)
 public class TestRuncContainerRuntime {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRuncContainerRuntime.class);
@@ -160,10 +163,13 @@ public class TestRuncContainerRuntime {
     });
   }
 
-  @Parameterized.Parameter
   public boolean https;
 
-  @Before
+  public void initHttps(boolean pHttps) throws ContainerExecutionException {
+    this.https = pHttps;
+    setup();
+  }
+
   public void setup() throws ContainerExecutionException {
     mockExecutor = Mockito
         .mock(PrivilegedOperationExecutor.class);
@@ -319,7 +325,7 @@ public class TestRuncContainerRuntime {
         .setExecutionAttribute(RESOURCES_OPTIONS, resourcesOptions);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     File tmpDir = new File(tmpPath);
     FileUtils.deleteDirectory(tmpDir);
@@ -439,7 +445,7 @@ public class TestRuncContainerRuntime {
       throws PrivilegedOperationException {
     PrivilegedOperation op = capturePrivilegedOperation(1);
 
-    Assert.assertEquals(PrivilegedOperation.OperationType
+    assertEquals(PrivilegedOperation.OperationType
         .RUN_RUNC_CONTAINER, op.getOperationType());
     return new File(op.getArguments().get(0));
   }
@@ -532,34 +538,34 @@ public class TestRuncContainerRuntime {
 
     expectedConfigSize = (https) ? 16 : 13;
 
-    Assert.assertEquals(expectedConfigSize, configSize);
-    Assert.assertEquals("0.1", configVersion);
-    Assert.assertEquals(runAsUser, configRunAsUser);
-    Assert.assertEquals(user, configUser);
-    Assert.assertEquals(containerId, configContainerId);
-    Assert.assertEquals(appId, configAppId);
-    Assert.assertEquals(pidFilePath.toString(), configPidFile);
-    Assert.assertEquals(nmPrivateContainerScriptPath.toUri().toString(),
+    assertEquals(expectedConfigSize, configSize);
+    assertEquals("0.1", configVersion);
+    assertEquals(runAsUser, configRunAsUser);
+    assertEquals(user, configUser);
+    assertEquals(containerId, configContainerId);
+    assertEquals(appId, configAppId);
+    assertEquals(pidFilePath.toString(), configPidFile);
+    assertEquals(nmPrivateContainerScriptPath.toUri().toString(),
         configContainerScriptPath);
-    Assert.assertEquals(nmPrivateTokensPath.toUri().getPath(),
+    assertEquals(nmPrivateTokensPath.toUri().getPath(),
         configContainerCredentialsPath);
 
     if (https) {
-      Assert.assertEquals(1, configHttps);
-      Assert.assertEquals(nmPrivateKeystorePath.toUri().toString(),
+      assertEquals(1, configHttps);
+      assertEquals(nmPrivateKeystorePath.toUri().toString(),
           configKeystorePath);
-      Assert.assertEquals(nmPrivateTruststorePath.toUri().toString(),
+      assertEquals(nmPrivateTruststorePath.toUri().toString(),
           configTruststorePath);
     } else {
-      Assert.assertEquals(0, configHttps);
-      Assert.assertNull(configKeystorePath);
-      Assert.assertNull(configTruststorePath);
+      assertEquals(0, configHttps);
+      assertNull(configKeystorePath);
+      assertNull(configTruststorePath);
     }
 
-    Assert.assertEquals(localDirs, configLocalDirsList);
-    Assert.assertEquals(logDirs, configLogDirsList);
-    Assert.assertEquals(0, configLayersList.size());
-    Assert.assertEquals(layersToKeep, configLayersToKeep);
+    assertEquals(localDirs, configLocalDirsList);
+    assertEquals(logDirs, configLogDirsList);
+    assertEquals(0, configLayersList.size());
+    assertEquals(layersToKeep, configLayersToKeep);
 
     List<OCIMount> configMounts = ociRuntimeConfig.getMounts();
     verifyRuncMounts(expectedMounts, configMounts);
@@ -567,10 +573,10 @@ public class TestRuncContainerRuntime {
     List<String> processArgsList = ociProcessConfig.getArgs();
     String configArgs = "".join(",", processArgsList);
 
-    Assert.assertEquals(containerWorkDir.toString(), configContainerWorkDir);
-    Assert.assertEquals("bash," + containerWorkDir + "/launch_container.sh",
+    assertEquals(containerWorkDir.toString(), configContainerWorkDir);
+    assertEquals("bash," + containerWorkDir + "/launch_container.sh",
         configArgs);
-    Assert.assertEquals(cpuShares, configCpuShares);
+    assertEquals(cpuShares, configCpuShares);
 
     return runcContainerExecutorConfig;
   }
@@ -578,7 +584,7 @@ public class TestRuncContainerRuntime {
 
   private void verifyRuncMounts(List<OCIMount> expectedRuncMounts,
       List<OCIMount> configMounts) throws IOException {
-    Assert.assertEquals(expectedRuncMounts.size(), configMounts.size());
+    assertEquals(expectedRuncMounts.size(), configMounts.size());
     boolean found;
     for (OCIMount expectedMount : expectedRuncMounts) {
       found = false;
@@ -604,8 +610,10 @@ public class TestRuncContainerRuntime {
     }
   }
 
-  @Test
-  public void testSelectRuncContainerType() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testSelectRuncContainerType(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     Map<String, String> envRuncType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -613,16 +621,19 @@ public class TestRuncContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_RUNC);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertFalse(RuncContainerRuntime
+    assertFalse(RuncContainerRuntime
         .isRuncContainerRequested(conf, null));
-    Assert.assertTrue(RuncContainerRuntime
+    assertTrue(RuncContainerRuntime
         .isRuncContainerRequested(conf, envRuncType));
-    Assert.assertFalse(RuncContainerRuntime
+    assertFalse(RuncContainerRuntime
         .isRuncContainerRequested(conf, envOtherType));
   }
 
-  @Test
-  public void testSelectRuncContainerTypeWithRuncAsDefault() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testSelectRuncContainerTypeWithRuncAsDefault(boolean pHttps)
+      throws ContainerExecutionException {
+    initHttps(pHttps);
     Map<String, String> envRuncType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -632,16 +643,19 @@ public class TestRuncContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_RUNC);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertTrue(RuncContainerRuntime
+    assertTrue(RuncContainerRuntime
         .isRuncContainerRequested(conf, null));
-    Assert.assertTrue(RuncContainerRuntime
+    assertTrue(RuncContainerRuntime
         .isRuncContainerRequested(conf, envRuncType));
-    Assert.assertFalse(RuncContainerRuntime
+    assertFalse(RuncContainerRuntime
         .isRuncContainerRequested(conf, envOtherType));
   }
 
-  @Test
-  public void testSelectRuncContainerTypeWithDefaultSet() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testSelectRuncContainerTypeWithDefaultSet(boolean pHttps)
+      throws ContainerExecutionException {
+    initHttps(pHttps);
     Map<String, String> envRuncType = new HashMap<>();
     Map<String, String> envOtherType = new HashMap<>();
 
@@ -650,18 +664,20 @@ public class TestRuncContainerRuntime {
         ContainerRuntimeConstants.CONTAINER_RUNTIME_RUNC);
     envOtherType.put(ContainerRuntimeConstants.ENV_CONTAINER_TYPE, "other");
 
-    Assert.assertFalse(RuncContainerRuntime
+    assertFalse(RuncContainerRuntime
         .isRuncContainerRequested(conf, null));
-    Assert.assertTrue(RuncContainerRuntime
+    assertTrue(RuncContainerRuntime
         .isRuncContainerRequested(conf, envRuncType));
-    Assert.assertFalse(RuncContainerRuntime
+    assertFalse(RuncContainerRuntime
         .isRuncContainerRequested(conf, envOtherType));
   }
 
-  @Test
-  public void testRuncContainerLaunch()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testRuncContainerLaunch(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     MockRuncContainerRuntime runtime = new MockRuncContainerRuntime(
         mockExecutor, mockCGroupsHandler);
 
@@ -672,9 +688,11 @@ public class TestRuncContainerRuntime {
     verifyRuncConfig(configFile);
   }
 
-  @Test
-  public void testRuncContainerLaunchWithDefaultImage()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testRuncContainerLaunchWithDefaultImage(boolean pHttps)
       throws ContainerExecutionException, IOException {
+    initHttps(pHttps);
     String runcImage = "busybox:1.2.3";
     conf.set(YarnConfiguration.NM_RUNC_IMAGE_NAME, runcImage);
     env.remove(RuncContainerRuntime.ENV_RUNC_CONTAINER_IMAGE);
@@ -688,9 +706,11 @@ public class TestRuncContainerRuntime {
         .getManifestFromImageTag(runcImage);
   }
 
-  @Test
-  public void testCGroupParent() throws ContainerExecutionException,
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testCGroupParent(boolean pHttps) throws ContainerExecutionException,
       PrivilegedOperationException, IOException {
+    initHttps(pHttps);
     // Case 1: neither hierarchy nor resource options set,
     // so cgroup should not be set
     MockRuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -705,7 +725,7 @@ public class TestRuncContainerRuntime {
 
     String configCgroupsPath = runcContainerExecutorConfig
         .getOciRuntimeConfig().getLinux().getCgroupsPath();
-    Assert.assertNull(configCgroupsPath);
+    assertNull(configCgroupsPath);
 
     // Case 2: hierarchy set, but resource options not,
     // so cgroup should not be set
@@ -724,7 +744,7 @@ public class TestRuncContainerRuntime {
 
     configCgroupsPath = runcContainerExecutorConfig.getOciRuntimeConfig()
         .getLinux().getCgroupsPath();
-    Assert.assertNull(configCgroupsPath);
+    assertNull(configCgroupsPath);
 
     // Case 3: resource options set, so cgroup should be set
     String resourceOptionsCpu = "/sys/fs/cgroup/cpu/" + hierarchy +
@@ -743,7 +763,7 @@ public class TestRuncContainerRuntime {
 
     configCgroupsPath = runcContainerExecutorConfig.getOciRuntimeConfig()
         .getLinux().getCgroupsPath();
-    Assert.assertEquals("/" + hierarchy, configCgroupsPath);
+    assertEquals("/" + hierarchy, configCgroupsPath);
 
     // Case 4: cgroupsHandler is null, so cgroup should not be set
     resourceOptionsCpu = "/sys/fs/cgroup/cpu/" + hierarchy +
@@ -762,14 +782,16 @@ public class TestRuncContainerRuntime {
 
     configCgroupsPath = runcContainerExecutorConfig.getOciRuntimeConfig()
         .getLinux().getCgroupsPath();
-    Assert.assertNull(configCgroupsPath);
+    assertNull(configCgroupsPath);
   }
 
 
-  @Test
-  public void testDefaultROMounts()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDefaultROMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     String roMount1 = tmpPath + "/foo";
     File roMountFile1 = new File(roMount1);
     roMountFile1.mkdirs();
@@ -801,8 +823,10 @@ public class TestRuncContainerRuntime {
     verifyRuncConfig(configFile);
   }
 
-  @Test
-  public void testDefaultROMountsInvalid() throws ContainerExecutionException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDefaultROMountsInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setStrings(NM_RUNC_DEFAULT_RO_MOUNTS,
         "source,target");
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -811,16 +835,18 @@ public class TestRuncContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testDefaultRWMounts()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDefaultRWMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     String rwMount1 = tmpPath + "/foo";
     File rwMountFile1 = new File(rwMount1);
     rwMountFile1.mkdirs();
@@ -852,8 +878,10 @@ public class TestRuncContainerRuntime {
     verifyRuncConfig(configFile);
   }
 
-  @Test
-  public void testDefaultRWMountsInvalid() throws ContainerExecutionException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDefaultRWMountsInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     conf.setStrings(NM_RUNC_DEFAULT_RW_MOUNTS,
         "source,target");
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -862,16 +890,18 @@ public class TestRuncContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testUserMounts()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUserMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
+    initHttps(pHttps);
     String roMount = tmpPath + "/foo";
     File roMountFile = new File(roMount);
     roMountFile.mkdirs();
@@ -908,8 +938,10 @@ public class TestRuncContainerRuntime {
     verifyRuncConfig(configFile);
   }
 
-  @Test
-  public void testUserMountsInvalid() throws ContainerExecutionException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUserMountsInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     env.put(ENV_RUNC_CONTAINER_MOUNTS,
         "source:target");
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -918,14 +950,16 @@ public class TestRuncContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testUserMountsModeInvalid() throws ContainerExecutionException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUserMountsModeInvalid(boolean pHttps) throws ContainerExecutionException {
+    initHttps(pHttps);
     env.put(ENV_RUNC_CONTAINER_MOUNTS,
         "source:target:other");
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -934,15 +968,17 @@ public class TestRuncContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testUserMountsModeNullInvalid()
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUserMountsModeNullInvalid(boolean pHttps)
       throws ContainerExecutionException {
+    initHttps(pHttps);
     env.put(ENV_RUNC_CONTAINER_MOUNTS,
         "s\0ource:target:ro");
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
@@ -951,14 +987,16 @@ public class TestRuncContainerRuntime {
 
     try {
       runtime.launchContainer(builder.build());
-      Assert.fail("Expected a launch container failure due to invalid mount.");
+      fail("Expected a launch container failure due to invalid mount.");
     } catch (ContainerExecutionException e) {
       LOG.info("Caught expected exception : " + e);
     }
   }
 
-  @Test
-  public void testRuncHostnamePattern() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testRuncHostnamePattern(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     String[] validNames = {"ab", "a.b.c.d", "a1-b.cd.ef", "0AB.", "C_D-"};
 
     String[] invalidNames = {"a", "a#.b.c", "-a.b.c", "a@b.c", "a/b/c"};
@@ -970,28 +1008,36 @@ public class TestRuncContainerRuntime {
     for (String name : invalidNames) {
       try {
         RuncContainerRuntime.validateHostname(name);
-        Assert.fail(name + " is an invalid hostname and should fail the regex");
+        fail(name + " is an invalid hostname and should fail the regex");
       } catch (ContainerExecutionException ce) {
         continue;
       }
     }
   }
 
-  @Test
-  public void testValidRuncHostnameLength() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testValidRuncHostnameLength(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     String validLength = "example.test.site";
     RuncContainerRuntime.validateHostname(validLength);
   }
 
-  @Test(expected = ContainerExecutionException.class)
-  public void testInvalidRuncHostnameLength() throws Exception {
-    String invalidLength =
-        "exampleexampleexampleexampleexampleexampleexampleexample.test.site";
-    RuncContainerRuntime.validateHostname(invalidLength);
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testInvalidRuncHostnameLength(boolean pHttps) throws Exception {
+    initHttps(pHttps);
+    assertThrows(ContainerExecutionException.class, () -> {
+      String invalidLength =
+          "exampleexampleexampleexampleexampleexampleexampleexample.test.site";
+      RuncContainerRuntime.validateHostname(invalidLength);
+    });
   }
 
-  @Test
-  public void testGetLocalResources() throws Exception {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testGetLocalResources(boolean pHttps) throws Exception {
+    initHttps(pHttps);
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(
         mockExecutor, mockCGroupsHandler);
     runtime.initialize(conf, nmContext);
@@ -1003,8 +1049,8 @@ public class TestRuncContainerRuntime {
     LocalResource testConfig = runtimeObject.getConfig();
     List<LocalResource> testLayers = runtimeObject.getOCILayers();
 
-    Assert.assertEquals(config, testConfig);
-    Assert.assertEquals(layers, testLayers);
+    assertEquals(config, testConfig);
+    assertEquals(layers, testLayers);
 
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
@@ -170,6 +170,7 @@ public class TestRuncContainerRuntime {
     setup();
   }
 
+  @SuppressWarnings("checkstyle:methodlength")
   public void setup() throws ContainerExecutionException {
     mockExecutor = Mockito
         .mock(PrivilegedOperationExecutor.class);
@@ -611,7 +612,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testSelectRuncContainerType(boolean pHttps) throws ContainerExecutionException {
     initHttps(pHttps);
     Map<String, String> envRuncType = new HashMap<>();
@@ -630,7 +631,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testSelectRuncContainerTypeWithRuncAsDefault(boolean pHttps)
       throws ContainerExecutionException {
     initHttps(pHttps);
@@ -652,7 +653,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testSelectRuncContainerTypeWithDefaultSet(boolean pHttps)
       throws ContainerExecutionException {
     initHttps(pHttps);
@@ -673,7 +674,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testRuncContainerLaunch(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
@@ -689,7 +690,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testRuncContainerLaunchWithDefaultImage(boolean pHttps)
       throws ContainerExecutionException, IOException {
     initHttps(pHttps);
@@ -707,7 +708,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testCGroupParent(boolean pHttps) throws ContainerExecutionException,
       PrivilegedOperationException, IOException {
     initHttps(pHttps);
@@ -787,7 +788,7 @@ public class TestRuncContainerRuntime {
 
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testDefaultROMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
@@ -824,7 +825,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testDefaultROMountsInvalid(boolean pHttps) throws ContainerExecutionException {
     initHttps(pHttps);
     conf.setStrings(NM_RUNC_DEFAULT_RO_MOUNTS,
@@ -842,7 +843,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testDefaultRWMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
@@ -879,7 +880,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testDefaultRWMountsInvalid(boolean pHttps) throws ContainerExecutionException {
     initHttps(pHttps);
     conf.setStrings(NM_RUNC_DEFAULT_RW_MOUNTS,
@@ -897,7 +898,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testUserMounts(boolean pHttps)
       throws ContainerExecutionException, PrivilegedOperationException,
       IOException {
@@ -939,7 +940,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testUserMountsInvalid(boolean pHttps) throws ContainerExecutionException {
     initHttps(pHttps);
     env.put(ENV_RUNC_CONTAINER_MOUNTS,
@@ -957,7 +958,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testUserMountsModeInvalid(boolean pHttps) throws ContainerExecutionException {
     initHttps(pHttps);
     env.put(ENV_RUNC_CONTAINER_MOUNTS,
@@ -975,7 +976,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testUserMountsModeNullInvalid(boolean pHttps)
       throws ContainerExecutionException {
     initHttps(pHttps);
@@ -994,7 +995,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testRuncHostnamePattern(boolean pHttps) throws Exception {
     initHttps(pHttps);
     String[] validNames = {"ab", "a.b.c.d", "a1-b.cd.ef", "0AB.", "C_D-"};
@@ -1016,7 +1017,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testValidRuncHostnameLength(boolean pHttps) throws Exception {
     initHttps(pHttps);
     String validLength = "example.test.site";
@@ -1024,7 +1025,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testInvalidRuncHostnameLength(boolean pHttps) throws Exception {
     initHttps(pHttps);
     assertThrows(ContainerExecutionException.class, () -> {
@@ -1035,7 +1036,7 @@ public class TestRuncContainerRuntime {
   }
 
   @MethodSource("data")
-  @ParameterizedTest
+  @ParameterizedTest(name = "https={0}")
   public void testGetLocalResources(boolean pHttps) throws Exception {
     initHttps(pHttps);
     RuncContainerRuntime runtime = new MockRuncContainerRuntime(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestRuncContainerRuntime.java
@@ -165,7 +165,7 @@ public class TestRuncContainerRuntime {
 
   public boolean https;
 
-  public void initHttps(boolean pHttps) throws ContainerExecutionException {
+  private void initHttps(boolean pHttps) throws ContainerExecutionException {
     this.https = pHttps;
     setup();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerClient.java
@@ -28,15 +28,15 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.LocalDirsHandlerService;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerExecutionException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -45,12 +45,12 @@ public class TestDockerClient {
   private static final File TEST_ROOT_DIR = GenericTestUtils.getTestDir(
       TestDockerClient.class.getName());
 
-  @Before
+  @BeforeEach
   public void setup() {
     TEST_ROOT_DIR.mkdirs();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_ROOT_DIR);
   }
@@ -78,7 +78,7 @@ public class TestDockerClient {
         mockContext);
     dirsHandler.stop();
     File tmpFile = new File(tmpPath);
-    assertTrue(tmpFile + " was not created", tmpFile.exists());
+    assertTrue(tmpFile.exists(), tmpFile + " was not created");
   }
 
   @Test
@@ -107,8 +107,8 @@ public class TestDockerClient {
           mockContext);
       fail("Expected exception writing command file");
     } catch (ContainerExecutionException e) {
-      assertTrue("Expected key validation error", e.getMessage()
-          .contains("'=' found in entry for docker command file"));
+      assertTrue(e.getMessage().contains("'=' found in entry for docker command file"),
+          "Expected key validation error");
     }
 
     try {
@@ -118,8 +118,8 @@ public class TestDockerClient {
       dockerClient.writeCommandToTempFile(dockerCmd, cid, mockContext);
       fail("Expected exception writing command file");
     } catch (ContainerExecutionException e) {
-      assertTrue("Expected value validation error", e.getMessage()
-          .contains("'\\n' found in entry for docker command file"));
+      assertTrue(e.getMessage().contains("'\\n' found in entry for docker command file"),
+          "Expected value validation error");
     }
     dirsHandler.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerCommandExecutor.java
@@ -32,9 +32,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resource
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.DockerLinuxContainerRuntime;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.TestDockerContainerRuntime;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerRuntimeContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -48,9 +47,9 @@ import java.util.concurrent.ConcurrentMap;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.CONTAINER_ID_STR;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker.DockerCommandExecutor.DockerContainerStatus;
 import static org.eclipse.jetty.server.handler.gzip.GzipHttpOutputInterceptor.LOG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,7 +79,7 @@ public class TestDockerCommandExecutor {
   private Context nmContext;
   private ApplicationAttemptId appAttemptId;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     mockExecutor = mock(PrivilegedOperationExecutor.class);
     mockCGroupsHandler = mock(CGroupsHandler.class);
@@ -403,7 +402,7 @@ public class TestDockerCommandExecutor {
     try {
       List<String> dockerCommands = new ArrayList<>();
       for (PrivilegedOperation op : ops) {
-        Assert.assertEquals(op.getOperationType(),
+        assertEquals(op.getOperationType(),
             PrivilegedOperation.OperationType.RUN_DOCKER_CMD);
         String dockerCommandFile = op.getArguments().get(0);
         List<String> dockerCommandFileContents = Files

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerImagesCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerImagesCommand.java
@@ -55,8 +55,9 @@ public class TestDockerImagesCommand {
     assertEquals("images", StringUtils.join(",",
         dockerImagesCommand.getDockerCommandWithArguments()
             .get("docker-command")));
-    assertEquals("image name", "foo", StringUtils.join(",",
-        dockerImagesCommand.getDockerCommandWithArguments().get("image")));
+    assertEquals("foo",
+        StringUtils.join(",", dockerImagesCommand.getDockerCommandWithArguments().get("image")),
+        "image name");
     assertEquals(2, dockerImagesCommand.getDockerCommandWithArguments().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerImagesCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerImagesCommand.java
@@ -17,10 +17,10 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the docker images command and its command
@@ -31,7 +31,7 @@ public class TestDockerImagesCommand {
 
   private static final String IMAGE_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerImagesCommand = new DockerImagesCommand();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerInspectCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerInspectCommand.java
@@ -17,11 +17,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the docker inspect command and its command
@@ -33,7 +33,7 @@ public class TestDockerInspectCommand {
 
   private static final String CONTAINER_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerInspectCommand = new DockerInspectCommand(CONTAINER_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerKillCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerKillCommand.java
@@ -20,11 +20,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the docker kill command and its command line arguments.
@@ -36,7 +36,7 @@ public class TestDockerKillCommand {
   private static final String SIGNAL = "SIGUSR2";
   private static final String CONTAINER_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerKillCommand = new DockerKillCommand(CONTAINER_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerLoadCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerLoadCommand.java
@@ -17,10 +17,10 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the docker load command and its command
@@ -31,7 +31,7 @@ public class TestDockerLoadCommand {
 
   private static final String LOCAL_IMAGE_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerLoadCommand = new DockerLoadCommand(LOCAL_IMAGE_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerPullCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerPullCommand.java
@@ -17,10 +17,10 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the docker pull command and its command
@@ -31,7 +31,7 @@ public class TestDockerPullCommand {
 
   private static final String IMAGE_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerPullCommand = new DockerPullCommand(IMAGE_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerRmCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerRmCommand.java
@@ -16,11 +16,11 @@
  */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the docker rm command and any command
@@ -35,7 +35,7 @@ public class TestDockerRmCommand {
   private static final String CONTAINER_NAME = "foo";
   private static final String CGROUP_HIERARCHY_NAME = "hadoop-yarn";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     dockerRmCommand = new DockerRmCommand(CONTAINER_NAME, null);
     dockerRmCommandWithCgroupArg =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerRunCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerRunCommand.java
@@ -17,13 +17,13 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the docker run command and its command
@@ -38,7 +38,7 @@ public class TestDockerRunCommand {
   private static final String IMAGE_NAME = "image_name";
   private static final String CLIENT_CONFIG_PATH = "/path/to/client.json";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     dockerRunCommand = new DockerRunCommand(CONTAINER_NAME, USER_ID,
         IMAGE_NAME);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerStartCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerStartCommand.java
@@ -17,10 +17,10 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the docker start command and any command line arguments.
@@ -31,7 +31,7 @@ public class TestDockerStartCommand {
 
   private static final String CONTAINER_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     dockerStartCommand = new DockerStartCommand(CONTAINER_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerStopCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerStopCommand.java
@@ -20,11 +20,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the docker stop command and its command
@@ -37,7 +37,7 @@ public class TestDockerStopCommand {
   private static final int GRACE_PERIOD = 10;
   private static final String CONTAINER_NAME = "foo";
 
-  @Before
+  @BeforeEach
   public void setup() {
     dockerStopCommand = new DockerStopCommand(CONTAINER_NAME);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerVolumeCommand.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/docker/TestDockerVolumeCommand.java
@@ -17,28 +17,28 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestDockerVolumeCommand {
   @Test
   public void testDockerVolumeCommand() {
     DockerVolumeCommand dockerVolumeCommand = new DockerVolumeCommand("create");
     assertEquals("volume", dockerVolumeCommand.getCommandOption());
-    Assert.assertTrue(
+    assertTrue(
         dockerVolumeCommand.getDockerCommandWithArguments().get("sub-command")
             .contains("create"));
 
     dockerVolumeCommand.setDriverName("driver1");
     dockerVolumeCommand.setVolumeName("volume1");
 
-    Assert.assertTrue(
+    assertTrue(
         dockerVolumeCommand.getDockerCommandWithArguments().get("driver")
             .contains("driver1"));
 
-    Assert.assertTrue(
+    assertTrue(
         dockerVolumeCommand.getDockerCommandWithArguments().get("volume")
             .contains("volume1"));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
@@ -17,9 +17,10 @@
 */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -86,9 +87,9 @@ import org.apache.hadoop.yarn.server.nodemanager.api.ResourceLocalizationSpec;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalResourceStatus;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerAction;
 import org.apache.hadoop.yarn.server.nodemanager.api.protocolrecords.LocalizerStatus;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -111,7 +112,7 @@ public class TestContainerLocalizer {
   static final InetSocketAddress nmAddr =
       new InetSocketAddress("foobar", 8040);
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     FileUtils.deleteDirectory(new File(basedir.toUri().getRawPath()));
   }
@@ -217,7 +218,8 @@ public class TestContainerLocalizer {
         status -> !containerId.equals(status.getLocalizerId())));
   }
 
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testMainFailure() throws Exception {
     ContainerLocalizerWrapper wrapper = new ContainerLocalizerWrapper();
     ContainerLocalizer localizer = wrapper.setupContainerLocalizerForTest();
@@ -231,9 +233,9 @@ public class TestContainerLocalizer {
     // run localization, it should fail
     try {
       localizer.runLocalization(nmAddr);
-      Assert.fail("Localization succeeded unexpectedly!");
+      fail("Localization succeeded unexpectedly!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("Sigh, no token!"));
+      assertTrue(e.getMessage().contains("Sigh, no token!"));
     }
   }
 
@@ -304,7 +306,7 @@ public class TestContainerLocalizer {
         any(UserGroupInformation.class));
     try {
       localizer.runLocalization(nmAddr);
-      Assert.fail("Localization succeeded unexpectedly!");
+      fail("Localization succeeded unexpectedly!");
     } catch (IOException e) {
       verify(localizer).closeFileSystems(any(UserGroupInformation.class));
     }
@@ -368,10 +370,10 @@ public class TestContainerLocalizer {
       shexcA = localizerA.getDownloader().getShexc();
       shexcB = localizerB.getDownloader().getShexc();
 
-      assertTrue("Localizer A process not running, but should be",
-          shexcA.getProcess().isAlive());
-      assertTrue("Localizer B process not running, but should be",
-          shexcB.getProcess().isAlive());
+      assertTrue(shexcA.getProcess().isAlive(),
+          "Localizer A process not running, but should be");
+      assertTrue(shexcB.getProcess().isAlive(),
+          "Localizer B process not running, but should be");
 
       // Stop heartbeat from giving anymore resources to download
       testA.heartbeatResponse++;
@@ -383,10 +385,10 @@ public class TestContainerLocalizer {
       threadA.join();
       shexcA.getProcess().waitFor(10000, TimeUnit.MILLISECONDS);
 
-      assertFalse("Localizer A process is still running, but shouldn't be",
-          shexcA.getProcess().isAlive());
-      assertTrue("Localizer B process not running, but should be",
-          shexcB.getProcess().isAlive());
+      assertFalse(shexcA.getProcess().isAlive(),
+          "Localizer A process is still running, but shouldn't be");
+      assertTrue(shexcB.getProcess().isAlive(),
+          "Localizer B process not running, but should be");
 
     } finally {
       // Make sure everything gets cleaned up
@@ -671,7 +673,8 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     return ret;
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testUserCacheDirPermission() throws Exception {
     Configuration conf = new Configuration();
     conf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "077");
@@ -693,13 +696,11 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     //Localize and check the directory permission are correct.
     localizer
         .download(destDirPath, rsrc, UserGroupInformation.getCurrentUser());
-    Assert
-        .assertEquals("Cache directory permissions filecache/0/0 is incorrect",
-            USERCACHE_DIR_PERM,
-            lfs.getFileStatus(destDirPath.getParent()).getPermission());
-    Assert.assertEquals("Cache directory permissions filecache/0 is incorrect",
-        USERCACHE_DIR_PERM,
-        lfs.getFileStatus(destDirPath.getParent().getParent()).getPermission());
+    assertEquals(USERCACHE_DIR_PERM, lfs.getFileStatus(destDirPath.getParent()).getPermission(),
+        "Cache directory permissions filecache/0/0 is incorrect");
+    assertEquals(USERCACHE_DIR_PERM,
+        lfs.getFileStatus(destDirPath.getParent().getParent()).getPermission(),
+        "Cache directory permissions filecache/0 is incorrect");
   }
 
   @Test
@@ -714,10 +715,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
-      Assert.assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
-      Assert.assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+      assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
-    Assert.assertTrue(javaOpts.contains("-Xmx256m"));
+    assertTrue(javaOpts.contains("-Xmx256m"));
   }
 
   @Test
@@ -732,10 +733,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
-      Assert.assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
-      Assert.assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+      assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
-    Assert.assertTrue(javaOpts.contains("-Xmx256m"));
+    assertTrue(javaOpts.contains("-Xmx256m"));
   }
 
   @Test
@@ -750,11 +751,11 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         " userOption1 userOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
-    Assert.assertEquals(4, javaOpts.size());
-    Assert.assertTrue(javaOpts.get(0).equals("adminOption1"));
-    Assert.assertTrue(javaOpts.get(1).equals("adminOption2"));
-    Assert.assertTrue(javaOpts.get(2).equals("userOption1"));
-    Assert.assertTrue(javaOpts.get(3).equals("userOption2"));
+    assertEquals(4, javaOpts.size());
+    assertTrue(javaOpts.get(0).equals("adminOption1"));
+    assertTrue(javaOpts.get(1).equals("adminOption2"));
+    assertTrue(javaOpts.get(2).equals("userOption1"));
+    assertTrue(javaOpts.get(3).equals("userOption2"));
   }
 
   @Test
@@ -767,10 +768,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         "adminOption1 adminOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
-    Assert.assertEquals(3, javaOpts.size());
-    Assert.assertTrue(javaOpts.get(0).equals("adminOption1"));
-    Assert.assertTrue(javaOpts.get(1).equals("adminOption2"));
-    Assert.assertTrue(javaOpts.get(2).equals("-Xmx256m"));
+    assertEquals(3, javaOpts.size());
+    assertTrue(javaOpts.get(0).equals("adminOption1"));
+    assertTrue(javaOpts.get(1).equals("adminOption2"));
+    assertTrue(javaOpts.get(2).equals("-Xmx256m"));
   }
 
   @Test
@@ -783,9 +784,9 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         "userOption1 userOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
-    Assert.assertEquals(2, javaOpts.size());
-    Assert.assertTrue(javaOpts.get(0).equals("userOption1"));
-    Assert.assertTrue(javaOpts.get(1).equals("userOption2"));
+    assertEquals(2, javaOpts.size());
+    assertTrue(javaOpts.get(0).equals("userOption1"));
+    assertTrue(javaOpts.get(1).equals("userOption2"));
   }
 
   @Test
@@ -796,7 +797,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     Configuration conf = new Configuration();
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
-    Assert.assertEquals(1, javaOpts.size());
-    Assert.assertTrue(javaOpts.get(0).equals("-Xmx256m"));
+    assertEquals(1, javaOpts.size());
+    assertTrue(javaOpts.get(0).equals("-Xmx256m"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheCleanup.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheCleanup.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +36,7 @@ import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.DeletionService;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.LocalCacheCleaner.LocalCacheCleanerStats;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests the clean up of local caches the node manager uses for the

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 
 import static org.mockito.Mockito.mock;
 
-import org.junit.Assert;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -31,7 +30,12 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreServic
 import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecretManager;
 import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerInNM;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLocalCacheDirectoryManager {
 
@@ -43,7 +47,7 @@ public class TestLocalCacheDirectoryManager {
 
     LocalCacheDirectoryManager hDir = new LocalCacheDirectoryManager(conf);
     // Test root directory path = ""
-    Assert.assertTrue(hDir.getRelativePathForLocalization().isEmpty());
+    assertTrue(hDir.getRelativePathForLocalization().isEmpty());
 
     // Testing path generation from "0" to "0/0/z/z"
     for (int i = 1; i <= 37 * 36 * 36; i++) {
@@ -58,7 +62,7 @@ public class TestLocalCacheDirectoryManager {
       for (int j = 1; j < num.length(); j++) {
         sb.append(Path.SEPARATOR).append(num.charAt(j));
       }
-      Assert.assertEquals(sb.toString(), hDir.getRelativePathForLocalization());
+      assertEquals(sb.toString(), hDir.getRelativePathForLocalization());
     }
 
     String testPath1 = "4";
@@ -71,8 +75,8 @@ public class TestLocalCacheDirectoryManager {
     hDir.decrementFileCountForPath(testPath1);
     hDir.decrementFileCountForPath(testPath2);
     // After below call directory "4" should become full.
-    Assert.assertEquals(testPath1, hDir.getRelativePathForLocalization());
-    Assert.assertEquals(testPath2, hDir.getRelativePathForLocalization());
+    assertEquals(testPath1, hDir.getRelativePathForLocalization());
+    assertEquals(testPath2, hDir.getRelativePathForLocalization());
   }
 
   @Test
@@ -94,9 +98,9 @@ public class TestLocalCacheDirectoryManager {
     } catch (Exception e1) {
       e = e1;
     }
-    Assert.assertNotNull(e);
-    Assert.assertEquals(YarnRuntimeException.class, e.getClass());
-    Assert.assertEquals(e.getMessage(),
+    assertNotNull(e);
+    assertEquals(YarnRuntimeException.class, e.getClass());
+    assertEquals(e.getMessage(),
       YarnConfiguration.NM_LOCAL_CACHE_MAX_FILES_PER_DIRECTORY
           + " parameter is configured with a value less than 37.");
 
@@ -112,25 +116,25 @@ public class TestLocalCacheDirectoryManager {
     String rootPath = "";
     String firstSubDir = "0";
     for (int i = 0; i < 4; i++) {
-      Assert.assertEquals(rootPath, dir.getRelativePathForLocalization());
+      assertEquals(rootPath, dir.getRelativePathForLocalization());
     }
     // Releasing two files from the root directory.
     dir.decrementFileCountForPath(rootPath);
     dir.decrementFileCountForPath(rootPath);
     // Space for two files should be available in root directory.
-    Assert.assertEquals(rootPath, dir.getRelativePathForLocalization());
-    Assert.assertEquals(rootPath, dir.getRelativePathForLocalization());
+    assertEquals(rootPath, dir.getRelativePathForLocalization());
+    assertEquals(rootPath, dir.getRelativePathForLocalization());
     // As no space is now available in root directory so it should be from
     // first sub directory
-    Assert.assertEquals(firstSubDir, dir.getRelativePathForLocalization());
+    assertEquals(firstSubDir, dir.getRelativePathForLocalization());
   }
 
   @Test
   public void testDirectoryConversion() {
     for (int i = 0; i < 10000; ++i) {
       String path = Directory.getRelativePath(i);
-      Assert.assertEquals("Incorrect conversion for " + i, i,
-          Directory.getDirectoryNumber(path));
+      assertEquals(i,
+          Directory.getDirectoryNumber(path), "Incorrect conversion for " + i);
     }
   }
 
@@ -142,31 +146,31 @@ public class TestLocalCacheDirectoryManager {
     LocalCacheDirectoryManager mgr = new LocalCacheDirectoryManager(conf);
     final String rootPath = "";
     mgr.incrementFileCountForPath(rootPath);
-    Assert.assertEquals(rootPath, mgr.getRelativePathForLocalization());
-    Assert.assertFalse("root dir should be full",
-        rootPath.equals(mgr.getRelativePathForLocalization()));
+    assertEquals(rootPath, mgr.getRelativePathForLocalization());
+    assertFalse(
+       rootPath.equals(mgr.getRelativePathForLocalization()), "root dir should be full");
     // finish filling the other directory
     mgr.getRelativePathForLocalization();
     // free up space in the root dir
     mgr.decrementFileCountForPath(rootPath);
     mgr.decrementFileCountForPath(rootPath);
-    Assert.assertEquals(rootPath, mgr.getRelativePathForLocalization());
-    Assert.assertEquals(rootPath, mgr.getRelativePathForLocalization());
+    assertEquals(rootPath, mgr.getRelativePathForLocalization());
+    assertEquals(rootPath, mgr.getRelativePathForLocalization());
     String otherDir = mgr.getRelativePathForLocalization();
-    Assert.assertFalse("root dir should be full", otherDir.equals(rootPath));
+    assertFalse(otherDir.equals(rootPath), "root dir should be full");
 
     final String deepDir0 = "d/e/e/p/0";
     final String deepDir1 = "d/e/e/p/1";
     final String deepDir2 = "d/e/e/p/2";
     final String deepDir3 = "d/e/e/p/3";
     mgr.incrementFileCountForPath(deepDir0);
-    Assert.assertEquals(otherDir, mgr.getRelativePathForLocalization());
-    Assert.assertEquals(deepDir0, mgr.getRelativePathForLocalization());
-    Assert.assertEquals("total dir count incorrect after increment",
-        deepDir1, mgr.getRelativePathForLocalization());
+    assertEquals(otherDir, mgr.getRelativePathForLocalization());
+    assertEquals(deepDir0, mgr.getRelativePathForLocalization());
+    assertEquals(deepDir1, mgr.getRelativePathForLocalization(),
+        "total dir count incorrect after increment");
     mgr.incrementFileCountForPath(deepDir2);
     mgr.incrementFileCountForPath(deepDir1);
     mgr.incrementFileCountForPath(deepDir2);
-    Assert.assertEquals(deepDir3, mgr.getRelativePathForLocalization());
+    assertEquals(deepDir3, mgr.getRelativePathForLocalization());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalCacheDirectoryManager.java
@@ -147,8 +147,8 @@ public class TestLocalCacheDirectoryManager {
     final String rootPath = "";
     mgr.incrementFileCountForPath(rootPath);
     assertEquals(rootPath, mgr.getRelativePathForLocalization());
-    assertFalse(
-       rootPath.equals(mgr.getRelativePathForLocalization()), "root dir should be full");
+    assertFalse(rootPath.equals(mgr.getRelativePathForLocalization()),
+        "root dir should be full");
     // finish filling the other directory
     mgr.getRelativePathForLocalization();
     // free up space in the root dir

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalResource.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalResource.java
@@ -31,8 +31,10 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.Loca
 import static org.apache.hadoop.yarn.api.records.LocalResourceType.*;
 import static org.apache.hadoop.yarn.api.records.LocalResourceVisibility.*;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLocalResource {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalizedResource.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestLocalizedResource.java
@@ -17,7 +17,7 @@
 */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -44,7 +44,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.even
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.event.ResourceLocalizedEvent;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.event.ResourceReleaseEvent;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.event.ResourceRequestEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 
 public class TestLocalizedResource {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
@@ -19,11 +19,12 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -70,7 +71,6 @@ import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.deletion.task.FileDeletionMatcher;
 import org.apache.hadoop.yarn.server.nodemanager.executor.LocalizerStartContext;
-import org.junit.Assert;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.AbstractFileSystem;
@@ -151,10 +151,11 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecret
 import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerInNM;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -173,13 +174,13 @@ public class TestResourceLocalizationService {
   private FileContext lfs;
   private NMContext nmContext;
   private NodeManagerMetrics metrics;
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     mockServer = mock(Server.class);
     doReturn(new InetSocketAddress(123)).when(mockServer).getListenerAddress();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     spylfs = spy(FileContext.getLocalFSFileContext().getDefaultFileSystem());
@@ -194,7 +195,7 @@ public class TestResourceLocalizationService {
     metrics = mock(NodeManagerMetrics.class);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     conf = null;
     try {
@@ -446,27 +447,27 @@ public class TestResourceLocalizationService {
       int privRsrcCount = 0;
       for (LocalizedResource lr : privTracker) {
         privRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 2, lr.getRefCount());
-        Assert.assertEquals(privReq, lr.getRequest());
+        assertEquals(2, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(privReq, lr.getRequest());
       }
-      Assert.assertEquals(1, privRsrcCount);
+      assertEquals(1, privRsrcCount);
 
       int pubRsrcCount = 0;
       for (LocalizedResource lr : pubTracker) {
         pubRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 1, lr.getRefCount());
+        assertEquals(1, lr.getRefCount(), "Incorrect reference count");
         pubRsrcs.remove(lr.getRequest());
       }
-      Assert.assertEquals(0, pubRsrcs.size());
-      Assert.assertEquals(2, pubRsrcCount);
+      assertEquals(0, pubRsrcs.size());
+      assertEquals(2, pubRsrcCount);
 
       int appRsrcCount = 0;
       for (LocalizedResource lr : appTracker) {
         appRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 1, lr.getRefCount());
-        Assert.assertEquals(appReq, lr.getRequest());
+        assertEquals(1, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(appReq, lr.getRequest());
       }
-      Assert.assertEquals(1, appRsrcCount);
+      assertEquals(1, appRsrcCount);
       
       //Send Cleanup Event
       spyService.handle(new ContainerLocalizationCleanupEvent(c, req));
@@ -482,25 +483,25 @@ public class TestResourceLocalizationService {
       privRsrcCount = 0;
       for (LocalizedResource lr : privTracker) {
         privRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 1, lr.getRefCount());
-        Assert.assertEquals(privReq, lr.getRequest());
+        assertEquals(1, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(privReq, lr.getRequest());
       }
-      Assert.assertEquals(1, privRsrcCount);
+      assertEquals(1, privRsrcCount);
 
       pubRsrcCount = 0;
       for (LocalizedResource lr : pubTracker) {
         pubRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 0, lr.getRefCount());
+        assertEquals(0, lr.getRefCount(), "Incorrect reference count");
         pubRsrcs.remove(lr.getRequest());
       }
-      Assert.assertEquals(0, pubRsrcs.size());
-      Assert.assertEquals(2, pubRsrcCount);
+      assertEquals(0, pubRsrcs.size());
+      assertEquals(2, pubRsrcCount);
 
       appRsrcCount = 0;
       for (LocalizedResource lr : appTracker) {
         appRsrcCount++;
       }
-      Assert.assertEquals(0, appRsrcCount);
+      assertEquals(0, appRsrcCount);
     } finally {
       dispatcher.stop();
       delService.stop();
@@ -663,22 +664,22 @@ public class TestResourceLocalizationService {
 
       // Simulate completion of localization for most resources with
       // possibly different sizes than in the request
-      assertNotNull("Localization not started", privLr1.getLocalPath());
+      assertNotNull(privLr1.getLocalPath(), "Localization not started");
       privTracker1.handle(new ResourceLocalizedEvent(privReq1,
           privLr1.getLocalPath(), privLr1.getSize() + 5));
-      assertNotNull("Localization not started", privLr2.getLocalPath());
+      assertNotNull(privLr2.getLocalPath(), "Localization not started");
       privTracker1.handle(new ResourceLocalizedEvent(privReq2,
           privLr2.getLocalPath(), privLr2.getSize() + 10));
-      assertNotNull("Localization not started", appLr1.getLocalPath());
+      assertNotNull(appLr1.getLocalPath(), "Localization not started");
       appTracker1.handle(new ResourceLocalizedEvent(appReq1,
           appLr1.getLocalPath(), appLr1.getSize()));
-      assertNotNull("Localization not started", appLr3.getLocalPath());
+      assertNotNull(appLr3.getLocalPath(), "Localization not started");
       appTracker2.handle(new ResourceLocalizedEvent(appReq3,
           appLr3.getLocalPath(), appLr3.getSize() + 7));
-      assertNotNull("Localization not started", pubLr1.getLocalPath());
+      assertNotNull(pubLr1.getLocalPath(), "Localization not started");
       pubTracker.handle(new ResourceLocalizedEvent(pubReq1,
           pubLr1.getLocalPath(), pubLr1.getSize() + 1000));
-      assertNotNull("Localization not started", pubLr2.getLocalPath());
+      assertNotNull(pubLr2.getLocalPath(), "Localization not started");
       pubTracker.handle(new ResourceLocalizedEvent(pubReq2,
           pubLr2.getLocalPath(), pubLr2.getSize() + 99999));
 
@@ -724,7 +725,7 @@ public class TestResourceLocalizationService {
       assertEquals(appLr1.getSize(), recoveredRsrc.getSize());
       assertEquals(ResourceState.LOCALIZED, recoveredRsrc.getState());
       recoveredRsrc = appTracker2.getLocalizedResource(appReq2);
-      assertNull("in-progress resource should not be present", recoveredRsrc);
+      assertNull(recoveredRsrc, "in-progress resource should not be present");
       recoveredRsrc = appTracker2.getLocalizedResource(appReq3);
       assertEquals(appReq3, recoveredRsrc.getRequest());
       assertEquals(appLr3.getLocalPath(), recoveredRsrc.getLocalPath());
@@ -737,7 +738,8 @@ public class TestResourceLocalizationService {
   }
   
 
-  @Test( timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   @SuppressWarnings("unchecked") // mocked generics
   public void testLocalizerRunnerException() throws Exception {
     DrainDispatcher dispatcher = new DrainDispatcher();
@@ -816,7 +818,8 @@ public class TestResourceLocalizationService {
     }
   }
 
-  @Test( timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   @SuppressWarnings("unchecked") // mocked generics
   public void testLocalizationHeartbeat() throws Exception {
     List<Path> localDirs = new ArrayList<Path>();
@@ -1126,7 +1129,8 @@ public class TestResourceLocalizationService {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testDownloadingResourcesOnContainerKill() throws Exception {
     List<Path> localDirs = new ArrayList<Path>();
     String[] sDirs = new String[1];
@@ -1826,16 +1830,16 @@ public class TestResourceLocalizationService {
 
       // verify directory creation
 
-      Assert.assertEquals(
-          "Cache directory permissions filecache/0 is incorrect", expectedPerm,
-          lfs.getFileStatus(overflowFolder).getPermission());
+      assertEquals(expectedPerm, lfs.getFileStatus(overflowFolder).getPermission(),
+          "Cache directory permissions filecache/0 is incorrect");
 
     } finally {
       dispatcher.stop();
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   @SuppressWarnings("unchecked")
   public void testLocalizerHeartbeatWhenAppCleaningUp() throws Exception {
     conf.set(YarnConfiguration.NM_LOCAL_DIRS,
@@ -1918,8 +1922,8 @@ public class TestResourceLocalizationService {
 
       // First heartbeat which schedules first resource.
       LocalizerHeartbeatResponse response = spyService.heartbeat(stat);
-      assertEquals("NM should tell localizer to be LIVE in Heartbeat.",
-          LocalizerAction.LIVE, response.getLocalizerAction());
+      assertEquals(LocalizerAction.LIVE, response.getLocalizerAction(),
+          "NM should tell localizer to be LIVE in Heartbeat.");
 
       // Cleanup container.
       spyService.handle(new ContainerLocalizationCleanupEvent(c, rsrcs));
@@ -1945,8 +1949,8 @@ public class TestResourceLocalizationService {
       }
       // Send another heartbeat.
       response = spyService.heartbeat(stat);
-      assertEquals("NM should tell localizer to DIE in Heartbeat.",
-          LocalizerAction.DIE, response.getLocalizerAction());
+      assertEquals(LocalizerAction.DIE, response.getLocalizerAction(),
+          "NM should tell localizer to DIE in Heartbeat.");
       exec.setStopLocalization();
     } finally {
       spyService.stop();
@@ -1954,7 +1958,8 @@ public class TestResourceLocalizationService {
     }
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   @SuppressWarnings("unchecked") // mocked generics
   public void testFailedPublicResource() throws Exception {
     List<Path> localDirs = new ArrayList<Path>();
@@ -2137,7 +2142,7 @@ public class TestResourceLocalizationService {
       LocalResourcesTracker tracker =
           spyService.getLocalResourcesTracker(LocalResourceVisibility.PUBLIC,
             user, appId);
-      Assert.assertNull(tracker.getLocalizedResource(pubReq));
+      assertNull(tracker.getLocalizedResource(pubReq));
 
       // test IllegalArgumentException
       String name = Long.toHexString(r.nextLong());
@@ -2163,7 +2168,7 @@ public class TestResourceLocalizationService {
       tracker =
           spyService.getLocalResourcesTracker(LocalResourceVisibility.PUBLIC,
           user, appId);
-      Assert.assertNull(tracker.getLocalizedResource(pubReq));
+      assertNull(tracker.getLocalizedResource(pubReq));
 
       // test RejectedExecutionException by shutting down the thread pool
       PublicLocalizer publicLocalizer = spyService.getPublicLocalizer();
@@ -2174,7 +2179,7 @@ public class TestResourceLocalizationService {
       tracker =
           spyService.getLocalResourcesTracker(LocalResourceVisibility.PUBLIC,
             user, appId);
-      Assert.assertNull(tracker.getLocalizedResource(pubReq));
+      assertNull(tracker.getLocalizedResource(pubReq));
 
     } finally {
       // if we call stop with events in the queue, an InterruptedException gets
@@ -2184,7 +2189,8 @@ public class TestResourceLocalizationService {
     }
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   @SuppressWarnings("unchecked")
   public void testParallelDownloadAttemptsForPrivateResource() throws Exception {
 
@@ -2250,8 +2256,7 @@ public class TestResourceLocalizationService {
       dispatcher1.getEventHandler().handle(
         createContainerLocalizationEvent(container1,
           LocalResourceVisibility.PRIVATE, req));
-      Assert
-        .assertTrue(waitForPrivateDownloadToStart(rls, localizerId1, 1, 5000));
+      assertTrue(waitForPrivateDownloadToStart(rls, localizerId1, 1, 5000));
 
       // Container - 2 now makes the request.
       ContainerImpl container2 = createMockContainer(user, 2);
@@ -2264,8 +2269,7 @@ public class TestResourceLocalizationService {
       dispatcher1.getEventHandler().handle(
         createContainerLocalizationEvent(container2,
           LocalResourceVisibility.PRIVATE, req));
-      Assert
-        .assertTrue(waitForPrivateDownloadToStart(rls, localizerId2, 1, 5000));
+      assertTrue(waitForPrivateDownloadToStart(rls, localizerId2, 1, 5000));
 
       // Retrieving localized resource.
       LocalResourcesTracker tracker =
@@ -2273,9 +2277,9 @@ public class TestResourceLocalizationService {
             appId);
       LocalizedResource lr = tracker.getLocalizedResource(req);
       // Resource would now have moved into DOWNLOADING state
-      Assert.assertEquals(ResourceState.DOWNLOADING, lr.getState());
+      assertEquals(ResourceState.DOWNLOADING, lr.getState());
       // Resource should have one permit
-      Assert.assertEquals(1, lr.sem.availablePermits());
+      assertEquals(1, lr.sem.availablePermits());
 
       // Resource Localization Service receives first heart beat from
       // ContainerLocalizer for container1
@@ -2283,11 +2287,11 @@ public class TestResourceLocalizationService {
           rls.heartbeat(createLocalizerStatus(localizerId1));
 
       // Resource must have been added to scheduled map
-      Assert.assertEquals(1, localizerRunner1.scheduled.size());
+      assertEquals(1, localizerRunner1.scheduled.size());
       // Checking resource in the response and also available permits for it.
-      Assert.assertEquals(req.getResource(), response1.getResourceSpecs()
+      assertEquals(req.getResource(), response1.getResourceSpecs()
         .get(0).getResource().getResource());
-      Assert.assertEquals(0, lr.sem.availablePermits());
+      assertEquals(0, lr.sem.availablePermits());
 
       // Resource Localization Service now receives first heart beat from
       // ContainerLocalizer for container2
@@ -2295,21 +2299,20 @@ public class TestResourceLocalizationService {
           rls.heartbeat(createLocalizerStatus(localizerId2));
 
       // Resource must not have been added to scheduled map
-      Assert.assertEquals(0, localizerRunner2.scheduled.size());
+      assertEquals(0, localizerRunner2.scheduled.size());
       // No resource is returned in response
-      Assert.assertEquals(0, response2.getResourceSpecs().size());
+      assertEquals(0, response2.getResourceSpecs().size());
 
       // ContainerLocalizer - 1 now sends failed resource heartbeat.
       rls.heartbeat(createLocalizerStatusForFailedResource(localizerId1, req));
 
       // Resource Localization should fail and state is modified accordingly.
       // Also Local should be release on the LocalizedResource.
-      Assert
-        .assertTrue(waitForResourceState(lr, rls, req,
+      assertTrue(waitForResourceState(lr, rls, req,
           LocalResourceVisibility.PRIVATE, user, appId, ResourceState.FAILED,
           5000));
-      Assert.assertTrue(lr.getState().equals(ResourceState.FAILED));
-      Assert.assertEquals(0, localizerRunner1.scheduled.size());
+      assertTrue(lr.getState().equals(ResourceState.FAILED));
+      assertEquals(0, localizerRunner1.scheduled.size());
 
       // Now Container-2 once again sends heart beat to resource localization
       // service
@@ -2321,9 +2324,9 @@ public class TestResourceLocalizationService {
       // Resource must not have been added to scheduled map.
       // Also as the resource has failed download it will be removed from
       // pending list.
-      Assert.assertEquals(0, localizerRunner2.scheduled.size());
-      Assert.assertEquals(0, localizerRunner2.pending.size());
-      Assert.assertEquals(0, response2.getResourceSpecs().size());
+      assertEquals(0, localizerRunner2.scheduled.size());
+      assertEquals(0, localizerRunner2.pending.size());
+      assertEquals(0, response2.getResourceSpecs().size());
 
     } finally {
       if (dispatcher1 != null) {
@@ -2334,7 +2337,8 @@ public class TestResourceLocalizationService {
   
   
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   @SuppressWarnings("unchecked")
   public void testLocalResourcePath() throws Exception {
 
@@ -2422,8 +2426,7 @@ public class TestResourceLocalizationService {
 
       // Now waiting for resource download to start. Here actual will not start
       // Only the resources will be populated into pending list.
-      Assert
-        .assertTrue(waitForPrivateDownloadToStart(rls, localizerId1, 2, 5000));
+      assertTrue(waitForPrivateDownloadToStart(rls, localizerId1, 2, 5000));
 
       // Validating user and application cache paths
 
@@ -2457,12 +2460,12 @@ public class TestResourceLocalizationService {
           if (resourceSpec.getResource().getVisibility() ==
               LocalResourceVisibility.APPLICATION) {
             appRsrc = true;
-            Assert.assertEquals(userAppCachePath, destinationDirectory
+            assertEquals(userAppCachePath, destinationDirectory
               .getParent().toUri().toString());
           } else if (resourceSpec.getResource().getVisibility() == 
               LocalResourceVisibility.PRIVATE) {
             privRsrc = true;
-            Assert.assertEquals(userCachePath, destinationDirectory.getParent()
+            assertEquals(userCachePath, destinationDirectory.getParent()
               .toUri().toString());
           } else {
             throw new Exception("Unexpected resource received.");
@@ -2470,7 +2473,7 @@ public class TestResourceLocalizationService {
         }
       }
       // We should receive both the resources (Application and Private)
-      Assert.assertTrue(appRsrc && privRsrc);
+      assertTrue(appRsrc && privRsrc);
     } finally {
       if (dispatcher1 != null) {
         dispatcher1.stop();
@@ -2505,7 +2508,8 @@ public class TestResourceLocalizationService {
       LocalizationEventType.INIT_APPLICATION_RESOURCES, app);
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   @SuppressWarnings("unchecked")
   public void testParallelDownloadAttemptsForPublicResource() throws Exception {
 
@@ -2547,7 +2551,7 @@ public class TestResourceLocalizationService {
       spyService.init(conf);
 
       // Initially pending map should be empty for public localizer
-      Assert.assertEquals(0, spyService.getPublicLocalizer().pending.size());
+      assertEquals(0, spyService.getPublicLocalizer().pending.size());
 
       LocalResourceRequest req =
           new LocalResourceRequest(new Path("/tmp"), 123L,
@@ -2571,23 +2575,23 @@ public class TestResourceLocalizationService {
           LocalResourceVisibility.PUBLIC, req));
 
       // Waiting for resource to change into DOWNLOADING state.
-      Assert.assertTrue(waitForResourceState(null, spyService, req,
+      assertTrue(waitForResourceState(null, spyService, req,
         LocalResourceVisibility.PUBLIC, user, null, ResourceState.DOWNLOADING,
         5000));
 
       // Waiting for download to start.
-      Assert.assertTrue(waitForPublicDownloadToStart(spyService, 1, 5000));
+      assertTrue(waitForPublicDownloadToStart(spyService, 1, 5000));
 
       LocalizedResource lr =
           getLocalizedResource(spyService, req, LocalResourceVisibility.PUBLIC,
             user, null);
       // Resource would now have moved into DOWNLOADING state
-      Assert.assertEquals(ResourceState.DOWNLOADING, lr.getState());
+      assertEquals(ResourceState.DOWNLOADING, lr.getState());
 
       // pending should have this resource now.
-      Assert.assertEquals(1, spyService.getPublicLocalizer().pending.size());
+      assertEquals(1, spyService.getPublicLocalizer().pending.size());
       // Now resource should have 0 permit.
-      Assert.assertEquals(0, lr.sem.availablePermits());
+      assertEquals(0, lr.sem.availablePermits());
 
       // Container - 2
 
@@ -2599,7 +2603,7 @@ public class TestResourceLocalizationService {
 
       // Waiting for download to start. This should return false as new download
       // will not start
-      Assert.assertFalse(waitForPublicDownloadToStart(spyService, 2, 5000));
+      assertFalse(waitForPublicDownloadToStart(spyService, 2, 5000));
 
       // Now Failing the resource download. As a part of it
       // resource state is changed and then lock is released.
@@ -2610,9 +2614,9 @@ public class TestResourceLocalizationService {
         null).handle(locFailedEvent);
 
       // Waiting for resource to change into FAILED state.
-      Assert.assertTrue(waitForResourceState(lr, spyService, req,
+      assertTrue(waitForResourceState(lr, spyService, req,
         LocalResourceVisibility.PUBLIC, user, null, ResourceState.FAILED, 5000));
-      Assert.assertTrue(waitForResourceState(lr, spyService, req,
+      assertTrue(waitForResourceState(lr, spyService, req,
           LocalResourceVisibility.APPLICATION, user, appId, ResourceState.FAILED, 5000));
 
       // releasing lock as a part of download failed process.
@@ -2634,9 +2638,9 @@ public class TestResourceLocalizationService {
       dispatcher1.getEventHandler().handle(localizerEvent);
       // Waiting for download to start. This should return false as new download
       // will not start
-      Assert.assertFalse(waitForPublicDownloadToStart(spyService, 1, 5000));
+      assertFalse(waitForPublicDownloadToStart(spyService, 1, 5000));
       // Checking available permits now.
-      Assert.assertEquals(1, lr.sem.availablePermits());
+      assertEquals(1, lr.sem.availablePermits());
 
     } finally {
       if (dispatcher1 != null) {
@@ -2855,9 +2859,8 @@ public class TestResourceLocalizationService {
     Token<? extends TokenIdentifier> tk = getToken(id);
     String fingerprint = ResourceLocalizationService.buildTokenFingerprint(tk);
     assertNotNull(fingerprint);
-    assertTrue(
-        "Expected token fingerprint of 10 hex bytes delimited by space.",
-        fingerprint.matches("^(([0-9a-f]){2} ){9}([0-9a-f]){2}$"));
+    assertTrue(fingerprint.matches("^(([0-9a-f]){2} ){9}([0-9a-f]){2}$"),
+        "Expected token fingerprint of 10 hex bytes delimited by space.");
     creds.addToken(new Text("tok" + id), tk);
     when(c.getCredentials()).thenReturn(creds);
     when(c.toString()).thenReturn(cId.toString());
@@ -3050,26 +3053,26 @@ public class TestResourceLocalizationService {
       int privRsrcCount = 0;
       for (LocalizedResource lr : privTracker) {
         privRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 2, lr.getRefCount());
-        Assert.assertEquals(privReq, lr.getRequest());
+        assertEquals(2, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(privReq, lr.getRequest());
       }
-      Assert.assertEquals(1, privRsrcCount);
+      assertEquals(1, privRsrcCount);
 
       int appRsrcCount = 0;
       for (LocalizedResource lr : appTracker) {
         appRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 1, lr.getRefCount());
-        Assert.assertEquals(appReq, lr.getRequest());
+        assertEquals(1, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(appReq, lr.getRequest());
       }
-      Assert.assertEquals(1, appRsrcCount);
+      assertEquals(1, appRsrcCount);
 
       int pubRsrcCount = 0;
       for (LocalizedResource lr : pubTracker) {
         pubRsrcCount++;
-        Assert.assertEquals("Incorrect reference count", 1, lr.getRefCount());
-        Assert.assertEquals(pubReq, lr.getRequest());
+        assertEquals(1, lr.getRefCount(), "Incorrect reference count");
+        assertEquals(pubReq, lr.getRequest());
       }
-      Assert.assertEquals(1, pubRsrcCount);
+      assertEquals(1, pubRsrcCount);
 
       // setup mocks for test, a set of dirs with IOExceptions and let the rest
       // go through
@@ -3100,7 +3103,7 @@ public class TestResourceLocalizationService {
                 delService, user, containerLocalDirs.get(i), null)));
             verify(delService, times(1)).delete(argThat(new FileDeletionMatcher(
                 delService, null, nmLocalContainerDirs.get(i), null)));
-            Assert.fail("deletion attempts for invalid dirs");
+            fail("deletion attempts for invalid dirs");
           } catch (Throwable e) {
             continue;
           }
@@ -3148,7 +3151,7 @@ public class TestResourceLocalizationService {
                 delService, user, containerLocalDirs.get(i), null)));
             verify(delService, times(1)).delete(argThat(new FileDeletionMatcher(
                 delService, null, nmLocalContainerDirs.get(i), null)));
-            Assert.fail("deletion attempts for invalid dirs");
+            fail("deletion attempts for invalid dirs");
           } catch (Throwable e) {
             continue;
           }
@@ -3226,12 +3229,12 @@ public class TestResourceLocalizationService {
       LocalResourcesTracker pubTracker =
           spyService.getLocalResourcesTracker(LocalResourceVisibility.PUBLIC,
               user, appId);
-      Assert.assertNotNull("dirHandler for appTracker is null!",
-          ((LocalResourcesTrackerImpl)appTracker).getDirsHandler());
-      Assert.assertNotNull("dirHandler for privTracker is null!",
-          ((LocalResourcesTrackerImpl)privTracker).getDirsHandler());
-      Assert.assertNotNull("dirHandler for pubTracker is null!",
-          ((LocalResourcesTrackerImpl)pubTracker).getDirsHandler());
+      assertNotNull(((LocalResourcesTrackerImpl)appTracker).getDirsHandler(),
+          "dirHandler for appTracker is null!");
+      assertNotNull(((LocalResourcesTrackerImpl)privTracker).getDirsHandler(),
+          "dirHandler for privTracker is null!");
+      assertNotNull(((LocalResourcesTrackerImpl)pubTracker).getDirsHandler(),
+          "dirHandler for pubTracker is null!");
     } finally {
       dispatcher.stop();
       delService.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceLocalizationService.java
@@ -820,7 +820,7 @@ public class TestResourceLocalizationService {
 
   @Test
   @Timeout(value = 10)
-  @SuppressWarnings("unchecked") // mocked generics
+  @SuppressWarnings({"unchecked", "methodlength"}) // mocked generics
   public void testLocalizationHeartbeat() throws Exception {
     List<Path> localDirs = new ArrayList<Path>();
     String[] sDirs = new String[1];

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceSet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceSet.java
@@ -100,7 +100,7 @@ public class TestResourceSet {
         .iterator().next();
     assertEquals(LocalizationState.FAILED,
         status.getLocalizationState(), "status");
-    assertEquals("diagnostics", "file does not exist",
-        status.getDiagnostics());
+    assertEquals("file does not exist",
+        status.getDiagnostics(), "diagnostics");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceSet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestResourceSet.java
@@ -25,12 +25,13 @@ import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.LocalizationState;
 import org.apache.hadoop.yarn.api.records.LocalizationStatus;
 import org.apache.hadoop.yarn.api.records.URL;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests of {@link ResourceSet}.
@@ -47,12 +48,11 @@ public class TestResourceSet {
             0, System.currentTimeMillis()));
     resourceSet.addResources(resources);
 
-    Assert.assertEquals("num statuses", 1,
-        resourceSet.getLocalizationStatuses().size());
+    assertEquals(1, resourceSet.getLocalizationStatuses().size(), "num statuses");
     LocalizationStatus status = resourceSet.getLocalizationStatuses()
         .iterator().next();
-    Assert.assertEquals("status", LocalizationState.PENDING,
-        status.getLocalizationState());
+    assertEquals(LocalizationState.PENDING,
+        status.getLocalizationState(), "status");
   }
 
   @Test
@@ -70,12 +70,12 @@ public class TestResourceSet {
     LocalResourceRequest lrr = new LocalResourceRequest(resource1);
     resourceSet.resourceLocalized(lrr, new Path("file1.txt"));
 
-    Assert.assertEquals("num statuses", 1,
-        resourceSet.getLocalizationStatuses().size());
+    assertEquals(1,
+        resourceSet.getLocalizationStatuses().size(), "num statuses");
     LocalizationStatus status = resourceSet.getLocalizationStatuses()
         .iterator().next();
-    Assert.assertEquals("status", LocalizationState.COMPLETED,
-        status.getLocalizationState());
+    assertEquals(LocalizationState.COMPLETED,
+        status.getLocalizationState(), "status");
   }
 
 
@@ -94,13 +94,13 @@ public class TestResourceSet {
     LocalResourceRequest lrr = new LocalResourceRequest(resource1);
     resourceSet.resourceLocalizationFailed(lrr, "file does not exist");
 
-    Assert.assertEquals("num statuses", 1,
-        resourceSet.getLocalizationStatuses().size());
+    assertEquals(1,
+        resourceSet.getLocalizationStatuses().size(), "num statuses");
     LocalizationStatus status = resourceSet.getLocalizationStatuses()
         .iterator().next();
-    Assert.assertEquals("status", LocalizationState.FAILED,
-        status.getLocalizationState());
-    Assert.assertEquals("diagnostics", "file does not exist",
+    assertEquals(LocalizationState.FAILED,
+        status.getLocalizationState(), "status");
+    assertEquals("diagnostics", "file does not exist",
         status.getDiagnostics());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/sharedcache/TestSharedCacheUploadService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/sharedcache/TestSharedCacheUploadService.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.sharedcache;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSharedCacheUploadService {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/sharedcache/TestSharedCacheUploader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/sharedcache/TestSharedCacheUploader.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.sharedcache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doReturn;
@@ -41,7 +41,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.api.SCMUploaderProtocol;
 import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSharedCacheUploader {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestAppLogAggregatorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestAppLogAggregatorImpl.java
@@ -51,9 +51,9 @@ import org.apache.hadoop.yarn.server.nodemanager.security.NMContainerTokenSecret
 import org.apache.hadoop.yarn.server.nodemanager.security.NMTokenSecretManagerInNM;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -69,7 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -86,7 +86,7 @@ public class TestAppLogAggregatorImpl {
   private static final File REMOTE_LOG_FILE = new File("target",
       TestAppLogAggregatorImpl.class.getName() + "-remoteLogFile");
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     if(LOCAL_LOG_DIR.exists()) {
       FileUtils.cleanDirectory(LOCAL_LOG_DIR);
@@ -96,7 +96,7 @@ public class TestAppLogAggregatorImpl {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     FileUtils.deleteDirectory(LOCAL_LOG_DIR);
     FileUtils.deleteQuietly(REMOTE_LOG_FILE);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -1585,7 +1585,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   @Test
   @Timeout(value = 50)
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "methodlength"})
   public void testLogAggregationServiceWithPatterns() throws Exception {
 
     LogAggregationContext logAggregationContextWithIncludePatterns =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -150,6 +150,8 @@ import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
@@ -184,6 +186,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   private NodeId nodeId = NodeId.newInstance("0.0.0.0", 5555);
 
+  @BeforeEach
   @Override
   @SuppressWarnings("unchecked")
   public void setup() throws IOException {
@@ -195,6 +198,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     UserGroupInformation.setConfiguration(conf);
   }
 
+  @AfterEach
   @Override
   public void tearDown() throws IOException, InterruptedException {
     super.tearDown();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/logaggregation/TestLogAggregationService.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregatio
 
 import static org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.HDFS_DELEGATION_KIND;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -147,8 +150,8 @@ import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.eclipse.jetty.util.MultiException;
@@ -255,10 +258,9 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       for (String fileType : new String[]{"stdout", "stderr", "syslog", "zero"}) {
         File f = new File(containerLogDir, fileType);
         GenericTestUtils.waitFor(() -> !f.exists(), 1000, 1000 * 50);
-        Assert.assertFalse("File [" + f + "] was not deleted", f.exists());
+        assertFalse(f.exists(), "File [" + f + "] was not deleted");
       }
-      Assert.assertFalse("Directory [" + app1LogDir + "] was not deleted",
-          app1LogDir.exists());
+      assertFalse(app1LogDir.exists(), "Directory [" + app1LogDir + "] was not deleted");
     } else {
       List<Path> dirList = new ArrayList<>();
       dirList.add(new Path(app1LogDir.toURI()));
@@ -270,10 +272,9 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       Thread.sleep(5000);
       for (String fileType : new String[]{"stdout", "stderr", "syslog"}) {
         File f = new File(containerLogDir, fileType);
-        Assert.assertTrue("File [" + f + "] was not deleted", f.exists());
+        assertTrue(f.exists(), "File [" + f + "] was not deleted");
       }
-      Assert.assertTrue("Directory [" + app1LogDir + "] was not deleted",
-          app1LogDir.exists());
+      assertTrue(app1LogDir.exists(), "Directory [" + app1LogDir + "] was not deleted");
     }
     delSrvc.stop();
 
@@ -281,8 +282,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         .getLogAggregationFileController(conf)
         .getRemoteNodeLogFileForApp(application1, this.user, nodeId);
 
-    Assert.assertTrue("Log file [" + logFilePath + "] not found", new File(
-        logFilePath.toUri().getPath()).exists());
+    assertTrue(new File(logFilePath.toUri().getPath()).exists(),
+        "Log file [" + logFilePath + "] not found");
     
     dispatcher.await();
     
@@ -416,7 +417,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     assertEquals(0, logAggregationService.getNumAggregators());
     LogAggregationFileController format1 =
         logAggregationService.getLogAggregationFileController(conf);
-    Assert.assertFalse(new File(format1.getRemoteNodeLogFileForApp(
+    assertFalse(new File(format1.getRemoteNodeLogFileForApp(
         application1, this.user, this.nodeId).toUri().getPath())
         .exists());
 
@@ -677,7 +678,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     logAggregationService.init(this.conf);
     logAggregationService.start();
     boolean existsBefore = aNewFile.exists();
-    assertTrue("The new file already exists!", !existsBefore);
+    assertTrue(!existsBefore, "The new file already exists!");
 
     ApplicationId appId = ApplicationId.newInstance(
         System.currentTimeMillis(), 1);
@@ -690,7 +691,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     dispatcher.await();
 
     boolean existsAfter = aNewFile.exists();
-    assertTrue("The new aggregate file is not successfully created", existsAfter);
+    assertTrue(existsAfter, "The new aggregate file is not successfully created");
     aNewFile.delete(); //housekeeping
     logAggregationService.stop();
   }
@@ -721,8 +722,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         UserGroupInformation.getLoginUser().getPrimaryGroupName();
     FileSystem fs = FileSystem.get(this.conf);
     FileStatus fileStatus = fs.getFileStatus(aNewFile);
-    Assert.assertEquals("The new aggregate file is not successfully created",
-        fileStatus.getGroup(), targetGroup);
+    assertEquals(fileStatus.getGroup(), targetGroup,
+        "The new aggregate file is not successfully created");
 
     fs.delete(aNewFile, true);
     logAggregationService.stop();
@@ -943,8 +944,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     AppLogAggregator appAgg =
         logAggregationService.getAppLogAggregators().get(appId);
-    Assert.assertFalse("Aggregation should be disabled",
-        appAgg.isAggregationEnabled());
+    assertFalse(appAgg.isAggregationEnabled(), "Aggregation should be disabled");
 
     // Enabled aggregation
     logAggregationService.handle(new LogHandlerTokenUpdatedEvent());
@@ -952,11 +952,10 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     appAgg =
         logAggregationService.getAppLogAggregators().get(appId);
-    Assert.assertFalse("Aggregation should be enabled",
-        appAgg.isAggregationEnabled());
+    assertFalse(appAgg.isAggregationEnabled(), "Aggregation should be enabled");
 
     // Check disabled apps are cleared
-    Assert.assertEquals(0, logAggregationService.getInvalidTokenApps().size());
+    assertEquals(0, logAggregationService.getInvalidTokenApps().size());
 
     logAggregationService.handle(new LogHandlerAppFinishedEvent(
         BuilderUtils.newApplicationId(1, 5)));
@@ -1021,18 +1020,18 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
           FileContext.getFileContext(qualifiedLogDir.toUri(), this.conf)
             .listStatus(appLogDir);
     } catch (FileNotFoundException fnf) {
-      Assert.fail("Should have log files");
+      fail("Should have log files");
     }
     if (numOfLogsPerContainer == 0) {
-      Assert.assertTrue(!nodeFiles.hasNext());
+      assertTrue(!nodeFiles.hasNext());
       return null;
     }
 
-    Assert.assertTrue(nodeFiles.hasNext());
+    assertTrue(nodeFiles.hasNext());
     FileStatus targetNodeFile = null;
     if (! multiLogs) {
       targetNodeFile = nodeFiles.next();
-      Assert.assertTrue(targetNodeFile.getPath().getName().equals(
+      assertTrue(targetNodeFile.getPath().getName().equals(
         LogAggregationUtils.getNodeString(logAggregationService.getNodeId())));
     } else {
       long fileCreateTime = 0;
@@ -1049,13 +1048,13 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         }
       }
       String[] fileName = targetNodeFile.getPath().getName().split("_");
-      Assert.assertTrue(fileName.length == 3);
-      Assert.assertEquals(fileName[0] + ":" + fileName[1],
+      assertTrue(fileName.length == 3);
+      assertEquals(fileName[0] + ":" + fileName[1],
         logAggregationService.getNodeId().toString());
     }
     AggregatedLogFormat.LogReader reader =
         new AggregatedLogFormat.LogReader(this.conf, targetNodeFile.getPath());
-    Assert.assertEquals(this.user, reader.getApplicationOwner());
+    assertEquals(this.user, reader.getApplicationOwner());
     verifyAcls(reader.getApplicationAcls());
 
     List<String> fileTypes = new ArrayList<String>();
@@ -1083,15 +1082,15 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
             String writtenLines[] = baos.toString().split(
               System.getProperty("line.separator"));
 
-            Assert.assertEquals("LogType:", writtenLines[0].substring(0, 8));
+            assertEquals("LogType:", writtenLines[0].substring(0, 8));
             String fileType = writtenLines[0].substring(8);
             fileTypes.add(fileType);
 
-            Assert.assertEquals("LogLength:", writtenLines[1].substring(0, 10));
+            assertEquals("LogLength:", writtenLines[1].substring(0, 10));
             String fileLengthStr = writtenLines[1].substring(10);
             long fileLength = Long.parseLong(fileLengthStr);
 
-            Assert.assertEquals("Log Contents:",
+            assertEquals("Log Contents:",
               writtenLines[2].substring(0, 13));
 
             String logContents = StringUtils.join(
@@ -1112,37 +1111,39 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       }
 
       // 1 for each container
-      Assert.assertTrue("number of containers with logs should be at least " +
-          minNumOfContainers,logMap.size() >= minNumOfContainers);
-      Assert.assertTrue("number of containers with logs should be at most " +
-          minNumOfContainers,logMap.size() <= maxNumOfContainers);
+      assertTrue(logMap.size() >= minNumOfContainers,
+          "number of containers with logs should be at least " +
+          minNumOfContainers);
+      assertTrue(logMap.size() <= maxNumOfContainers,
+          "number of containers with logs should be at most " +
+          minNumOfContainers);
       for (ContainerId cId : expectedContainerIds) {
         String containerStr = cId.toString();
         Map<String, String> thisContainerMap = logMap.remove(containerStr);
-        Assert.assertEquals(numOfLogsPerContainer, thisContainerMap.size());
+        assertEquals(numOfLogsPerContainer, thisContainerMap.size());
         for (String fileType : logFiles) {
           String expectedValue =
               containerStr + " Hello " + fileType + "!\nEnd of LogType:"
                   + fileType;
           LOG.info("Expected log-content : " + new String(expectedValue));
           String foundValue = thisContainerMap.remove(fileType);
-          Assert.assertNotNull(cId + " " + fileType
-              + " not present in aggregated log-file!", foundValue);
-          Assert.assertEquals(expectedValue, foundValue);
+          assertNotNull(foundValue, cId + " " + fileType
+              + " not present in aggregated log-file!");
+          assertEquals(expectedValue, foundValue);
         }
         for (String emptyFile : zeroLengthLogFiles) {
           String foundValue = thisContainerMap.remove(emptyFile);
           String expectedValue = "\nEnd of LogType:" + emptyFile;
-          Assert.assertEquals(expectedValue, foundValue);
+          assertEquals(expectedValue, foundValue);
         }
-        Assert.assertEquals(0, thisContainerMap.size());
+        assertEquals(0, thisContainerMap.size());
       }
-      Assert.assertTrue("number of remaining containers should be at least " +
-          (minNumOfContainers - expectedContainerIds.length),
-          logMap.size() >= minNumOfContainers - expectedContainerIds.length);
-      Assert.assertTrue("number of remaining containers should be at most " +
-          (maxNumOfContainers - expectedContainerIds.length),
-          logMap.size() <= maxNumOfContainers - expectedContainerIds.length);
+      assertTrue(logMap.size() >= minNumOfContainers - expectedContainerIds.length,
+          "number of remaining containers should be at least " +
+          (minNumOfContainers - expectedContainerIds.length));
+      assertTrue(logMap.size() <= maxNumOfContainers - expectedContainerIds.length,
+          "number of remaining containers should be at most " +
+          (maxNumOfContainers - expectedContainerIds.length));
 
       return new LogFileStatusInLastCycle(targetNodeFile.getPath().getName(),
           fileTypes);
@@ -1216,9 +1217,9 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   private void verifyAcls(Map<ApplicationAccessType, String> logAcls) {
-    Assert.assertEquals(this.acls.size(), logAcls.size());
+    assertEquals(this.acls.size(), logAcls.size());
     for (ApplicationAccessType appAccessType : this.acls.keySet()) {
-      Assert.assertEquals(this.acls.get(appAccessType),
+      assertEquals(this.acls.get(appAccessType),
           logAcls.get(appAccessType));
     }
   }
@@ -1238,7 +1239,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     return appAcls;
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testFixedSizeThreadPool() throws Exception {
     // store configured thread pool size temporarily for restoration
     int initThreadPoolSize = conf.getInt(YarnConfiguration
@@ -1340,8 +1342,9 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         }
     };
 
-    assertTrue("The thread pool size must be invalid to use with this " +
-        "method", isInputInvalid.get());
+    assertTrue(isInputInvalid.get(),
+        "The thread pool size must be invalid to use with this " +
+        "method");
 
 
     // store configured thread pool size temporarily for restoration
@@ -1365,11 +1368,11 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     ThreadPoolExecutor executorService = (ThreadPoolExecutor)
         logAggregationService.threadPool;
-    assertEquals("The thread pool size should be set to the value of YARN" +
+    assertEquals(YarnConfiguration.DEFAULT_NM_LOG_AGGREGATION_THREAD_POOL_SIZE,
+        executorService.getMaximumPoolSize(),
+        "The thread pool size should be set to the value of YARN" +
         ".DEFAULT_NM_LOG_AGGREGATION_THREAD_POOL_SIZE because the configured "
-         + " thread pool size is " + "invalid.",
-        YarnConfiguration.DEFAULT_NM_LOG_AGGREGATION_THREAD_POOL_SIZE,
-        executorService.getMaximumPoolSize());
+        + " thread pool size is " + "invalid.");
 
     logAggregationService.stop();
     logAggregationService.close();
@@ -1379,7 +1382,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
          initThreadPoolSize);
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testStopAfterError() throws Exception {
     DeletionService delSrvc = mock(DeletionService.class);
 
@@ -1430,8 +1434,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       Thread.sleep(100);
       timeToWait -= 100;
     }
-    Assert.assertEquals("Log aggregator failed to cleanup!", 0,
-        logAggregationService.getNumAggregators());
+    assertEquals(0, logAggregationService.getNumAggregators(),
+        "Log aggregator failed to cleanup!");
     logAggregationService.stop();
     logAggregationService.close();
   }
@@ -1450,7 +1454,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     // batch up exceptions so junit presents them as one
     MultiException failures = new MultiException();
     try {
-      assertEquals("expected events", expectedEvents.length, actualEvents.size());
+      assertEquals(expectedEvents.length, actualEvents.size(), "expected events");
     } catch (Throwable e) {
       failures.add(e);
     }
@@ -1463,7 +1467,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
               ? eventToString(expectedEvents[n], methods) : null;
           String actual = (n < actualEvents.size())
               ? eventToString(actualEvents.get(n), methods) : null;
-          assertEquals("event#"+n, expect, actual);
+          assertEquals(expect, actual, "event#"+n);
         } catch (Throwable e) {
           failures.add(e);
         }
@@ -1478,14 +1482,14 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       for (T actualEvent : actualEvents) {
         try {
           String actual = eventToString(actualEvent, methods);
-          assertTrue("unexpected event: "+actual, expectedSet.remove(actual));
+          assertTrue(expectedSet.remove(actual), "unexpected event: "+actual);
         } catch (Throwable e) {
           failures.add(e);
         }
       }
       for (String expected : expectedSet) {
         try {
-          Assert.fail("missing event: "+expected);
+          fail("missing event: "+expected);
         } catch (Throwable e) {
           failures.add(e);
         }
@@ -1575,7 +1579,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
       "getApplicationID");
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testLogAggregationServiceWithPatterns() throws Exception {
 
@@ -1758,7 +1763,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   @SuppressWarnings("resource")
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   public void testLogAggregationServiceWithPatternsAndIntervals()
       throws Exception {
     LogAggregationContext logAggregationContext =
@@ -1823,7 +1829,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     aggregator.doLogAggregationOutOfBand();
 
-    Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+    assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 1, false, null));
 
     String[] logFiles = new String[] { "stdout" };
@@ -1841,7 +1847,7 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     // even if the app is running but the container finishes.
     aggregator.doLogAggregationOutOfBand();
 
-    Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+    assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 2, false, null));
 
     // This container finishes.
@@ -1856,7 +1862,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     logAggregationService.stop();
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testNoneContainerPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -1876,7 +1883,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifyLogAggFinishEvent(appId);
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testFailedContainerPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -1900,7 +1908,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifyLogAggFinishEvent(appId);
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testLimitSizeContainerLogAggregationPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -1929,7 +1938,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifyLogAggFinishEvent(appId);
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testAMOrFailedContainerPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -1954,7 +1964,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifyLogAggFinishEvent(appId);
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testFailedOrKilledContainerPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -1979,7 +1990,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifyLogAggFinishEvent(appId);
   }
 
-  @Test(timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   public void testLogAggregationAbsentContainer() throws Exception {
     ApplicationId appId = createApplication();
     LogAggregationService logAggregationService =
@@ -1992,7 +2004,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         containerId, ContainerType.APPLICATION_MASTER, 100));
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testAMOnlyContainerPolicy() throws Exception {
     ApplicationId appId = createApplication();
@@ -2019,7 +2032,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   // the same number of successful containers as
   // SampleContainerLogAggregationPolicy.DEFAULT_SAMPLE_MIN_THRESHOLD.
   // and verify all those containers' logs are aggregated.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWithSmallApp() throws Exception {
     setupAndTestSampleContainerPolicy(
@@ -2033,7 +2047,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   // more successful containers than
   // SampleContainerLogAggregationPolicy.DEFAULT_SAMPLE_MIN_THRESHOLD.
   // and verify some of those containers' logs are aggregated.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWithLargeApp() throws Exception {
     setupAndTestSampleContainerPolicy(
@@ -2045,7 +2060,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   // Test sample container policy with zero sample rate.
   // and verify there is no sampling beyond the MIN_THRESHOLD containers.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWithZeroSampleRate() throws Exception {
     setupAndTestSampleContainerPolicy(
@@ -2056,7 +2072,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   // Test sample container policy with 100 percent sample rate.
   // and verify all containers' logs are aggregated.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWith100PercentSampleRate()
       throws Exception {
@@ -2069,7 +2086,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   // Test sample container policy with zero min threshold.
   // and verify some containers' logs are aggregated.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWithZeroMinThreshold()
       throws Exception {
@@ -2080,7 +2098,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
   // Test sample container policy with customized settings.
   // and verify some containers' logs are aggregated.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testSampleContainerPolicyWithCustomizedSettings()
       throws Exception {
@@ -2088,7 +2107,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   // Test cluster-wide sample container policy.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testClusterSampleContainerPolicy()
       throws Exception {
@@ -2096,7 +2116,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
   // Test the default cluster-wide sample container policy.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testDefaultClusterSampleContainerPolicy() throws Exception {
     setupAndTestSampleContainerPolicy(
@@ -2109,7 +2130,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   // The application specifies invalid policy class
   // NM should fallback to the default policy which is to aggregate all
   // containers.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testInvalidPolicyClassName() throws Exception {
     ApplicationId appId = createApplication();
@@ -2121,7 +2143,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   // The application specifies LogAggregationContext, but not policy class.
   // NM should fallback to the default policy which is to aggregate all
   // containers.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testNullPolicyClassName() throws Exception {
     ApplicationId appId = createApplication();
@@ -2133,7 +2156,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   // The application doesn't specifies LogAggregationContext.
   // NM should fallback to the default policy which is to aggregate all
   // containers.
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   @SuppressWarnings("unchecked")
   public void testDefaultPolicyWithoutLogAggregationContext()
       throws Exception {
@@ -2364,12 +2388,14 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
             "getApplicationID");
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   public void testLogAggregationServiceWithInterval() throws Exception {
     testLogAggregationService(false);
   }
 
-  @Test (timeout = 50000)
+  @Test
+  @Timeout(value = 50)
   public void testLogAggregationServiceWithRetention() throws Exception {
     testLogAggregationService(true);
   }
@@ -2450,21 +2476,21 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     aggregator.doLogAggregationOutOfBand();
 
     if (retentionSizeLimitation) {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 1, true, null));
     } else {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 1, false, null));
     }
     // Container logs should be uploaded
     logFileStatusInLastCycle = verifyContainerLogs(logAggregationService, application,
         new ContainerId[] {container}, logFiles1, 4, true, EMPTY_FILES);
     for(String logFile : logFiles1) {
-      Assert.assertTrue(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
+      assertTrue(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
         .contains(logFile));
     }
     // Make sure the std_final is not uploaded.
-    Assert.assertFalse(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
+    assertFalse(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
       .contains("std_final"));
 
     Thread.sleep(2000);
@@ -2474,10 +2500,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
 
     // Same logs will not be aggregated again.
     // Only one aggregated log file in Remote file directory.
-    Assert.assertTrue(
-        "Only one aggregated log file in Remote file directory expected",
-        waitAndCheckLogNum(logAggregationService, application, 50, 1, true,
-            null));
+    assertTrue(waitAndCheckLogNum(logAggregationService, application, 50, 1, true,
+        null), "Only one aggregated log file in Remote file directory expected");
 
     Thread.sleep(2000);
 
@@ -2488,10 +2512,10 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     aggregator.doLogAggregationOutOfBand();
 
     if (retentionSizeLimitation) {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 1, true, logFileStatusInLastCycle.getLogFilePathInLastCycle()));
     } else {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 2, false, null));
     }
     // Container logs should be uploaded
@@ -2499,11 +2523,11 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
         new ContainerId[] {container}, logFiles2, 4, true, EMPTY_FILES);
 
     for(String logFile : logFiles2) {
-      Assert.assertTrue(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
+      assertTrue(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
         .contains(logFile));
     }
     // Make sure the std_final is not uploaded.
-    Assert.assertFalse(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
+    assertFalse(logFileStatusInLastCycle.getLogFileTypesInLastCycle()
       .contains("std_final"));
 
     Thread.sleep(2000);
@@ -2519,10 +2543,10 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     dispatcher.await();
     logAggregationService.handle(new LogHandlerAppFinishedEvent(application));
     if (retentionSizeLimitation) {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 1, true, logFileStatusInLastCycle.getLogFilePathInLastCycle()));
     } else {
-      Assert.assertTrue(waitAndCheckLogNum(logAggregationService, application,
+      assertTrue(waitAndCheckLogNum(logAggregationService, application,
         50, 3, false, null));
     }
 
@@ -2537,7 +2561,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
   }
 
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testAddNewTokenSentFromRMForLogAggregation() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -2591,7 +2616,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     logAggregationService.stop();
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testRemoveExpiredDelegationTokensBeforeUpload() throws Exception {
     Configuration conf = new YarnConfiguration();
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -2656,7 +2682,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     return expiredToken;
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testSkipUnnecessaryNNOperationsForShortJob() throws Exception {
     LogAggregationContext logAggregationContext =
         Records.newRecord(LogAggregationContext.class);
@@ -2665,7 +2692,8 @@ public class TestLogAggregationService extends BaseContainerManagerTest {
     verifySkipUnnecessaryNNOperations(logAggregationContext, 0, 2, 0);
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testSkipUnnecessaryNNOperationsForService() throws Exception {
     this.conf.setLong(
         YarnConfiguration.NM_LOG_AGGREGATION_ROLL_MONITORING_INTERVAL_SECONDS,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/TestNonAggregatingLogHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/loghandler/TestNonAggregatingLogHandler.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.loghandler;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -78,9 +78,9 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMMemoryStateStoreServ
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMNullStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -99,7 +99,7 @@ public class TestNonAggregatingLogHandler {
   ContainerId container11;
   LocalDirsHandlerService dirsHandler;
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void setup() {
     mockDelService = mock(DeletionService.class);
@@ -113,7 +113,7 @@ public class TestNonAggregatingLogHandler {
     dirsHandler = new LocalDirsHandlerService();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     dirsHandler.stop();
     dirsHandler.close();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainerMetrics.java
@@ -26,16 +26,15 @@ import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class TestContainerMetrics {
@@ -51,30 +50,30 @@ public class TestContainerMetrics {
 
     metrics.recordMemoryUsage(1024);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 0, collector.getRecords().size());
+    assertEquals(0, collector.getRecords().size(), ERR);
 
     Thread.sleep(110);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), ERR);
     collector.clear();
 
     Thread.sleep(110);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), ERR);
     collector.clear();
 
     metrics.finished(false);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), ERR);
     collector.clear();
 
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), ERR);
     collector.clear();
 
     Thread.sleep(110);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), ERR);
   }
 
   @Test
@@ -100,7 +99,7 @@ public class TestContainerMetrics {
 
     Thread.sleep(110);
     metrics.getMetrics(collector, true);
-    assertEquals(ERR, 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(),ERR);
     MetricsRecord record = collector.getRecords().get(0);
 
     MetricsRecords.assertTag(record, ContainerMetrics.PROCESSID_INFO.name(),
@@ -197,14 +196,13 @@ public class TestContainerMetrics {
         String metricName = metric.name();
         if (expectedValues.containsKey(metricName)) {
           Long expectedValue = expectedValues.get(metricName);
-          Assert.assertEquals(
-              "Metric " + metricName + " doesn't have expected value",
-              expectedValue, metric.value());
+          assertEquals(expectedValue, metric.value(),
+              "Metric " + metricName + " doesn't have expected value");
           testResults.add(metricName);
         }
       }
     }
-    Assert.assertEquals(expectedValues.keySet(), testResults);
+    assertEquals(expectedValues.keySet(), testResults);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainerMetrics.java
@@ -99,7 +99,7 @@ public class TestContainerMetrics {
 
     Thread.sleep(110);
     metrics.getMetrics(collector, true);
-    assertEquals(1, collector.getRecords().size(),ERR);
+    assertEquals(1, collector.getRecords().size(), ERR);
     MetricsRecord record = collector.getRecords().get(0);
 
     MetricsRecords.assertTag(record, ContainerMetrics.PROCESSID_INFO.name(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitor.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -87,9 +87,9 @@ import org.apache.hadoop.yarn.util.ProcfsBasedProcessTree;
 import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
 import org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
@@ -104,7 +104,7 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
     LOG = LoggerFactory.getLogger(TestContainersMonitor.class);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf.setClass(
         YarnConfiguration.NM_MON_RESOURCE_CALCULATOR,
@@ -185,35 +185,34 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
                                           "100",
                                           procfsRootDir.getAbsolutePath());
       pTree.updateProcessTree();
-      assertTrue("tree rooted at 100 should be over limit " +
-                    "after first iteration.",
-                  test.isProcessTreeOverLimit(pTree, "dummyId", limit));
+      assertTrue(test.isProcessTreeOverLimit(pTree, "dummyId", limit),
+          "tree rooted at 100 should be over limit " +
+          "after first iteration.");
 
       // the tree rooted at 200 is initially below limit.
       pTree = new ProcfsBasedProcessTree("200",
                                           procfsRootDir.getAbsolutePath());
       pTree.updateProcessTree();
-      assertFalse("tree rooted at 200 shouldn't be over limit " +
-                    "after one iteration.",
-                  test.isProcessTreeOverLimit(pTree, "dummyId", limit));
+      assertFalse(test.isProcessTreeOverLimit(pTree, "dummyId", limit),
+          "tree rooted at 200 shouldn't be over limit " +
+          "after one iteration.");
       // second iteration - now the tree has been over limit twice,
       // hence it should be declared over limit.
       pTree.updateProcessTree();
-      assertTrue(
-          "tree rooted at 200 should be over limit after 2 iterations",
-                  test.isProcessTreeOverLimit(pTree, "dummyId", limit));
+      assertTrue(test.isProcessTreeOverLimit(pTree, "dummyId", limit),
+          "tree rooted at 200 should be over limit after 2 iterations");
 
       // the tree rooted at 600 is never over limit.
       pTree = new ProcfsBasedProcessTree("600",
                                             procfsRootDir.getAbsolutePath());
       pTree.updateProcessTree();
-      assertFalse("tree rooted at 600 should never be over limit.",
-                    test.isProcessTreeOverLimit(pTree, "dummyId", limit));
+      assertFalse(test.isProcessTreeOverLimit(pTree, "dummyId", limit),
+          "tree rooted at 600 should never be over limit.");
 
       // another iteration does not make any difference.
       pTree.updateProcessTree();
-      assertFalse("tree rooted at 600 should never be over limit.",
-                    test.isProcessTreeOverLimit(pTree, "dummyId", limit));
+      assertFalse(test.isProcessTreeOverLimit(pTree, "dummyId", limit),
+          "tree rooted at 600 should never be over limit.");
     } finally {
       FileUtil.fullyDelete(procfsRootDir);
     }
@@ -325,17 +324,17 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
       Thread.sleep(1000);
       LOG.info("Waiting for process start-file to be created");
     }
-    Assert.assertTrue("ProcessStartFile doesn't exist!",
-        processStartFile.exists());
+    assertTrue(processStartFile.exists(),
+        "ProcessStartFile doesn't exist!");
 
     // Now verify the contents of the file
     BufferedReader reader =
         new BufferedReader(new FileReader(processStartFile));
-    Assert.assertEquals("Hello World!", reader.readLine());
+    assertEquals("Hello World!", reader.readLine());
     // Get the pid of the process
     String pid = reader.readLine().trim();
     // No more lines
-    Assert.assertEquals(null, reader.readLine());
+    assertEquals(null, reader.readLine());
 
     BaseContainerManagerTest.waitForContainerState(containerManager, cId,
         ContainerState.COMPLETE, 60);
@@ -346,7 +345,7 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
         GetContainerStatusesRequest.newInstance(containerIds);
     ContainerStatus containerStatus =
         containerManager.getContainerStatuses(gcsRequest).getContainerStatuses().get(0);
-    Assert.assertEquals(ContainerExitStatus.KILLED_EXCEEDED_VMEM,
+    assertEquals(ContainerExitStatus.KILLED_EXCEEDED_VMEM,
         containerStatus.getExitStatus());
     String expectedMsgPattern =
         "Container \\[pid=" + pid + ",containerID=" + cId + "\\] is running "
@@ -356,17 +355,17 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
             + "Killing container.\nDump of the process-tree for "
             + cId + " :\n";
     Pattern pat = Pattern.compile(expectedMsgPattern);
-    Assert.assertEquals("Expected message pattern is: " + expectedMsgPattern
-        + "\n\nObserved message is: " + containerStatus.getDiagnostics(),
-        true, pat.matcher(containerStatus.getDiagnostics()).find());
+    assertEquals(true,
+        pat.matcher(containerStatus.getDiagnostics()).find(),
+        "Expected message pattern is: " + expectedMsgPattern
+        + "\n\nObserved message is: " + containerStatus.getDiagnostics());
 
     // Assert that the process is not alive anymore
-    Assert.assertFalse("Process is still alive!",
-        exec.signalContainer(new ContainerSignalContext.Builder()
+    assertFalse(exec.signalContainer(new ContainerSignalContext.Builder()
             .setUser(user)
             .setPid(pid)
             .setSignal(Signal.NULL)
-            .build()));
+            .build()), "Process is still alive!");
   }
 
   @SuppressWarnings("unchecked")
@@ -433,11 +432,10 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
       monitor.stop();
     }
 
-    assertTrue("Expected a kill event", event instanceof ContainerKillEvent);
+    assertTrue(event instanceof ContainerKillEvent, "Expected a kill event");
     ContainerKillEvent cke = (ContainerKillEvent) event;
-    assertEquals("Unexpected container exit status",
-        ContainerExitStatus.KILLED_FOR_EXCESS_LOGS,
-        cke.getContainerExitStatus());
+    assertEquals(ContainerExitStatus.KILLED_FOR_EXCESS_LOGS,
+        cke.getContainerExitStatus(), "Unexpected container exit status");
   }
 
   @SuppressWarnings("unchecked")
@@ -520,14 +518,14 @@ public class TestContainersMonitor extends BaseContainerManagerTest {
       monitor.stop();
     }
 
-    assertTrue("Expected a kill event", event instanceof ContainerKillEvent);
+    assertTrue(event instanceof ContainerKillEvent, "Expected a kill event");
     ContainerKillEvent cke = (ContainerKillEvent) event;
-    assertEquals("Unexpected container exit status",
-        ContainerExitStatus.KILLED_FOR_EXCESS_LOGS,
-        cke.getContainerExitStatus());
+    assertEquals(ContainerExitStatus.KILLED_FOR_EXCESS_LOGS,
+        cke.getContainerExitStatus(), "Unexpected container exit status");
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testContainerMonitorMemFlags() {
     ContainersMonitor cm = null;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/TestContainersMonitorResourceChange.java
@@ -51,15 +51,15 @@ import org.apache.hadoop.yarn.server.nodemanager.executor.ContainerStartContext;
 import org.apache.hadoop.yarn.server.nodemanager.executor.DeletionAsUserContext;
 import org.apache.hadoop.yarn.server.nodemanager.executor.LocalizerStartContext;
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestContainersMonitorResourceChange {
 
@@ -155,7 +155,7 @@ public class TestContainersMonitorResourceChange {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     executor = new MockExecutor();
     dispatcher = new AsyncDispatcher();
@@ -177,7 +177,7 @@ public class TestContainersMonitorResourceChange {
     dispatcher.register(ContainerEventType.class, containerEventHandler);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (containersMonitor != null) {
       containersMonitor.stop();
@@ -311,10 +311,9 @@ public class TestContainersMonitorResourceChange {
     // Since MockCPUResourceCalculatorProcessTree will return a -1 as CPU
     // utilization, containersUtilization will not be calculated and hence it
     // will be 0.
-    assertEquals(
-        "Resource utilization must be default with MonitorThread's first run",
-        0, containersMonitor.getContainersUtilization()
-            .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)));
+    assertEquals(0, containersMonitor.getContainersUtilization()
+        .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)),
+        "Resource utilization must be default with MonitorThread's first run");
 
     // Verify the container utilization value. Since at least one round is done,
     // we can expect a non-zero value for container utilization as
@@ -340,10 +339,10 @@ public class TestContainersMonitorResourceChange {
       timeWaiting += WAIT_MS_PER_LOOP;
     }
 
-    assertTrue("Resource utilization is not changed after " +
-            timeoutMsecs / WAIT_MS_PER_LOOP + " updates",
-        0 != containersMonitor.getContainersUtilization()
-            .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)));
+    assertTrue(0 != containersMonitor.getContainersUtilization()
+        .compareTo(ResourceUtilization.newInstance(0, 0, 0.0f)),
+         "Resource utilization is not changed after " +
+         timeoutMsecs / WAIT_MS_PER_LOOP + " updates");
   }
 
   private ContainersMonitorImpl createContainersMonitor(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/TestResourcePluginManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/TestResourcePluginManager.java
@@ -73,6 +73,7 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
 
   @BeforeEach
   public void setup() throws Exception {
+    super.setUp();
     // setup resource-types.xml
     ResourceUtils.resetResourceTypes();
     String resourceTypesFile = "resource-types-pluggable-devices.xml";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/TestResourcePluginManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/TestResourcePluginManager.java
@@ -47,9 +47,10 @@ import org.apache.hadoop.yarn.server.nodemanager.health.NodeHealthCheckerService
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.TestResourceUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +58,7 @@ import java.util.Map;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
@@ -70,7 +71,7 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   private NodeManager nm;
   private String tempResourceTypesFile;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // setup resource-types.xml
     ResourceUtils.resetResourceTypes();
@@ -102,7 +103,7 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
     return rpm;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (nm != null) {
       try {
@@ -196,7 +197,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   /**
    * Make sure {@link ResourcePluginManager} is initialized during NM start up.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testResourcePluginManagerInitialization() throws Exception {
     final ResourcePluginManager rpm = stubResourcePluginmanager();
     nm = new ResourcePluginMockNM(rpm);
@@ -209,7 +211,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   /**
    * Make sure {@link ResourcePluginManager} is invoked during NM update.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNodeStatusUpdaterWithResourcePluginsEnabled()
       throws Exception {
     final ResourcePluginManager rpm = stubResourcePluginmanager();
@@ -230,7 +233,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   /**
    * Make sure ResourcePluginManager is used to initialize ResourceHandlerChain.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testLinuxContainerExecutorWithResourcePluginsEnabled() {
     final ResourcePluginManager rpm = stubResourcePluginmanager();
     final LinuxContainerExecutor lce = new MyLCE();
@@ -290,7 +294,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
    * We use spy object of real rpm to verify "initializePluggableDevicePlugins"
    * because use mock rpm will not working
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitializationWithPluggableDeviceFrameworkDisabled()
       throws Exception {
     ResourcePluginManager rpm = new ResourcePluginManager();
@@ -309,7 +314,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   }
 
   // No related configuration set.
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitializationWithPluggableDeviceFrameworkDisabled2()
       throws Exception {
     ResourcePluginManager rpm = new ResourcePluginManager();
@@ -326,7 +332,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   }
 
   // Enable framework and configure pluggable device classes
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitializationWithPluggableDeviceFrameworkEnabled()
       throws Exception {
     ResourcePluginManager rpm = new ResourcePluginManager();
@@ -349,7 +356,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
 
   // Enable pluggable framework, but leave device classes un-configured
   // initializePluggableDevicePlugins invoked but it should throw an exception
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitializationWithPluggableDeviceFrameworkEnabled2()
       throws ClassNotFoundException {
     ResourcePluginManager rpm = new ResourcePluginManager();
@@ -373,7 +381,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
     assertThat(fail).isTrue();
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNormalInitializationOfPluggableDeviceClasses() {
     ResourcePluginManager rpm = new ResourcePluginManager();
 
@@ -398,7 +407,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   }
 
   // Fail to load a class which doesn't implement interface DevicePlugin
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testLoadInvalidPluggableDeviceClasses() {
     ResourcePluginManager rpm = new ResourcePluginManager();
 
@@ -425,7 +435,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
   }
 
   // Fail to register duplicated resource name.
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testLoadDuplicateResourceNameDevicePlugin() {
     ResourcePluginManager rpm = new ResourcePluginManager();
 
@@ -458,7 +469,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
    * Fail a plugin due to incompatible interface implemented.
    * It doesn't implement the "getRegisterRequestInfo"
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testIncompatibleDevicePlugin() {
     ResourcePluginManager rpm = new ResourcePluginManager();
 
@@ -511,7 +523,8 @@ public class TestResourcePluginManager extends NodeManagerTestBase {
     assertThat(dmm.getDevicePluginSchedulers().size()).isOne();
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testRequestedResourceNameIsConfigured() {
     ResourcePluginManager rpm = new ResourcePluginManager();
     String resourceName = "a.com/a";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
@@ -19,10 +19,11 @@
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.com.nec;
 
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -50,18 +51,18 @@ import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Shell.CommandExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for NECVEPlugin class.
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestNECVEPlugin {
   private static final String DEFAULT_SCRIPT_NAME = "nec-ve-get.py";
   private static final String[] EMPTY_SEARCH_DIRS = new String[] {};
@@ -84,7 +85,7 @@ public class TestNECVEPlugin {
 
   private NECVEPlugin plugin;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     env = new HashMap<>();
     envProvider = (String var) -> env.get(var);
@@ -101,7 +102,7 @@ public class TestNECVEPlugin {
         0);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     if (testFolder != null) {
       File f = new File(testFolder);
@@ -120,14 +121,14 @@ public class TestNECVEPlugin {
 
     Set<Device> devices = plugin.getDevices();
 
-    assertEquals("Number of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "Number of devices");
     Device device = devices.iterator().next();
-    assertEquals("Device id", 0, device.getId());
-    assertEquals("Device path", "/dev/ve0", device.getDevPath());
-    assertEquals("Bus Id", "0000:65:00.0", device.getBusID());
-    assertEquals("Status", "ONLINE", device.getStatus());
-    assertEquals("Major number", 243, device.getMajorNumber());
-    assertEquals("Minor number", 0, device.getMinorNumber());
+    assertEquals(0, device.getId(), "Device id");
+    assertEquals("/dev/ve0", device.getDevPath(), "Device path");
+    assertEquals("0000:65:00.0", device.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device.getStatus(), "Status");
+    assertEquals(243, device.getMajorNumber(), "Major number");
+    assertEquals(0, device.getMinorNumber(), "Minor number");
   }
 
   @Test
@@ -158,34 +159,34 @@ public class TestNECVEPlugin {
 
     Set<Device> devices = plugin.getDevices();
 
-    assertEquals("Number of devices", 3, devices.size());
+    assertEquals(3, devices.size(), "Number of devices");
     List<Device> devicesList = Lists.newArrayList(devices);
     // Sort devices by id
     Collections.sort(devicesList, DEVICE_COMPARATOR);
 
     Device device0 = devicesList.get(0);
-    assertEquals("Device id", 0, device0.getId());
-    assertEquals("Device path", "/dev/ve0", device0.getDevPath());
-    assertEquals("Bus Id", "0000:65:00.0", device0.getBusID());
-    assertEquals("Status", "ONLINE", device0.getStatus());
-    assertEquals("Major number", 243, device0.getMajorNumber());
-    assertEquals("Minor number", 0, device0.getMinorNumber());
+    assertEquals(0, device0.getId(), "Device id");
+    assertEquals("/dev/ve0", device0.getDevPath(), "Device path");
+    assertEquals("0000:65:00.0", device0.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device0.getStatus(), "Status");
+    assertEquals(243, device0.getMajorNumber(), "Major number");
+    assertEquals(0, device0.getMinorNumber(), "Minor number");
 
     Device device1 = devicesList.get(1);
-    assertEquals("Device id", 1, device1.getId());
-    assertEquals("Device path", "/dev/ve1", device1.getDevPath());
-    assertEquals("Bus Id", "0000:66:00.0", device1.getBusID());
-    assertEquals("Status", "ONLINE", device1.getStatus());
-    assertEquals("Major number", 244, device1.getMajorNumber());
-    assertEquals("Minor number", 1, device1.getMinorNumber());
+    assertEquals(1, device1.getId(), "Device id");
+    assertEquals("/dev/ve1", device1.getDevPath(), "Device path");
+    assertEquals("0000:66:00.0", device1.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device1.getStatus(), "Status");
+    assertEquals(244, device1.getMajorNumber(), "Major number");
+    assertEquals(1, device1.getMinorNumber(), "Minor number");
 
     Device device2 = devicesList.get(2);
-    assertEquals("Device id", 2, device2.getId());
-    assertEquals("Device path", "/dev/ve2", device2.getDevPath());
-    assertEquals("Bus Id", "0000:67:00.0", device2.getBusID());
-    assertEquals("Status", "ONLINE", device2.getStatus());
-    assertEquals("Major number", 245, device2.getMajorNumber());
-    assertEquals("Minor number", 2, device2.getMinorNumber());
+    assertEquals(2, device2.getId(), "Device id");
+    assertEquals("/dev/ve2", device2.getDevPath(), "Device path");
+    assertEquals("0000:67:00.0", device2.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device2.getStatus(), "Status");
+    assertEquals(245, device2.getMajorNumber(), "Major number");
+    assertEquals(2, device2.getMinorNumber(), "Minor number");
   }
 
   @Test
@@ -206,7 +207,7 @@ public class TestNECVEPlugin {
 
     Set<Device> devices = plugin.getDevices();
 
-    assertEquals("Number of devices", 0, devices.size());
+    assertEquals(0, devices.size(), "Number of devices");
   }
 
   @Test
@@ -231,25 +232,25 @@ public class TestNECVEPlugin {
 
     Set<Device> devices = plugin.getDevices();
 
-    assertEquals("Number of devices", 2, devices.size());
+    assertEquals(2, devices.size(), "Number of devices");
     List<Device> devicesList = Lists.newArrayList(devices);
     Collections.sort(devicesList, DEVICE_COMPARATOR);
 
     Device device0 = devicesList.get(0);
-    assertEquals("Device id", 0, device0.getId());
-    assertEquals("Device path", "/dev/ve0", device0.getDevPath());
-    assertEquals("Bus Id", "0000:65:00.0", device0.getBusID());
-    assertEquals("Status", "ONLINE", device0.getStatus());
-    assertEquals("Major number", 243, device0.getMajorNumber());
-    assertEquals("Minor number", 0, device0.getMinorNumber());
+    assertEquals(0, device0.getId(), "Device id");
+    assertEquals("/dev/ve0", device0.getDevPath(), "Device path");
+    assertEquals("0000:65:00.0", device0.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device0.getStatus(), "Status");
+    assertEquals(243, device0.getMajorNumber(), "Major number");
+    assertEquals(0, device0.getMinorNumber(), "Minor number");
 
     Device device1 = devicesList.get(1);
-    assertEquals("Device id", 1, device1.getId());
-    assertEquals("Device path", "/dev/ve1", device1.getDevPath());
-    assertEquals("Bus Id", "0000:66:00.0", device1.getBusID());
-    assertEquals("Status", "ONLINE", device1.getStatus());
-    assertEquals("Major number", 244, device1.getMajorNumber());
-    assertEquals("Minor number", 1, device1.getMinorNumber());
+    assertEquals(1, device1.getId(), "Device id");
+    assertEquals("/dev/ve1", device1.getDevPath(), "Device path");
+    assertEquals("0000:66:00.0", device1.getBusID(), "Bus Id");
+    assertEquals("ONLINE", device1.getStatus(), "Status");
+    assertEquals(244, device1.getMajorNumber(), "Major number");
+    assertEquals(1, device1.getMinorNumber(), "Minor number");
   }
 
   @Test
@@ -277,7 +278,7 @@ public class TestNECVEPlugin {
     Path scriptPath = Paths.get(testFolder, DEFAULT_SCRIPT_NAME);
     Files.createFile(scriptPath);
     scriptPath.toFile().setExecutable(true);
-    assertTrue("Cannot set executable flag", scriptPath.toFile().canExecute());
+    assertTrue(scriptPath.toFile().canExecute(), "Cannot set executable flag");
 
     env.put("NEC_VE_GET_SCRIPT_PATH",
         testFolder + "/" + DEFAULT_SCRIPT_NAME);
@@ -287,30 +288,34 @@ public class TestNECVEPlugin {
     verifyBinaryPathSet(scriptPath);
   }
 
-  @Test(expected = ResourceHandlerException.class)
+  @Test
   public void testExplicitPathPointsToDirectory()
       throws ResourceHandlerException, IOException {
-    setupTestDirectory("_temp_" + System.currentTimeMillis());
+    assertThrows(ResourceHandlerException.class, () -> {
+      setupTestDirectory("_temp_" + System.currentTimeMillis());
 
-    env.put("NEC_VE_GET_SCRIPT_PATH", testFolder);
+      env.put("NEC_VE_GET_SCRIPT_PATH", testFolder);
 
-    plugin = new NECVEPlugin(envProvider, EMPTY_SEARCH_DIRS, udevUtil);
+      plugin = new NECVEPlugin(envProvider, EMPTY_SEARCH_DIRS, udevUtil);
+    });
   }
 
-  @Test(expected = ResourceHandlerException.class)
+  @Test
   public void testExplicitPathIsNotExecutable()
       throws ResourceHandlerException, IOException{
-    setupTestDirectory("_temp_" + System.currentTimeMillis());
+    assertThrows(ResourceHandlerException.class, ()->{
+      setupTestDirectory("_temp_" + System.currentTimeMillis());
 
-    Path scriptPath = Paths.get(testFolder, DEFAULT_SCRIPT_NAME);
-    Files.createFile(scriptPath);
-    scriptPath.toFile().setExecutable(false);
-    assertFalse("File is executable", scriptPath.toFile().canExecute());
+      Path scriptPath = Paths.get(testFolder, DEFAULT_SCRIPT_NAME);
+      Files.createFile(scriptPath);
+      scriptPath.toFile().setExecutable(false);
+      assertFalse(scriptPath.toFile().canExecute(), "File is executable");
 
-    env.put("NEC_VE_GET_SCRIPT_PATH",
-        testFolder + "/" + DEFAULT_SCRIPT_NAME);
+      env.put("NEC_VE_GET_SCRIPT_PATH",
+              testFolder + "/" + DEFAULT_SCRIPT_NAME);
 
-    plugin = new NECVEPlugin(envProvider, EMPTY_SEARCH_DIRS, udevUtil);
+      plugin = new NECVEPlugin(envProvider, EMPTY_SEARCH_DIRS, udevUtil);
+    });
   }
 
   @Test
@@ -353,9 +358,9 @@ public class TestNECVEPlugin {
 
     Set<Device> allocated = plugin.allocateDevices(available, 1, env);
 
-    assertEquals("No. of devices", 1, allocated.size());
+    assertEquals(1, allocated.size(), "No. of devices");
     Device allocatedDevice = allocated.iterator().next();
-    assertSame("Device", device, allocatedDevice);
+    assertSame(device, allocatedDevice, "Device");
   }
 
   @Test
@@ -371,9 +376,9 @@ public class TestNECVEPlugin {
 
     Set<Device> allocated = plugin.allocateDevices(available, 2, env);
 
-    assertEquals("No. of devices", 2, allocated.size());
-    assertTrue("Device missing", allocated.contains(device0));
-    assertTrue("Device missing", allocated.contains(device1));
+    assertEquals(2, allocated.size(), "No. of devices");
+    assertTrue(allocated.contains(device0), "Device missing");
+    assertTrue(allocated.contains(device1), "Device missing");
   }
 
   @Test
@@ -391,9 +396,9 @@ public class TestNECVEPlugin {
 
     Set<Device> devices = plugin.getDevices();
 
-    assertEquals("No. of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "No. of devices");
     Device device = devices.iterator().next();
-    assertSame("Device", device, testDevice);
+    assertSame(device, testDevice, "Device");
     verifyZeroInteractions(mockCommandExecutor);
     verify(mockEnvProvider).apply(eq("NEC_USE_UDEV"));
     verifyNoMoreInteractions(mockEnvProvider);
@@ -440,8 +445,8 @@ public class TestNECVEPlugin {
   }
 
   private void verifyBinaryPathSet(Path expectedPath) {
-    assertEquals("Binary path", expectedPath.toString(),
-        plugin.getBinaryPath());
+    assertEquals( expectedPath.toString(),
+        plugin.getBinaryPath(), "Binary path");
     verifyZeroInteractions(udevUtil);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestNECVEPlugin.java
@@ -445,8 +445,7 @@ public class TestNECVEPlugin {
   }
 
   private void verifyBinaryPathSet(Path expectedPath) {
-    assertEquals( expectedPath.toString(),
-        plugin.getBinaryPath(), "Binary path");
+    assertEquals(expectedPath.toString(), plugin.getBinaryPath(), "Binary path");
     verifyZeroInteractions(udevUtil);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.com.nec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyChar;
@@ -39,26 +41,21 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Shell.CommandExecutor;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for VEDeviceDiscoverer class.
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestVEDeviceDiscoverer {
   private static final Comparator<Device> DEVICE_COMPARATOR =
       Comparator.comparingInt(Device::getId);
-
-  @Rule
-  public ExpectedException expected = ExpectedException.none();
 
   @Mock
   private UdevUtil udevUtil;
@@ -69,7 +66,7 @@ public class TestVEDeviceDiscoverer {
   private String testFolder;
   private VEDeviceDiscoverer discoverer;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     Function<String[], CommandExecutor> commandExecutorProvider =
         (String[] cmd) -> mockCommandExecutor;
@@ -78,7 +75,7 @@ public class TestVEDeviceDiscoverer {
     setupTestDirectory();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     if (testFolder != null) {
       File f = new File(testFolder);
@@ -96,13 +93,13 @@ public class TestVEDeviceDiscoverer {
 
     Set<Device> devices = discoverer.getDevicesFromPath(testFolder);
 
-    assertEquals("Number of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "Number of devices");
     Device device = devices.iterator().next();
-    assertEquals("Device ID", 0, device.getId());
-    assertEquals("Major number", 8, device.getMajorNumber());
-    assertEquals("Minor number", 1, device.getMinorNumber());
-    assertEquals("Status", "ONLINE", device.getStatus());
-    assertTrue("Device is not healthy", device.isHealthy());
+    assertEquals(0, device.getId(), "Device ID");
+    assertEquals(8, device.getMajorNumber(), "Major number");
+    assertEquals(1, device.getMinorNumber(), "Minor number");
+    assertEquals("ONLINE", device.getStatus(), "Status");
+    assertTrue(device.isHealthy(), "Device is not healthy");
   }
 
   @Test
@@ -119,30 +116,30 @@ public class TestVEDeviceDiscoverer {
 
     Set<Device> devices = discoverer.getDevicesFromPath(testFolder);
 
-    assertEquals("Number of devices", 3, devices.size());
+    assertEquals(3, devices.size(), "Number of devices");
     List<Device> devicesList = Lists.newArrayList(devices);
     devicesList.sort(DEVICE_COMPARATOR);
 
     Device device0 = devicesList.get(0);
-    assertEquals("Device ID", 0, device0.getId());
-    assertEquals("Major number", 8, device0.getMajorNumber());
-    assertEquals("Minor number", 1, device0.getMinorNumber());
-    assertEquals("Status", "ONLINE", device0.getStatus());
-    assertTrue("Device is not healthy", device0.isHealthy());
+    assertEquals(0, device0.getId(), "Device ID");
+    assertEquals(8, device0.getMajorNumber(), "Major number");
+    assertEquals(1, device0.getMinorNumber(), "Minor number");
+    assertEquals("ONLINE", device0.getStatus(), "Status");
+    assertTrue(device0.isHealthy(), "Device is not healthy");
 
     Device device1 = devicesList.get(1);
-    assertEquals("Device ID", 1, device1.getId());
-    assertEquals("Major number", 9, device1.getMajorNumber());
-    assertEquals("Minor number", 1, device1.getMinorNumber());
-    assertEquals("Status", "ONLINE", device1.getStatus());
-    assertTrue("Device is not healthy", device1.isHealthy());
+    assertEquals(1, device1.getId(), "Device ID");
+    assertEquals(9, device1.getMajorNumber(), "Major number");
+    assertEquals(1, device1.getMinorNumber(), "Minor number");
+    assertEquals("ONLINE", device1.getStatus(), "Status");
+    assertTrue(device1.isHealthy(), "Device is not healthy");
 
     Device device2 = devicesList.get(2);
-    assertEquals("Device ID", 2, device2.getId());
-    assertEquals("Major number", 10, device2.getMajorNumber());
-    assertEquals("Minor number", 1, device2.getMinorNumber());
-    assertEquals("Status", "ONLINE", device2.getStatus());
-    assertTrue("Device is not healthy", device2.isHealthy());
+    assertEquals(2, device2.getId(), "Device ID");
+    assertEquals(10, device2.getMajorNumber(), "Major number");
+    assertEquals(1, device2.getMinorNumber(), "Minor number");
+    assertEquals("ONLINE", device2.getStatus(), "Status");
+    assertTrue(device2.isHealthy(), "Device is not healthy");
   }
 
   @Test
@@ -155,13 +152,13 @@ public class TestVEDeviceDiscoverer {
 
     Set<Device> devices = discoverer.getDevicesFromPath(testFolder);
 
-    assertEquals("Number of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "Number of devices");
     Device device = devices.iterator().next();
-    assertEquals("Device ID", 0, device.getId());
-    assertEquals("Major number", 8, device.getMajorNumber());
-    assertEquals("Minor number", 1, device.getMinorNumber());
-    assertEquals("Status", "Unknown (-1)", device.getStatus());
-    assertFalse("Device should not be healthy", device.isHealthy());
+    assertEquals(0, device.getId(), "Device ID");
+    assertEquals(8, device.getMajorNumber(), "Major number");
+    assertEquals(1, device.getMinorNumber(), "Minor number");
+    assertEquals("Unknown (-1)", device.getStatus(), "Status");
+    assertFalse(device.isHealthy(), "Device should not be healthy");
   }
 
   @Test
@@ -174,13 +171,13 @@ public class TestVEDeviceDiscoverer {
 
     Set<Device> devices = discoverer.getDevicesFromPath(testFolder);
 
-    assertEquals("Number of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "Number of devices");
     Device device = devices.iterator().next();
-    assertEquals("Device ID", 0, device.getId());
-    assertEquals("Major number", 8, device.getMajorNumber());
-    assertEquals("Minor number", 1, device.getMinorNumber());
-    assertEquals("Status", "Unknown (5)", device.getStatus());
-    assertFalse("Device should not be healthy", device.isHealthy());
+    assertEquals(0, device.getId(), "Device ID");
+    assertEquals(8, device.getMajorNumber(), "Major number");
+    assertEquals(1, device.getMinorNumber(), "Minor number");
+    assertEquals("Unknown (5)", device.getStatus(), "Status");
+    assertFalse(device.isHealthy(), "Device should not be healthy");
   }
 
   @Test
@@ -201,16 +198,16 @@ public class TestVEDeviceDiscoverer {
     devicesList.sort(DEVICE_COMPARATOR);
 
     Device device0 = devicesList.get(0);
-    assertEquals("Major number", 16, device0.getMajorNumber());
-    assertEquals("Minor number", 1, device0.getMinorNumber());
+    assertEquals(16, device0.getMajorNumber(), "Major number");
+    assertEquals(1, device0.getMinorNumber(), "Minor number");
 
     Device device1 = devicesList.get(1);
-    assertEquals("Major number", 29, device1.getMajorNumber());
-    assertEquals("Minor number", 2, device1.getMinorNumber());
+    assertEquals(29, device1.getMajorNumber(), "Major number");
+    assertEquals(2, device1.getMinorNumber(), "Minor number");
 
     Device device2 = devicesList.get(2);
-    assertEquals("Major number", 4, device2.getMajorNumber());
-    assertEquals("Minor number", 60, device2.getMinorNumber());
+    assertEquals(4, device2.getMajorNumber(), "Major number");
+    assertEquals(60, device2.getMinorNumber(), "Minor number");
   }
 
   @Test
@@ -231,24 +228,24 @@ public class TestVEDeviceDiscoverer {
 
     Set<Device> devices = discoverer.getDevicesFromPath(testFolder);
 
-    assertEquals("Number of devices", 1, devices.size());
+    assertEquals(1, devices.size(), "Number of devices");
     Device device = devices.iterator().next();
-    assertEquals("Device ID", 0, device.getId());
-    assertEquals("Major number", 8, device.getMajorNumber());
-    assertEquals("Minor number", 1, device.getMinorNumber());
-    assertEquals("Status", "ONLINE", device.getStatus());
-    assertTrue("Device is not healthy", device.isHealthy());
+    assertEquals(0, device.getId(), "Device ID");
+    assertEquals(8, device.getMajorNumber(), "Major number");
+    assertEquals(1, device.getMinorNumber(), "Minor number");
+    assertEquals("ONLINE", device.getStatus(), "Status");
+    assertTrue(device.isHealthy(), "Device is not healthy");
   }
 
   @Test
   public void testNonBlockOrCharFilesAreRejected() throws IOException {
-    expected.expect(IllegalArgumentException.class);
-    expected.expectMessage("File is neither a char nor block device");
-    createVeSlotFile(0);
-    when(mockCommandExecutor.getOutput()).thenReturn(
-        "0:0:regular file");
-
-    discoverer.getDevicesFromPath(testFolder);
+    IllegalArgumentException exception =
+      assertThrows(IllegalArgumentException.class, () -> {
+      createVeSlotFile(0);
+      when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
+      discoverer.getDevicesFromPath(testFolder);
+    });
+    assertThat(exception.getMessage()).contains("File is neither a char nor block device");
   }
 
   private void setupTestDirectory() throws IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
@@ -240,11 +240,11 @@ public class TestVEDeviceDiscoverer {
   @Test
   public void testNonBlockOrCharFilesAreRejected() throws IOException {
     IllegalArgumentException exception =
-      assertThrows(IllegalArgumentException.class, () -> {
-      createVeSlotFile(0);
-      when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
-      discoverer.getDevicesFromPath(testFolder);
-    });
+        assertThrows(IllegalArgumentException.class, () -> {
+        createVeSlotFile(0);
+        when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
+        discoverer.getDevicesFromPath(testFolder);
+      });
     assertThat(exception.getMessage()).contains("File is neither a char nor block device");
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
@@ -241,10 +241,10 @@ public class TestVEDeviceDiscoverer {
   public void testNonBlockOrCharFilesAreRejected() throws IOException {
     IllegalArgumentException exception =
           assertThrows(IllegalArgumentException.class, () -> {
-          createVeSlotFile(0);
-          when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
-          discoverer.getDevicesFromPath(testFolder);
-        });
+            createVeSlotFile(0);
+            when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
+            discoverer.getDevicesFromPath(testFolder);
+          });
     assertThat(exception.getMessage()).contains("File is neither a char nor block device");
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nec/TestVEDeviceDiscoverer.java
@@ -240,11 +240,11 @@ public class TestVEDeviceDiscoverer {
   @Test
   public void testNonBlockOrCharFilesAreRejected() throws IOException {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> {
-        createVeSlotFile(0);
-        when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
-        discoverer.getDevicesFromPath(testFolder);
-      });
+          assertThrows(IllegalArgumentException.class, () -> {
+          createVeSlotFile(0);
+          when(mockCommandExecutor.getOutput()).thenReturn("0:0:regular file");
+          discoverer.getDevicesFromPath(testFolder);
+        });
     assertThat(exception.getMessage()).contains("File is neither a char nor block device");
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nvidia/TestNvidiaGPUPluginForRuntimeV2.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/com/nvidia/TestNvidiaGPUPluginForRuntimeV2.java
@@ -22,8 +22,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.Device;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.DeviceRuntimeSpec;
 import org.apache.hadoop.yarn.server.nodemanager.api.deviceplugin.YarnRuntimeType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +39,10 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -90,7 +93,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
         .setMajorNumber(195)
         .setMinorNumber(1).build());
     Set<Device> devices = plugin.getDevices();
-    Assert.assertEquals(expectedDevices, devices);
+    assertEquals(expectedDevices, devices);
   }
 
   @Test
@@ -100,7 +103,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
 
     DeviceRuntimeSpec spec = plugin.onDevicesAllocated(allocatedDevices,
         YarnRuntimeType.RUNTIME_DEFAULT);
-    Assert.assertNull(spec);
+    assertNull(spec);
 
     // allocate one device
     allocatedDevices.add(Device.Builder.newInstance()
@@ -111,8 +114,8 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
         .setMinorNumber(0).build());
     spec = plugin.onDevicesAllocated(allocatedDevices,
         YarnRuntimeType.RUNTIME_DOCKER);
-    Assert.assertEquals("nvidia", spec.getContainerRuntime());
-    Assert.assertEquals("0", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
+    assertEquals("nvidia", spec.getContainerRuntime());
+    assertEquals("0", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
 
     // two device allowed
     allocatedDevices.add(Device.Builder.newInstance()
@@ -123,8 +126,8 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
         .setMinorNumber(1).build());
     spec = plugin.onDevicesAllocated(allocatedDevices,
         YarnRuntimeType.RUNTIME_DOCKER);
-    Assert.assertEquals("nvidia", spec.getContainerRuntime());
-    Assert.assertEquals("0,1", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
+    assertEquals("nvidia", spec.getContainerRuntime());
+    assertEquals("0,1", spec.getEnvs().get("NVIDIA_VISIBLE_DEVICES"));
   }
 
   private NvidiaGPUPluginForRuntimeV2 mockEightGPUPlugin() throws IOException {
@@ -268,7 +271,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
         1, env);
     assertThat(allocation).hasSize(1);
     verify(spyPlugin).basicSchedule(anySet(), anyInt(), anySet());
-    Assert.assertFalse(spyPlugin.isTopoInitialized());
+    assertFalse(spyPlugin.isTopoInitialized());
 
     // Case 1. allocate 1 device
     reset(spyPlugin);
@@ -279,7 +282,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     reset(spyPlugin);
     // Case 2. allocate all available
     allocation = spyPlugin.allocateDevices(allDevices, allDevices.size(), env);
-    Assert.assertEquals(allocation.size(), allDevices.size());
+    assertEquals(allocation.size(), allDevices.size());
     verify(spyPlugin).basicSchedule(anySet(), anyInt(), anySet());
     // Case 3. allocate 2 devices
     reset(spyPlugin);
@@ -289,14 +292,14 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
     Device[] allocatedDevices =
         allocation.toArray(new Device[count]);
     // Check weights
-    Assert.assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
+    assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
         .P2PLinkSameCPUSocket.getWeight(),
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // Case 4. allocate 3 devices
@@ -306,7 +309,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin, times(0)).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
@@ -318,7 +321,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
             .P2PLinkSameCPUSocket.getWeight()
             + 2 * NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkCrossCPUSocket.getWeight();
-    Assert.assertEquals(expectedWeight,
+    assertEquals(expectedWeight,
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // Case 5. allocate 2 GPUs from three available devices
     reset(spyPlugin);
@@ -331,24 +334,24 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin, times(0)).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
     allocatedDevices =
         allocation.toArray(new Device[count]);
     // check weights
-    Assert.assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
+    assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkSameCPUSocket.getWeight(),
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // it should allocate GPU 2 and 3
     for (Device device : allocation) {
       if (device.getMinorNumber() == 2) {
-        Assert.assertTrue(true);
+        assertTrue(true);
       } else if (device.getMinorNumber() == 3) {
-        Assert.assertTrue(true);
+        assertTrue(true);
       } else {
-        Assert.assertTrue("Should allocate GPU 2 and 3", false);
+        assertTrue(false, "Should allocate GPU 2 and 3");
       }
     }
   }
@@ -366,12 +369,12 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     // Case 1. allocate 1 device
     Set<Device> allocation = spyPlugin.allocateDevices(allDevices, 1, env);
     // ensure no topology scheduling needed
-    Assert.assertEquals(allocation.size(), 1);
+    assertEquals(allocation.size(), 1);
     verify(spyPlugin).basicSchedule(anySet(), anyInt(), anySet());
     reset(spyPlugin);
     // Case 2. allocate all available
     allocation = spyPlugin.allocateDevices(allDevices, allDevices.size(), env);
-    Assert.assertEquals(allocation.size(), allDevices.size());
+    assertEquals(allocation.size(), allDevices.size());
     verify(spyPlugin).basicSchedule(anySet(), anyInt(), anySet());
     // Case 3. allocate 2 devices
     reset(spyPlugin);
@@ -381,14 +384,14 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
     Device[] allocatedDevices =
         allocation.toArray(new Device[count]);
     // Check weights
-    Assert.assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
+    assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
         .P2PLinkCrossCPUSocket.getWeight(),
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // Case 4. allocate 3 devices
@@ -398,7 +401,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin, times(0)).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
@@ -410,7 +413,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
             .P2PLinkSameCPUSocket.getWeight()
             + 2 * NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkCrossCPUSocket.getWeight();
-    Assert.assertEquals(expectedWeight,
+    assertEquals(expectedWeight,
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // Case 5. allocate 2 GPUs from three available devices
     reset(spyPlugin);
@@ -423,20 +426,20 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     assertThat(allocation).hasSize(count);
     // the costTable should be init and used topology scheduling
     verify(spyPlugin, times(0)).initCostTable();
-    Assert.assertTrue(spyPlugin.isTopoInitialized());
+    assertTrue(spyPlugin.isTopoInitialized());
     verify(spyPlugin).topologyAwareSchedule(anySet(), anyInt(), anyMap(),
         anySet(), anyMap());
     assertThat(allocation).hasSize(count);
     allocatedDevices =
         allocation.toArray(new Device[count]);
     // check weights
-    Assert.assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
+    assertEquals(NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkCrossCPUSocket.getWeight(),
         spyPlugin.computeCostOfDevices(allocatedDevices));
     // it should allocate GPU 1 and 2
     for (Device device : allocation) {
       if (device.getMinorNumber() == 0) {
-        Assert.assertTrue("Shouldn't allocate GPU 0", false);
+        assertTrue(false, "Shouldn't allocate GPU 0");
       }
     }
   }
@@ -449,7 +452,7 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     spyPlugin.initCostTable();
     Map<String, Integer> devicePairToWeight = spyPlugin.getDevicePairToWeight();
     // 12 combinations when choose 2 GPUs from 8 respect the order. 8!/6!
-    Assert.assertEquals(56, devicePairToWeight.size());
+    assertEquals(56, devicePairToWeight.size());
     int sameCPUWeight =
         NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkSameCPUSocket.getWeight();
@@ -460,33 +463,33 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
         NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkNVLink2.getWeight();
 
-    Assert.assertEquals(nv1Weight, (int)devicePairToWeight.get("0-1"));
-    Assert.assertEquals(nv1Weight, (int)devicePairToWeight.get("1-0"));
+    assertEquals(nv1Weight, (int)devicePairToWeight.get("0-1"));
+    assertEquals(nv1Weight, (int)devicePairToWeight.get("1-0"));
 
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("0-4"));
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("4-0"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("0-4"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("4-0"));
 
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("0-3"));
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("3-0"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("0-3"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("3-0"));
 
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("6-3"));
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("3-6"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("6-3"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("3-6"));
 
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("6-7"));
-    Assert.assertEquals(nv2Weight, (int)devicePairToWeight.get("7-6"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("6-7"));
+    assertEquals(nv2Weight, (int)devicePairToWeight.get("7-6"));
 
-    Assert.assertEquals(nv1Weight, (int)devicePairToWeight.get("1-3"));
-    Assert.assertEquals(nv1Weight, (int)devicePairToWeight.get("3-1"));
+    assertEquals(nv1Weight, (int)devicePairToWeight.get("1-3"));
+    assertEquals(nv1Weight, (int)devicePairToWeight.get("3-1"));
 
     // verify cost Table
     Map<Integer, List<Map.Entry<Set<Device>, Integer>>> costTable =
         spyPlugin.getCostTable();
-    Assert.assertNull(costTable.get(1));
+    assertNull(costTable.get(1));
     // C8:2 = 8!/2!/6! = 28
-    Assert.assertEquals(28, costTable.get(2).size());
+    assertEquals(28, costTable.get(2).size());
     // C8:4 = 8!/4!/4! = 70
-    Assert.assertEquals(70, costTable.get(4).size());
-    Assert.assertNull(costTable.get(8));
+    assertEquals(70, costTable.get(4).size());
+    assertNull(costTable.get(8));
 
     Set<Device> allDevices = spyPlugin.getDevices();
     Map<String, String> env = new HashMap<>();
@@ -507,38 +510,38 @@ public class TestNvidiaGPUPluginForRuntimeV2 {
     spyPlugin.initCostTable();
     Map<String, Integer> devicePairToWeight = spyPlugin.getDevicePairToWeight();
     // 12 combinations when choose 2 GPUs from 4 respect the order. 4!/2!
-    Assert.assertEquals(12, devicePairToWeight.size());
+    assertEquals(12, devicePairToWeight.size());
     int sameCPUWeight =
         NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkSameCPUSocket.getWeight();
     int crossCPUWeight =
         NvidiaGPUPluginForRuntimeV2.DeviceLinkType
             .P2PLinkCrossCPUSocket.getWeight();
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("0-1"));
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("1-0"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("0-1"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("1-0"));
 
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("0-2"));
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("2-0"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("0-2"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("2-0"));
 
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("0-3"));
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("3-0"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("0-3"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("3-0"));
 
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("1-2"));
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("2-1"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("1-2"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("2-1"));
 
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("1-3"));
-    Assert.assertEquals(crossCPUWeight, (int)devicePairToWeight.get("3-1"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("1-3"));
+    assertEquals(crossCPUWeight, (int)devicePairToWeight.get("3-1"));
 
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("2-3"));
-    Assert.assertEquals(sameCPUWeight, (int)devicePairToWeight.get("3-2"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("2-3"));
+    assertEquals(sameCPUWeight, (int)devicePairToWeight.get("3-2"));
 
     // verify cost Table
     Map<Integer, List<Map.Entry<Set<Device>, Integer>>> costTable =
         spyPlugin.getCostTable();
-    Assert.assertNull(costTable.get(1));
-    Assert.assertEquals(6, costTable.get(2).size());
-    Assert.assertEquals(4, costTable.get(3).size());
-    Assert.assertNull(costTable.get(4));
+    assertNull(costTable.get(1));
+    assertEquals(6, costTable.get(2).size());
+    assertEquals(4, costTable.get(3).size());
+    assertNull(costTable.get(4));
   }
   /**
    * Test GPU topology allocation.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDeviceMappingManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDeviceMappingManager.java
@@ -41,10 +41,9 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.Contai
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.TestResourceUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +61,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for DeviceMappingManager.
@@ -81,7 +89,7 @@ public class TestDeviceMappingManager {
   private PrivilegedOperationExecutor mockPrivilegedExecutor;
   private Context mockCtx;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // setup resource-types.xml
     conf = new YarnConfiguration();
@@ -130,7 +138,7 @@ public class TestDeviceMappingManager {
     when(mockCtx.getConf()).thenReturn(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     // cleanup resource-types.xml
     File dest = new File(this.tempResourceTypesFile);
@@ -204,21 +212,21 @@ public class TestDeviceMappingManager {
         containerSet.get(resourceName2).entrySet()) {
       totalAllocatedCount += entry.getValue();
     }
-    Assert.assertEquals(totalAllocatedCount, used1.size() + used2.size());
+    assertEquals(totalAllocatedCount, used1.size() + used2.size());
     // Ensure each container has correct devices
     for (Map.Entry<Container, Integer> entry :
         containerSet.get(resourceName1).entrySet()) {
       int containerWanted = entry.getValue();
       int actualAllocated = dmm.getAllocatedDevices(resourceName1,
           entry.getKey().getContainerId()).size();
-      Assert.assertEquals(containerWanted, actualAllocated);
+      assertEquals(containerWanted, actualAllocated);
     }
     for (Map.Entry<Container, Integer> entry :
         containerSet.get(resourceName2).entrySet()) {
       int containerWanted = entry.getValue();
       int actualAllocated = dmm.getAllocatedDevices(resourceName2,
           entry.getKey().getContainerId()).size();
-      Assert.assertEquals(containerWanted, actualAllocated);
+      assertEquals(containerWanted, actualAllocated);
     }
   }
 
@@ -273,9 +281,9 @@ public class TestDeviceMappingManager {
         anyString(), any(ContainerId.class));
 
     // Ensure all devices are back
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName1).size());
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName2).size());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDevicePluginAdapter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/deviceframework/TestDevicePluginAdapter.java
@@ -54,10 +54,9 @@ import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.NMDeviceResourceInfo;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.TestResourceUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +73,10 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -105,7 +108,7 @@ public class TestDevicePluginAdapter {
   private CGroupsHandler mockCGroupsHandler;
   private PrivilegedOperationExecutor mockPrivilegedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     this.conf = new YarnConfiguration();
     // setup resource-types.xml
@@ -117,7 +120,7 @@ public class TestDevicePluginAdapter {
     mockPrivilegedExecutor = mock(PrivilegedOperationExecutor.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     // cleanup resource-types.xml
     File dest = new File(this.tempResourceTypesFile);
@@ -167,7 +170,7 @@ public class TestDevicePluginAdapter {
     verify(mockCGroupsHandler).initializeCGroupController(
         CGroupsHandler.CGroupController.DEVICES);
     int size = dmm.getAvailableDevices(resourceName);
-    Assert.assertEquals(3, size);
+    assertEquals(3, size);
     // Case 1. A container c1 requests 1 device
     Container c1 = mockContainerWithDeviceRequest(1,
         resourceName,
@@ -175,13 +178,13 @@ public class TestDevicePluginAdapter {
     // preStart
     adapter.getDeviceResourceHandler().preStart(c1);
     // check book keeping
-    Assert.assertEquals(2,
+    assertEquals(2,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllocatedDevices(resourceName, c1.getContainerId()).size());
     verify(mockShellWrapper, times(2)).getDeviceFileType(anyString());
     // check device cgroup create operation
@@ -189,11 +192,11 @@ public class TestDevicePluginAdapter {
         "c-256:1-rwm,c-256:2-rwm", "256:0");
     // postComplete
     adapter.getDeviceResourceHandler().postComplete(getContainerId(1));
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
     // check cgroup delete operation
     verify(mockCGroupsHandler).deleteCGroup(
@@ -211,13 +214,13 @@ public class TestDevicePluginAdapter {
     // preStart
     adapter.getDeviceResourceHandler().preStart(c2);
     // check book keeping
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllocatedDevices(resourceName, c2.getContainerId()).size());
     verify(mockShellWrapper, times(0)).getDeviceFileType(anyString());
     // check device cgroup create operation
@@ -229,11 +232,11 @@ public class TestDevicePluginAdapter {
         null, "256:0,256:1,256:2");
     // postComplete
     adapter.getDeviceResourceHandler().postComplete(getContainerId(2));
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
     // check cgroup delete operation
     verify(mockCGroupsHandler).deleteCGroup(
@@ -251,11 +254,11 @@ public class TestDevicePluginAdapter {
     // preStart
     adapter.getDeviceResourceHandler().preStart(c3);
     // check book keeping
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
     verify(mockShellWrapper, times(3)).getDeviceFileType(anyString());
     // check device cgroup create operation
@@ -267,13 +270,13 @@ public class TestDevicePluginAdapter {
         "c-256:0-rwm,c-256:1-rwm,c-256:2-rwm", null);
     // postComplete
     adapter.getDeviceResourceHandler().postComplete(getContainerId(3));
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllocatedDevices(resourceName, c3.getContainerId()).size());
     // check cgroup delete operation
     verify(mockCGroupsHandler).deleteCGroup(
@@ -293,7 +296,7 @@ public class TestDevicePluginAdapter {
         ArgumentCaptor.forClass(PrivilegedOperation.class);
     verify(mockPrivilegedExecutor, times(invokeTimesOfPrivilegedExecutor))
         .executePrivilegedOperation(args.capture(), eq(true));
-    Assert.assertEquals(PrivilegedOperation.OperationType.DEVICE,
+    assertEquals(PrivilegedOperation.OperationType.DEVICE,
         args.getValue().getOperationType());
     List<String> expectedArgs = new ArrayList<>();
     expectedArgs.add(DeviceResourceHandlerImpl.CONTAINER_ID_CLI_OPTION);
@@ -306,7 +309,7 @@ public class TestDevicePluginAdapter {
       expectedArgs.add(DeviceResourceHandlerImpl.ALLOWED_DEVICES_CLI_OPTION);
       expectedArgs.add(allowedParam);
     }
-    Assert.assertArrayEquals(expectedArgs.toArray(),
+    assertArrayEquals(expectedArgs.toArray(),
         args.getValue().getArguments().toArray());
   }
 
@@ -411,7 +414,7 @@ public class TestDevicePluginAdapter {
     adapter.createResourceHandler(context,
         mockCGroupsHandler, mockPrivilegedExecutor);
     adapter.getDeviceResourceHandler().bootstrap(conf);
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
     // mock NMStateStore
     Device storedDevice = Device.Builder.newInstance()
@@ -438,14 +441,14 @@ public class TestDevicePluginAdapter {
     runningContainersMap.put(getContainerId(0), nmContainer);
     adapter.getDeviceResourceHandler().reacquireContainer(
         getContainerId(0));
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(2,
+    assertEquals(2,
         dmm.getAvailableDevices(resourceName));
     Map<Device, ContainerId> used = dmm.getAllUsedDevices().get(resourceName);
-    Assert.assertTrue(used.keySet().contains(storedDevice));
+    assertTrue(used.keySet().contains(storedDevice));
 
     // Test case 2. c1 wants get recovered.
     // But stored device is already allocated to c2
@@ -463,18 +466,16 @@ public class TestDevicePluginAdapter {
     } catch (ResourceHandlerException e) {
       caughtException = true;
     }
-    Assert.assertTrue(
-        "Should fail since requested device is assigned already",
-        caughtException);
+    assertTrue(caughtException, "Should fail since requested device is assigned already");
     // don't affect c0 allocation state
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(2,
+    assertEquals(2,
         dmm.getAvailableDevices(resourceName));
     used = dmm.getAllUsedDevices().get(resourceName);
-    Assert.assertTrue(used.keySet().contains(storedDevice));
+    assertTrue(used.keySet().contains(storedDevice));
   }
 
   @Test
@@ -521,13 +522,13 @@ public class TestDevicePluginAdapter {
     } catch (ResourceHandlerException e) {
       exception = true;
     }
-    Assert.assertTrue("Should throw exception in preStart", exception);
+    assertTrue(exception, "Should throw exception in preStart");
     // no device assigned
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
-    Assert.assertEquals(0,
+    assertEquals(0,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAvailableDevices(resourceName));
 
   }
@@ -564,7 +565,7 @@ public class TestDevicePluginAdapter {
         mockCGroupsHandler, mockPrivilegedExecutor);
     adapter.getDeviceResourceHandler().bootstrap(conf);
     int size = dmm.getAvailableDevices(resourceName);
-    Assert.assertEquals(3, size);
+    assertEquals(3, size);
 
     // A container c1 requests 1 device
     Container c1 = mockContainerWithDeviceRequest(0,
@@ -575,11 +576,11 @@ public class TestDevicePluginAdapter {
     // Use customized scheduler
     verify(spyPlugin, times(1)).allocateDevices(
         anySet(), anyInt(), anyMap());
-    Assert.assertEquals(2,
+    assertEquals(2,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
   }
 
@@ -641,7 +642,7 @@ public class TestDevicePluginAdapter {
         mockCGroupsHandler, mockPrivilegedExecutor);
     adapter.getDeviceResourceHandler().bootstrap(conf);
     int size = dmm.getAvailableDevices(resourceName);
-    Assert.assertEquals(3, size);
+    assertEquals(3, size);
 
     // A container c1 requests 1 device
     Container c1 = mockContainerWithDeviceRequest(0,
@@ -650,29 +651,29 @@ public class TestDevicePluginAdapter {
     // preStart
     adapter.getDeviceResourceHandler().preStart(c1);
     // check book keeping
-    Assert.assertEquals(2,
+    assertEquals(2,
         dmm.getAvailableDevices(resourceName));
-    Assert.assertEquals(1,
+    assertEquals(1,
         dmm.getAllUsedDevices().get(resourceName).size());
-    Assert.assertEquals(3,
+    assertEquals(3,
         dmm.getAllAllowedDevices().get(resourceName).size());
     // get REST return value
     NMDeviceResourceInfo response =
         (NMDeviceResourceInfo) adapter.getNMResourceInfo();
-    Assert.assertEquals(1, response.getAssignedDevices().size());
-    Assert.assertEquals(3, response.getTotalDevices().size());
+    assertEquals(1, response.getAssignedDevices().size());
+    assertEquals(3, response.getTotalDevices().size());
     Device device = response.getAssignedDevices().get(0).getDevice();
     String cId = response.getAssignedDevices().get(0).getContainerId();
-    Assert.assertTrue(dmm.getAllAllowedDevices().get(resourceName)
+    assertTrue(dmm.getAllAllowedDevices().get(resourceName)
         .contains(device));
-    Assert.assertTrue(dmm.getAllUsedDevices().get(resourceName)
+    assertTrue(dmm.getAllUsedDevices().get(resourceName)
         .containsValue(ContainerId.fromString(cId)));
     //finish container
     adapter.getDeviceResourceHandler().postComplete(getContainerId(0));
     response =
         (NMDeviceResourceInfo) adapter.getNMResourceInfo();
-    Assert.assertEquals(0, response.getAssignedDevices().size());
-    Assert.assertEquals(3, response.getTotalDevices().size());
+    assertEquals(0, response.getAssignedDevices().size());
+    assertEquals(3, response.getTotalDevices().size());
   }
 
   /**
@@ -739,9 +740,9 @@ public class TestDevicePluginAdapter {
     verify(spyPlugin).onDevicesAllocated(
         allocatedDevice,
         YarnRuntimeType.RUNTIME_DOCKER);
-    Assert.assertEquals("nvidia-docker", dvc.getDriverName());
-    Assert.assertEquals("create", dvc.getSubCommand());
-    Assert.assertEquals("nvidia_driver_352.68", dvc.getVolumeName());
+    assertEquals("nvidia-docker", dvc.getDriverName());
+    assertEquals("create", dvc.getSubCommand());
+    assertEquals("nvidia_driver_352.68", dvc.getVolumeName());
 
     // then the DockerLinuxContainerRuntime will update docker run command
     DockerRunCommand drc =
@@ -762,9 +763,9 @@ public class TestDevicePluginAdapter {
     verify(spyDmm, times(0)).getAllocatedDevices(resourceName,
         c1.getContainerId());
     String runStr = drc.toString();
-    Assert.assertTrue(
+    assertTrue(
         runStr.contains("nvidia_driver_352.68:/usr/local/nvidia:ro"));
-    Assert.assertTrue(runStr.contains("/dev/hdwA0:/dev/hdwA0"));
+    assertTrue(runStr.contains("/dev/hdwA0:/dev/hdwA0"));
     // Third, cleanup in getCleanupDockerVolumesCommand
     dcp.getCleanupDockerVolumesCommand(c1);
     // Ensure device plugin's onDeviceReleased is invoked
@@ -842,7 +843,7 @@ public class TestDevicePluginAdapter {
         allocatedDevice,
         YarnRuntimeType.RUNTIME_DOCKER);
     // No volume creation request
-    Assert.assertNull(dvc);
+    assertNull(dvc);
 
     // then the DockerLinuxContainerRuntime will update docker run command
     DockerRunCommand drc =
@@ -861,8 +862,8 @@ public class TestDevicePluginAdapter {
     // ensure that allocation is get once from device mapping manager
     verify(spyDmm, times(0)).getAllocatedDevices(resourceName,
         c1.getContainerId());
-    Assert.assertEquals("0,1", drc.getEnv().get("NVIDIA_VISIBLE_DEVICES"));
-    Assert.assertTrue(drc.toString().contains("runtime=nvidia"));
+    assertEquals("0,1", drc.getEnv().get("NVIDIA_VISIBLE_DEVICES"));
+    assertTrue(drc.toString().contains("runtime=nvidia"));
     // Third, cleanup in getCleanupDockerVolumesCommand
     dcp.getCleanupDockerVolumesCommand(c1);
     // Ensure device plugin's onDeviceReleased is invoked

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestAoclOutputParser.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestAoclOutputParser.java
@@ -18,14 +18,14 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.fpga;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.fpga.IntelFpgaOpenclPlugin.InnerShellExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for AoclDiagnosticOutputParser.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestIntelFpgaOpenclPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestIntelFpgaOpenclPlugin.java
@@ -45,7 +45,7 @@ public class TestIntelFpgaOpenclPlugin {
 
     String path = plugin.retrieveIPfilePath("fpga", "workDir", resources);
 
-    assertEquals("Retrieved IP file path", "/test/fpga.aocx", path);
+    assertEquals("/test/fpga.aocx", path, "Retrieved IP file path");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestIntelFpgaOpenclPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/fpga/TestIntelFpgaOpenclPlugin.java
@@ -25,16 +25,16 @@ import java.util.Map;
 import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestIntelFpgaOpenclPlugin {
   private IntelFpgaOpenclPlugin plugin;
 
-  @Before
+  @BeforeEach
   public void setup() {
     plugin = new IntelFpgaOpenclPlugin();
   }
@@ -54,14 +54,14 @@ public class TestIntelFpgaOpenclPlugin {
 
     String path = plugin.retrieveIPfilePath("dummy", "workDir", resources);
 
-    assertNull("Retrieved IP file path", path);
+    assertNull(path, "Retrieved IP file path");
   }
 
   @Test
   public void testLocalizedIpfileNotFoundWithNoLocalResources() {
     String path = plugin.retrieveIPfilePath("fpga", "workDir", null);
 
-    assertNull("Retrieved IP file path", path);
+    assertNull(path, "Retrieved IP file path");
   }
 
   @Test
@@ -70,7 +70,7 @@ public class TestIntelFpgaOpenclPlugin {
 
     String path = plugin.retrieveIPfilePath(null, "workDir", resources);
 
-    assertNull("Retrieved IP file path", path);
+    assertNull(path, "Retrieved IP file path");
   }
 
   private Map<Path, List<String>> createResources() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestGpuResourcePlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestGpuResourcePlugin.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.resourceplugin.gpu;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,8 +32,7 @@ import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.GpuDeviceInforma
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.NMGpuResourceInfo;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.PerGpuDeviceInformation;
 import org.apache.hadoop.yarn.server.nodemanager.webapp.dao.gpu.PerGpuUtilizations;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.util.List;
 
 public class TestGpuResourcePlugin {
@@ -50,16 +53,18 @@ public class TestGpuResourcePlugin {
     return gpuDiscoverer;
   }
 
-  @Test(expected = YarnException.class)
+  @Test
   public void testResourceHandlerNotInitialized() throws YarnException {
-    GpuDiscoverer gpuDiscoverer = createMockDiscoverer();
-    GpuNodeResourceUpdateHandler gpuNodeResourceUpdateHandler =
-        mock(GpuNodeResourceUpdateHandler.class);
+    assertThrows(YarnException.class, () -> {
+      GpuDiscoverer gpuDiscoverer = createMockDiscoverer();
+      GpuNodeResourceUpdateHandler gpuNodeResourceUpdateHandler =
+          mock(GpuNodeResourceUpdateHandler.class);
 
-    GpuResourcePlugin target =
-        new GpuResourcePlugin(gpuNodeResourceUpdateHandler, gpuDiscoverer);
+      GpuResourcePlugin target =
+          new GpuResourcePlugin(gpuNodeResourceUpdateHandler, gpuDiscoverer);
 
-    target.getNMResourceInfo();
+      target.getNMResourceInfo();
+    });
   }
 
   @Test
@@ -92,18 +97,17 @@ public class TestGpuResourcePlugin {
 
     NMGpuResourceInfo resourceInfo =
         (NMGpuResourceInfo) target.getNMResourceInfo();
-    Assert.assertNotNull("GpuDeviceInformation should not be null",
-        resourceInfo.getGpuDeviceInformation());
+    assertNotNull(
+        resourceInfo.getGpuDeviceInformation(), "GpuDeviceInformation should not be null");
 
     List<PerGpuDeviceInformation> gpus =
         resourceInfo.getGpuDeviceInformation().getGpus();
-    Assert.assertNotNull("List of PerGpuDeviceInformation should not be null",
-        gpus);
+    assertNotNull(gpus, "List of PerGpuDeviceInformation should not be null");
 
-    Assert.assertEquals("List of PerGpuDeviceInformation should have a " +
-        "size of 1", 1, gpus.size());
-    Assert.assertEquals("Product name of GPU does not match",
-        "testGpu", gpus.get(0).getProductName());
+    assertEquals(1, gpus.size(), "List of PerGpuDeviceInformation should have a " +
+        "size of 1");
+    assertEquals("testGpu", gpus.get(0).getProductName(),
+        "Product name of GPU does not match");
   }
 
   @Test
@@ -122,7 +126,7 @@ public class TestGpuResourcePlugin {
 
     NMGpuResourceInfo resourceInfo =
         (NMGpuResourceInfo) target.getNMResourceInfo();
-    Assert.assertNull(resourceInfo.getGpuDeviceInformation());
+    assertNull(resourceInfo.getGpuDeviceInformation());
   }
 
   @Test
@@ -133,7 +137,7 @@ public class TestGpuResourcePlugin {
     GpuNodeResourceUpdateHandler gpuNodeResourceUpdateHandler =
         new GpuNodeResourceUpdateHandler(gpuDiscoverer, new Configuration());
 
-    Assert.assertEquals(0.5F,
+    assertEquals(0.5F,
         gpuNodeResourceUpdateHandler.getAvgNodeGpuUtilization(), 1e-6);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestNvidiaDockerV1CommandPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestNvidiaDockerV1CommandPlugin.java
@@ -31,8 +31,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Reso
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker.DockerRunCommand;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker.DockerVolumeCommand;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.runtime.ContainerExecutionException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -42,6 +41,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -119,14 +122,14 @@ public class TestNvidiaDockerV1CommandPlugin {
 
     // getResourceMapping is null, so commandline won't be updated
     commandPlugin.updateDockerRunCommand(runCommand, nmContainer);
-    Assert.assertTrue(commandlinesEquals(originalCommandline,
+    assertTrue(commandlinesEquals(originalCommandline,
         runCommand.getDockerCommandWithArguments()));
 
     // no GPU resource assigned, so commandline won't be updated
     ResourceMappings resourceMappings = new ResourceMappings();
     when(nmContainer.getResourceMappings()).thenReturn(resourceMappings);
     commandPlugin.updateDockerRunCommand(runCommand, nmContainer);
-    Assert.assertTrue(commandlinesEquals(originalCommandline,
+    assertTrue(commandlinesEquals(originalCommandline,
         runCommand.getDockerCommandWithArguments()));
 
     // Assign GPU resource, init will be invoked
@@ -146,7 +149,7 @@ public class TestNvidiaDockerV1CommandPlugin {
     } catch (ContainerExecutionException e) {
       caughtException = true;
     }
-    Assert.assertTrue(caughtException);
+    assertTrue(caughtException);
 
     // Start HTTP server
     MyHandler handler = new MyHandler();
@@ -169,7 +172,7 @@ public class TestNvidiaDockerV1CommandPlugin {
     } catch (ContainerExecutionException e) {
       caughtException = true;
     }
-    Assert.assertTrue(caughtException);
+    assertTrue(caughtException);
 
     // Start use invalid options
     handler.response = "INVALID_RESPONSE";
@@ -178,7 +181,7 @@ public class TestNvidiaDockerV1CommandPlugin {
     } catch (ContainerExecutionException e) {
       caughtException = true;
     }
-    Assert.assertTrue(caughtException);
+    assertTrue(caughtException);
 
     /* Test get docker run command */
     handler.response = "--device=/dev/nvidiactl --device=/dev/nvidia-uvm "
@@ -192,24 +195,24 @@ public class TestNvidiaDockerV1CommandPlugin {
         runCommand.getDockerCommandWithArguments();
 
     // Command line will be updated
-    Assert.assertFalse(commandlinesEquals(originalCommandline, newCommandLine));
+    assertFalse(commandlinesEquals(originalCommandline, newCommandLine));
     // Volume driver should not be included by final commandline
-    Assert.assertFalse(newCommandLine.containsKey("volume-driver"));
-    Assert.assertTrue(newCommandLine.containsKey("devices"));
-    Assert.assertTrue(newCommandLine.containsKey("mounts"));
+    assertFalse(newCommandLine.containsKey("volume-driver"));
+    assertTrue(newCommandLine.containsKey("devices"));
+    assertTrue(newCommandLine.containsKey("mounts"));
 
     /* Test get docker volume command */
     commandPlugin = new MyNvidiaDockerV1CommandPlugin(conf);
 
     // When requests Gpu == false, returned docker volume command is null,
-    Assert.assertNull(commandPlugin.getCreateDockerVolumeCommand(nmContainer));
+    assertNull(commandPlugin.getCreateDockerVolumeCommand(nmContainer));
 
     // set requests Gpu to true
     commandPlugin.setRequestsGpu(true);
 
     DockerVolumeCommand dockerVolumeCommand = commandPlugin.getCreateDockerVolumeCommand(
         nmContainer);
-    Assert.assertEquals(
+    assertEquals(
         "volume docker-command=volume " + "driver=nvidia-docker "
             + "sub-command=create " + "volume=nvidia_driver_352.68",
         dockerVolumeCommand.toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestNvidiaDockerV2CommandPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/resourceplugin/gpu/TestNvidiaDockerV2CommandPlugin.java
@@ -24,14 +24,15 @@ import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ResourceMappings;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.docker.DockerRunCommand;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -96,14 +97,14 @@ public class TestNvidiaDockerV2CommandPlugin {
 
     // getResourceMapping is null, so commandline won't be updated
     commandPlugin.updateDockerRunCommand(runCommand, nmContainer);
-    Assert.assertTrue(commandlinesEquals(originalCommandline,
+    assertTrue(commandlinesEquals(originalCommandline,
         runCommand.getDockerCommandWithArguments()));
 
     // no GPU resource assigned, so commandline won't be updated
     ResourceMappings resourceMappings = new ResourceMappings();
     when(nmContainer.getResourceMappings()).thenReturn(resourceMappings);
     commandPlugin.updateDockerRunCommand(runCommand, nmContainer);
-    Assert.assertTrue(commandlinesEquals(originalCommandline,
+    assertTrue(commandlinesEquals(originalCommandline,
         runCommand.getDockerCommandWithArguments()));
 
     // Assign GPU resource
@@ -120,11 +121,11 @@ public class TestNvidiaDockerV2CommandPlugin {
         runCommand.getDockerCommandWithArguments();
 
     // Command line will be updated
-    Assert.assertFalse(commandlinesEquals(originalCommandline, newCommandLine));
+    assertFalse(commandlinesEquals(originalCommandline, newCommandLine));
     // NVIDIA_VISIBLE_DEVICES will be set
-    Assert.assertTrue(
+    assertTrue(
         runCommand.getEnv().get("NVIDIA_VISIBLE_DEVICES").equals("0,1"));
     // runtime should exist
-    Assert.assertTrue(newCommandLine.containsKey("runtime"));
+    assertTrue(newCommandLine.containsKey("runtime"));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestAllocationBasedResourceUtilizationTracker.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestAllocationBasedResourceUtilizationTracker.java
@@ -28,9 +28,11 @@ import org.apache.hadoop.yarn.server.nodemanager.Context;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitor;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor.ContainersMonitorImpl;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the {@link AllocationBasedResourceUtilizationTracker} class.
@@ -39,7 +41,7 @@ public class TestAllocationBasedResourceUtilizationTracker {
 
   private ContainerScheduler mockContainerScheduler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockContainerScheduler = mock(ContainerScheduler.class);
     ContainersMonitor containersMonitor =
@@ -67,9 +69,9 @@ public class TestAllocationBasedResourceUtilizationTracker {
     Container testContainer = mock(Container.class);
     when(testContainer.getResource()).thenReturn(Resource.newInstance(512, 4));
     for (int i = 0; i < 2; i++) {
-      Assert.assertTrue(tracker.hasResourcesAvailable(testContainer));
+      assertTrue(tracker.hasResourcesAvailable(testContainer));
       tracker.addContainerResources(testContainer);
     }
-    Assert.assertFalse(tracker.hasResourcesAvailable(testContainer));
+    assertFalse(tracker.hasResourcesAvailable(testContainer));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerBehaviorCompatibility.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerBehaviorCompatibility.java
@@ -26,14 +26,15 @@ import org.apache.hadoop.yarn.api.records.ExecutionType;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.BaseContainerManagerTest;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Make sure ContainerScheduler related changes are compatible
@@ -46,7 +47,7 @@ public class TestContainerSchedulerBehaviorCompatibility
     super();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf.setInt(YarnConfiguration.NM_VCORES, 1);
     conf.setInt(YarnConfiguration.NM_OPPORTUNISTIC_CONTAINERS_MAX_QUEUE_LENGTH,
@@ -91,7 +92,7 @@ public class TestContainerSchedulerBehaviorCompatibility
       nRunningContainers = cs.getNumRunningContainers();
       nTried++;
       if (nTried > maxTry) {
-        Assert.fail("Failed to get either number of queuing containers to 0 or "
+        fail("Failed to get either number of queuing containers to 0 or "
             + "number of running containers to 0, #queued=" + nQueuedContainers
             + ", #running=" + nRunningContainers);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerOppContainersByResources.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerOppContainersByResources.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.BaseContainerM
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.BaseContainerSchedulerTest;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,6 +44,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the behavior of {@link ContainerScheduler} when its queueing policy
@@ -57,6 +59,7 @@ public class TestContainerSchedulerOppContainersByResources
       throws UnsupportedFileSystemException {
   }
 
+  @BeforeEach
   @Override
   public void setup() throws IOException {
     conf.set(YarnConfiguration.NM_OPPORTUNISTIC_CONTAINERS_QUEUE_POLICY,
@@ -137,15 +140,15 @@ public class TestContainerSchedulerOppContainersByResources
     // Check that nothing is queued
     ContainerScheduler containerScheduler =
         containerManager.getContainerScheduler();
-    Assert.assertEquals(0,
+    assertEquals(0,
         containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(0,
+    assertEquals(0,
         containerScheduler.getNumQueuedGuaranteedContainers());
-    Assert.assertEquals(0,
+    assertEquals(0,
         containerScheduler.getNumQueuedOpportunisticContainers());
-    Assert.assertEquals(0,
+    assertEquals(0,
         metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerQueuing.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerQueuing.java
@@ -42,8 +42,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerChain;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,6 +51,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -118,12 +119,12 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     List<ContainerStatus> containerStatuses = containerManager
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
-      Assert.assertEquals(
+      assertEquals(
           org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
           status.getState());
     }
-    Assert.assertEquals(0, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(0, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -168,20 +169,20 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     List<ContainerStatus> containerStatuses = containerManager
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
-      Assert.assertEquals(ContainerSubState.SCHEDULED,
+      assertEquals(ContainerSubState.SCHEDULED,
           status.getContainerSubState());
     }
 
     ContainerScheduler containerScheduler =
         containerManager.getContainerScheduler();
     // Ensure both containers are properly queued.
-    Assert.assertEquals(2, containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(1,
+    assertEquals(2, containerScheduler.getNumQueuedContainers());
+    assertEquals(1,
         containerScheduler.getNumQueuedGuaranteedContainers());
-    Assert.assertEquals(1,
+    assertEquals(1,
         containerScheduler.getNumQueuedOpportunisticContainers());
-    Assert.assertEquals(1, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(1, metrics.getQueuedGuaranteedContainers());
+    assertEquals(1, metrics.getQueuedOpportunisticContainers());
+    assertEquals(1, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -233,10 +234,10 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
       if (status.getContainerId().equals(createContainerId(0))) {
-        Assert.assertEquals(ContainerSubState.RUNNING,
+        assertEquals(ContainerSubState.RUNNING,
             status.getContainerSubState());
       } else {
-        Assert.assertEquals(ContainerSubState.SCHEDULED,
+        assertEquals(ContainerSubState.SCHEDULED,
             status.getContainerSubState());
       }
     }
@@ -244,13 +245,13 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     ContainerScheduler containerScheduler =
         containerManager.getContainerScheduler();
     // Ensure two containers are properly queued.
-    Assert.assertEquals(2, containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(0,
+    assertEquals(2, containerScheduler.getNumQueuedContainers());
+    assertEquals(0,
         containerScheduler.getNumQueuedGuaranteedContainers());
-    Assert.assertEquals(2,
+    assertEquals(2,
         containerScheduler.getNumQueuedOpportunisticContainers());
-    Assert.assertEquals(2, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(2, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -310,14 +311,14 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
       if (status.getContainerId().equals(createContainerId(0))) {
-        Assert.assertEquals(ContainerSubState.RUNNING,
+        assertEquals(ContainerSubState.RUNNING,
             status.getContainerSubState());
       } else if (status.getContainerId().equals(createContainerId(
           maxOppQueueLength + 1))) {
-        Assert.assertTrue(status.getDiagnostics().contains(
+        assertTrue(status.getDiagnostics().contains(
             "Opportunistic container queue is full"));
       } else {
-        Assert.assertEquals(ContainerSubState.SCHEDULED,
+        assertEquals(ContainerSubState.SCHEDULED,
             status.getContainerSubState());
       }
       System.out.println("\nStatus : [" + status + "]\n");
@@ -325,15 +326,15 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
 
     ContainerScheduler containerScheduler =
         containerManager.getContainerScheduler();
-    Assert.assertEquals(maxOppQueueLength,
+    assertEquals(maxOppQueueLength,
         containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(0,
+    assertEquals(0,
         containerScheduler.getNumQueuedGuaranteedContainers());
-    Assert.assertEquals(maxOppQueueLength,
+    assertEquals(maxOppQueueLength,
         containerScheduler.getNumQueuedOpportunisticContainers());
-    Assert.assertEquals(maxOppQueueLength,
+    assertEquals(maxOppQueueLength,
         metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -392,20 +393,20 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
       if (status.getContainerId().equals(createContainerId(0))) {
-        Assert.assertTrue(status.getDiagnostics().contains(
+        assertTrue(status.getDiagnostics().contains(
             "Container Killed to make room for Guaranteed Container"));
       } else if (status.getContainerId().equals(createContainerId(1))) {
-        Assert.assertEquals(ContainerSubState.SCHEDULED,
+        assertEquals(ContainerSubState.SCHEDULED,
             status.getContainerSubState());
       } else if (status.getContainerId().equals(createContainerId(2))) {
-        Assert.assertEquals(ContainerSubState.RUNNING,
+        assertEquals(ContainerSubState.RUNNING,
             status.getContainerSubState());
       }
       System.out.println("\nStatus : [" + status + "]\n");
     }
 
-    Assert.assertEquals(1, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(1, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
 
     // Make sure the remaining OPPORTUNISTIC container starts its execution.
     BaseContainerManagerTest.waitForNMContainerState(containerManager,
@@ -415,12 +416,12 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         createContainerId(1)));
     ContainerStatus contStatus1 = containerManager.getContainerStatuses(
         statRequest).getContainerStatuses().get(0);
-    Assert.assertEquals(
+    assertEquals(
         org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
         contStatus1.getState());
 
-    Assert.assertEquals(0, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(0, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -486,17 +487,17 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
       if (status.getContainerId().equals(createContainerId(0))) {
-        Assert.assertTrue(status.getDiagnostics().contains(
+        assertTrue(status.getDiagnostics().contains(
             "Container Paused to make room for Guaranteed Container"));
       } else if (status.getContainerId().equals(createContainerId(1))) {
-        Assert.assertEquals(
+        assertEquals(
             org.apache.hadoop.yarn.api.records.ContainerState.RUNNING,
             status.getState());
       }
       System.out.println("\nStatus : [" + status + "]\n");
     }
-    Assert.assertEquals(1, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(1, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
 
     // Make sure that the GUARANTEED container completes
     BaseContainerManagerTest.waitForNMContainerState(containerManager,
@@ -509,7 +510,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.getStates().get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -530,7 +531,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
             ContainerState.DONE), containerStates);
     List<ContainerEventType> containerEventTypes =
         listener.getEvents().get(createContainerId(0));
-    Assert.assertEquals(Arrays.asList(ContainerEventType.INIT_CONTAINER,
+    assertEquals(Arrays.asList(ContainerEventType.INIT_CONTAINER,
         ContainerEventType.CONTAINER_LAUNCHED,
         ContainerEventType.PAUSE_CONTAINER,
         ContainerEventType.CONTAINER_PAUSED,
@@ -621,9 +622,9 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     GenericTestUtils.waitFor(
         () -> containerScheduler.getNumQueuedContainers() == 6
             && metrics.getQueuedOpportunisticContainers() == 6, 100, 3000);
-    Assert.assertEquals(6, containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(6, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(6, containerScheduler.getNumQueuedContainers());
+    assertEquals(6, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
 
     ContainerQueuingLimit containerQueuingLimit = ContainerQueuingLimit
         .newInstance();
@@ -631,7 +632,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     containerScheduler.updateQueuingLimit(containerQueuingLimit);
     GenericTestUtils.waitFor(
         () -> containerScheduler.getNumQueuedContainers() == 2, 100, 3000);
-    Assert.assertEquals(2, containerScheduler.getNumQueuedContainers());
+    assertEquals(2, containerScheduler.getNumQueuedContainers());
 
     List<ContainerId> statList = new ArrayList<ContainerId>();
     for (int i = 1; i < 7; i++) {
@@ -655,10 +656,10 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         }
       }
     }
-    Assert.assertEquals(4, deQueuedContainers);
-    Assert.assertEquals(2, numQueuedOppContainers);
-    Assert.assertEquals(2, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(4, deQueuedContainers);
+    assertEquals(2, numQueuedOppContainers);
+    assertEquals(2, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -716,7 +717,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         (numTries-- > 0)) {
       Thread.sleep(100);
     }
-    Assert.assertEquals(2, containerScheduler.getNumQueuedContainers());
+    assertEquals(2, containerScheduler.getNumQueuedContainers());
 
     containerManager.stopContainers(
         StopContainersRequest.newInstance(Arrays.asList(createContainerId(2))));
@@ -726,7 +727,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         (numTries-- > 0)) {
       Thread.sleep(100);
     }
-    Assert.assertEquals(1, containerScheduler.getNumQueuedContainers());
+    assertEquals(1, containerScheduler.getNumQueuedContainers());
   }
 
   /**
@@ -802,9 +803,9 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
       System.out.println("\nStatus : [" + status + "]\n");
     }
 
-    Assert.assertEquals(2, killedContainers);
-    Assert.assertEquals(0, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(2, killedContainers);
+    assertEquals(0, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -869,9 +870,9 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
       System.out.println("\nStatus : [" + status + "]\n");
     }
 
-    Assert.assertEquals(2, killedContainers);
-    Assert.assertEquals(0, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(2, killedContainers);
+    assertEquals(0, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
   }
 
   /**
@@ -932,10 +933,10 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
       System.out.println("\nStatus : [" + status + "]\n");
     }
 
-    Assert.assertEquals(1, runningContainersNo);
-    Assert.assertEquals(2, queuedContainersNo);
-    Assert.assertEquals(2, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(1, runningContainersNo);
+    assertEquals(2, queuedContainersNo);
+    assertEquals(2, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
 
     // Stop one of the two queued containers.
     StopContainersRequest stopRequest = StopContainersRequest.
@@ -966,12 +967,12 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         Thread.sleep(1000);
       }
     }
-    Assert.assertEquals(1, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(createContainerId(0),
+    assertEquals(1, metrics.getQueuedOpportunisticContainers());
+    assertEquals(createContainerId(0),
         map.get(ContainerSubState.RUNNING).getContainerId());
-    Assert.assertEquals(createContainerId(1),
+    assertEquals(createContainerId(1),
         map.get(ContainerSubState.DONE).getContainerId());
-    Assert.assertEquals(createContainerId(2),
+    assertEquals(createContainerId(2),
         map.get(ContainerSubState.SCHEDULED).getContainerId());
   }
 
@@ -1022,10 +1023,10 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
         .getContainerStatuses(statRequest).getContainerStatuses();
     for (ContainerStatus status : containerStatuses) {
       if (status.getContainerId().equals(createContainerId(0))) {
-        Assert.assertEquals(ContainerSubState.RUNNING,
+        assertEquals(ContainerSubState.RUNNING,
             status.getContainerSubState());
       } else {
-        Assert.assertEquals(ContainerSubState.SCHEDULED,
+        assertEquals(ContainerSubState.SCHEDULED,
             status.getContainerSubState());
       }
     }
@@ -1035,10 +1036,10 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     containerScheduler.resourceHandlerChain =
         mock(ResourceHandlerChain.class);
     // Ensure two containers are properly queued.
-    Assert.assertEquals(1, containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(0,
+    assertEquals(1, containerScheduler.getNumQueuedContainers());
+    assertEquals(0,
         containerScheduler.getNumQueuedGuaranteedContainers());
-    Assert.assertEquals(1,
+    assertEquals(1,
         containerScheduler.getNumQueuedOpportunisticContainers());
 
     // Promote Queued Opportunistic Container
@@ -1054,9 +1055,9 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     ContainerUpdateResponse updateResponse =
         containerManager.updateContainer(updateRequest);
 
-    Assert.assertEquals(1,
+    assertEquals(1,
         updateResponse.getSuccessfullyUpdatedContainers().size());
-    Assert.assertEquals(0, updateResponse.getFailedRequests().size());
+    assertEquals(0, updateResponse.getFailedRequests().size());
 
     waitForContainerState(containerManager, createContainerId(0),
         org.apache.hadoop.yarn.api.records.ContainerState.COMPLETE);
@@ -1066,25 +1067,25 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
 
     containerStatuses = containerManager
         .getContainerStatuses(statRequest).getContainerStatuses();
-    Assert.assertEquals(1, containerStatuses.size());
+    assertEquals(1, containerStatuses.size());
 
     for (ContainerStatus status : containerStatuses) {
       if (org.apache.hadoop.yarn.api.records.ContainerState.RUNNING ==
           status.getState()) {
-        Assert.assertEquals(
+        assertEquals(
             ExecutionType.GUARANTEED, status.getExecutionType());
       }
     }
 
     // Ensure no containers are queued.
-    Assert.assertEquals(0, containerScheduler.getNumQueuedContainers());
-    Assert.assertEquals(0, metrics.getQueuedOpportunisticContainers());
-    Assert.assertEquals(0, metrics.getQueuedGuaranteedContainers());
+    assertEquals(0, containerScheduler.getNumQueuedContainers());
+    assertEquals(0, metrics.getQueuedOpportunisticContainers());
+    assertEquals(0, metrics.getQueuedGuaranteedContainers());
 
     List<org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
         ContainerState> containerStates =
         listener.getStates().get(createContainerId(1));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
             ContainerState.NEW,
         org.apache.hadoop.yarn.server.nodemanager.containermanager.container.
@@ -1095,7 +1096,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
             ContainerState.RUNNING), containerStates);
     List<ContainerEventType> containerEventTypes =
         listener.getEvents().get(createContainerId(1));
-    Assert.assertEquals(Arrays.asList(
+    assertEquals(Arrays.asList(
         ContainerEventType.INIT_CONTAINER,
         ContainerEventType.UPDATE_CONTAINER_TOKEN,
         ContainerEventType.CONTAINER_LAUNCHED), containerEventTypes);
@@ -1139,9 +1140,9 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     ContainerUpdateResponse updateResponse =
         containerManager.updateContainer(updateRequest);
 
-    Assert.assertEquals(
+    assertEquals(
         1, updateResponse.getSuccessfullyUpdatedContainers().size());
-    Assert.assertTrue(updateResponse.getFailedRequests().isEmpty());
+    assertTrue(updateResponse.getFailedRequests().isEmpty());
 
     final GetContainerStatusesRequest statRequest =
             GetContainerStatusesRequest.newInstance(
@@ -1157,7 +1158,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
       } catch (YarnException | IOException e) {
         return false;
       }
-      Assert.assertEquals(1, containerStatuses.size());
+      assertEquals(1, containerStatuses.size());
       ContainerStatus status = containerStatuses.get(0);
       return (status.getState() == expectedState
               && status.getExecutionType() == ExecutionType.OPPORTUNISTIC);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerQueuing.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerQueuing.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Cont
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.ContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerChain;
 import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class TestContainerSchedulerQueuing extends BaseContainerSchedulerTest {
     super();
   }
 
+  @BeforeEach
   @Override
   public void setup() throws IOException {
     conf.setInt(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/scheduler/TestContainerSchedulerRecovery.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.yarn.server.nodemanager.containermanager.scheduler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,9 +37,9 @@ import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService
         .RecoveredContainerState;
 import org.apache.hadoop.yarn.server.nodemanager.recovery.NMStateStoreService.RecoveredContainerStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -98,7 +98,7 @@ public class TestContainerSchedulerRecovery {
     spy = new ContainerScheduler(context, dispatcher, metrics, 0);
   }
 
-  @Before public void setUp() throws Exception {
+  @BeforeEach public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     setupContainerMonitor();
     when(container.getContainerId()).thenReturn(containerId);
@@ -109,7 +109,7 @@ public class TestContainerSchedulerRecovery {
     when(containerId.getContainerId()).thenReturn(123L);
   }
 
-  @After public void tearDown() {
+  @AfterEach public void tearDown() {
   }
 
   /*Test if a container is recovered as QUEUED, GUARANTEED,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/executor/TestContainerReapContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/executor/TestContainerReapContext.java
@@ -17,10 +17,10 @@
 package org.apache.hadoop.yarn.server.nodemanager.executor;
 
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -32,7 +32,7 @@ public class TestContainerReapContext {
   private Container container;
   private ContainerReapContext context;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     container = mock(Container.class);
     context = new ContainerReapContext.Builder()


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11263. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-nodemanager.

### How was this patch tested?

Junit & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

