### PR TITLE
HADOOP-19448 [branch-3.4]: [ABFS][FNSOverBlob] Optimizing the current create and mkdir flow

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/ConcurrentWriteOperationDetectedException.java
@@ -20,12 +20,29 @@ package org.apache.hadoop.fs.azurebfs.contracts.exceptions;
 
 /**
  * Thrown when a concurrent write operation is detected.
+ * This exception is used to indicate that parallel access to the create path
+ * has been detected, which violates the single writer semantics.
  */
 @org.apache.hadoop.classification.InterfaceAudience.Public
 @org.apache.hadoop.classification.InterfaceStability.Evolving
 public class ConcurrentWriteOperationDetectedException
     extends AzureBlobFileSystemException {
 
+  private static final String ERROR_MESSAGE = "Parallel access to the create path detected. Failing request "
+      + "to honor single writer semantics";
+
+  /**
+   * Constructs a new ConcurrentWriteOperationDetectedException with a default error message.
+   */
+  public ConcurrentWriteOperationDetectedException() {
+    super(ERROR_MESSAGE);
+  }
+
+  /**
+   * Constructs a new ConcurrentWriteOperationDetectedException with the specified error message.
+   *
+   * @param message the detail message.
+   */
   public ConcurrentWriteOperationDetectedException(String message) {
     super(message);
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.Permissions;
@@ -555,6 +556,26 @@ public abstract class AbfsClient implements Closeable {
       String eTag,
       ContextEncryptionAdapter contextEncryptionAdapter,
       TracingContext tracingContext) throws AzureBlobFileSystemException;
+
+  /**
+   * Conditionally creates or overwrites a file at the specified relative path.
+   * This method ensures that the file is created or overwritten based on the provided parameters.
+   *
+   * @param relativePath The relative path of the file to be created or overwritten.
+   * @param statistics The file system statistics to be updated.
+   * @param permissions The permissions to be set on the file.
+   * @param isAppendBlob Specifies if the file is an append blob.
+   * @param contextEncryptionAdapter The encryption context adapter for handling encryption.
+   * @param tracingContext The tracing context for tracking the operation.
+   * @return An AbfsRestOperation object containing the result of the operation.
+   * @throws IOException If an I/O error occurs during the operation.
+   */
+  public abstract AbfsRestOperation conditionalCreateOverwriteFile(String relativePath,
+      FileSystem.Statistics statistics,
+      Permissions permissions,
+      boolean isAppendBlob,
+      ContextEncryptionAdapter contextEncryptionAdapter,
+      TracingContext tracingContext) throws IOException;
 
   /**
    * Performs a pre-check for a createNonRecursivePreCheck operation. Checks if parentPath

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobDeleteHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobDeleteHandler.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
@@ -37,6 +40,9 @@ import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceError
  * deleting the blobs and creating the parent directory marker file if needed.
  */
 public class BlobDeleteHandler extends ListActionTaker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      BlobDeleteHandler.class);
 
   private final Path path;
 
@@ -151,18 +157,12 @@ public class BlobDeleteHandler extends ListActionTaker {
       throws AzureBlobFileSystemException {
     if (!path.isRoot() && !path.getParent().isRoot()) {
       try {
-        getAbfsClient().createPath(path.getParent().toUri().getPath(),
-            false,
-            false,
-            null,
-            false,
+        getAbfsClient().createMarkerAtPath(path.getParent().toUri().getPath(),
             null,
             null,
             tracingContext);
       } catch (AbfsRestOperationException ex) {
-        if (ex.getStatusCode() != HTTP_CONFLICT) {
-          throw ex;
-        }
+        LOG.debug("Marker creation failed for parent path {} ", path.getParent().toUri().getPath());
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobRenameHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobRenameHandler.java
@@ -127,11 +127,14 @@ public class BlobRenameHandler extends ListActionTaker {
       RenameAtomicity renameAtomicity = null;
       if (pathInformation.getIsDirectory()
           && pathInformation.getIsImplicit()) {
-        AbfsRestOperation createMarkerOp = getAbfsClient().createPath(
-            src.toUri().getPath(),
-            false, false, null,
-            false, null, null, tracingContext);
-        pathInformation.setETag(extractEtagHeader(createMarkerOp.getResult()));
+        try {
+          AbfsRestOperation createMarkerOp = getAbfsClient().createMarkerAtPath(
+              src.toUri().getPath(), null, null, tracingContext);
+          pathInformation.setETag(
+              extractEtagHeader(createMarkerOp.getResult()));
+        } catch (AbfsRestOperationException ex) {
+          LOG.debug("Marker creation failed for src path {} ", src.toUri().getPath());
+        }
       }
       try {
         if (isAtomicRename) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsNetworkStatistics.java
@@ -96,8 +96,8 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
        // 1 create request = 1 connection made and 1 send request
       if (client instanceof AbfsBlobClient && !getIsNamespaceEnabled(fs)) {
         expectedRequestsSent += (directory);
-        // Per directory, we have 2 calls :- GetBlobProperties and PutBlob and 1 ListBlobs call (implicit check) for the path.
-        expectedConnectionsMade += ((directory * 2) + 1);
+        // Per directory, we have 2 calls :- 1 PutBlob and 1 ListBlobs call.
+        expectedConnectionsMade += ((directory * 2));
       } else {
         expectedRequestsSent++;
         expectedConnectionsMade++;
@@ -176,12 +176,12 @@ public class ITestAbfsNetworkStatistics extends AbstractAbfsIntegrationTest {
        *    + getFileStatus to fetch the file ETag
        *    + create overwrite=true
        *    = 3 connections and 2 send requests in case of Dfs Client
-       *    = 7 connections (5 GBP and 2 PutBlob calls) in case of Blob Client
+       *    = 1 ListBlob + 2 GPS + 2 PutBlob
        */
       if (fs.getAbfsStore().getAbfsConfiguration().isConditionalCreateOverwriteEnabled()) {
         if (client instanceof AbfsBlobClient && !getIsNamespaceEnabled(fs)) {
           expectedRequestsSent += 2;
-          expectedConnectionsMade += 7;
+          expectedConnectionsMade += 5;
         } else {
           expectedConnectionsMade += 3;
           expectedRequestsSent += 2;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -510,36 +509,6 @@ public class ITestAzureBlobFileSystemAppend extends
       fs1.mkdirs(filePath);
       outputStream.hsync();
     }
-  }
-
-  /**
-   * Checks a list of futures for exceptions.
-   *
-   * This method iterates over a list of futures, waits for each task to complete,
-   * and handles any exceptions thrown by the lambda expressions. If a
-   * RuntimeException is caught, it increments the exceptionCaught counter.
-   * If an unexpected exception is caught, it prints the exception to the standard error.
-   * Finally, it asserts that no RuntimeExceptions were caught.
-   *
-   * @param futures The list of futures to check for exceptions.
-   */
-  private void checkFuturesForExceptions(List<Future<?>> futures, int exceptionVal) {
-    int exceptionCaught = 0;
-    for (Future<?> future : futures) {
-      try {
-        future.get(); // wait for the task to complete and handle any exceptions thrown by the lambda expression
-      } catch (ExecutionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof RuntimeException) {
-          exceptionCaught++;
-        } else {
-          System.err.println("Unexpected exception caught: " + cause);
-        }
-      } catch (InterruptedException e) {
-        // handle interruption
-      }
-    }
-    assertEquals(exceptionCaught, exceptionVal);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemInitAndCreate.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
 import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -145,7 +145,7 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
 
     // One request to server
     if (client instanceof AbfsBlobClient && !getIsNamespaceEnabled(fs)) {
-      // 1 GetBlobProperties + 1 PutBlob call.
+      // 1 ListBlobs + 1 GetBlobProperties
       mkdirRequestCount +=2;
     } else {
       mkdirRequestCount++;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -112,7 +112,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
 
       //request should not fail for invalid clientCorrelationID
       AbfsRestOperation op = fs.getAbfsClient()
-          .createPath(path, false, true, permissions, false, null, null,
+          .createPath(path, true, true, permissions, false, null, null,
               tracingContext);
 
       int statusCode = op.getResult().getStatusCode();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -452,8 +452,12 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
         (currentAuthType == AuthType.SharedKey)
         || (currentAuthType == AuthType.OAuth));
 
-    // TODO : [FnsOverBlob][HADOOP-19234] Update to work with Blob Endpoint as well when Fns Over Blob is ready.
-    AbfsClient client = mock(AbfsDfsClient.class);
+    AbfsClient client;
+    if (AbfsServiceType.DFS.equals(abfsConfig.getFsConfiguredServiceType())) {
+      client = mock(AbfsDfsClient.class);
+    } else {
+      client = mock(AbfsBlobClient.class);
+    }
     AbfsPerfTracker tracker = new AbfsPerfTracker(
         "test",
         abfsConfig.getAccountName(),


### PR DESCRIPTION
Implementing Create and Mkdir file system APIs for FNS(HNS Disabled) accounts on Blob Endpoint involves a lot of checks and marker file creations to handle implicit explicit cases of paths involved in these APIs.

This PR proposes a few optimizations to reduce the network calls wherever possible and in case where create/mkdir is bound to fail, it should fail faster before doing any post checks,

