### PR TITLE
YARN-11267. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-router.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -200,6 +200,10 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jettison</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -52,8 +53,11 @@ public class WeightedPolicyInfo {
   private static final Logger LOG =
       LoggerFactory.getLogger(WeightedPolicyInfo.class);
   private static ObjectMapper mapper = new ObjectMapper();
+  @JsonProperty("routerPolicyWeights")
   private Map<SubClusterIdInfo, Float> routerPolicyWeights = new HashMap<>();
+  @JsonProperty("amrmPolicyWeights")
   private Map<SubClusterIdInfo, Float> amrmPolicyWeights = new HashMap<>();
+  @JsonProperty("headroomAlpha")
   private float headroomAlpha;
 
   public WeightedPolicyInfo() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterIdInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterIdInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.store.records;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -55,6 +56,7 @@ public class SubClusterIdInfo {
    * Get the sub-cluster identifier as {@link SubClusterId}.
    * @return the sub-cluster id.
    */
+  @JsonProperty("id")
   public SubClusterId toId() {
     return SubClusterId.newInstance(id);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -667,9 +667,13 @@ public class FederationClientInterceptor
       // If kill home sub-cluster application is successful,
       // we will try to kill the same application in other sub-clusters.
       if (response != null) {
-        ClientMethod remoteMethod = new ClientMethod("forceKillApplication",
-            new Class[]{KillApplicationRequest.class}, new Object[]{request});
-        invokeConcurrent(remoteMethod, KillApplicationResponse.class, subClusterId);
+        try {
+          ClientMethod remoteMethod = new ClientMethod("forceKillApplication",
+              new Class[]{KillApplicationRequest.class}, new Object[]{request});
+          invokeConcurrent(remoteMethod, KillApplicationResponse.class, subClusterId);
+        } catch (Exception e) {
+
+        }
       }
     } catch (Exception e) {
       routerMetrics.incrAppsFailedKilled();
@@ -816,7 +820,7 @@ public class FederationClientInterceptor
       GetClusterMetricsRequest request) throws YarnException, IOException {
     if (request == null) {
       routerMetrics.incrGetClusterMetricsFailedRetrieved();
-      String msg = "Missing getApplications request.";
+      String msg = "Missing getClusterMetrics request.";
       RouterAuditLogger.logFailure(user.getShortUserName(), GET_CLUSTERMETRICS, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
@@ -1386,7 +1390,7 @@ public class FederationClientInterceptor
       GetLabelsToNodesRequest request) throws YarnException, IOException {
     if (request == null) {
       routerMetrics.incrLabelsToNodesFailedRetrieved();
-      String msg = "Missing getNodesToLabels request.";
+      String msg = "Missing getLabelsToNodes request.";
       RouterAuditLogger.logFailure(user.getShortUserName(), GET_LABELSTONODES, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
@@ -86,7 +86,6 @@ public class DefaultRMAdminRequestInterceptor
   private static final Logger LOG =
       LoggerFactory.getLogger(DefaultRMAdminRequestInterceptor.class);
   private ResourceManagerAdministrationProtocol rmAdminProxy;
-  private UserGroupInformation user = null;
 
   @Override
   public void init(String userName) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.yarn.webapp.WebApp;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -107,7 +106,7 @@ public class TestRouter {
     for (Class<?> protocolClass : manager.getProtocolsWithAcls()) {
       AccessControlList accessList = manager.getProtocolsAcls(protocolClass);
       if (protocolClass == protocol) {
-        Assertions.assertEquals(accessList.getAclString(), aclString);
+        assertEquals(accessList.getAclString(), aclString);
       }
     }
   }
@@ -164,9 +163,9 @@ public class TestRouter {
 
     // Why is 5, because when Filter passes,
     // CrossOriginFilter will set 5 values to Map
-    Assertions.assertEquals(5, mockRes.getHeaders().size());
+    assertEquals(5, mockRes.getHeaders().size());
     String allowResult = mockRes.getHeader("Access-Control-Allow-Credentials");
-    Assertions.assertEquals("true", allowResult);
+    assertEquals("true", allowResult);
 
     // 2. Simulate [example.org] for access
     HttpServletRequest mockReq2 = Mockito.mock(HttpServletRequest.class);
@@ -184,7 +183,7 @@ public class TestRouter {
 
     // Why is 0, because when the Filter fails,
     // CrossOriginFilter will not set any value
-    Assertions.assertEquals(0, mockRes2.getHeaders().size());
+    assertEquals(0, mockRes2.getHeaders().size());
 
     router.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -34,8 +34,8 @@ import org.apache.hadoop.yarn.webapp.WebApp;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.FilterChain;
@@ -107,7 +107,7 @@ public class TestRouter {
     for (Class<?> protocolClass : manager.getProtocolsWithAcls()) {
       AccessControlList accessList = manager.getProtocolsAcls(protocolClass);
       if (protocolClass == protocol) {
-        Assert.assertEquals(accessList.getAclString(), aclString);
+        Assertions.assertEquals(accessList.getAclString(), aclString);
       }
     }
   }
@@ -164,9 +164,9 @@ public class TestRouter {
 
     // Why is 5, because when Filter passes,
     // CrossOriginFilter will set 5 values to Map
-    Assert.assertEquals(5, mockRes.getHeaders().size());
+    Assertions.assertEquals(5, mockRes.getHeaders().size());
     String allowResult = mockRes.getHeader("Access-Control-Allow-Credentials");
-    Assert.assertEquals("true", allowResult);
+    Assertions.assertEquals("true", allowResult);
 
     // 2. Simulate [example.org] for access
     HttpServletRequest mockReq2 = Mockito.mock(HttpServletRequest.class);
@@ -184,7 +184,7 @@ public class TestRouter {
 
     // Why is 0, because when the Filter fails,
     // CrossOriginFilter will not set any value
-    Assert.assertEquals(0, mockRes2.getHeaders().size());
+    Assertions.assertEquals(0, mockRes2.getHeaders().size());
 
     router.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.router;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +38,6 @@ import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -203,8 +203,8 @@ public class TestRouterAuditLogger {
             throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assertions.assertNotNull(clientId);
-      Assertions.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
+      assertNotNull(clientId);
+      assertEquals(ClientId.BYTE_LENGTH, clientId.length);
       // test with ip set
       testSuccessLogFormat(true);
       testFailureLogFormat(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,9 +37,9 @@ import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -56,7 +56,8 @@ public class TestRouterAuditLogger {
   private static final ApplicationId APPID = mock(ApplicationId.class);
   private static final SubClusterId SUBCLUSTERID = mock(SubClusterId.class);
 
-  @Before public void setUp() throws Exception {
+  @BeforeEach
+  public void setUp() throws Exception {
     when(APPID.toString()).thenReturn("app_1");
     when(SUBCLUSTERID.toString()).thenReturn("sc0");
   }
@@ -202,8 +203,8 @@ public class TestRouterAuditLogger {
             throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(clientId);
-      Assert.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
+      Assertions.assertNotNull(clientId);
+      Assertions.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
       // test with ip set
       testSuccessLogFormat(true);
       testFailureLogFormat(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
@@ -17,7 +17,8 @@
  */
 package org.apache.hadoop.yarn.server.router;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -45,18 +46,17 @@ public class TestRouterMetrics {
 
     LOG.info("Test: aggregate metrics are initialized correctly");
 
-    Assertions.assertEquals(0, metrics.getNumSucceededAppsCreated());
-    Assertions.assertEquals(0, metrics.getNumSucceededAppsSubmitted());
-    Assertions.assertEquals(0, metrics.getNumSucceededAppsKilled());
-    Assertions.assertEquals(0, metrics.getNumSucceededAppsRetrieved());
-    Assertions.assertEquals(0,
-        metrics.getNumSucceededAppAttemptsRetrieved());
+    assertEquals(0, metrics.getNumSucceededAppsCreated());
+    assertEquals(0, metrics.getNumSucceededAppsSubmitted());
+    assertEquals(0, metrics.getNumSucceededAppsKilled());
+    assertEquals(0, metrics.getNumSucceededAppsRetrieved());
+    assertEquals(0, metrics.getNumSucceededAppAttemptsRetrieved());
 
-    Assertions.assertEquals(0, metrics.getAppsFailedCreated());
-    Assertions.assertEquals(0, metrics.getAppsFailedSubmitted());
-    Assertions.assertEquals(0, metrics.getAppsFailedKilled());
-    Assertions.assertEquals(0, metrics.getAppsFailedRetrieved());
-    Assertions.assertEquals(0,
+    assertEquals(0, metrics.getAppsFailedCreated());
+    assertEquals(0, metrics.getAppsFailedSubmitted());
+    assertEquals(0, metrics.getAppsFailedKilled());
+    assertEquals(0, metrics.getAppsFailedRetrieved());
+    assertEquals(0,
         metrics.getAppAttemptsFailedRetrieved());
 
     LOG.info("Test: aggregate metrics are updated correctly");
@@ -73,15 +73,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getNewApplication(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsCreated());
-    Assertions.assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
 
     goodSubCluster.getNewApplication(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsCreated());
-    Assertions.assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
   }
 
   /**
@@ -94,7 +94,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getNewApplication();
 
-    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
   }
 
   /**
@@ -108,15 +108,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.submitApplication(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsSubmitted());
-    Assertions.assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
 
     goodSubCluster.submitApplication(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsSubmitted());
-    Assertions.assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
   }
 
   /**
@@ -129,7 +129,7 @@ public class TestRouterMetrics {
 
     badSubCluster.submitApplication();
 
-    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
   }
 
   /**
@@ -143,15 +143,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.forceKillApplication(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsKilled());
-    Assertions.assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
 
     goodSubCluster.forceKillApplication(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsKilled());
-    Assertions.assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
   }
 
   /**
@@ -164,7 +164,7 @@ public class TestRouterMetrics {
 
     badSubCluster.forceKillApplication();
 
-    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
   }
 
   /**
@@ -178,15 +178,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationReport(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsRetrieved());
-    Assertions.assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
+    assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
 
     goodSubCluster.getApplicationReport(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
+    assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
   }
 
   /**
@@ -199,7 +199,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationReport();
 
-    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
   }
 
   /**
@@ -214,16 +214,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationAttemptReport(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assertions.assertEquals(100,
+    assertEquals(100,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
 
     goodSubCluster.getApplicationAttemptReport(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -238,7 +238,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationAttemptReport();
 
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppAttemptReportFailedRetrieved());
   }
 
@@ -253,16 +253,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationsReport(100);
 
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assertions.assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
+    assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
 
     goodSubCluster.getApplicationsReport(200);
 
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
+    assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
   }
 
@@ -277,7 +277,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationsReport();
 
-    Assertions.assertEquals(totalBadbefore + 1,
+    assertEquals(totalBadbefore + 1,
         metrics.getMultipleAppsFailedRetrieved());
   }
 
@@ -289,14 +289,14 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterMetrics() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterMetricsRetrieved();
     goodSubCluster.getClusterMetrics(100);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assertions.assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
     goodSubCluster.getClusterMetrics(200);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
   }
 
@@ -308,7 +308,7 @@ public class TestRouterMetrics {
   public void testGetClusterMetricsFailed() {
     long totalBadbefore = metrics.getClusterMetricsFailedRetrieved();
     badSubCluster.getClusterMetrics();
-    Assertions.assertEquals(totalBadbefore + 1,
+    assertEquals(totalBadbefore + 1,
         metrics.getClusterMetricsFailedRetrieved());
   }
 
@@ -1011,12 +1011,12 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodesRetrieved();
     goodSubCluster.getClusterNodes(150);
-    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodes(300);
-    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1024,19 +1024,19 @@ public class TestRouterMetrics {
   public void testGetClusterNodesFailed() {
     long totalBadBefore = metrics.getClusterNodesFailedRetrieved();
     badSubCluster.getClusterNodes();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetNodeToLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetNodeToLabelsRetrieved();
     goodSubCluster.getNodeToLabels(150);
-    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodeToLabels(300);
-    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1044,19 +1044,19 @@ public class TestRouterMetrics {
   public void testGetNodeToLabelsFailed() {
     long totalBadBefore = metrics.getNodeToLabelsFailedRetrieved();
     badSubCluster.getNodeToLabels();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededLabelsToNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetLabelsToNodesRetrieved();
     goodSubCluster.getLabelToNodes(150);
-    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assertions.assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getLabelToNodes(300);
-    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1064,21 +1064,21 @@ public class TestRouterMetrics {
   public void testGetLabelsToNodesFailed() {
     long totalBadBefore = metrics.getLabelsToNodesFailedRetrieved();
     badSubCluster.getLabelToNodes();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededClusterNodeLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeLabelsRetrieved();
     goodSubCluster.getClusterNodeLabels(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeLabels(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1086,21 +1086,21 @@ public class TestRouterMetrics {
   public void testClusterNodeLabelsFailed() {
     long totalBadBefore = metrics.getGetClusterNodeLabelsFailedRetrieved();
     badSubCluster.getClusterNodeLabels();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededQueueUserAcls() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueUserAclsRetrieved();
     goodSubCluster.getQueueUserAcls(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetQueueUserAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueUserAcls(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1108,20 +1108,20 @@ public class TestRouterMetrics {
   public void testQueueUserAclsFailed() {
     long totalBadBefore = metrics.getQueueUserAclsFailedRetrieved();
     badSubCluster.getQueueUserAcls();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
   }
   @Test
   public void testSucceededListReservations() {
     long totalGoodBefore = metrics.getNumSucceededListReservationsRetrieved();
     goodSubCluster.getListReservations(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListReservationsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservations(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1129,21 +1129,21 @@ public class TestRouterMetrics {
   public void testListReservationsFailed() {
     long totalBadBefore = metrics.getListReservationsFailedRetrieved();
     badSubCluster.getListReservations();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetApplicationAttempts() {
     long totalGoodBefore = metrics.getNumSucceededAppAttemptsRetrieved();
     goodSubCluster.getApplicationAttempts(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getApplicationAttempts(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1151,21 +1151,21 @@ public class TestRouterMetrics {
   public void testGetApplicationAttemptsFailed() {
     long totalBadBefore = metrics.getAppAttemptsFailedRetrieved();
     badSubCluster.getApplicationAttempts();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainerReport() {
     long totalGoodBefore = metrics.getNumSucceededGetContainerReportRetrieved();
     goodSubCluster.getContainerReport(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetContainerReportRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainerReport(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1173,21 +1173,21 @@ public class TestRouterMetrics {
   public void testGetContainerReportFailed() {
     long totalBadBefore = metrics.getContainerReportFailedRetrieved();
     badSubCluster.getContainerReport();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainers() {
     long totalGoodBefore = metrics.getNumSucceededGetContainersRetrieved();
     goodSubCluster.getContainers(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetContainersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainers(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assertions.assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1195,21 +1195,21 @@ public class TestRouterMetrics {
   public void testGetContainersFailed() {
     long totalBadBefore = metrics.getContainersFailedRetrieved();
     badSubCluster.getContainers();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetResourceTypeInfo() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceTypeInfoRetrieved();
     goodSubCluster.getResourceTypeInfo(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceTypeInfo(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1217,21 +1217,21 @@ public class TestRouterMetrics {
   public void testGetResourceTypeInfoFailed() {
     long totalBadBefore = metrics.getGetResourceTypeInfoRetrieved();
     badSubCluster.getResourceTypeInfo();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
   }
 
   @Test
   public void testSucceededFailApplicationAttempt() {
     long totalGoodBefore = metrics.getNumSucceededFailAppAttemptRetrieved();
     goodSubCluster.getFailApplicationAttempt(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFailApplicationAttempt(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1239,21 +1239,21 @@ public class TestRouterMetrics {
   public void testFailApplicationAttemptFailed() {
     long totalBadBefore = metrics.getFailApplicationAttemptFailedRetrieved();
     badSubCluster.getFailApplicationAttempt();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
   }
 
   @Test
   public void testSucceededUpdateApplicationPriority() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppPriorityRetrieved();
     goodSubCluster.getUpdateApplicationPriority(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationPriority(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1261,7 +1261,7 @@ public class TestRouterMetrics {
   public void testUpdateApplicationPriorityFailed() {
     long totalBadBefore = metrics.getUpdateApplicationPriorityFailedRetrieved();
     badSubCluster.getUpdateApplicationPriority();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationPriorityFailedRetrieved());
   }
 
@@ -1269,14 +1269,14 @@ public class TestRouterMetrics {
   public void testSucceededUpdateAppTimeoutsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppTimeoutsRetrieved();
     goodSubCluster.getUpdateApplicationTimeouts(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationTimeouts(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1284,7 +1284,7 @@ public class TestRouterMetrics {
   public void testUpdateAppTimeoutsFailed() {
     long totalBadBefore = metrics.getUpdateApplicationTimeoutsFailedRetrieved();
     badSubCluster.getUpdateApplicationTimeouts();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationTimeoutsFailedRetrieved());
   }
 
@@ -1292,14 +1292,14 @@ public class TestRouterMetrics {
   public void testSucceededSignalToContainerRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSignalToContainerRetrieved();
     goodSubCluster.getSignalToContainerTimeouts(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSignalToContainerTimeouts(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1307,7 +1307,7 @@ public class TestRouterMetrics {
   public void testSignalToContainerFailed() {
     long totalBadBefore = metrics.getSignalToContainerFailedRetrieved();
     badSubCluster.getSignalContainer();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSignalToContainerFailedRetrieved());
   }
 
@@ -1315,14 +1315,14 @@ public class TestRouterMetrics {
   public void testSucceededGetQueueInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueInfoRetrieved();
     goodSubCluster.getQueueInfoRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueInfoRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1330,7 +1330,7 @@ public class TestRouterMetrics {
   public void testGetQueueInfoFailed() {
     long totalBadBefore = metrics.getQueueInfoFailedRetrieved();
     badSubCluster.getQueueInfo();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getQueueInfoFailedRetrieved());
   }
 
@@ -1338,14 +1338,14 @@ public class TestRouterMetrics {
   public void testSucceededMoveApplicationAcrossQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved();
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1353,7 +1353,7 @@ public class TestRouterMetrics {
   public void testMoveApplicationAcrossQueuesRetrievedFailed() {
     long totalBadBefore = metrics.getMoveApplicationAcrossQueuesFailedRetrieved();
     badSubCluster.moveApplicationAcrossQueuesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getMoveApplicationAcrossQueuesFailedRetrieved());
   }
 
@@ -1361,14 +1361,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfilesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfilesRetrieved();
     goodSubCluster.getResourceProfilesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfilesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1376,7 +1376,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfilesRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfilesFailedRetrieved();
     badSubCluster.getResourceProfilesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getResourceProfilesFailedRetrieved());
   }
 
@@ -1384,14 +1384,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfileRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfileRetrieved();
     goodSubCluster.getResourceProfileRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfileRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1399,7 +1399,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfileRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfileFailedRetrieved();
     badSubCluster.getResourceProfileFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getResourceProfileFailedRetrieved());
   }
 
@@ -1407,14 +1407,14 @@ public class TestRouterMetrics {
   public void testSucceededGetAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAttributesToNodesRetrieved();
     goodSubCluster.getAttributesToNodesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAttributesToNodesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1422,7 +1422,7 @@ public class TestRouterMetrics {
   public void testGetAttributesToNodesRetrievedFailed() {
     long totalBadBefore = metrics.getAttributesToNodesFailedRetrieved();
     badSubCluster.getAttributesToNodesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAttributesToNodesFailedRetrieved());
   }
 
@@ -1430,14 +1430,14 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeAttributesRetrieved();
     goodSubCluster.getClusterNodeAttributesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeAttributesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1445,7 +1445,7 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getClusterNodeAttributesFailedRetrieved();
     badSubCluster.getClusterNodeAttributesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getClusterNodeAttributesFailedRetrieved());
   }
 
@@ -1453,14 +1453,14 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNodesToAttributesRetrieved();
     goodSubCluster.getNodesToAttributesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodesToAttributesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1468,7 +1468,7 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getNodesToAttributesFailedRetrieved();
     badSubCluster.getNodesToAttributesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNodesToAttributesFailedRetrieved());
   }
 
@@ -1476,14 +1476,14 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNewReservationRetrieved();
     goodSubCluster.getNewReservationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNewReservationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1491,7 +1491,7 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrievedFailed() {
     long totalBadBefore = metrics.getNewReservationFailedRetrieved();
     badSubCluster.getNewReservationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNewReservationFailedRetrieved());
   }
 
@@ -1499,14 +1499,14 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSubmitReservationRetrieved();
     goodSubCluster.getSubmitReservationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSubmitReservationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1514,7 +1514,7 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrievedFailed() {
     long totalBadBefore = metrics.getSubmitReservationFailedRetrieved();
     badSubCluster.getSubmitReservationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSubmitReservationFailedRetrieved());
   }
 
@@ -1522,14 +1522,14 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateReservationRetrieved();
     goodSubCluster.getUpdateReservationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateReservationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1537,7 +1537,7 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateReservationFailedRetrieved();
     badSubCluster.getUpdateReservationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateReservationFailedRetrieved());
   }
 
@@ -1545,14 +1545,14 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteReservationRetrieved();
     goodSubCluster.getDeleteReservationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeleteReservationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1560,7 +1560,7 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrievedFailed() {
     long totalBadBefore = metrics.getDeleteReservationFailedRetrieved();
     badSubCluster.getDeleteReservationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeleteReservationFailedRetrieved());
   }
 
@@ -1568,14 +1568,14 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListReservationRetrieved();
     goodSubCluster.getListReservationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1583,7 +1583,7 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrievedFailed() {
     long totalBadBefore = metrics.getListReservationFailedRetrieved();
     badSubCluster.getListReservationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getListReservationFailedRetrieved());
   }
 
@@ -1591,14 +1591,14 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppActivitiesRetrieved();
     goodSubCluster.getAppActivitiesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppActivitiesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1606,7 +1606,7 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getAppActivitiesFailedRetrieved();
     badSubCluster.getAppActivitiesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppActivitiesFailedRetrieved());
   }
 
@@ -1614,14 +1614,14 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppStatisticsRetrieved();
     goodSubCluster.getAppStatisticsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppStatisticsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1629,7 +1629,7 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsRetrievedFailed() {
     long totalBadBefore = metrics.getAppStatisticsFailedRetrieved();
     badSubCluster.getAppStatisticsFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppStatisticsFailedRetrieved());
   }
 
@@ -1637,14 +1637,14 @@ public class TestRouterMetrics {
   public void testGetAppPriorityLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppPriorityRetrieved();
     goodSubCluster.getAppPriorityRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppPriorityRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1652,7 +1652,7 @@ public class TestRouterMetrics {
   public void testGetAppPriorityRetrievedFailed() {
     long totalBadBefore = metrics.getAppPriorityFailedRetrieved();
     badSubCluster.getAppPriorityFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppPriorityFailedRetrieved());
   }
 
@@ -1660,14 +1660,14 @@ public class TestRouterMetrics {
   public void testGetAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppQueueRetrieved();
     goodSubCluster.getAppQueueRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppQueueRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1675,7 +1675,7 @@ public class TestRouterMetrics {
   public void testGetAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getAppQueueFailedRetrieved();
     badSubCluster.getAppQueueFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppQueueFailedRetrieved());
   }
 
@@ -1683,14 +1683,14 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppQueueRetrieved();
     goodSubCluster.getUpdateQueueRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateQueueRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1698,7 +1698,7 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateAppQueueFailedRetrieved();
     badSubCluster.getUpdateQueueFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateAppQueueFailedRetrieved());
   }
 
@@ -1706,14 +1706,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutRetrieved();
     goodSubCluster.getAppTimeoutRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1721,7 +1721,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutFailedRetrieved();
     badSubCluster.getAppTimeoutFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutFailedRetrieved());
   }
 
@@ -1729,14 +1729,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutsRetrieved();
     goodSubCluster.getAppTimeoutsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1744,7 +1744,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutsFailedRetrieved();
     badSubCluster.getAppTimeoutsFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutsFailedRetrieved());
   }
 
@@ -1752,14 +1752,14 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetRMNodeLabelsRetrieved();
     goodSubCluster.getRMNodeLabelsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRMNodeLabelsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1767,7 +1767,7 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrievedFailed() {
     long totalBadBefore = metrics.getRMNodeLabelsFailedRetrieved();
     badSubCluster.getRMNodeLabelsFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getRMNodeLabelsFailedRetrieved());
   }
 
@@ -1775,14 +1775,14 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckUserAccessToQueueRetrieved();
     goodSubCluster.getCheckUserAccessToQueueRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckUserAccessToQueueRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1790,7 +1790,7 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrievedFailed() {
     long totalBadBefore = metrics.getCheckUserAccessToQueueFailedRetrieved();
     badSubCluster.getCheckUserAccessToQueueFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getCheckUserAccessToQueueFailedRetrieved());
   }
 
@@ -1798,14 +1798,14 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetDelegationTokenRetrieved();
     goodSubCluster.getGetDelegationTokenRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGetDelegationTokenRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1813,7 +1813,7 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getDelegationTokenFailedRetrieved();
     badSubCluster.getDelegationTokenFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDelegationTokenFailedRetrieved());
   }
 
@@ -1821,14 +1821,14 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRenewDelegationTokenRetrieved();
     goodSubCluster.getRenewDelegationTokenRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRenewDelegationTokenRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1836,7 +1836,7 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getRenewDelegationTokenFailedRetrieved();
     badSubCluster.getRenewDelegationTokenFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getRenewDelegationTokenFailedRetrieved());
   }
 
@@ -1844,14 +1844,14 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshAdminAclsRetrieved();
     goodSubCluster.getRefreshAdminAclsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshAdminAclsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1859,7 +1859,7 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshAdminAclsFailedRetrieved();
     badSubCluster.getRefreshAdminAclsFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshAdminAclsFailedRetrieved());
   }
 
@@ -1867,14 +1867,14 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshServiceAclsRetrieved();
     goodSubCluster.getRefreshServiceAclsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshServiceAclsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1882,7 +1882,7 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshServiceAclsFailedRetrieved();
     badSubCluster.getRefreshServiceAclsFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshServiceAclsFailedRetrieved());
   }
 
@@ -1890,14 +1890,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodesRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1905,7 +1905,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodesFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodesFailedRetrieved());
   }
 
@@ -1913,14 +1913,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodeRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodeRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1928,7 +1928,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelOnNodeRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodeFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodeFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodeFailedRetrieved());
   }
 
@@ -1936,14 +1936,14 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDumpSchedulerLogsRetrieved();
     goodSubCluster.getDumpSchedulerLogsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDumpSchedulerLogsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1951,7 +1951,7 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrievedFailed() {
     long totalBadBefore = metrics.getDumpSchedulerLogsFailedRetrieved();
     badSubCluster.getDumpSchedulerLogsFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDumpSchedulerLogsFailedRetrieved());
   }
 
@@ -1959,14 +1959,14 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetActivitiesRetrieved();
     goodSubCluster.getActivitiesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getActivitiesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1974,7 +1974,7 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getActivitiesFailedRetrieved();
     badSubCluster.getActivitiesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getActivitiesFailedRetrieved());
   }
 
@@ -1982,14 +1982,14 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetBulkActivitiesRetrieved();
     goodSubCluster.getBulkActivitiesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBulkActivitiesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1997,7 +1997,7 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getBulkActivitiesFailedRetrieved();
     badSubCluster.getBulkActivitiesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getBulkActivitiesFailedRetrieved());
   }
 
@@ -2005,14 +2005,14 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeregisterSubClusterRetrieved();
     goodSubCluster.getDeregisterSubClusterRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeregisterSubClusterRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2020,7 +2020,7 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrievedFailed() {
     long totalBadBefore = metrics.getDeregisterSubClusterFailedRetrieved();
     badSubCluster.getDeregisterSubClusterFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeregisterSubClusterFailedRetrieved());
   }
 
@@ -2028,14 +2028,14 @@ public class TestRouterMetrics {
   public void testAddToClusterNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededAddToClusterNodeLabelsRetrieved();
     goodSubCluster.addToClusterNodeLabelsRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.addToClusterNodeLabelsRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2043,7 +2043,7 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getSchedulerConfigurationFailedRetrieved();
     badSubCluster.getSchedulerConfigurationFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2051,14 +2051,14 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetSchedulerConfigurationRetrieved();
     goodSubCluster.getSchedulerConfigurationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSchedulerConfigurationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2066,7 +2066,7 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateSchedulerConfigurationFailedRetrieved();
     badSubCluster.updateSchedulerConfigurationFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2074,14 +2074,14 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved();
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2089,21 +2089,21 @@ public class TestRouterMetrics {
   public void testGetClusterInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterInfoFailedRetrieved();
     badSubCluster.getClusterInfoFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterInfoRetrieved();
     goodSubCluster.getClusterInfoRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterInfoRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2111,21 +2111,21 @@ public class TestRouterMetrics {
   public void testGetClusterUserInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterUserInfoFailedRetrieved();
     badSubCluster.getClusterUserInfoFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterUserInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
     goodSubCluster.getClusterUserInfoRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterUserInfoRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2133,21 +2133,21 @@ public class TestRouterMetrics {
   public void testUpdateNodeResourceRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateNodeResourceFailedRetrieved();
     badSubCluster.getUpdateNodeResourceFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
   }
 
   @Test
   public void testUpdateNodeResourceRetrieved() {
-    long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
+    long totalGoodBefore = metrics.getNumSucceededUpdateNodeResourceRetrieved();
     goodSubCluster.getUpdateNodeResourceRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateNodeResourceRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2155,21 +2155,21 @@ public class TestRouterMetrics {
   public void testRefreshNodesResourcesRetrievedFailed() {
     long totalBadBefore = metrics.getRefreshNodesResourcesFailedRetrieved();
     badSubCluster.getRefreshNodesResourcesFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
   }
 
   @Test
   public void testRefreshNodesResourcesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshNodesResourcesRetrieved();
     goodSubCluster.getRefreshNodesResourcesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshNodesResourcesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2177,7 +2177,7 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesFailedRetrieved() {
     long totalBadBefore = metrics.getCheckForDecommissioningNodesFailedRetrieved();
     badSubCluster.getCheckForDecommissioningNodesFailed();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getCheckForDecommissioningNodesFailedRetrieved());
   }
 
@@ -2185,14 +2185,14 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckForDecommissioningNodesRetrieved();
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2200,21 +2200,21 @@ public class TestRouterMetrics {
   public void testRefreshClusterMaxPriorityFailedRetrieved() {
     long totalBadBefore = metrics.getRefreshClusterMaxPriorityFailedRetrieved();
     badSubCluster.getRefreshClusterMaxPriorityFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
   }
 
   @Test
   public void testRefreshClusterMaxPriorityRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved();
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2222,21 +2222,21 @@ public class TestRouterMetrics {
   public void testGetMapAttributesToNodesFailedRetrieved() {
     long totalBadBefore = metrics.getMapAttributesToNodesFailedRetrieved();
     badSubCluster.getMapAttributesToNodesFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
   }
 
   @Test
   public void testGetMapAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMapAttributesToNodesRetrieved();
     goodSubCluster.getMapAttributesToNodesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getMapAttributesToNodesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2244,21 +2244,21 @@ public class TestRouterMetrics {
   public void testGetGroupsForUserFailedRetrieved() {
     long totalBadBefore = metrics.getGroupsForUserFailedRetrieved();
     badSubCluster.getGroupsForUserFailed();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
   }
 
   @Test
   public void testGetGroupsForUserRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetGroupsForUsersRetrieved();
     goodSubCluster.getGroupsForUsersRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGroupsForUsersRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2266,21 +2266,21 @@ public class TestRouterMetrics {
   public void testSaveFederationQueuePolicyFailedRetrieved() {
     long totalBadBefore = metrics.getSaveFederationQueuePolicyFailedRetrieved();
     badSubCluster.getSaveFederationQueuePolicyFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
   }
 
   @Test
   public void testSaveFederationQueuePolicyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSaveFederationQueuePolicyRetrieved();
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2288,7 +2288,7 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getBatchSaveFederationQueuePoliciesFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2296,15 +2296,15 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved();
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
@@ -2313,7 +2313,7 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getListFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getListFederationQueuePoliciesFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getListFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2321,14 +2321,14 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved();
     goodSubCluster.getListFederationQueuePoliciesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListFederationQueuePoliciesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2336,7 +2336,7 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersFailedRetrieved() {
     long totalBadBefore = metrics.getFederationSubClustersFailedRetrieved();
     badSubCluster.getFederationSubClustersFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getFederationSubClustersFailedRetrieved());
   }
 
@@ -2344,14 +2344,14 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetFederationSubClustersRetrieved();
     goodSubCluster.getFederationSubClustersRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFederationSubClustersRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2359,7 +2359,7 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesFailedRetrieved() {
     long totalBadBefore = metrics.getDeleteFederationPoliciesByQueuesRetrieved();
     badSubCluster.getDeleteFederationPoliciesByQueuesFailedRetrieved();
-    Assertions.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeleteFederationPoliciesByQueuesRetrieved());
   }
 
@@ -2367,15 +2367,15 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved();
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(150);
-    Assertions.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assertions.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(300);
-    Assertions.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assertions.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,23 +40,23 @@ public class TestRouterMetrics {
 
   private static final Double ASSERT_DOUBLE_DELTA = 0.01;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
 
     LOG.info("Test: aggregate metrics are initialized correctly");
 
-    Assert.assertEquals(0, metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0, metrics.getNumSucceededAppsCreated());
+    Assertions.assertEquals(0, metrics.getNumSucceededAppsSubmitted());
+    Assertions.assertEquals(0, metrics.getNumSucceededAppsKilled());
+    Assertions.assertEquals(0, metrics.getNumSucceededAppsRetrieved());
+    Assertions.assertEquals(0,
         metrics.getNumSucceededAppAttemptsRetrieved());
 
-    Assert.assertEquals(0, metrics.getAppsFailedCreated());
-    Assert.assertEquals(0, metrics.getAppsFailedSubmitted());
-    Assert.assertEquals(0, metrics.getAppsFailedKilled());
-    Assert.assertEquals(0, metrics.getAppsFailedRetrieved());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0, metrics.getAppsFailedCreated());
+    Assertions.assertEquals(0, metrics.getAppsFailedSubmitted());
+    Assertions.assertEquals(0, metrics.getAppsFailedKilled());
+    Assertions.assertEquals(0, metrics.getAppsFailedRetrieved());
+    Assertions.assertEquals(0,
         metrics.getAppAttemptsFailedRetrieved());
 
     LOG.info("Test: aggregate metrics are updated correctly");
@@ -73,15 +73,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getNewApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
+    Assertions.assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
 
     goodSubCluster.getNewApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
+    Assertions.assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
   }
 
   /**
@@ -94,7 +94,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getNewApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
+    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
   }
 
   /**
@@ -108,15 +108,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.submitApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
+    Assertions.assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
 
     goodSubCluster.submitApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
+    Assertions.assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
   }
 
   /**
@@ -129,7 +129,7 @@ public class TestRouterMetrics {
 
     badSubCluster.submitApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
+    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
   }
 
   /**
@@ -143,15 +143,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.forceKillApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
+    Assertions.assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
 
     goodSubCluster.forceKillApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
+    Assertions.assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
   }
 
   /**
@@ -164,7 +164,7 @@ public class TestRouterMetrics {
 
     badSubCluster.forceKillApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
+    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
   }
 
   /**
@@ -178,15 +178,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
+    Assertions.assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
 
     goodSubCluster.getApplicationReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
+    Assertions.assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
   }
 
   /**
@@ -199,7 +199,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationReport();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
+    Assertions.assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
   }
 
   /**
@@ -214,16 +214,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationAttemptReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assert.assertEquals(100,
+    Assertions.assertEquals(100,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
 
     goodSubCluster.getApplicationAttemptReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -238,7 +238,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationAttemptReport();
 
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppAttemptReportFailedRetrieved());
   }
 
@@ -253,16 +253,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationsReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
+    Assertions.assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
 
     goodSubCluster.getApplicationsReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
+    Assertions.assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
   }
 
@@ -277,7 +277,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationsReport();
 
-    Assert.assertEquals(totalBadbefore + 1,
+    Assertions.assertEquals(totalBadbefore + 1,
         metrics.getMultipleAppsFailedRetrieved());
   }
 
@@ -289,14 +289,14 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterMetrics() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterMetricsRetrieved();
     goodSubCluster.getClusterMetrics(100);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    Assertions.assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
     goodSubCluster.getClusterMetrics(200);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    Assertions.assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
   }
 
@@ -308,7 +308,7 @@ public class TestRouterMetrics {
   public void testGetClusterMetricsFailed() {
     long totalBadbefore = metrics.getClusterMetricsFailedRetrieved();
     badSubCluster.getClusterMetrics();
-    Assert.assertEquals(totalBadbefore + 1,
+    Assertions.assertEquals(totalBadbefore + 1,
         metrics.getClusterMetricsFailedRetrieved());
   }
 
@@ -1011,12 +1011,12 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodesRetrieved();
     goodSubCluster.getClusterNodes(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
+    Assertions.assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodes(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1024,19 +1024,19 @@ public class TestRouterMetrics {
   public void testGetClusterNodesFailed() {
     long totalBadBefore = metrics.getClusterNodesFailedRetrieved();
     badSubCluster.getClusterNodes();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetNodeToLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetNodeToLabelsRetrieved();
     goodSubCluster.getNodeToLabels(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    Assertions.assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodeToLabels(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1044,19 +1044,19 @@ public class TestRouterMetrics {
   public void testGetNodeToLabelsFailed() {
     long totalBadBefore = metrics.getNodeToLabelsFailedRetrieved();
     badSubCluster.getNodeToLabels();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededLabelsToNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetLabelsToNodesRetrieved();
     goodSubCluster.getLabelToNodes(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    Assertions.assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getLabelToNodes(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    Assertions.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1064,21 +1064,21 @@ public class TestRouterMetrics {
   public void testGetLabelsToNodesFailed() {
     long totalBadBefore = metrics.getLabelsToNodesFailedRetrieved();
     badSubCluster.getLabelToNodes();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededClusterNodeLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeLabelsRetrieved();
     goodSubCluster.getClusterNodeLabels(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeLabels(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1086,21 +1086,21 @@ public class TestRouterMetrics {
   public void testClusterNodeLabelsFailed() {
     long totalBadBefore = metrics.getGetClusterNodeLabelsFailedRetrieved();
     badSubCluster.getClusterNodeLabels();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededQueueUserAcls() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueUserAclsRetrieved();
     goodSubCluster.getQueueUserAcls(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetQueueUserAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueUserAcls(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1108,20 +1108,20 @@ public class TestRouterMetrics {
   public void testQueueUserAclsFailed() {
     long totalBadBefore = metrics.getQueueUserAclsFailedRetrieved();
     badSubCluster.getQueueUserAcls();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
   }
   @Test
   public void testSucceededListReservations() {
     long totalGoodBefore = metrics.getNumSucceededListReservationsRetrieved();
     goodSubCluster.getListReservations(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededListReservationsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservations(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1129,21 +1129,21 @@ public class TestRouterMetrics {
   public void testListReservationsFailed() {
     long totalBadBefore = metrics.getListReservationsFailedRetrieved();
     badSubCluster.getListReservations();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetApplicationAttempts() {
     long totalGoodBefore = metrics.getNumSucceededAppAttemptsRetrieved();
     goodSubCluster.getApplicationAttempts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getApplicationAttempts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1151,21 +1151,21 @@ public class TestRouterMetrics {
   public void testGetApplicationAttemptsFailed() {
     long totalBadBefore = metrics.getAppAttemptsFailedRetrieved();
     badSubCluster.getApplicationAttempts();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainerReport() {
     long totalGoodBefore = metrics.getNumSucceededGetContainerReportRetrieved();
     goodSubCluster.getContainerReport(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetContainerReportRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainerReport(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1173,21 +1173,21 @@ public class TestRouterMetrics {
   public void testGetContainerReportFailed() {
     long totalBadBefore = metrics.getContainerReportFailedRetrieved();
     badSubCluster.getContainerReport();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainers() {
     long totalGoodBefore = metrics.getNumSucceededGetContainersRetrieved();
     goodSubCluster.getContainers(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetContainersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainers(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
+    Assertions.assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1195,21 +1195,21 @@ public class TestRouterMetrics {
   public void testGetContainersFailed() {
     long totalBadBefore = metrics.getContainersFailedRetrieved();
     badSubCluster.getContainers();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetResourceTypeInfo() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceTypeInfoRetrieved();
     goodSubCluster.getResourceTypeInfo(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceTypeInfo(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1217,21 +1217,21 @@ public class TestRouterMetrics {
   public void testGetResourceTypeInfoFailed() {
     long totalBadBefore = metrics.getGetResourceTypeInfoRetrieved();
     badSubCluster.getResourceTypeInfo();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
   }
 
   @Test
   public void testSucceededFailApplicationAttempt() {
     long totalGoodBefore = metrics.getNumSucceededFailAppAttemptRetrieved();
     goodSubCluster.getFailApplicationAttempt(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFailApplicationAttempt(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1239,21 +1239,21 @@ public class TestRouterMetrics {
   public void testFailApplicationAttemptFailed() {
     long totalBadBefore = metrics.getFailApplicationAttemptFailedRetrieved();
     badSubCluster.getFailApplicationAttempt();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
   }
 
   @Test
   public void testSucceededUpdateApplicationPriority() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppPriorityRetrieved();
     goodSubCluster.getUpdateApplicationPriority(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationPriority(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1261,7 +1261,7 @@ public class TestRouterMetrics {
   public void testUpdateApplicationPriorityFailed() {
     long totalBadBefore = metrics.getUpdateApplicationPriorityFailedRetrieved();
     badSubCluster.getUpdateApplicationPriority();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationPriorityFailedRetrieved());
   }
 
@@ -1269,14 +1269,14 @@ public class TestRouterMetrics {
   public void testSucceededUpdateAppTimeoutsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppTimeoutsRetrieved();
     goodSubCluster.getUpdateApplicationTimeouts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationTimeouts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1284,7 +1284,7 @@ public class TestRouterMetrics {
   public void testUpdateAppTimeoutsFailed() {
     long totalBadBefore = metrics.getUpdateApplicationTimeoutsFailedRetrieved();
     badSubCluster.getUpdateApplicationTimeouts();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationTimeoutsFailedRetrieved());
   }
 
@@ -1292,14 +1292,14 @@ public class TestRouterMetrics {
   public void testSucceededSignalToContainerRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSignalToContainerRetrieved();
     goodSubCluster.getSignalToContainerTimeouts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSignalToContainerTimeouts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1307,7 +1307,7 @@ public class TestRouterMetrics {
   public void testSignalToContainerFailed() {
     long totalBadBefore = metrics.getSignalToContainerFailedRetrieved();
     badSubCluster.getSignalContainer();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getSignalToContainerFailedRetrieved());
   }
 
@@ -1315,14 +1315,14 @@ public class TestRouterMetrics {
   public void testSucceededGetQueueInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueInfoRetrieved();
     goodSubCluster.getQueueInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1330,7 +1330,7 @@ public class TestRouterMetrics {
   public void testGetQueueInfoFailed() {
     long totalBadBefore = metrics.getQueueInfoFailedRetrieved();
     badSubCluster.getQueueInfo();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getQueueInfoFailedRetrieved());
   }
 
@@ -1338,14 +1338,14 @@ public class TestRouterMetrics {
   public void testSucceededMoveApplicationAcrossQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved();
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1353,7 +1353,7 @@ public class TestRouterMetrics {
   public void testMoveApplicationAcrossQueuesRetrievedFailed() {
     long totalBadBefore = metrics.getMoveApplicationAcrossQueuesFailedRetrieved();
     badSubCluster.moveApplicationAcrossQueuesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getMoveApplicationAcrossQueuesFailedRetrieved());
   }
 
@@ -1361,14 +1361,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfilesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfilesRetrieved();
     goodSubCluster.getResourceProfilesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfilesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1376,7 +1376,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfilesRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfilesFailedRetrieved();
     badSubCluster.getResourceProfilesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getResourceProfilesFailedRetrieved());
   }
 
@@ -1384,14 +1384,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfileRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfileRetrieved();
     goodSubCluster.getResourceProfileRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfileRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1399,7 +1399,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfileRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfileFailedRetrieved();
     badSubCluster.getResourceProfileFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getResourceProfileFailedRetrieved());
   }
 
@@ -1407,14 +1407,14 @@ public class TestRouterMetrics {
   public void testSucceededGetAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAttributesToNodesRetrieved();
     goodSubCluster.getAttributesToNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAttributesToNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1422,7 +1422,7 @@ public class TestRouterMetrics {
   public void testGetAttributesToNodesRetrievedFailed() {
     long totalBadBefore = metrics.getAttributesToNodesFailedRetrieved();
     badSubCluster.getAttributesToNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAttributesToNodesFailedRetrieved());
   }
 
@@ -1430,14 +1430,14 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeAttributesRetrieved();
     goodSubCluster.getClusterNodeAttributesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeAttributesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1445,7 +1445,7 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getClusterNodeAttributesFailedRetrieved();
     badSubCluster.getClusterNodeAttributesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getClusterNodeAttributesFailedRetrieved());
   }
 
@@ -1453,14 +1453,14 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNodesToAttributesRetrieved();
     goodSubCluster.getNodesToAttributesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodesToAttributesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1468,7 +1468,7 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getNodesToAttributesFailedRetrieved();
     badSubCluster.getNodesToAttributesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNodesToAttributesFailedRetrieved());
   }
 
@@ -1476,14 +1476,14 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNewReservationRetrieved();
     goodSubCluster.getNewReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNewReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1491,7 +1491,7 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrievedFailed() {
     long totalBadBefore = metrics.getNewReservationFailedRetrieved();
     badSubCluster.getNewReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNewReservationFailedRetrieved());
   }
 
@@ -1499,14 +1499,14 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSubmitReservationRetrieved();
     goodSubCluster.getSubmitReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSubmitReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1514,7 +1514,7 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrievedFailed() {
     long totalBadBefore = metrics.getSubmitReservationFailedRetrieved();
     badSubCluster.getSubmitReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getSubmitReservationFailedRetrieved());
   }
 
@@ -1522,14 +1522,14 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateReservationRetrieved();
     goodSubCluster.getUpdateReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1537,7 +1537,7 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateReservationFailedRetrieved();
     badSubCluster.getUpdateReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getUpdateReservationFailedRetrieved());
   }
 
@@ -1545,14 +1545,14 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteReservationRetrieved();
     goodSubCluster.getDeleteReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeleteReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1560,7 +1560,7 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrievedFailed() {
     long totalBadBefore = metrics.getDeleteReservationFailedRetrieved();
     badSubCluster.getDeleteReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getDeleteReservationFailedRetrieved());
   }
 
@@ -1568,14 +1568,14 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListReservationRetrieved();
     goodSubCluster.getListReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1583,7 +1583,7 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrievedFailed() {
     long totalBadBefore = metrics.getListReservationFailedRetrieved();
     badSubCluster.getListReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getListReservationFailedRetrieved());
   }
 
@@ -1591,14 +1591,14 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppActivitiesRetrieved();
     goodSubCluster.getAppActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1606,7 +1606,7 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getAppActivitiesFailedRetrieved();
     badSubCluster.getAppActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppActivitiesFailedRetrieved());
   }
 
@@ -1614,14 +1614,14 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppStatisticsRetrieved();
     goodSubCluster.getAppStatisticsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppStatisticsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1629,7 +1629,7 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsRetrievedFailed() {
     long totalBadBefore = metrics.getAppStatisticsFailedRetrieved();
     badSubCluster.getAppStatisticsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppStatisticsFailedRetrieved());
   }
 
@@ -1637,14 +1637,14 @@ public class TestRouterMetrics {
   public void testGetAppPriorityLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppPriorityRetrieved();
     goodSubCluster.getAppPriorityRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppPriorityRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1652,7 +1652,7 @@ public class TestRouterMetrics {
   public void testGetAppPriorityRetrievedFailed() {
     long totalBadBefore = metrics.getAppPriorityFailedRetrieved();
     badSubCluster.getAppPriorityFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppPriorityFailedRetrieved());
   }
 
@@ -1660,14 +1660,14 @@ public class TestRouterMetrics {
   public void testGetAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppQueueRetrieved();
     goodSubCluster.getAppQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1675,7 +1675,7 @@ public class TestRouterMetrics {
   public void testGetAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getAppQueueFailedRetrieved();
     badSubCluster.getAppQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppQueueFailedRetrieved());
   }
 
@@ -1683,14 +1683,14 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppQueueRetrieved();
     goodSubCluster.getUpdateQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1698,7 +1698,7 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateAppQueueFailedRetrieved();
     badSubCluster.getUpdateQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getUpdateAppQueueFailedRetrieved());
   }
 
@@ -1706,14 +1706,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutRetrieved();
     goodSubCluster.getAppTimeoutRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1721,7 +1721,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutFailedRetrieved();
     badSubCluster.getAppTimeoutFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutFailedRetrieved());
   }
 
@@ -1729,14 +1729,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutsRetrieved();
     goodSubCluster.getAppTimeoutsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1744,7 +1744,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutsFailedRetrieved();
     badSubCluster.getAppTimeoutsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutsFailedRetrieved());
   }
 
@@ -1752,14 +1752,14 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetRMNodeLabelsRetrieved();
     goodSubCluster.getRMNodeLabelsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRMNodeLabelsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1767,7 +1767,7 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrievedFailed() {
     long totalBadBefore = metrics.getRMNodeLabelsFailedRetrieved();
     badSubCluster.getRMNodeLabelsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getRMNodeLabelsFailedRetrieved());
   }
 
@@ -1775,14 +1775,14 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckUserAccessToQueueRetrieved();
     goodSubCluster.getCheckUserAccessToQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckUserAccessToQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1790,7 +1790,7 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrievedFailed() {
     long totalBadBefore = metrics.getCheckUserAccessToQueueFailedRetrieved();
     badSubCluster.getCheckUserAccessToQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getCheckUserAccessToQueueFailedRetrieved());
   }
 
@@ -1798,14 +1798,14 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetDelegationTokenRetrieved();
     goodSubCluster.getGetDelegationTokenRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGetDelegationTokenRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1813,7 +1813,7 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getDelegationTokenFailedRetrieved();
     badSubCluster.getDelegationTokenFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getDelegationTokenFailedRetrieved());
   }
 
@@ -1821,14 +1821,14 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRenewDelegationTokenRetrieved();
     goodSubCluster.getRenewDelegationTokenRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRenewDelegationTokenRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1836,7 +1836,7 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getRenewDelegationTokenFailedRetrieved();
     badSubCluster.getRenewDelegationTokenFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getRenewDelegationTokenFailedRetrieved());
   }
 
@@ -1844,14 +1844,14 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshAdminAclsRetrieved();
     goodSubCluster.getRefreshAdminAclsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshAdminAclsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1859,7 +1859,7 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshAdminAclsFailedRetrieved();
     badSubCluster.getRefreshAdminAclsFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshAdminAclsFailedRetrieved());
   }
 
@@ -1867,14 +1867,14 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshServiceAclsRetrieved();
     goodSubCluster.getRefreshServiceAclsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshServiceAclsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1882,7 +1882,7 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshServiceAclsFailedRetrieved();
     badSubCluster.getRefreshServiceAclsFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshServiceAclsFailedRetrieved());
   }
 
@@ -1890,14 +1890,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodesRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1905,7 +1905,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodesFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodesFailedRetrieved());
   }
 
@@ -1913,14 +1913,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodeRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodeRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1928,7 +1928,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelOnNodeRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodeFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodeFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodeFailedRetrieved());
   }
 
@@ -1936,14 +1936,14 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDumpSchedulerLogsRetrieved();
     goodSubCluster.getDumpSchedulerLogsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDumpSchedulerLogsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1951,7 +1951,7 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrievedFailed() {
     long totalBadBefore = metrics.getDumpSchedulerLogsFailedRetrieved();
     badSubCluster.getDumpSchedulerLogsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getDumpSchedulerLogsFailedRetrieved());
   }
 
@@ -1959,14 +1959,14 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetActivitiesRetrieved();
     goodSubCluster.getActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1974,7 +1974,7 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getActivitiesFailedRetrieved();
     badSubCluster.getActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getActivitiesFailedRetrieved());
   }
 
@@ -1982,14 +1982,14 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetBulkActivitiesRetrieved();
     goodSubCluster.getBulkActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBulkActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1997,7 +1997,7 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getBulkActivitiesFailedRetrieved();
     badSubCluster.getBulkActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getBulkActivitiesFailedRetrieved());
   }
 
@@ -2005,14 +2005,14 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeregisterSubClusterRetrieved();
     goodSubCluster.getDeregisterSubClusterRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeregisterSubClusterRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2020,7 +2020,7 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrievedFailed() {
     long totalBadBefore = metrics.getDeregisterSubClusterFailedRetrieved();
     badSubCluster.getDeregisterSubClusterFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getDeregisterSubClusterFailedRetrieved());
   }
 
@@ -2028,14 +2028,14 @@ public class TestRouterMetrics {
   public void testAddToClusterNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededAddToClusterNodeLabelsRetrieved();
     goodSubCluster.addToClusterNodeLabelsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.addToClusterNodeLabelsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2043,7 +2043,7 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getSchedulerConfigurationFailedRetrieved();
     badSubCluster.getSchedulerConfigurationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2051,14 +2051,14 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetSchedulerConfigurationRetrieved();
     goodSubCluster.getSchedulerConfigurationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSchedulerConfigurationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2066,7 +2066,7 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateSchedulerConfigurationFailedRetrieved();
     badSubCluster.updateSchedulerConfigurationFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getUpdateSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2074,14 +2074,14 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved();
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2089,21 +2089,21 @@ public class TestRouterMetrics {
   public void testGetClusterInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterInfoFailedRetrieved();
     badSubCluster.getClusterInfoFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterInfoRetrieved();
     goodSubCluster.getClusterInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2111,21 +2111,21 @@ public class TestRouterMetrics {
   public void testGetClusterUserInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterUserInfoFailedRetrieved();
     badSubCluster.getClusterUserInfoFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterUserInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
     goodSubCluster.getClusterUserInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterUserInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2133,21 +2133,21 @@ public class TestRouterMetrics {
   public void testUpdateNodeResourceRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateNodeResourceFailedRetrieved();
     badSubCluster.getUpdateNodeResourceFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
   }
 
   @Test
   public void testUpdateNodeResourceRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
     goodSubCluster.getUpdateNodeResourceRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateNodeResourceRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2155,21 +2155,21 @@ public class TestRouterMetrics {
   public void testRefreshNodesResourcesRetrievedFailed() {
     long totalBadBefore = metrics.getRefreshNodesResourcesFailedRetrieved();
     badSubCluster.getRefreshNodesResourcesFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
   }
 
   @Test
   public void testRefreshNodesResourcesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshNodesResourcesRetrieved();
     goodSubCluster.getRefreshNodesResourcesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshNodesResourcesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2177,7 +2177,7 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesFailedRetrieved() {
     long totalBadBefore = metrics.getCheckForDecommissioningNodesFailedRetrieved();
     badSubCluster.getCheckForDecommissioningNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getCheckForDecommissioningNodesFailedRetrieved());
   }
 
@@ -2185,14 +2185,14 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckForDecommissioningNodesRetrieved();
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2200,21 +2200,21 @@ public class TestRouterMetrics {
   public void testRefreshClusterMaxPriorityFailedRetrieved() {
     long totalBadBefore = metrics.getRefreshClusterMaxPriorityFailedRetrieved();
     badSubCluster.getRefreshClusterMaxPriorityFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
   }
 
   @Test
   public void testRefreshClusterMaxPriorityRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved();
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2222,21 +2222,21 @@ public class TestRouterMetrics {
   public void testGetMapAttributesToNodesFailedRetrieved() {
     long totalBadBefore = metrics.getMapAttributesToNodesFailedRetrieved();
     badSubCluster.getMapAttributesToNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
   }
 
   @Test
   public void testGetMapAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMapAttributesToNodesRetrieved();
     goodSubCluster.getMapAttributesToNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getMapAttributesToNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2244,21 +2244,21 @@ public class TestRouterMetrics {
   public void testGetGroupsForUserFailedRetrieved() {
     long totalBadBefore = metrics.getGroupsForUserFailedRetrieved();
     badSubCluster.getGroupsForUserFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
   }
 
   @Test
   public void testGetGroupsForUserRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetGroupsForUsersRetrieved();
     goodSubCluster.getGroupsForUsersRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGroupsForUsersRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2266,21 +2266,21 @@ public class TestRouterMetrics {
   public void testSaveFederationQueuePolicyFailedRetrieved() {
     long totalBadBefore = metrics.getSaveFederationQueuePolicyFailedRetrieved();
     badSubCluster.getSaveFederationQueuePolicyFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
+    Assertions.assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
   }
 
   @Test
   public void testSaveFederationQueuePolicyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSaveFederationQueuePolicyRetrieved();
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2288,7 +2288,7 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getBatchSaveFederationQueuePoliciesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2296,15 +2296,15 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved();
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
@@ -2313,7 +2313,7 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getListFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getListFederationQueuePoliciesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getListFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2321,14 +2321,14 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved();
     goodSubCluster.getListFederationQueuePoliciesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListFederationQueuePoliciesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2336,7 +2336,7 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersFailedRetrieved() {
     long totalBadBefore = metrics.getFederationSubClustersFailedRetrieved();
     badSubCluster.getFederationSubClustersFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getFederationSubClustersFailedRetrieved());
   }
 
@@ -2344,14 +2344,14 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetFederationSubClustersRetrieved();
     goodSubCluster.getFederationSubClustersRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFederationSubClustersRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2359,7 +2359,7 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesFailedRetrieved() {
     long totalBadBefore = metrics.getDeleteFederationPoliciesByQueuesRetrieved();
     badSubCluster.getDeleteFederationPoliciesByQueuesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    Assertions.assertEquals(totalBadBefore + 1,
         metrics.getDeleteFederationPoliciesByQueuesRetrieved());
   }
 
@@ -2367,15 +2367,15 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved();
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    Assertions.assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assert.assertEquals(150,
+    Assertions.assertEquals(150,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    Assertions.assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assert.assertEquals(225,
+    Assertions.assertEquals(225,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterServerUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterServerUtil.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationReque
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationRequestsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationSubmissionRequestInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ResourceInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.yarn.server.router.webapp.TestFederationInterceptorREST.getReservationSubmissionRequestInfo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestRouterServerUtil {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.GetApplicationHome
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestRouterStoreCommands {
 
@@ -41,7 +41,7 @@ public class TestRouterStoreCommands {
   private MemoryFederationStateStore stateStore;
   private FederationStateStoreFacade facade;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
     conf = new YarnConfiguration();
     stateStore = new MemoryFederationStateStore();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router.cleaner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -29,7 +32,6 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatRequest;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatResponse;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -93,13 +95,13 @@ public class TestSubClusterCleaner {
     // Step3. All clusters have expired,
     // so the current Federation has no active subClusters.
     int count = facade.getActiveSubClustersCount();
-    Assertions.assertEquals(0, count);
+    assertEquals(0, count);
 
     // Step4. Check Active SubCluster Status.
     // We want all subClusters to be SC_LOST.
     subClustersMap.values().forEach(subClusterInfo -> {
       SubClusterState subClusterState = subClusterInfo.getState();
-      Assertions.assertEquals(SubClusterState.SC_LOST, subClusterState);
+      assertEquals(SubClusterState.SC_LOST, subClusterState);
     });
   }
 
@@ -121,7 +123,7 @@ public class TestSubClusterCleaner {
 
     // Step4. At this point we should have 2 subClusters that are surviving clusters.
     int count = facade.getActiveSubClustersCount();
-    Assertions.assertEquals(2, count);
+    assertEquals(2, count);
 
     // Step5. The result we expect is that SC-0 and SC-1 are in the RUNNING state,
     // and SC-2 and SC-3 are in the SC_LOST state.
@@ -137,7 +139,7 @@ public class TestSubClusterCleaner {
     SubClusterHeartbeatRequest request = SubClusterHeartbeatRequest.newInstance(
         subClusterId, Time.now(), SubClusterState.SC_RUNNING, "test");
     SubClusterHeartbeatResponse response = stateStore.subClusterHeartbeat(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
   }
 
   private void expiredSubcluster(String pSubClusterId) {
@@ -153,6 +155,6 @@ public class TestSubClusterCleaner {
     if (subClusterInfo == null) {
       throw new YarnException("subClusterId=" + pSubClusterId + " does not exist.");
     }
-    Assertions.assertEquals(expectState, subClusterInfo.getState());
+    assertEquals(expectState, subClusterInfo.getState());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatRequest;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatResponse;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -48,7 +48,7 @@ public class TestSubClusterCleaner {
   private final static int NUM_SUBCLUSTERS = 4;
   private final static long EXPIRATION_TIME = Time.now() - 5000;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
     conf = new YarnConfiguration();
     conf.setLong(YarnConfiguration.ROUTER_SUBCLUSTER_EXPIRATION_TIME, 1000);
@@ -93,13 +93,13 @@ public class TestSubClusterCleaner {
     // Step3. All clusters have expired,
     // so the current Federation has no active subClusters.
     int count = facade.getActiveSubClustersCount();
-    Assert.assertEquals(0, count);
+    Assertions.assertEquals(0, count);
 
     // Step4. Check Active SubCluster Status.
     // We want all subClusters to be SC_LOST.
     subClustersMap.values().forEach(subClusterInfo -> {
       SubClusterState subClusterState = subClusterInfo.getState();
-      Assert.assertEquals(SubClusterState.SC_LOST, subClusterState);
+      Assertions.assertEquals(SubClusterState.SC_LOST, subClusterState);
     });
   }
 
@@ -121,7 +121,7 @@ public class TestSubClusterCleaner {
 
     // Step4. At this point we should have 2 subClusters that are surviving clusters.
     int count = facade.getActiveSubClustersCount();
-    Assert.assertEquals(2, count);
+    Assertions.assertEquals(2, count);
 
     // Step5. The result we expect is that SC-0 and SC-1 are in the RUNNING state,
     // and SC-2 and SC-3 are in the SC_LOST state.
@@ -137,7 +137,7 @@ public class TestSubClusterCleaner {
     SubClusterHeartbeatRequest request = SubClusterHeartbeatRequest.newInstance(
         subClusterId, Time.now(), SubClusterState.SC_RUNNING, "test");
     SubClusterHeartbeatResponse response = stateStore.subClusterHeartbeat(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
   }
 
   private void expiredSubcluster(String pSubClusterId) {
@@ -153,6 +153,6 @@ public class TestSubClusterCleaner {
     if (subClusterInfo == null) {
       throw new YarnException("subClusterId=" + pSubClusterId + " does not exist.");
     }
-    Assert.assertEquals(expectState, subClusterInfo.getState());
+    Assertions.assertEquals(expectState, subClusterInfo.getState());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -101,7 +102,6 @@ import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -125,7 +125,7 @@ public abstract class BaseRouterClientRMTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterClientRMService getRouterClientRMService() {
-    Assertions.assertNotNull(this.clientrmService);
+    assertNotNull(this.clientrmService);
     return this.clientrmService;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
@@ -100,9 +100,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base class for all the RouterClientRMService test cases. It provides utility
@@ -125,7 +125,7 @@ public abstract class BaseRouterClientRMTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterClientRMService getRouterClientRMService() {
-    Assert.assertNotNull(this.clientrmService);
+    Assertions.assertNotNull(this.clientrmService);
     return this.clientrmService;
   }
 
@@ -154,7 +154,7 @@ public abstract class BaseRouterClientRMTest {
     return schedulerConf;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.conf = createConfiguration();
     this.dispatcher = new AsyncDispatcher();
@@ -171,7 +171,7 @@ public abstract class BaseRouterClientRMTest {
     return this.conf;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (clientrmService != null) {
       clientrmService.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
@@ -18,12 +18,13 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.hadoop.yarn.api.protocolrecords.MoveApplicationAcrossQueuesRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.MoveApplicationAcrossQueuesResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.ClientRMService;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * This class mocks the ClientRequestInterceptor.
@@ -65,7 +66,7 @@ public class MockClientRequestInterceptor
       // allow plan follower to synchronize
       Thread.sleep(1050);
     } catch (Exception e) {
-      Assertions.fail(e.getMessage());
+      fail(e.getMessage());
     }
     super.setRMClient(mockRM.getClientRMService());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.yarn.api.protocolrecords.MoveApplicationAcrossQueuesRes
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.ClientRMService;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * This class mocks the ClientRequestInterceptor.
@@ -65,7 +65,7 @@ public class MockClientRequestInterceptor
       // allow plan follower to synchronize
       Thread.sleep(1050);
     } catch (Exception e) {
-      Assert.fail(e.getMessage());
+      Assertions.fail(e.getMessage());
     }
     super.setRMClient(mockRM.getClientRMService());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestApplicationSubmissionContextInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestApplicationSubmissionContextInterceptor.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ApplicationSubmissionContextPB
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.RouterServerUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extends the {@code BaseRouterClientRMTest} and overrides methods in order to

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -160,7 +164,8 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,6 +194,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
   private final static long DEFAULT_DURATION = 10 * 60 * 1000;
 
+  @BeforeEach
   @Override
   public void setUp() throws IOException {
     super.setUpConfig();
@@ -217,12 +223,13 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assertions.fail();
+      fail();
     }
 
     DefaultMetricsSystem.setMiniClusterMode(true);
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();
@@ -270,9 +277,9 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
     GetNewApplicationResponse response = interceptor.getNewApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(response.getApplicationId());
-    Assertions.assertEquals(response.getApplicationId().getClusterTimestamp(),
+    assertNotNull(response);
+    assertNotNull(response.getApplicationId());
+    assertEquals(response.getApplicationId().getClusterTimestamp(),
         ResourceManager.getClusterTimeStamp());
   }
 
@@ -290,10 +297,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult);
-    Assertions.assertTrue(subClusters.contains(scIdResult));
+    assertNotNull(scIdResult);
+    assertTrue(subClusters.contains(scIdResult));
   }
 
   private SubmitApplicationRequest mockSubmitApplicationRequest(
@@ -326,17 +333,17 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // First attempt
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult);
+    assertNotNull(scIdResult);
 
     // First retry
     response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     SubClusterId scIdResult2 = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult2);
-    Assertions.assertEquals(scIdResult, scIdResult);
+    assertNotNull(scIdResult2);
+    assertEquals(scIdResult, scIdResult);
   }
 
   /**
@@ -384,12 +391,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we are going to kill later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     KillApplicationRequest requestKill = KillApplicationRequest.newInstance(appId);
     KillApplicationResponse responseKill = interceptor.forceKillApplication(requestKill);
-    Assertions.assertNotNull(responseKill);
+    assertNotNull(responseKill);
   }
 
   @Test
@@ -413,9 +420,9 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we are going to kill later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     SubClusterId subClusterId = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     subClusterSet.remove(subClusterId);
 
@@ -443,12 +450,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       GetApplicationReportRequest requestGet = GetApplicationReportRequest.newInstance(appId);
       GetApplicationReportResponse responseGet =
           clientRMProxyForSubCluster.getApplicationReport(requestGet);
-      Assertions.assertNotNull(responseGet);
+      assertNotNull(responseGet);
       ApplicationReport applicationReport = responseGet.getApplicationReport();
-      Assertions.assertNotNull(applicationReport);
+      assertNotNull(applicationReport);
       YarnApplicationState yarnApplicationState = applicationReport.getYarnApplicationState();
-      Assertions.assertNotNull(yarnApplicationState);
-      Assertions.assertEquals(YarnApplicationState.KILLED, yarnApplicationState);
+      assertNotNull(yarnApplicationState);
+      assertEquals(YarnApplicationState.KILLED, yarnApplicationState);
     }
   }
 
@@ -507,8 +514,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we want the report later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     GetApplicationReportRequest requestGet =
         GetApplicationReportRequest.newInstance(appId);
@@ -516,7 +523,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationReportResponse responseGet =
         interceptor.getApplicationReport(requestGet);
 
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
   }
 
   /**
@@ -573,8 +580,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we want the applicationAttempt report later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts Get ApplicationAttemptId
     GetApplicationAttemptsRequest attemptsRequest =
@@ -588,7 +595,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
           interceptor.getApplicationAttempts(attemptsRequest);
     }
 
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     GetApplicationAttemptReportRequest requestGet =
          GetApplicationAttemptReportRequest.newInstance(
@@ -597,7 +604,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationAttemptReportResponse responseGet =
          interceptor.getApplicationAttemptReport(requestGet);
 
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
   }
 
   /**
@@ -664,7 +671,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterMetricsResponse response =
         interceptor.getClusterMetrics(GetClusterMetricsRequest.newInstance());
-    Assertions.assertEquals(subClusters.size(),
+    assertEquals(subClusters.size(),
         response.getClusterMetrics().getNumNodeManagers());
 
     // Clear Membership
@@ -677,7 +684,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         new Object[] {GetClusterMetricsRequest.newInstance()});
     Collection<GetClusterMetricsResponse> clusterMetrics = interceptor.invokeConcurrent(
         remoteMethod, GetClusterMetricsResponse.class);
-    Assertions.assertTrue(clusterMetrics.isEmpty());
+    assertTrue(clusterMetrics.isEmpty());
 
     // Restore membership
     stateStore.setMembership(membership);
@@ -696,14 +703,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     Set<String> appTypes = Collections.singleton("MockApp");
     GetApplicationsRequest requestGet = GetApplicationsRequest.newInstance(appTypes);
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
   }
 
   /**
@@ -730,16 +737,16 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     Set<String> appTypes = Collections.singleton("SPARK");
 
     GetApplicationsRequest requestGet = GetApplicationsRequest.newInstance(appTypes);
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertTrue(responseGet.getApplicationList().isEmpty());
+    assertNotNull(responseGet);
+    assertTrue(responseGet.getApplicationList().isEmpty());
   }
 
   /**
@@ -756,8 +763,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(
         YarnApplicationState.class);
@@ -768,8 +775,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertTrue(responseGet.getApplicationList().isEmpty());
+    assertNotNull(responseGet);
+    assertTrue(responseGet.getApplicationList().isEmpty());
   }
 
   @Test
@@ -781,7 +788,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterNodesResponse response =
         interceptor.getClusterNodes(GetClusterNodesRequest.newInstance());
-    Assertions.assertEquals(subClusters.size(), response.getNodeReports().size());
+    assertEquals(subClusters.size(), response.getNodeReports().size());
   }
 
   @Test
@@ -793,7 +800,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetNodesToLabelsResponse response =
         interceptor.getNodeToLabels(GetNodesToLabelsRequest.newInstance());
-    Assertions.assertEquals(0, response.getNodeToLabels().size());
+    assertEquals(0, response.getNodeToLabels().size());
   }
 
   @Test
@@ -805,7 +812,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetLabelsToNodesResponse response =
         interceptor.getLabelsToNodes(GetLabelsToNodesRequest.newInstance());
-    Assertions.assertEquals(0, response.getLabelsToNodes().size());
+    assertEquals(0, response.getLabelsToNodes().size());
   }
 
   @Test
@@ -817,7 +824,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterNodeLabelsResponse response =
         interceptor.getClusterNodeLabels(GetClusterNodeLabelsRequest.newInstance());
-    Assertions.assertEquals(0, response.getNodeLabelList().size());
+    assertEquals(0, response.getNodeLabelList().size());
   }
 
   @Test
@@ -832,7 +839,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetQueueUserAclsInfoResponse response = interceptor.getQueueUserAcls(
         GetQueueUserAclsInfoRequest.newInstance());
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     List<QueueACL> submitAndAdministerAcl = new ArrayList<>();
     submitAndAdministerAcl.add(QueueACL.SUBMIT_APPLICATIONS);
@@ -845,7 +852,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         filter(acl->acl.getQueueName().equals("root")).
         collect(Collectors.toList()).get(0);
 
-    Assertions.assertEquals(exceptRootQueueACLInfo, queueRootQueueACLInfo);
+    assertEquals(exceptRootQueueACLInfo, queueRootQueueACLInfo);
   }
 
   @Test
@@ -860,8 +867,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     ReservationId reservationId = ReservationId.newInstance(1653487680L, 1L);
     ReservationListResponse response = interceptor.listReservations(
         ReservationListRequest.newInstance("root.decided", reservationId.toString()));
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(0, response.getReservationAllocationState().size());
+    assertNotNull(response);
+    assertEquals(0, response.getReservationAllocationState().size());
   }
 
   @Test
@@ -880,8 +887,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -895,7 +902,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
           interceptor.getApplicationAttempts(attemptsRequest);
     }
 
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     // Call GetContainers
     GetContainersRequest containersRequest =
@@ -904,7 +911,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetContainersResponse containersResponse =
         interceptor.getContainers(containersRequest);
 
-    Assertions.assertNotNull(containersResponse);
+    assertNotNull(containersResponse);
   }
 
   @Test
@@ -923,8 +930,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -937,7 +944,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       attemptsResponse =
           interceptor.getApplicationAttempts(attemptsRequest);
     }
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     ApplicationAttemptId attemptId = attemptsResponse.getApplicationAttemptList().
         get(0).getApplicationAttemptId();
@@ -949,7 +956,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetContainerReportResponse containerReportResponse =
          interceptor.getContainerReport(containerReportRequest);
 
-    Assertions.assertEquals(containerReportResponse, null);
+    assertEquals(containerReportResponse, null);
   }
 
   @Test
@@ -968,8 +975,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -977,7 +984,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationAttemptsResponse attemptsResponse =
          interceptor.getApplicationAttempts(attemptsRequest);
 
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
   }
 
   @Test
@@ -989,7 +996,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetAllResourceTypeInfoResponse response =
         interceptor.getResourceTypeInfo(GetAllResourceTypeInfoRequest.newInstance());
-    Assertions.assertEquals(2, response.getResourceTypeInfo().size());
+    assertEquals(2, response.getResourceTypeInfo().size());
   }
 
   @Test
@@ -1008,11 +1015,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1025,7 +1032,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     ApplicationAttemptId attemptId = attemptsResponse.getApplicationAttemptList().
         get(0).getApplicationAttemptId();
@@ -1035,7 +1042,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     FailApplicationAttemptResponse responseFailAppAttempt =
         interceptor.failApplicationAttempt(requestFailAppAttempt);
 
-    Assertions.assertNotNull(responseFailAppAttempt);
+    assertNotNull(responseFailAppAttempt);
   }
 
   @Test
@@ -1054,11 +1061,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1071,7 +1078,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     Priority priority = Priority.newInstance(20);
     UpdateApplicationPriorityRequest requestUpdateAppPriority =
@@ -1079,8 +1086,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     UpdateApplicationPriorityResponse responseAppPriority =
         interceptor.updateApplicationPriority(requestUpdateAppPriority);
 
-    Assertions.assertNotNull(responseAppPriority);
-    Assertions.assertEquals(20,
+    assertNotNull(responseAppPriority);
+    assertEquals(20,
         responseAppPriority.getApplicationPriority().getPriority());
   }
 
@@ -1100,11 +1107,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1117,7 +1124,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assertions.assertNotNull(attemptsResponse);
+    assertNotNull(attemptsResponse);
 
     String appTimeout =
         Times.formatISO8601(System.currentTimeMillis() + 5 * 1000);
@@ -1131,8 +1138,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     String responseTimeOut =
         timeoutsResponse.getApplicationTimeouts().get(ApplicationTimeoutType.LIFETIME);
-    Assertions.assertNotNull(timeoutsResponse);
-    Assertions.assertEquals(appTimeout, responseTimeOut);
+    assertNotNull(timeoutsResponse);
+    assertEquals(appTimeout, responseTimeOut);
   }
 
   @Test
@@ -1150,11 +1157,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1173,7 +1180,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SignalContainerResponse signalContainerResponse =
         interceptor.signalToContainer(signalContainerRequest);
 
-    Assertions.assertNotNull(signalContainerResponse);
+    assertNotNull(signalContainerResponse);
   }
 
   @Test
@@ -1191,11 +1198,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1212,7 +1219,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     MoveApplicationAcrossQueuesResponse acrossQueuesResponse =
         interceptor.moveApplicationAcrossQueues(acrossQueuesRequest);
 
-    Assertions.assertNotNull(acrossQueuesResponse);
+    assertNotNull(acrossQueuesResponse);
   }
 
 
@@ -1228,15 +1235,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetQueueInfoResponse response = interceptor.getQueueInfo(
         GetQueueInfoRequest.newInstance("root", true, true, true));
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     QueueInfo queueInfo = response.getQueueInfo();
-    Assertions.assertNotNull(queueInfo);
-    Assertions.assertEquals("root", queueInfo.getQueueName());
-    Assertions.assertEquals(4.0, queueInfo.getCapacity(), 0);
-    Assertions.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
-    Assertions.assertEquals(12, queueInfo.getChildQueues().size(), 0);
-    Assertions.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
+    assertNotNull(queueInfo);
+    assertEquals("root", queueInfo.getQueueName());
+    assertEquals(4.0, queueInfo.getCapacity(), 0);
+    assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
+    assertEquals(12, queueInfo.getChildQueues().size(), 0);
+    assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
   }
 
   @Test
@@ -1244,15 +1251,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // We have set up a unit test where we access queue information for subcluster1.
     GetQueueInfoResponse response = interceptor.getQueueInfo(
         GetQueueInfoRequest.newInstance("root", true, true, true, "1"));
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     QueueInfo queueInfo = response.getQueueInfo();
-    Assertions.assertNotNull(queueInfo);
-    Assertions.assertEquals("root", queueInfo.getQueueName());
-    Assertions.assertEquals(1.0, queueInfo.getCapacity(), 0);
-    Assertions.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
-    Assertions.assertEquals(3, queueInfo.getChildQueues().size(), 0);
-    Assertions.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
+    assertNotNull(queueInfo);
+    assertEquals("root", queueInfo.getQueueName());
+    assertEquals(1.0, queueInfo.getCapacity(), 0);
+    assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
+    assertEquals(3, queueInfo.getChildQueues().size(), 0);
+    assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
   }
 
   @Test
@@ -1267,20 +1274,20 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetAllResourceProfilesRequest request = GetAllResourceProfilesRequest.newInstance();
     GetAllResourceProfilesResponse response = interceptor.getResourceProfiles(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Map<String, Resource> resProfiles = response.getResourceProfiles();
 
     Resource maxResProfiles = resProfiles.get("maximum");
-    Assertions.assertEquals(32768, maxResProfiles.getMemorySize());
-    Assertions.assertEquals(16, maxResProfiles.getVirtualCores());
+    assertEquals(32768, maxResProfiles.getMemorySize());
+    assertEquals(16, maxResProfiles.getVirtualCores());
 
     Resource defaultResProfiles = resProfiles.get("default");
-    Assertions.assertEquals(8192, defaultResProfiles.getMemorySize());
-    Assertions.assertEquals(8, defaultResProfiles.getVirtualCores());
+    assertEquals(8192, defaultResProfiles.getMemorySize());
+    assertEquals(8, defaultResProfiles.getVirtualCores());
 
     Resource minimumResProfiles = resProfiles.get("minimum");
-    Assertions.assertEquals(4096, minimumResProfiles.getMemorySize());
-    Assertions.assertEquals(4, minimumResProfiles.getVirtualCores());
+    assertEquals(4096, minimumResProfiles.getMemorySize());
+    assertEquals(4, minimumResProfiles.getVirtualCores());
   }
 
   @Test
@@ -1296,23 +1303,23 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetResourceProfileRequest request = GetResourceProfileRequest.newInstance("maximum");
     GetResourceProfileResponse response = interceptor.getResourceProfile(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(32768, response.getResource().getMemorySize());
-    Assertions.assertEquals(16, response.getResource().getVirtualCores());
+    assertNotNull(response);
+    assertEquals(32768, response.getResource().getMemorySize());
+    assertEquals(16, response.getResource().getVirtualCores());
 
     GetResourceProfileRequest request2 = GetResourceProfileRequest.newInstance("default");
     GetResourceProfileResponse response2 = interceptor.getResourceProfile(request2);
 
-    Assertions.assertNotNull(response2);
-    Assertions.assertEquals(8192, response2.getResource().getMemorySize());
-    Assertions.assertEquals(8, response2.getResource().getVirtualCores());
+    assertNotNull(response2);
+    assertEquals(8192, response2.getResource().getMemorySize());
+    assertEquals(8, response2.getResource().getVirtualCores());
 
     GetResourceProfileRequest request3 = GetResourceProfileRequest.newInstance("minimum");
     GetResourceProfileResponse response3 = interceptor.getResourceProfile(request3);
 
-    Assertions.assertNotNull(response3);
-    Assertions.assertEquals(4096, response3.getResource().getMemorySize());
-    Assertions.assertEquals(4, response3.getResource().getVirtualCores());
+    assertNotNull(response3);
+    assertEquals(4096, response3.getResource().getMemorySize());
+    assertEquals(4, response3.getResource().getVirtualCores());
   }
 
   @Test
@@ -1327,17 +1334,17 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetAttributesToNodesResponse response =
         interceptor.getAttributesToNodes(GetAttributesToNodesRequest.newInstance());
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
-    Assertions.assertNotNull(attrs);
-    Assertions.assertEquals(4, attrs.size());
+    assertNotNull(attrs);
+    assertEquals(4, attrs.size());
 
     NodeAttribute gpu = NodeAttribute.newInstance(NodeAttribute.PREFIX_CENTRALIZED, "GPU",
         NodeAttributeType.STRING, "nvidia");
     NodeToAttributeValue attributeValue1 =
         NodeToAttributeValue.newInstance("0-host1", gpu.getAttributeValue());
     NodeAttributeKey gpuKey = gpu.getAttributeKey();
-    Assertions.assertTrue(attrs.get(gpuKey).contains(attributeValue1));
+    assertTrue(attrs.get(gpuKey).contains(attributeValue1));
   }
 
   @Test
@@ -1352,20 +1359,20 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetClusterNodeAttributesResponse response =
         interceptor.getClusterNodeAttributes(GetClusterNodeAttributesRequest.newInstance());
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
-    Assertions.assertNotNull(nodeAttributeInfos);
-    Assertions.assertEquals(4, nodeAttributeInfos.size());
+    assertNotNull(nodeAttributeInfos);
+    assertEquals(4, nodeAttributeInfos.size());
 
     NodeAttributeInfo nodeAttributeInfo1 =
         NodeAttributeInfo.newInstance(NodeAttributeKey.newInstance("GPU"),
         NodeAttributeType.STRING);
-    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
 
     NodeAttributeInfo nodeAttributeInfo2 =
         NodeAttributeInfo.newInstance(NodeAttributeKey.newInstance("OS"),
         NodeAttributeType.STRING);
-    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
   }
 
   @Test
@@ -1381,15 +1388,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     Set<String> hostNames = Collections.singleton("0-host1");
     GetNodesToAttributesResponse response =
         interceptor.getNodesToAttributes(GetNodesToAttributesRequest.newInstance(hostNames));
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Map<String, Set<NodeAttribute>> nodeAttributeMap = response.getNodeToAttributes();
-    Assertions.assertNotNull(nodeAttributeMap);
-    Assertions.assertEquals(1, nodeAttributeMap.size());
+    assertNotNull(nodeAttributeMap);
+    assertEquals(1, nodeAttributeMap.size());
 
     NodeAttribute gpu = NodeAttribute.newInstance(NodeAttribute.PREFIX_CENTRALIZED, "GPU",
         NodeAttributeType.STRING, "nvida");
-    Assertions.assertTrue(nodeAttributeMap.get("0-host1").contains(gpu));
+    assertTrue(nodeAttributeMap.get("0-host1").contains(gpu));
   }
 
   @Test
@@ -1403,12 +1410,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     ReservationId reservationId = response.getReservationId();
-    Assertions.assertNotNull(reservationId);
-    Assertions.assertTrue(reservationId.toString().contains("reservation"));
-    Assertions.assertEquals(reservationId.getClusterTimestamp(), ResourceManager.getClusterTimeStamp());
+    assertNotNull(reservationId);
+    assertTrue(reservationId.toString().contains("reservation"));
+    assertEquals(reservationId.getClusterTimestamp(), ResourceManager.getClusterTimeStamp());
   }
 
   @Test
@@ -1418,7 +1425,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     // Submit Reservation
     ReservationId reservationId = response.getReservationId();
@@ -1428,11 +1435,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assertions.assertNotNull(submissionResponse);
+    assertNotNull(submissionResponse);
 
     SubClusterId subClusterId = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assertions.assertNotNull(subClusterId);
-    Assertions.assertTrue(subClusters.contains(subClusterId));
+    assertNotNull(subClusterId);
+    assertTrue(subClusters.contains(subClusterId));
   }
 
   @Test
@@ -1487,7 +1494,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     // First Submit Reservation
     ReservationId reservationId = response.getReservationId();
@@ -1496,21 +1503,21 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         rDefinition, "decided", reservationId);
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assertions.assertNotNull(submissionResponse);
+    assertNotNull(submissionResponse);
 
     SubClusterId subClusterId1 = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assertions.assertNotNull(subClusterId1);
-    Assertions.assertTrue(subClusters.contains(subClusterId1));
+    assertNotNull(subClusterId1);
+    assertTrue(subClusters.contains(subClusterId1));
 
     // First Retry, repeat the submission
     ReservationSubmissionResponse submissionResponse1 =
         interceptor.submitReservation(rSubmissionRequest);
-    Assertions.assertNotNull(submissionResponse1);
+    assertNotNull(submissionResponse1);
 
     // Expect reserved clusters to be consistent
     SubClusterId subClusterId2 = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assertions.assertNotNull(subClusterId2);
-    Assertions.assertEquals(subClusterId1, subClusterId2);
+    assertNotNull(subClusterId2);
+    assertEquals(subClusterId1, subClusterId2);
   }
 
   @Test
@@ -1520,7 +1527,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     // allow plan follower to synchronize, manually trigger an assignment
     Map<SubClusterId, MockRM> mockRMs = interceptor.getMockRMs();
@@ -1537,7 +1544,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assertions.assertNotNull(submissionResponse);
+    assertNotNull(submissionResponse);
 
     // Update Reservation
     ReservationDefinition rDefinition2 = createReservationDefinition(2048, 1);
@@ -1545,10 +1552,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         ReservationUpdateRequest.newInstance(rDefinition2, reservationId);
     ReservationUpdateResponse updateResponse =
         interceptor.updateReservation(updateRequest);
-    Assertions.assertNotNull(updateResponse);
+    assertNotNull(updateResponse);
 
     SubClusterId subClusterId = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assertions.assertNotNull(subClusterId);
+    assertNotNull(subClusterId);
   }
 
   @Test
@@ -1558,7 +1565,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     // allow plan follower to synchronize, manually trigger an assignment
     Map<SubClusterId, MockRM> mockRMs = interceptor.getMockRMs();
@@ -1575,12 +1582,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assertions.assertNotNull(submissionResponse);
+    assertNotNull(submissionResponse);
 
     // Delete Reservation
     ReservationDeleteRequest deleteRequest = ReservationDeleteRequest.newInstance(reservationId);
     ReservationDeleteResponse deleteResponse = interceptor.deleteReservation(deleteRequest);
-    Assertions.assertNotNull(deleteResponse);
+    assertNotNull(deleteResponse);
 
     LambdaTestUtils.intercept(YarnException.class,
         "Reservation " + reservationId + " does not exist",
@@ -1628,14 +1635,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // If we don't configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE,
     // we expect to get 5 threads
     int minThreads = interceptor.getNumMinThreads(this.getConf());
-    Assertions.assertEquals(5, minThreads);
+    assertEquals(5, minThreads);
 
     // If we configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE,
     // we expect to get 3 threads
     this.getConf().unset(YarnConfiguration.ROUTER_USER_CLIENT_THREADS_SIZE);
     this.getConf().setInt(YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE, 3);
     int minThreads2 = interceptor.getNumMinThreads(this.getConf());
-    Assertions.assertEquals(3, minThreads2);
+    assertEquals(3, minThreads2);
   }
 
   @Test
@@ -1643,14 +1650,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // If we don't configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE,
     // we expect to get 5 threads
     int minThreads = interceptor.getNumMaxThreads(this.getConf());
-    Assertions.assertEquals(5, minThreads);
+    assertEquals(5, minThreads);
 
     // If we configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE,
     // we expect to get 8 threads
     this.getConf().unset(YarnConfiguration.ROUTER_USER_CLIENT_THREADS_SIZE);
     this.getConf().setInt(YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE, 8);
     int minThreads2 = interceptor.getNumMaxThreads(this.getConf());
-    Assertions.assertEquals(8, minThreads2);
+    assertEquals(8, minThreads2);
   }
 
   @Test
@@ -1674,43 +1681,43 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer1");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
-    Assertions.assertNotNull(delegationToken);
-    Assertions.assertEquals("RM_DELEGATION_TOKEN", delegationToken.getKind());
+    assertNotNull(delegationToken);
+    assertEquals("RM_DELEGATION_TOKEN", delegationToken.getKind());
 
     // Step2. Serialize the returned Token as RMDelegationTokenIdentifier.
     org.apache.hadoop.security.token.Token<RMDelegationTokenIdentifier> token =
         ConverterUtils.convertFromYarn(delegationToken, (Text) null);
     RMDelegationTokenIdentifier rMDelegationTokenIdentifier = token.decodeIdentifier();
-    Assertions.assertNotNull(rMDelegationTokenIdentifier);
+    assertNotNull(rMDelegationTokenIdentifier);
 
     // Step3. Verify the returned data of the token.
     String renewer = rMDelegationTokenIdentifier.getRenewer().toString();
     long issueDate = rMDelegationTokenIdentifier.getIssueDate();
     long maxDate = rMDelegationTokenIdentifier.getMaxDate();
-    Assertions.assertEquals("renewer1", renewer);
+    assertEquals("renewer1", renewer);
 
     long tokenMaxLifetime = this.getConf().getLong(
         YarnConfiguration.RM_DELEGATION_TOKEN_MAX_LIFETIME_KEY,
         YarnConfiguration.RM_DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT);
-    Assertions.assertEquals(issueDate + tokenMaxLifetime, maxDate);
+    assertEquals(issueDate + tokenMaxLifetime, maxDate);
 
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
-    Assertions.assertNotNull(managerState);
+    assertNotNull(managerState);
 
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assertions.assertNotNull(delegationTokenState);
-    Assertions.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
+    assertNotNull(delegationTokenState);
+    assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
 
     long tokenRenewInterval = this.getConf().getLong(
         YarnConfiguration.RM_DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
         YarnConfiguration.RM_DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
     RouterStoreToken resultRouterStoreToken = delegationTokenState.get(rMDelegationTokenIdentifier);
-    Assertions.assertNotNull(resultRouterStoreToken);
+    assertNotNull(resultRouterStoreToken);
     long renewDate = resultRouterStoreToken.getRenewDate();
-    Assertions.assertEquals(issueDate + tokenRenewInterval, renewDate);
+    assertEquals(issueDate + tokenRenewInterval, renewDate);
   }
 
   @Test
@@ -1730,7 +1737,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer2");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
 
     org.apache.hadoop.security.token.Token<RMDelegationTokenIdentifier> token =
@@ -1738,28 +1745,28 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     RMDelegationTokenIdentifier rMDelegationTokenIdentifier = token.decodeIdentifier();
     String renewer = rMDelegationTokenIdentifier.getRenewer().toString();
     long maxDate = rMDelegationTokenIdentifier.getMaxDate();
-    Assertions.assertEquals("renewer2", renewer);
+    assertEquals("renewer2", renewer);
 
     // Step2. Call renewDelegationToken to refresh delegationToken.
     RenewDelegationTokenRequest renewRequest = Records.newRecord(RenewDelegationTokenRequest.class);
     renewRequest.setDelegationToken(delegationToken);
     RenewDelegationTokenResponse renewResponse = interceptor.renewDelegationToken(renewRequest);
-    Assertions.assertNotNull(renewResponse);
+    assertNotNull(renewResponse);
 
     long expDate = renewResponse.getNextExpirationTime();
-    Assertions.assertTrue(expDate <= maxDate);
+    assertTrue(expDate <= maxDate);
 
     // Step3. Compare whether the expirationTime returned to
     // the client is consistent with the renewDate in the stateStore
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assertions.assertNotNull(delegationTokenState);
-    Assertions.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
+    assertNotNull(delegationTokenState);
+    assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
     RouterStoreToken resultRouterStoreToken = delegationTokenState.get(rMDelegationTokenIdentifier);
-    Assertions.assertNotNull(resultRouterStoreToken);
+    assertNotNull(resultRouterStoreToken);
     long renewDate = resultRouterStoreToken.getRenewDate();
-    Assertions.assertEquals(expDate, renewDate);
+    assertEquals(expDate, renewDate);
   }
 
   @Test
@@ -1775,7 +1782,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer3");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
 
     // Step2. Call CancelDelegationToken to cancel delegationToken.
@@ -1783,14 +1790,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         CancelDelegationTokenRequest.newInstance(delegationToken);
     CancelDelegationTokenResponse cancelTokenResponse =
         interceptor.cancelDelegationToken(cancelTokenRequest);
-    Assertions.assertNotNull(cancelTokenResponse);
+    assertNotNull(cancelTokenResponse);
 
     // Step3. Query the data in the StateStore and confirm that the Delegation has been deleted.
     // At this point, the size of delegationTokenState should be 0.
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assertions.assertNotNull(delegationTokenState);
-    Assertions.assertEquals(0, delegationTokenState.size());
+    assertNotNull(delegationTokenState);
+    assertEquals(0, delegationTokenState.size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -1337,7 +1337,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     assertNotNull(response);
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
     assertNotNull(attrs);
-    assertEquals(4, attrs.size());
+    assertEquals(5, attrs.size());
 
     NodeAttribute gpu = NodeAttribute.newInstance(NodeAttribute.PREFIX_CENTRALIZED, "GPU",
         NodeAttributeType.STRING, "nvidia");
@@ -1362,7 +1362,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     assertNotNull(response);
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
     assertNotNull(nodeAttributeInfos);
-    assertEquals(4, nodeAttributeInfos.size());
+    assertEquals(5, nodeAttributeInfos.size());
 
     NodeAttributeInfo nodeAttributeInfo1 =
         NodeAttributeInfo.newInstance(NodeAttributeKey.newInstance("GPU"),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptor.java
@@ -160,8 +160,8 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,7 +217,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      Assertions.fail();
     }
 
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -270,9 +270,9 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
     GetNewApplicationResponse response = interceptor.getNewApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(response.getApplicationId());
-    Assert.assertEquals(response.getApplicationId().getClusterTimestamp(),
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(response.getApplicationId());
+    Assertions.assertEquals(response.getApplicationId().getClusterTimestamp(),
         ResourceManager.getClusterTimeStamp());
   }
 
@@ -290,10 +290,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult);
-    Assert.assertTrue(subClusters.contains(scIdResult));
+    Assertions.assertNotNull(scIdResult);
+    Assertions.assertTrue(subClusters.contains(scIdResult));
   }
 
   private SubmitApplicationRequest mockSubmitApplicationRequest(
@@ -326,17 +326,17 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // First attempt
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult);
+    Assertions.assertNotNull(scIdResult);
 
     // First retry
     response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     SubClusterId scIdResult2 = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult2);
-    Assert.assertEquals(scIdResult, scIdResult);
+    Assertions.assertNotNull(scIdResult2);
+    Assertions.assertEquals(scIdResult, scIdResult);
   }
 
   /**
@@ -384,12 +384,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we are going to kill later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     KillApplicationRequest requestKill = KillApplicationRequest.newInstance(appId);
     KillApplicationResponse responseKill = interceptor.forceKillApplication(requestKill);
-    Assert.assertNotNull(responseKill);
+    Assertions.assertNotNull(responseKill);
   }
 
   @Test
@@ -413,9 +413,9 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we are going to kill later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     SubClusterId subClusterId = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     subClusterSet.remove(subClusterId);
 
@@ -443,12 +443,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       GetApplicationReportRequest requestGet = GetApplicationReportRequest.newInstance(appId);
       GetApplicationReportResponse responseGet =
           clientRMProxyForSubCluster.getApplicationReport(requestGet);
-      Assert.assertNotNull(responseGet);
+      Assertions.assertNotNull(responseGet);
       ApplicationReport applicationReport = responseGet.getApplicationReport();
-      Assert.assertNotNull(applicationReport);
+      Assertions.assertNotNull(applicationReport);
       YarnApplicationState yarnApplicationState = applicationReport.getYarnApplicationState();
-      Assert.assertNotNull(yarnApplicationState);
-      Assert.assertEquals(YarnApplicationState.KILLED, yarnApplicationState);
+      Assertions.assertNotNull(yarnApplicationState);
+      Assertions.assertEquals(YarnApplicationState.KILLED, yarnApplicationState);
     }
   }
 
@@ -507,8 +507,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we want the report later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     GetApplicationReportRequest requestGet =
         GetApplicationReportRequest.newInstance(appId);
@@ -516,7 +516,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationReportResponse responseGet =
         interceptor.getApplicationReport(requestGet);
 
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
   }
 
   /**
@@ -573,8 +573,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application we want the applicationAttempt report later
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts Get ApplicationAttemptId
     GetApplicationAttemptsRequest attemptsRequest =
@@ -588,7 +588,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
           interceptor.getApplicationAttempts(attemptsRequest);
     }
 
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     GetApplicationAttemptReportRequest requestGet =
          GetApplicationAttemptReportRequest.newInstance(
@@ -597,7 +597,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationAttemptReportResponse responseGet =
          interceptor.getApplicationAttemptReport(requestGet);
 
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
   }
 
   /**
@@ -664,7 +664,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterMetricsResponse response =
         interceptor.getClusterMetrics(GetClusterMetricsRequest.newInstance());
-    Assert.assertEquals(subClusters.size(),
+    Assertions.assertEquals(subClusters.size(),
         response.getClusterMetrics().getNumNodeManagers());
 
     // Clear Membership
@@ -677,7 +677,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         new Object[] {GetClusterMetricsRequest.newInstance()});
     Collection<GetClusterMetricsResponse> clusterMetrics = interceptor.invokeConcurrent(
         remoteMethod, GetClusterMetricsResponse.class);
-    Assert.assertTrue(clusterMetrics.isEmpty());
+    Assertions.assertTrue(clusterMetrics.isEmpty());
 
     // Restore membership
     stateStore.setMembership(membership);
@@ -696,14 +696,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     Set<String> appTypes = Collections.singleton("MockApp");
     GetApplicationsRequest requestGet = GetApplicationsRequest.newInstance(appTypes);
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
   }
 
   /**
@@ -730,16 +730,16 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     Set<String> appTypes = Collections.singleton("SPARK");
 
     GetApplicationsRequest requestGet = GetApplicationsRequest.newInstance(appTypes);
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertTrue(responseGet.getApplicationList().isEmpty());
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertTrue(responseGet.getApplicationList().isEmpty());
   }
 
   /**
@@ -756,8 +756,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     EnumSet<YarnApplicationState> applicationStates = EnumSet.noneOf(
         YarnApplicationState.class);
@@ -768,8 +768,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     GetApplicationsResponse responseGet = interceptor.getApplications(requestGet);
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertTrue(responseGet.getApplicationList().isEmpty());
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertTrue(responseGet.getApplicationList().isEmpty());
   }
 
   @Test
@@ -781,7 +781,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterNodesResponse response =
         interceptor.getClusterNodes(GetClusterNodesRequest.newInstance());
-    Assert.assertEquals(subClusters.size(), response.getNodeReports().size());
+    Assertions.assertEquals(subClusters.size(), response.getNodeReports().size());
   }
 
   @Test
@@ -793,7 +793,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetNodesToLabelsResponse response =
         interceptor.getNodeToLabels(GetNodesToLabelsRequest.newInstance());
-    Assert.assertEquals(0, response.getNodeToLabels().size());
+    Assertions.assertEquals(0, response.getNodeToLabels().size());
   }
 
   @Test
@@ -805,7 +805,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetLabelsToNodesResponse response =
         interceptor.getLabelsToNodes(GetLabelsToNodesRequest.newInstance());
-    Assert.assertEquals(0, response.getLabelsToNodes().size());
+    Assertions.assertEquals(0, response.getLabelsToNodes().size());
   }
 
   @Test
@@ -817,7 +817,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetClusterNodeLabelsResponse response =
         interceptor.getClusterNodeLabels(GetClusterNodeLabelsRequest.newInstance());
-    Assert.assertEquals(0, response.getNodeLabelList().size());
+    Assertions.assertEquals(0, response.getNodeLabelList().size());
   }
 
   @Test
@@ -832,7 +832,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetQueueUserAclsInfoResponse response = interceptor.getQueueUserAcls(
         GetQueueUserAclsInfoRequest.newInstance());
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     List<QueueACL> submitAndAdministerAcl = new ArrayList<>();
     submitAndAdministerAcl.add(QueueACL.SUBMIT_APPLICATIONS);
@@ -845,7 +845,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         filter(acl->acl.getQueueName().equals("root")).
         collect(Collectors.toList()).get(0);
 
-    Assert.assertEquals(exceptRootQueueACLInfo, queueRootQueueACLInfo);
+    Assertions.assertEquals(exceptRootQueueACLInfo, queueRootQueueACLInfo);
   }
 
   @Test
@@ -860,8 +860,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     ReservationId reservationId = ReservationId.newInstance(1653487680L, 1L);
     ReservationListResponse response = interceptor.listReservations(
         ReservationListRequest.newInstance("root.decided", reservationId.toString()));
-    Assert.assertNotNull(response);
-    Assert.assertEquals(0, response.getReservationAllocationState().size());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(0, response.getReservationAllocationState().size());
   }
 
   @Test
@@ -880,8 +880,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -895,7 +895,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
           interceptor.getApplicationAttempts(attemptsRequest);
     }
 
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     // Call GetContainers
     GetContainersRequest containersRequest =
@@ -904,7 +904,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetContainersResponse containersResponse =
         interceptor.getContainers(containersRequest);
 
-    Assert.assertNotNull(containersResponse);
+    Assertions.assertNotNull(containersResponse);
   }
 
   @Test
@@ -923,8 +923,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -937,7 +937,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
       attemptsResponse =
           interceptor.getApplicationAttempts(attemptsRequest);
     }
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     ApplicationAttemptId attemptId = attemptsResponse.getApplicationAttemptList().
         get(0).getApplicationAttemptId();
@@ -949,7 +949,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetContainerReportResponse containerReportResponse =
          interceptor.getContainerReport(containerReportRequest);
 
-    Assert.assertEquals(containerReportResponse, null);
+    Assertions.assertEquals(containerReportResponse, null);
   }
 
   @Test
@@ -968,8 +968,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     // Call GetApplicationAttempts
     GetApplicationAttemptsRequest attemptsRequest =
@@ -977,7 +977,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetApplicationAttemptsResponse attemptsResponse =
          interceptor.getApplicationAttempts(attemptsRequest);
 
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
   }
 
   @Test
@@ -989,7 +989,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request.
     GetAllResourceTypeInfoResponse response =
         interceptor.getResourceTypeInfo(GetAllResourceTypeInfoRequest.newInstance());
-    Assert.assertEquals(2, response.getResourceTypeInfo().size());
+    Assertions.assertEquals(2, response.getResourceTypeInfo().size());
   }
 
   @Test
@@ -1008,11 +1008,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1025,7 +1025,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     ApplicationAttemptId attemptId = attemptsResponse.getApplicationAttemptList().
         get(0).getApplicationAttemptId();
@@ -1035,7 +1035,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     FailApplicationAttemptResponse responseFailAppAttempt =
         interceptor.failApplicationAttempt(requestFailAppAttempt);
 
-    Assert.assertNotNull(responseFailAppAttempt);
+    Assertions.assertNotNull(responseFailAppAttempt);
   }
 
   @Test
@@ -1054,11 +1054,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1071,7 +1071,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     Priority priority = Priority.newInstance(20);
     UpdateApplicationPriorityRequest requestUpdateAppPriority =
@@ -1079,8 +1079,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     UpdateApplicationPriorityResponse responseAppPriority =
         interceptor.updateApplicationPriority(requestUpdateAppPriority);
 
-    Assert.assertNotNull(responseAppPriority);
-    Assert.assertEquals(20,
+    Assertions.assertNotNull(responseAppPriority);
+    Assertions.assertEquals(20,
         responseAppPriority.getApplicationPriority().getPriority());
   }
 
@@ -1100,11 +1100,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1117,7 +1117,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         GetApplicationAttemptsRequest.newInstance(appId);
     GetApplicationAttemptsResponse attemptsResponse =
         interceptor.getApplicationAttempts(attemptsRequest);
-    Assert.assertNotNull(attemptsResponse);
+    Assertions.assertNotNull(attemptsResponse);
 
     String appTimeout =
         Times.formatISO8601(System.currentTimeMillis() + 5 * 1000);
@@ -1131,8 +1131,8 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     String responseTimeOut =
         timeoutsResponse.getApplicationTimeouts().get(ApplicationTimeoutType.LIFETIME);
-    Assert.assertNotNull(timeoutsResponse);
-    Assert.assertEquals(appTimeout, responseTimeOut);
+    Assertions.assertNotNull(timeoutsResponse);
+    Assertions.assertEquals(appTimeout, responseTimeOut);
   }
 
   @Test
@@ -1150,11 +1150,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1173,7 +1173,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     SignalContainerResponse signalContainerResponse =
         interceptor.signalToContainer(signalContainerRequest);
 
-    Assert.assertNotNull(signalContainerResponse);
+    Assertions.assertNotNull(signalContainerResponse);
   }
 
   @Test
@@ -1191,11 +1191,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // Submit the application
     SubmitApplicationResponse response = interceptor.submitApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     SubClusterId subClusterId = interceptor.getApplicationHomeSubCluster(appId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
 
     MockRM mockRM = interceptor.getMockRMs().get(subClusterId);
     mockRM.waitForState(appId, RMAppState.ACCEPTED);
@@ -1212,7 +1212,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     MoveApplicationAcrossQueuesResponse acrossQueuesResponse =
         interceptor.moveApplicationAcrossQueues(acrossQueuesRequest);
 
-    Assert.assertNotNull(acrossQueuesResponse);
+    Assertions.assertNotNull(acrossQueuesResponse);
   }
 
 
@@ -1228,15 +1228,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetQueueInfoResponse response = interceptor.getQueueInfo(
         GetQueueInfoRequest.newInstance("root", true, true, true));
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     QueueInfo queueInfo = response.getQueueInfo();
-    Assert.assertNotNull(queueInfo);
-    Assert.assertEquals("root", queueInfo.getQueueName());
-    Assert.assertEquals(4.0, queueInfo.getCapacity(), 0);
-    Assert.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
-    Assert.assertEquals(12, queueInfo.getChildQueues().size(), 0);
-    Assert.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
+    Assertions.assertNotNull(queueInfo);
+    Assertions.assertEquals("root", queueInfo.getQueueName());
+    Assertions.assertEquals(4.0, queueInfo.getCapacity(), 0);
+    Assertions.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
+    Assertions.assertEquals(12, queueInfo.getChildQueues().size(), 0);
+    Assertions.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
   }
 
   @Test
@@ -1244,15 +1244,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // We have set up a unit test where we access queue information for subcluster1.
     GetQueueInfoResponse response = interceptor.getQueueInfo(
         GetQueueInfoRequest.newInstance("root", true, true, true, "1"));
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     QueueInfo queueInfo = response.getQueueInfo();
-    Assert.assertNotNull(queueInfo);
-    Assert.assertEquals("root", queueInfo.getQueueName());
-    Assert.assertEquals(1.0, queueInfo.getCapacity(), 0);
-    Assert.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
-    Assert.assertEquals(3, queueInfo.getChildQueues().size(), 0);
-    Assert.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
+    Assertions.assertNotNull(queueInfo);
+    Assertions.assertEquals("root", queueInfo.getQueueName());
+    Assertions.assertEquals(1.0, queueInfo.getCapacity(), 0);
+    Assertions.assertEquals(0.0, queueInfo.getCurrentCapacity(), 0);
+    Assertions.assertEquals(3, queueInfo.getChildQueues().size(), 0);
+    Assertions.assertEquals(1, queueInfo.getAccessibleNodeLabels().size());
   }
 
   @Test
@@ -1267,20 +1267,20 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetAllResourceProfilesRequest request = GetAllResourceProfilesRequest.newInstance();
     GetAllResourceProfilesResponse response = interceptor.getResourceProfiles(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Map<String, Resource> resProfiles = response.getResourceProfiles();
 
     Resource maxResProfiles = resProfiles.get("maximum");
-    Assert.assertEquals(32768, maxResProfiles.getMemorySize());
-    Assert.assertEquals(16, maxResProfiles.getVirtualCores());
+    Assertions.assertEquals(32768, maxResProfiles.getMemorySize());
+    Assertions.assertEquals(16, maxResProfiles.getVirtualCores());
 
     Resource defaultResProfiles = resProfiles.get("default");
-    Assert.assertEquals(8192, defaultResProfiles.getMemorySize());
-    Assert.assertEquals(8, defaultResProfiles.getVirtualCores());
+    Assertions.assertEquals(8192, defaultResProfiles.getMemorySize());
+    Assertions.assertEquals(8, defaultResProfiles.getVirtualCores());
 
     Resource minimumResProfiles = resProfiles.get("minimum");
-    Assert.assertEquals(4096, minimumResProfiles.getMemorySize());
-    Assert.assertEquals(4, minimumResProfiles.getVirtualCores());
+    Assertions.assertEquals(4096, minimumResProfiles.getMemorySize());
+    Assertions.assertEquals(4, minimumResProfiles.getVirtualCores());
   }
 
   @Test
@@ -1296,23 +1296,23 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetResourceProfileRequest request = GetResourceProfileRequest.newInstance("maximum");
     GetResourceProfileResponse response = interceptor.getResourceProfile(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(32768, response.getResource().getMemorySize());
-    Assert.assertEquals(16, response.getResource().getVirtualCores());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(32768, response.getResource().getMemorySize());
+    Assertions.assertEquals(16, response.getResource().getVirtualCores());
 
     GetResourceProfileRequest request2 = GetResourceProfileRequest.newInstance("default");
     GetResourceProfileResponse response2 = interceptor.getResourceProfile(request2);
 
-    Assert.assertNotNull(response2);
-    Assert.assertEquals(8192, response2.getResource().getMemorySize());
-    Assert.assertEquals(8, response2.getResource().getVirtualCores());
+    Assertions.assertNotNull(response2);
+    Assertions.assertEquals(8192, response2.getResource().getMemorySize());
+    Assertions.assertEquals(8, response2.getResource().getVirtualCores());
 
     GetResourceProfileRequest request3 = GetResourceProfileRequest.newInstance("minimum");
     GetResourceProfileResponse response3 = interceptor.getResourceProfile(request3);
 
-    Assert.assertNotNull(response3);
-    Assert.assertEquals(4096, response3.getResource().getMemorySize());
-    Assert.assertEquals(4, response3.getResource().getVirtualCores());
+    Assertions.assertNotNull(response3);
+    Assertions.assertEquals(4096, response3.getResource().getMemorySize());
+    Assertions.assertEquals(4, response3.getResource().getVirtualCores());
   }
 
   @Test
@@ -1327,17 +1327,17 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetAttributesToNodesResponse response =
         interceptor.getAttributesToNodes(GetAttributesToNodesRequest.newInstance());
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
-    Assert.assertNotNull(attrs);
-    Assert.assertEquals(4, attrs.size());
+    Assertions.assertNotNull(attrs);
+    Assertions.assertEquals(4, attrs.size());
 
     NodeAttribute gpu = NodeAttribute.newInstance(NodeAttribute.PREFIX_CENTRALIZED, "GPU",
         NodeAttributeType.STRING, "nvidia");
     NodeToAttributeValue attributeValue1 =
         NodeToAttributeValue.newInstance("0-host1", gpu.getAttributeValue());
     NodeAttributeKey gpuKey = gpu.getAttributeKey();
-    Assert.assertTrue(attrs.get(gpuKey).contains(attributeValue1));
+    Assertions.assertTrue(attrs.get(gpuKey).contains(attributeValue1));
   }
 
   @Test
@@ -1352,20 +1352,20 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetClusterNodeAttributesResponse response =
         interceptor.getClusterNodeAttributes(GetClusterNodeAttributesRequest.newInstance());
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
-    Assert.assertNotNull(nodeAttributeInfos);
-    Assert.assertEquals(4, nodeAttributeInfos.size());
+    Assertions.assertNotNull(nodeAttributeInfos);
+    Assertions.assertEquals(4, nodeAttributeInfos.size());
 
     NodeAttributeInfo nodeAttributeInfo1 =
         NodeAttributeInfo.newInstance(NodeAttributeKey.newInstance("GPU"),
         NodeAttributeType.STRING);
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
+    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
 
     NodeAttributeInfo nodeAttributeInfo2 =
         NodeAttributeInfo.newInstance(NodeAttributeKey.newInstance("OS"),
         NodeAttributeType.STRING);
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
+    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
   }
 
   @Test
@@ -1381,15 +1381,15 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     Set<String> hostNames = Collections.singleton("0-host1");
     GetNodesToAttributesResponse response =
         interceptor.getNodesToAttributes(GetNodesToAttributesRequest.newInstance(hostNames));
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Map<String, Set<NodeAttribute>> nodeAttributeMap = response.getNodeToAttributes();
-    Assert.assertNotNull(nodeAttributeMap);
-    Assert.assertEquals(1, nodeAttributeMap.size());
+    Assertions.assertNotNull(nodeAttributeMap);
+    Assertions.assertEquals(1, nodeAttributeMap.size());
 
     NodeAttribute gpu = NodeAttribute.newInstance(NodeAttribute.PREFIX_CENTRALIZED, "GPU",
         NodeAttributeType.STRING, "nvida");
-    Assert.assertTrue(nodeAttributeMap.get("0-host1").contains(gpu));
+    Assertions.assertTrue(nodeAttributeMap.get("0-host1").contains(gpu));
   }
 
   @Test
@@ -1403,12 +1403,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // normal request
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     ReservationId reservationId = response.getReservationId();
-    Assert.assertNotNull(reservationId);
-    Assert.assertTrue(reservationId.toString().contains("reservation"));
-    Assert.assertEquals(reservationId.getClusterTimestamp(), ResourceManager.getClusterTimeStamp());
+    Assertions.assertNotNull(reservationId);
+    Assertions.assertTrue(reservationId.toString().contains("reservation"));
+    Assertions.assertEquals(reservationId.getClusterTimestamp(), ResourceManager.getClusterTimeStamp());
   }
 
   @Test
@@ -1418,7 +1418,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     // Submit Reservation
     ReservationId reservationId = response.getReservationId();
@@ -1428,11 +1428,11 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assert.assertNotNull(submissionResponse);
+    Assertions.assertNotNull(submissionResponse);
 
     SubClusterId subClusterId = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assert.assertNotNull(subClusterId);
-    Assert.assertTrue(subClusters.contains(subClusterId));
+    Assertions.assertNotNull(subClusterId);
+    Assertions.assertTrue(subClusters.contains(subClusterId));
   }
 
   @Test
@@ -1487,7 +1487,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     // First Submit Reservation
     ReservationId reservationId = response.getReservationId();
@@ -1496,21 +1496,21 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         rDefinition, "decided", reservationId);
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assert.assertNotNull(submissionResponse);
+    Assertions.assertNotNull(submissionResponse);
 
     SubClusterId subClusterId1 = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assert.assertNotNull(subClusterId1);
-    Assert.assertTrue(subClusters.contains(subClusterId1));
+    Assertions.assertNotNull(subClusterId1);
+    Assertions.assertTrue(subClusters.contains(subClusterId1));
 
     // First Retry, repeat the submission
     ReservationSubmissionResponse submissionResponse1 =
         interceptor.submitReservation(rSubmissionRequest);
-    Assert.assertNotNull(submissionResponse1);
+    Assertions.assertNotNull(submissionResponse1);
 
     // Expect reserved clusters to be consistent
     SubClusterId subClusterId2 = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assert.assertNotNull(subClusterId2);
-    Assert.assertEquals(subClusterId1, subClusterId2);
+    Assertions.assertNotNull(subClusterId2);
+    Assertions.assertEquals(subClusterId1, subClusterId2);
   }
 
   @Test
@@ -1520,7 +1520,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     // allow plan follower to synchronize, manually trigger an assignment
     Map<SubClusterId, MockRM> mockRMs = interceptor.getMockRMs();
@@ -1537,7 +1537,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assert.assertNotNull(submissionResponse);
+    Assertions.assertNotNull(submissionResponse);
 
     // Update Reservation
     ReservationDefinition rDefinition2 = createReservationDefinition(2048, 1);
@@ -1545,10 +1545,10 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         ReservationUpdateRequest.newInstance(rDefinition2, reservationId);
     ReservationUpdateResponse updateResponse =
         interceptor.updateReservation(updateRequest);
-    Assert.assertNotNull(updateResponse);
+    Assertions.assertNotNull(updateResponse);
 
     SubClusterId subClusterId = stateStoreUtil.queryReservationHomeSC(reservationId);
-    Assert.assertNotNull(subClusterId);
+    Assertions.assertNotNull(subClusterId);
   }
 
   @Test
@@ -1558,7 +1558,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // get new reservationId
     GetNewReservationRequest request = GetNewReservationRequest.newInstance();
     GetNewReservationResponse response = interceptor.getNewReservation(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     // allow plan follower to synchronize, manually trigger an assignment
     Map<SubClusterId, MockRM> mockRMs = interceptor.getMockRMs();
@@ -1575,12 +1575,12 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse submissionResponse =
         interceptor.submitReservation(rSubmissionRequest);
-    Assert.assertNotNull(submissionResponse);
+    Assertions.assertNotNull(submissionResponse);
 
     // Delete Reservation
     ReservationDeleteRequest deleteRequest = ReservationDeleteRequest.newInstance(reservationId);
     ReservationDeleteResponse deleteResponse = interceptor.deleteReservation(deleteRequest);
-    Assert.assertNotNull(deleteResponse);
+    Assertions.assertNotNull(deleteResponse);
 
     LambdaTestUtils.intercept(YarnException.class,
         "Reservation " + reservationId + " does not exist",
@@ -1628,14 +1628,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // If we don't configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE,
     // we expect to get 5 threads
     int minThreads = interceptor.getNumMinThreads(this.getConf());
-    Assert.assertEquals(5, minThreads);
+    Assertions.assertEquals(5, minThreads);
 
     // If we configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE,
     // we expect to get 3 threads
     this.getConf().unset(YarnConfiguration.ROUTER_USER_CLIENT_THREADS_SIZE);
     this.getConf().setInt(YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MINIMUM_POOL_SIZE, 3);
     int minThreads2 = interceptor.getNumMinThreads(this.getConf());
-    Assert.assertEquals(3, minThreads2);
+    Assertions.assertEquals(3, minThreads2);
   }
 
   @Test
@@ -1643,14 +1643,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     // If we don't configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE,
     // we expect to get 5 threads
     int minThreads = interceptor.getNumMaxThreads(this.getConf());
-    Assert.assertEquals(5, minThreads);
+    Assertions.assertEquals(5, minThreads);
 
     // If we configure YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE,
     // we expect to get 8 threads
     this.getConf().unset(YarnConfiguration.ROUTER_USER_CLIENT_THREADS_SIZE);
     this.getConf().setInt(YarnConfiguration.ROUTER_USER_CLIENT_THREAD_POOL_MAXIMUM_POOL_SIZE, 8);
     int minThreads2 = interceptor.getNumMaxThreads(this.getConf());
-    Assert.assertEquals(8, minThreads2);
+    Assertions.assertEquals(8, minThreads2);
   }
 
   @Test
@@ -1674,43 +1674,43 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer1");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
-    Assert.assertNotNull(delegationToken);
-    Assert.assertEquals("RM_DELEGATION_TOKEN", delegationToken.getKind());
+    Assertions.assertNotNull(delegationToken);
+    Assertions.assertEquals("RM_DELEGATION_TOKEN", delegationToken.getKind());
 
     // Step2. Serialize the returned Token as RMDelegationTokenIdentifier.
     org.apache.hadoop.security.token.Token<RMDelegationTokenIdentifier> token =
         ConverterUtils.convertFromYarn(delegationToken, (Text) null);
     RMDelegationTokenIdentifier rMDelegationTokenIdentifier = token.decodeIdentifier();
-    Assert.assertNotNull(rMDelegationTokenIdentifier);
+    Assertions.assertNotNull(rMDelegationTokenIdentifier);
 
     // Step3. Verify the returned data of the token.
     String renewer = rMDelegationTokenIdentifier.getRenewer().toString();
     long issueDate = rMDelegationTokenIdentifier.getIssueDate();
     long maxDate = rMDelegationTokenIdentifier.getMaxDate();
-    Assert.assertEquals("renewer1", renewer);
+    Assertions.assertEquals("renewer1", renewer);
 
     long tokenMaxLifetime = this.getConf().getLong(
         YarnConfiguration.RM_DELEGATION_TOKEN_MAX_LIFETIME_KEY,
         YarnConfiguration.RM_DELEGATION_TOKEN_MAX_LIFETIME_DEFAULT);
-    Assert.assertEquals(issueDate + tokenMaxLifetime, maxDate);
+    Assertions.assertEquals(issueDate + tokenMaxLifetime, maxDate);
 
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
-    Assert.assertNotNull(managerState);
+    Assertions.assertNotNull(managerState);
 
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assert.assertNotNull(delegationTokenState);
-    Assert.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
+    Assertions.assertNotNull(delegationTokenState);
+    Assertions.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
 
     long tokenRenewInterval = this.getConf().getLong(
         YarnConfiguration.RM_DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
         YarnConfiguration.RM_DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
     RouterStoreToken resultRouterStoreToken = delegationTokenState.get(rMDelegationTokenIdentifier);
-    Assert.assertNotNull(resultRouterStoreToken);
+    Assertions.assertNotNull(resultRouterStoreToken);
     long renewDate = resultRouterStoreToken.getRenewDate();
-    Assert.assertEquals(issueDate + tokenRenewInterval, renewDate);
+    Assertions.assertEquals(issueDate + tokenRenewInterval, renewDate);
   }
 
   @Test
@@ -1730,7 +1730,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer2");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
 
     org.apache.hadoop.security.token.Token<RMDelegationTokenIdentifier> token =
@@ -1738,28 +1738,28 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     RMDelegationTokenIdentifier rMDelegationTokenIdentifier = token.decodeIdentifier();
     String renewer = rMDelegationTokenIdentifier.getRenewer().toString();
     long maxDate = rMDelegationTokenIdentifier.getMaxDate();
-    Assert.assertEquals("renewer2", renewer);
+    Assertions.assertEquals("renewer2", renewer);
 
     // Step2. Call renewDelegationToken to refresh delegationToken.
     RenewDelegationTokenRequest renewRequest = Records.newRecord(RenewDelegationTokenRequest.class);
     renewRequest.setDelegationToken(delegationToken);
     RenewDelegationTokenResponse renewResponse = interceptor.renewDelegationToken(renewRequest);
-    Assert.assertNotNull(renewResponse);
+    Assertions.assertNotNull(renewResponse);
 
     long expDate = renewResponse.getNextExpirationTime();
-    Assert.assertTrue(expDate <= maxDate);
+    Assertions.assertTrue(expDate <= maxDate);
 
     // Step3. Compare whether the expirationTime returned to
     // the client is consistent with the renewDate in the stateStore
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assert.assertNotNull(delegationTokenState);
-    Assert.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
+    Assertions.assertNotNull(delegationTokenState);
+    Assertions.assertTrue(delegationTokenState.containsKey(rMDelegationTokenIdentifier));
     RouterStoreToken resultRouterStoreToken = delegationTokenState.get(rMDelegationTokenIdentifier);
-    Assert.assertNotNull(resultRouterStoreToken);
+    Assertions.assertNotNull(resultRouterStoreToken);
     long renewDate = resultRouterStoreToken.getRenewDate();
-    Assert.assertEquals(expDate, renewDate);
+    Assertions.assertEquals(expDate, renewDate);
   }
 
   @Test
@@ -1775,7 +1775,7 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
     GetDelegationTokenRequest request = mock(GetDelegationTokenRequest.class);
     when(request.getRenewer()).thenReturn("renewer3");
     GetDelegationTokenResponse response = interceptor.getDelegationToken(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Token delegationToken = response.getRMDelegationToken();
 
     // Step2. Call CancelDelegationToken to cancel delegationToken.
@@ -1783,14 +1783,14 @@ public class TestFederationClientInterceptor extends BaseRouterClientRMTest {
         CancelDelegationTokenRequest.newInstance(delegationToken);
     CancelDelegationTokenResponse cancelTokenResponse =
         interceptor.cancelDelegationToken(cancelTokenRequest);
-    Assert.assertNotNull(cancelTokenResponse);
+    Assertions.assertNotNull(cancelTokenResponse);
 
     // Step3. Query the data in the StateStore and confirm that the Delegation has been deleted.
     // At this point, the size of delegationTokenState should be 0.
     RouterRMDTSecretManagerState managerState = stateStore.getRouterRMSecretManagerState();
     Map<RMDelegationTokenIdentifier, RouterStoreToken> delegationTokenState =
         managerState.getTokenState();
-    Assert.assertNotNull(delegationTokenState);
-    Assert.assertEquals(0, delegationTokenState.size());
+    Assertions.assertNotNull(delegationTokenState);
+    Assertions.assertEquals(0, delegationTokenState.size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -19,7 +19,10 @@
 package org.apache.hadoop.yarn.server.router.clientrm;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.FEDERATION_POLICY_MANAGER;
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -52,8 +55,6 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -151,7 +152,7 @@ public class TestFederationClientInterceptorRetry
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assertions.fail();
+      fail();
     }
   }
 
@@ -221,8 +222,8 @@ public class TestFederationClientInterceptorRetry
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
     GetNewApplicationResponse response = interceptor.getNewApplication(request);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(ResourceManager.getClusterTimeStamp(),
+    assertNotNull(response);
+    assertEquals(ResourceManager.getClusterTimeStamp(),
         response.getApplicationId().getClusterTimestamp());
   }
 
@@ -289,19 +290,19 @@ public class TestFederationClientInterceptorRetry
 
     final SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     GetApplicationHomeSubClusterRequest getAppRequest =
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse getAppResponse =
         stateStore.getApplicationHomeSubCluster(getAppRequest);
-    Assertions.assertNotNull(getAppResponse);
+    assertNotNull(getAppResponse);
 
     ApplicationHomeSubCluster responseHomeSubCluster =
         getAppResponse.getApplicationHomeSubCluster();
-    Assertions.assertNotNull(responseHomeSubCluster);
+    assertNotNull(responseHomeSubCluster);
     SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
-    Assertions.assertEquals(good, respSubClusterId);
+    assertEquals(good, respSubClusterId);
   }
 
   @Test
@@ -310,8 +311,8 @@ public class TestFederationClientInterceptorRetry
     LOG.info("Test submitApplication with two bad, one good SC.");
 
     // This test must require the TestSequentialRouterPolicy policy
-    Assume.assumeThat(routerPolicyManagerName,
-        is(TestSequentialBroadcastPolicyManager.class.getName()));
+    assertThat(routerPolicyManagerName).
+        isEqualTo(TestSequentialBroadcastPolicyManager.class.getName());
 
     setupCluster(Arrays.asList(bad1, bad2, good));
     final ApplicationId appId =
@@ -335,7 +336,7 @@ public class TestFederationClientInterceptorRetry
     // 1st time will use bad2, 2nd time will use bad1, 3rd good
     interceptor.setNumSubmitRetries(2);
     SubmitApplicationResponse submitAppResponse = interceptor.submitApplication(request);
-    Assertions.assertNotNull(submitAppResponse);
+    assertNotNull(submitAppResponse);
 
     // We will get good
     checkSubmitSubCluster(appId, good);
@@ -347,13 +348,13 @@ public class TestFederationClientInterceptorRetry
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse getAppResponse =
         stateStore.getApplicationHomeSubCluster(getAppRequest);
-    Assertions.assertNotNull(getAppResponse);
-    Assertions.assertNotNull(getAppResponse);
+    assertNotNull(getAppResponse);
+    assertNotNull(getAppResponse);
     ApplicationHomeSubCluster responseHomeSubCluster =
         getAppResponse.getApplicationHomeSubCluster();
-    Assertions.assertNotNull(responseHomeSubCluster);
+    assertNotNull(responseHomeSubCluster);
     SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
-    Assertions.assertEquals(expectSubCluster, respSubClusterId);
+    assertEquals(expectSubCluster, respSubClusterId);
   }
 
   @Test
@@ -419,7 +420,7 @@ public class TestFederationClientInterceptorRetry
     GetClusterMetricsRequest request = GetClusterMetricsRequest.newInstance();
 
     GetClusterMetricsResponse clusterMetrics = interceptor.getClusterMetrics(request);
-    Assertions.assertNotNull(clusterMetrics);
+    assertNotNull(clusterMetrics);
 
     // If partial results are not allowed to be returned, an exception will be thrown.
     interceptor.setAllowPartialResult(false);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -52,9 +52,9 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -151,7 +151,7 @@ public class TestFederationClientInterceptorRetry
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -221,8 +221,8 @@ public class TestFederationClientInterceptorRetry
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
     GetNewApplicationResponse response = interceptor.getNewApplication(request);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(ResourceManager.getClusterTimeStamp(),
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(ResourceManager.getClusterTimeStamp(),
         response.getApplicationId().getClusterTimestamp());
   }
 
@@ -289,19 +289,19 @@ public class TestFederationClientInterceptorRetry
 
     final SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
     SubmitApplicationResponse response = interceptor.submitApplication(request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     GetApplicationHomeSubClusterRequest getAppRequest =
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse getAppResponse =
         stateStore.getApplicationHomeSubCluster(getAppRequest);
-    Assert.assertNotNull(getAppResponse);
+    Assertions.assertNotNull(getAppResponse);
 
     ApplicationHomeSubCluster responseHomeSubCluster =
         getAppResponse.getApplicationHomeSubCluster();
-    Assert.assertNotNull(responseHomeSubCluster);
+    Assertions.assertNotNull(responseHomeSubCluster);
     SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
-    Assert.assertEquals(good, respSubClusterId);
+    Assertions.assertEquals(good, respSubClusterId);
   }
 
   @Test
@@ -335,7 +335,7 @@ public class TestFederationClientInterceptorRetry
     // 1st time will use bad2, 2nd time will use bad1, 3rd good
     interceptor.setNumSubmitRetries(2);
     SubmitApplicationResponse submitAppResponse = interceptor.submitApplication(request);
-    Assert.assertNotNull(submitAppResponse);
+    Assertions.assertNotNull(submitAppResponse);
 
     // We will get good
     checkSubmitSubCluster(appId, good);
@@ -347,13 +347,13 @@ public class TestFederationClientInterceptorRetry
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse getAppResponse =
         stateStore.getApplicationHomeSubCluster(getAppRequest);
-    Assert.assertNotNull(getAppResponse);
-    Assert.assertNotNull(getAppResponse);
+    Assertions.assertNotNull(getAppResponse);
+    Assertions.assertNotNull(getAppResponse);
     ApplicationHomeSubCluster responseHomeSubCluster =
         getAppResponse.getApplicationHomeSubCluster();
-    Assert.assertNotNull(responseHomeSubCluster);
+    Assertions.assertNotNull(responseHomeSubCluster);
     SubClusterId respSubClusterId = responseHomeSubCluster.getHomeSubCluster();
-    Assert.assertEquals(expectSubCluster, respSubClusterId);
+    Assertions.assertEquals(expectSubCluster, respSubClusterId);
   }
 
   @Test
@@ -419,7 +419,7 @@ public class TestFederationClientInterceptorRetry
     GetClusterMetricsRequest request = GetClusterMetricsRequest.newInstance();
 
     GetClusterMetricsResponse clusterMetrics = interceptor.getClusterMetrics(request);
-    Assert.assertNotNull(clusterMetrics);
+    Assertions.assertNotNull(clusterMetrics);
 
     // If partial results are not allowed to be returned, an exception will be thrown.
     interceptor.setAllowPartialResult(false);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -55,10 +56,9 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,13 +74,11 @@ import static org.apache.hadoop.yarn.server.federation.policies.FederationPolicy
  * It tests the case with SubClusters down and the Router logic of retries. We
  * have 1 good SubCluster and 2 bad ones for all the tests.
  */
-@RunWith(Parameterized.class)
 public class TestFederationClientInterceptorRetry
     extends BaseRouterClientRMTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestFederationClientInterceptorRetry.class);
 
-  @Parameters
   public static Collection<String[]> getParameters() {
     return Arrays.asList(new String[][] {{UniformBroadcastPolicyManager.class.getName()},
         {TestSequentialBroadcastPolicyManager.class.getName()}});
@@ -102,8 +100,10 @@ public class TestFederationClientInterceptorRetry
 
   private static List<SubClusterId> scs = new ArrayList<>();
 
-  public TestFederationClientInterceptorRetry(String policyManagerName) {
+  private void initTestFederationClientInterceptorRetry(String policyManagerName)
+      throws IOException {
     this.routerPolicyManagerName = policyManagerName;
+    setUp();
   }
 
   @Override
@@ -135,6 +135,7 @@ public class TestFederationClientInterceptorRetry
     interceptor.registerBadSubCluster(bad2);
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();
@@ -184,9 +185,10 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of GetNewApplication in case the
    * cluster is composed of only 1 bad SubCluster.
    */
-  @Test
-  public void testGetNewApplicationOneBadSC() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetNewApplicationOneBadSC(String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getNewApplication with one bad SubCluster");
     setupCluster(Arrays.asList(bad2));
 
@@ -199,9 +201,10 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of GetNewApplication in case the
    * cluster is composed of only 2 bad SubClusters.
    */
-  @Test
-  public void testGetNewApplicationTwoBadSCs() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetNewApplicationTwoBadSCs(String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getNewApplication with two bad SubClusters");
     setupCluster(Arrays.asList(bad1, bad2));
 
@@ -214,9 +217,11 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of GetNewApplication in case the
    * cluster is composed of only 1 bad SubCluster and 1 good one.
    */
-  @Test
-  public void testGetNewApplicationOneBadOneGood() throws YarnException, IOException {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetNewApplicationOneBadOneGood(String policyManagerName)
+      throws YarnException, IOException {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getNewApplication with one bad, one good SC");
     setupCluster(Arrays.asList(good, bad2));
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
@@ -231,9 +236,10 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of SubmitApplication in case the
    * cluster is composed of only 1 bad SubCluster.
    */
-  @Test
-  public void testSubmitApplicationOneBadSC() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationOneBadSC(String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test submitApplication with one bad SubCluster");
     setupCluster(Arrays.asList(bad2));
 
@@ -260,9 +266,10 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of SubmitApplication in case the
    * cluster is composed of only 2 bad SubClusters.
    */
-  @Test
-  public void testSubmitApplicationTwoBadSCs() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationTwoBadSCs(String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test submitApplication with two bad SubClusters.");
     setupCluster(Arrays.asList(bad1, bad2));
 
@@ -278,10 +285,11 @@ public class TestFederationClientInterceptorRetry
    * This test validates the correctness of SubmitApplication in case the
    * cluster is composed of only 1 bad SubCluster and a good one.
    */
-  @Test
-  public void testSubmitApplicationOneBadOneGood()
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationOneBadOneGood(String policyManagerName)
       throws YarnException, IOException, InterruptedException {
-
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test submitApplication with one bad, one good SC.");
     setupCluster(Arrays.asList(good, bad2));
 
@@ -305,9 +313,11 @@ public class TestFederationClientInterceptorRetry
     assertEquals(good, respSubClusterId);
   }
 
-  @Test
-  public void testSubmitApplicationTwoBadOneGood() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationTwoBadOneGood(String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
+    assumeTrue(policyManagerName.equals(TestSequentialBroadcastPolicyManager.class.getName()));
     LOG.info("Test submitApplication with two bad, one good SC.");
 
     // This test must require the TestSequentialRouterPolicy policy
@@ -357,8 +367,11 @@ public class TestFederationClientInterceptorRetry
     assertEquals(expectSubCluster, respSubClusterId);
   }
 
-  @Test
-  public void testSubmitApplicationTwoBadNodeWithRealError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationTwoBadNodeWithRealError(String policyManagerName)
+      throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test submitApplication with two bad SubClusters.");
     setupCluster(Arrays.asList(bad1, bad2));
     interceptor.setNumSubmitRetries(1);
@@ -372,8 +385,11 @@ public class TestFederationClientInterceptorRetry
         () -> interceptor.submitApplication(request));
   }
 
-  @Test
-  public void testSubmitApplicationOneBadNodeWithRealError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testSubmitApplicationOneBadNodeWithRealError(String policyManagerName)
+      throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test submitApplication with one bad SubClusters.");
     setupCluster(Arrays.asList(bad1));
     interceptor.setNumSubmitRetries(0);
@@ -387,8 +403,11 @@ public class TestFederationClientInterceptorRetry
         () -> interceptor.submitApplication(request));
   }
 
-  @Test
-  public void testGetClusterMetricsTwoBadNodeWithRealError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetClusterMetricsTwoBadNodeWithRealError(String policyManagerName)
+      throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getClusterMetrics with two bad SubClusters.");
     setupCluster(Arrays.asList(bad1, bad2));
     GetClusterMetricsRequest request = GetClusterMetricsRequest.newInstance();
@@ -402,8 +421,11 @@ public class TestFederationClientInterceptorRetry
         () -> interceptor.getClusterMetrics(request));
   }
 
-  @Test
-  public void testGetClusterMetricsOneBadNodeWithRealError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetClusterMetricsOneBadNodeWithRealError(String policyManagerName)
+      throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getClusterMetrics with one bad SubClusters.");
     setupCluster(Arrays.asList(bad1));
     GetClusterMetricsRequest request = GetClusterMetricsRequest.newInstance();
@@ -413,8 +435,11 @@ public class TestFederationClientInterceptorRetry
         () -> interceptor.getClusterMetrics(request));
   }
 
-  @Test
-  public void testGetClusterMetricsOneBadOneGoodNodeWithRealError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("getParameters")
+  public void testGetClusterMetricsOneBadOneGoodNodeWithRealError(
+      String policyManagerName) throws Exception {
+    initTestFederationClientInterceptorRetry(policyManagerName);
     LOG.info("Test getClusterMetrics with one bad and one good SubCluster.");
     setupCluster(Arrays.asList(bad1, good));
     GetClusterMetricsRequest request = GetClusterMetricsRequest.newInstance();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -38,7 +44,6 @@ import org.apache.hadoop.yarn.api.protocolrecords.ReservationUpdateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService.RequestInterceptorChainWrapper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,20 +75,20 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assertions.assertEquals(PassThroughClientRequestInterceptor.class.getName(),
+        assertEquals(PassThroughClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assertions.assertEquals(MockClientRequestInterceptor.class.getName(),
+        assertEquals(MockClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assertions.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assertions.assertEquals(4
+    assertEquals(4
 ,         index, "The number of interceptors in chain does not match");
   }
 
@@ -99,46 +104,46 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     LOG.info("testRouterClientRMServiceE2E - Get New Application");
 
     GetNewApplicationResponse responseGetNewApp = getNewApplication(user);
-    Assertions.assertNotNull(responseGetNewApp);
+    assertNotNull(responseGetNewApp);
 
     LOG.info("testRouterClientRMServiceE2E - Submit Application");
 
     SubmitApplicationResponse responseSubmitApp =
         submitApplication(responseGetNewApp.getApplicationId(), user);
-    Assertions.assertNotNull(responseSubmitApp);
+    assertNotNull(responseSubmitApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Metrics");
 
     GetClusterMetricsResponse responseGetClusterMetrics =
         getClusterMetrics(user);
-    Assertions.assertNotNull(responseGetClusterMetrics);
+    assertNotNull(responseGetClusterMetrics);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Nodes");
 
     GetClusterNodesResponse responseGetClusterNodes = getClusterNodes(user);
-    Assertions.assertNotNull(responseGetClusterNodes);
+    assertNotNull(responseGetClusterNodes);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue Info");
 
     GetQueueInfoResponse responseGetQueueInfo = getQueueInfo(user);
-    Assertions.assertNotNull(responseGetQueueInfo);
+    assertNotNull(responseGetQueueInfo);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue User");
 
     GetQueueUserAclsInfoResponse responseGetQueueUser = getQueueUserAcls(user);
-    Assertions.assertNotNull(responseGetQueueUser);
+    assertNotNull(responseGetQueueUser);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Node");
 
     GetClusterNodeLabelsResponse responseGetClusterNode =
         getClusterNodeLabels(user);
-    Assertions.assertNotNull(responseGetClusterNode);
+    assertNotNull(responseGetClusterNode);
 
     LOG.info("testRouterClientRMServiceE2E - Move Application Across Queues");
 
     MoveApplicationAcrossQueuesResponse responseMoveApp =
         moveApplicationAcrossQueues(user, responseGetNewApp.getApplicationId());
-    Assertions.assertNotNull(responseMoveApp);
+    assertNotNull(responseMoveApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get New Reservation");
 
@@ -149,25 +154,25 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse responseSubmitReser =
         submitReservation(user, getNewReservationResponse.getReservationId());
-    Assertions.assertNotNull(responseSubmitReser);
+    assertNotNull(responseSubmitReser);
 
     LOG.info("testRouterClientRMServiceE2E - Update Reservation");
 
     ReservationUpdateResponse responseUpdateReser =
         updateReservation(user, getNewReservationResponse.getReservationId());
-    Assertions.assertNotNull(responseUpdateReser);
+    assertNotNull(responseUpdateReser);
 
     LOG.info("testRouterClientRMServiceE2E - Delete Reservation");
 
     ReservationDeleteResponse responseDeleteReser =
         deleteReservation(user, getNewReservationResponse.getReservationId());
-    Assertions.assertNotNull(responseDeleteReser);
+    assertNotNull(responseDeleteReser);
 
     LOG.info("testRouterClientRMServiceE2E - Kill Application");
 
     KillApplicationResponse responseKillApp =
         forceKillApplication(responseGetNewApp.getApplicationId(), user);
-    Assertions.assertNotNull(responseKillApp);
+    assertNotNull(responseKillApp);
   }
 
   /**
@@ -191,7 +196,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     getNewApplication("test8");
 
     pipelines = super.getRouterClientRMService().getPipelines();
-    Assertions.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     getNewApplication("test9");
     getNewApplication("test10");
@@ -200,13 +205,13 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assertions.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assertions.assertNotNull(chain, "test1 should not be evicted");
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assertions.assertNull(chain, "test2 should have been evicted");
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -241,7 +246,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
                     getRouterClientRMService().getInterceptorChain();
                 ClientRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assertions.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init client interceptor success for user " + user);
                 return interceptor;
               }
@@ -262,9 +267,9 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     client1.join();
     client2.join();
 
-    Assertions.assertNotNull(client1.interceptor);
-    Assertions.assertNotNull(client2.interceptor);
-    Assertions.assertTrue(client1.interceptor == client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.yarn.api.protocolrecords.ReservationUpdateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService.RequestInterceptorChainWrapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,21 +70,21 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(PassThroughClientRequestInterceptor.class.getName(),
+        Assertions.assertEquals(PassThroughClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockClientRequestInterceptor.class.getName(),
+        Assertions.assertEquals(MockClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        Assertions.fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    Assertions.assertEquals(4
+,         index, "The number of interceptors in chain does not match");
   }
 
   /**
@@ -99,46 +99,46 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     LOG.info("testRouterClientRMServiceE2E - Get New Application");
 
     GetNewApplicationResponse responseGetNewApp = getNewApplication(user);
-    Assert.assertNotNull(responseGetNewApp);
+    Assertions.assertNotNull(responseGetNewApp);
 
     LOG.info("testRouterClientRMServiceE2E - Submit Application");
 
     SubmitApplicationResponse responseSubmitApp =
         submitApplication(responseGetNewApp.getApplicationId(), user);
-    Assert.assertNotNull(responseSubmitApp);
+    Assertions.assertNotNull(responseSubmitApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Metrics");
 
     GetClusterMetricsResponse responseGetClusterMetrics =
         getClusterMetrics(user);
-    Assert.assertNotNull(responseGetClusterMetrics);
+    Assertions.assertNotNull(responseGetClusterMetrics);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Nodes");
 
     GetClusterNodesResponse responseGetClusterNodes = getClusterNodes(user);
-    Assert.assertNotNull(responseGetClusterNodes);
+    Assertions.assertNotNull(responseGetClusterNodes);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue Info");
 
     GetQueueInfoResponse responseGetQueueInfo = getQueueInfo(user);
-    Assert.assertNotNull(responseGetQueueInfo);
+    Assertions.assertNotNull(responseGetQueueInfo);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue User");
 
     GetQueueUserAclsInfoResponse responseGetQueueUser = getQueueUserAcls(user);
-    Assert.assertNotNull(responseGetQueueUser);
+    Assertions.assertNotNull(responseGetQueueUser);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Node");
 
     GetClusterNodeLabelsResponse responseGetClusterNode =
         getClusterNodeLabels(user);
-    Assert.assertNotNull(responseGetClusterNode);
+    Assertions.assertNotNull(responseGetClusterNode);
 
     LOG.info("testRouterClientRMServiceE2E - Move Application Across Queues");
 
     MoveApplicationAcrossQueuesResponse responseMoveApp =
         moveApplicationAcrossQueues(user, responseGetNewApp.getApplicationId());
-    Assert.assertNotNull(responseMoveApp);
+    Assertions.assertNotNull(responseMoveApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get New Reservation");
 
@@ -149,25 +149,25 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse responseSubmitReser =
         submitReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseSubmitReser);
+    Assertions.assertNotNull(responseSubmitReser);
 
     LOG.info("testRouterClientRMServiceE2E - Update Reservation");
 
     ReservationUpdateResponse responseUpdateReser =
         updateReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseUpdateReser);
+    Assertions.assertNotNull(responseUpdateReser);
 
     LOG.info("testRouterClientRMServiceE2E - Delete Reservation");
 
     ReservationDeleteResponse responseDeleteReser =
         deleteReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseDeleteReser);
+    Assertions.assertNotNull(responseDeleteReser);
 
     LOG.info("testRouterClientRMServiceE2E - Kill Application");
 
     KillApplicationResponse responseKillApp =
         forceKillApplication(responseGetNewApp.getApplicationId(), user);
-    Assert.assertNotNull(responseKillApp);
+    Assertions.assertNotNull(responseKillApp);
   }
 
   /**
@@ -191,7 +191,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     getNewApplication("test8");
 
     pipelines = super.getRouterClientRMService().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    Assertions.assertEquals(8, pipelines.size());
 
     getNewApplication("test9");
     getNewApplication("test10");
@@ -200,13 +200,13 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    Assertions.assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    Assertions.assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    Assertions.assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -241,7 +241,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
                     getRouterClientRMService().getInterceptorChain();
                 ClientRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                Assertions.assertNotNull(interceptor);
                 LOG.info("init client interceptor success for user " + user);
                 return interceptor;
               }
@@ -262,9 +262,9 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertTrue(client1.interceptor == client2.interceptor);
+    Assertions.assertNotNull(client1.interceptor);
+    Assertions.assertNotNull(client2.interceptor);
+    Assertions.assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -18,6 +18,11 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -63,7 +68,6 @@ import org.apache.hadoop.yarn.api.records.NodeToAttributeValue;
 import org.apache.hadoop.yarn.api.records.NodeAttributeInfo;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -80,14 +84,14 @@ public class TestRouterYarnClientUtils {
     responses.add(getClusterMetricsResponse(2));
     GetClusterMetricsResponse result = RouterYarnClientUtils.merge(responses);
     YarnClusterMetrics resultMetrics = result.getClusterMetrics();
-    Assertions.assertEquals(3, resultMetrics.getNumNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumActiveNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumLostNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
-    Assertions.assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
+    assertEquals(3, resultMetrics.getNumNodeManagers());
+    assertEquals(3, resultMetrics.getNumActiveNodeManagers());
+    assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
+    assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
+    assertEquals(3, resultMetrics.getNumLostNodeManagers());
+    assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
+    assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
+    assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
   }
 
   public GetClusterMetricsResponse getClusterMetricsResponse(int value) {
@@ -114,16 +118,16 @@ public class TestRouterYarnClientUtils {
     responses.add(getApplicationsResponse(2, false));
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(2, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(2, result.getApplicationList().size());
 
     String appName1 = result.getApplicationList().get(0).getName();
     String appName2 = result.getApplicationList().get(1).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assertions.assertEquals(false,
+    assertEquals(false,
         appName1.contains(UnmanagedApplicationManager.APP_NAME));
-    Assertions.assertEquals(false,
+    assertEquals(false,
         appName2.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
@@ -139,24 +143,24 @@ public class TestRouterYarnClientUtils {
     // Check response if partial results are enabled
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, true);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApplicationList().size());
     ApplicationReport appReport = result.getApplicationList().iterator().next();
     String appName = appReport.getName();
-    Assertions.assertTrue(appName.startsWith(PARTIAL_REPORT));
+    assertTrue(appName.startsWith(PARTIAL_REPORT));
 
     // Check ApplicationResourceUsageReport merge
     ApplicationResourceUsageReport resourceUsageReport =
         appReport.getApplicationResourceUsageReport();
 
-    Assertions.assertEquals(2, resourceUsageReport.getNumUsedContainers());
-    Assertions.assertEquals(4, resourceUsageReport.getNumReservedContainers());
+    assertEquals(2, resourceUsageReport.getNumUsedContainers());
+    assertEquals(4, resourceUsageReport.getNumReservedContainers());
 
     // Check response if partial results are disabled
     result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(result.getApplicationList().isEmpty());
+    assertNotNull(result);
+    assertTrue(result.getApplicationList().isEmpty());
   }
 
   /**
@@ -192,13 +196,13 @@ public class TestRouterYarnClientUtils {
 
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApplicationList().size());
 
     String appName = result.getApplicationList().get(0).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assertions.assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
+    assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
   /**
@@ -286,7 +290,7 @@ public class TestRouterYarnClientUtils {
 
     GetNodesToLabelsResponse response = RouterYarnClientUtils.
         mergeNodesToLabelsResponse(responses);
-    Assertions.assertEquals(expectedResponse, response.getNodeToLabels());
+    assertEquals(expectedResponse, response.getNodeToLabels());
   }
 
   @Test
@@ -327,7 +331,7 @@ public class TestRouterYarnClientUtils {
 
     GetClusterNodeLabelsResponse response = RouterYarnClientUtils.
         mergeClusterNodeLabelsResponse(responses);
-    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getNodeLabelList()));
   }
 
@@ -388,7 +392,7 @@ public class TestRouterYarnClientUtils {
     GetLabelsToNodesResponse response = RouterYarnClientUtils.
         mergeLabelsToNodes(responses);
 
-    Assertions.assertEquals(expectedResponse, response.getLabelsToNodes());
+    assertEquals(expectedResponse, response.getLabelsToNodes());
   }
 
   @Test
@@ -453,7 +457,7 @@ public class TestRouterYarnClientUtils {
 
     GetQueueUserAclsInfoResponse response =
         RouterYarnClientUtils.mergeQueueUserAcls(responses);
-    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
+    assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
         response.getUserAclsInfoList()));
   }
 
@@ -486,7 +490,7 @@ public class TestRouterYarnClientUtils {
 
     ReservationListResponse response =
         RouterYarnClientUtils.mergeReservationsList(responses);
-    Assertions.assertEquals(expectedResponse, response.getReservationAllocationState());
+    assertEquals(expectedResponse, response.getReservationAllocationState());
   }
 
   private ReservationListResponse createReservationListResponse(long startTime,
@@ -550,7 +554,7 @@ public class TestRouterYarnClientUtils {
     expectedResponse.add(resourceTypeInfo3);
     GetAllResourceTypeInfoResponse response =
         RouterYarnClientUtils.mergeResourceTypes(responses);
-    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getResourceTypeInfo()));
   }
 
@@ -585,8 +589,8 @@ public class TestRouterYarnClientUtils {
     GetAllResourceProfilesResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfilesResponse(responses);
     Resource resource = response.getResourceProfiles().get("maximum");
-    Assertions.assertEquals(3, resource.getVirtualCores());
-    Assertions.assertEquals(3072, resource.getMemorySize());
+    assertEquals(3, resource.getVirtualCores());
+    assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -619,8 +623,8 @@ public class TestRouterYarnClientUtils {
     GetResourceProfileResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfileResponse(responses);
     Resource resource = response.getResource();
-    Assertions.assertEquals(3, resource.getVirtualCores());
-    Assertions.assertEquals(3072, resource.getMemorySize());
+    assertEquals(3, resource.getVirtualCores());
+    assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -663,16 +667,16 @@ public class TestRouterYarnClientUtils {
     GetAttributesToNodesResponse response =
         RouterYarnClientUtils.mergeAttributesToNodesResponse(responses);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(2, response.getAttributesToNodes().size());
+    assertNotNull(response);
+    assertEquals(2, response.getAttributesToNodes().size());
 
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
 
     NodeAttributeKey gpuKey = gpu.getAttributeKey();
-    Assertions.assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
+    assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
 
     NodeAttributeKey dockerKey = docker.getAttributeKey();
-    Assertions.assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
+    assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
   }
 
   @Test
@@ -711,12 +715,12 @@ public class TestRouterYarnClientUtils {
     GetClusterNodeAttributesResponse response =
         RouterYarnClientUtils.mergeClusterNodeAttributesResponse(responses);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
-    Assertions.assertEquals(2, nodeAttributeInfos.size());
-    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
-    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
+    assertEquals(2, nodeAttributeInfos.size());
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
   }
 
   @Test
@@ -755,14 +759,14 @@ public class TestRouterYarnClientUtils {
     GetNodesToAttributesResponse response =
         RouterYarnClientUtils.mergeNodesToAttributesResponse(responses);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Map<String, Set<NodeAttribute>> hostToAttrs = response.getNodeToAttributes();
-    Assertions.assertNotNull(hostToAttrs);
-    Assertions.assertEquals(2, hostToAttrs.size());
-    Assertions.assertTrue(hostToAttrs.get("node1").contains(dist));
-    Assertions.assertTrue(hostToAttrs.get("node1").contains(gpu));
-    Assertions.assertTrue(hostToAttrs.get("node1").contains(os));
-    Assertions.assertTrue(hostToAttrs.get("node2").contains(docker));
+    assertNotNull(hostToAttrs);
+    assertEquals(2, hostToAttrs.size());
+    assertTrue(hostToAttrs.get("node1").contains(dist));
+    assertTrue(hostToAttrs.get("node1").contains(gpu));
+    assertTrue(hostToAttrs.get("node1").contains(os));
+    assertTrue(hostToAttrs.get("node2").contains(docker));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -63,8 +63,8 @@ import org.apache.hadoop.yarn.api.records.NodeToAttributeValue;
 import org.apache.hadoop.yarn.api.records.NodeAttributeInfo;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for RouterYarnClientUtils.
@@ -80,14 +80,14 @@ public class TestRouterYarnClientUtils {
     responses.add(getClusterMetricsResponse(2));
     GetClusterMetricsResponse result = RouterYarnClientUtils.merge(responses);
     YarnClusterMetrics resultMetrics = result.getClusterMetrics();
-    Assert.assertEquals(3, resultMetrics.getNumNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumActiveNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumLostNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumActiveNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumLostNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
+    Assertions.assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
   }
 
   public GetClusterMetricsResponse getClusterMetricsResponse(int value) {
@@ -114,16 +114,16 @@ public class TestRouterYarnClientUtils {
     responses.add(getApplicationsResponse(2, false));
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(2, result.getApplicationList().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(2, result.getApplicationList().size());
 
     String appName1 = result.getApplicationList().get(0).getName();
     String appName2 = result.getApplicationList().get(1).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         appName1.contains(UnmanagedApplicationManager.APP_NAME));
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         appName2.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
@@ -139,24 +139,24 @@ public class TestRouterYarnClientUtils {
     // Check response if partial results are enabled
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, true);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApplicationList().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getApplicationList().size());
     ApplicationReport appReport = result.getApplicationList().iterator().next();
     String appName = appReport.getName();
-    Assert.assertTrue(appName.startsWith(PARTIAL_REPORT));
+    Assertions.assertTrue(appName.startsWith(PARTIAL_REPORT));
 
     // Check ApplicationResourceUsageReport merge
     ApplicationResourceUsageReport resourceUsageReport =
         appReport.getApplicationResourceUsageReport();
 
-    Assert.assertEquals(2, resourceUsageReport.getNumUsedContainers());
-    Assert.assertEquals(4, resourceUsageReport.getNumReservedContainers());
+    Assertions.assertEquals(2, resourceUsageReport.getNumUsedContainers());
+    Assertions.assertEquals(4, resourceUsageReport.getNumReservedContainers());
 
     // Check response if partial results are disabled
     result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result.getApplicationList().isEmpty());
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.getApplicationList().isEmpty());
   }
 
   /**
@@ -192,13 +192,13 @@ public class TestRouterYarnClientUtils {
 
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApplicationList().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getApplicationList().size());
 
     String appName = result.getApplicationList().get(0).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assert.assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
+    Assertions.assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
   /**
@@ -286,7 +286,7 @@ public class TestRouterYarnClientUtils {
 
     GetNodesToLabelsResponse response = RouterYarnClientUtils.
         mergeNodesToLabelsResponse(responses);
-    Assert.assertEquals(expectedResponse, response.getNodeToLabels());
+    Assertions.assertEquals(expectedResponse, response.getNodeToLabels());
   }
 
   @Test
@@ -327,7 +327,7 @@ public class TestRouterYarnClientUtils {
 
     GetClusterNodeLabelsResponse response = RouterYarnClientUtils.
         mergeClusterNodeLabelsResponse(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getNodeLabelList()));
   }
 
@@ -388,7 +388,7 @@ public class TestRouterYarnClientUtils {
     GetLabelsToNodesResponse response = RouterYarnClientUtils.
         mergeLabelsToNodes(responses);
 
-    Assert.assertEquals(expectedResponse, response.getLabelsToNodes());
+    Assertions.assertEquals(expectedResponse, response.getLabelsToNodes());
   }
 
   @Test
@@ -453,7 +453,7 @@ public class TestRouterYarnClientUtils {
 
     GetQueueUserAclsInfoResponse response =
         RouterYarnClientUtils.mergeQueueUserAcls(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
+    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
         response.getUserAclsInfoList()));
   }
 
@@ -486,7 +486,7 @@ public class TestRouterYarnClientUtils {
 
     ReservationListResponse response =
         RouterYarnClientUtils.mergeReservationsList(responses);
-    Assert.assertEquals(expectedResponse, response.getReservationAllocationState());
+    Assertions.assertEquals(expectedResponse, response.getReservationAllocationState());
   }
 
   private ReservationListResponse createReservationListResponse(long startTime,
@@ -550,7 +550,7 @@ public class TestRouterYarnClientUtils {
     expectedResponse.add(resourceTypeInfo3);
     GetAllResourceTypeInfoResponse response =
         RouterYarnClientUtils.mergeResourceTypes(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    Assertions.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getResourceTypeInfo()));
   }
 
@@ -585,8 +585,8 @@ public class TestRouterYarnClientUtils {
     GetAllResourceProfilesResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfilesResponse(responses);
     Resource resource = response.getResourceProfiles().get("maximum");
-    Assert.assertEquals(3, resource.getVirtualCores());
-    Assert.assertEquals(3072, resource.getMemorySize());
+    Assertions.assertEquals(3, resource.getVirtualCores());
+    Assertions.assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -619,8 +619,8 @@ public class TestRouterYarnClientUtils {
     GetResourceProfileResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfileResponse(responses);
     Resource resource = response.getResource();
-    Assert.assertEquals(3, resource.getVirtualCores());
-    Assert.assertEquals(3072, resource.getMemorySize());
+    Assertions.assertEquals(3, resource.getVirtualCores());
+    Assertions.assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -663,16 +663,16 @@ public class TestRouterYarnClientUtils {
     GetAttributesToNodesResponse response =
         RouterYarnClientUtils.mergeAttributesToNodesResponse(responses);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(2, response.getAttributesToNodes().size());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(2, response.getAttributesToNodes().size());
 
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
 
     NodeAttributeKey gpuKey = gpu.getAttributeKey();
-    Assert.assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
+    Assertions.assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
 
     NodeAttributeKey dockerKey = docker.getAttributeKey();
-    Assert.assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
+    Assertions.assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
   }
 
   @Test
@@ -711,12 +711,12 @@ public class TestRouterYarnClientUtils {
     GetClusterNodeAttributesResponse response =
         RouterYarnClientUtils.mergeClusterNodeAttributesResponse(responses);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
-    Assert.assertEquals(2, nodeAttributeInfos.size());
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
+    Assertions.assertEquals(2, nodeAttributeInfos.size());
+    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
+    Assertions.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
   }
 
   @Test
@@ -755,14 +755,14 @@ public class TestRouterYarnClientUtils {
     GetNodesToAttributesResponse response =
         RouterYarnClientUtils.mergeNodesToAttributesResponse(responses);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Map<String, Set<NodeAttribute>> hostToAttrs = response.getNodeToAttributes();
-    Assert.assertNotNull(hostToAttrs);
-    Assert.assertEquals(2, hostToAttrs.size());
-    Assert.assertTrue(hostToAttrs.get("node1").contains(dist));
-    Assert.assertTrue(hostToAttrs.get("node1").contains(gpu));
-    Assert.assertTrue(hostToAttrs.get("node1").contains(os));
-    Assert.assertTrue(hostToAttrs.get("node2").contains(docker));
+    Assertions.assertNotNull(hostToAttrs);
+    Assertions.assertEquals(2, hostToAttrs.size());
+    Assertions.assertTrue(hostToAttrs.get("node1").contains(dist));
+    Assertions.assertTrue(hostToAttrs.get("node1").contains(gpu));
+    Assertions.assertTrue(hostToAttrs.get("node1").contains(os));
+    Assertions.assertTrue(hostToAttrs.get("node2").contains(docker));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.QueueACLsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +101,7 @@ public class TestableFederationClientInterceptor
           MockNM nm = mockRM.registerNode("127.0.0.1:1234", 8*1024, 4);
           mockNMs.put(subClusterId, nm);
         } catch (Exception e) {
-          Assert.fail(e.getMessage());
+          Assertions.fail(e.getMessage());
         }
         mockRMs.put(subClusterId, mockRM);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -58,7 +59,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.QueueACLsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +101,7 @@ public class TestableFederationClientInterceptor
           MockNM nm = mockRM.registerNode("127.0.0.1:1234", 8*1024, 4);
           mockNMs.put(subClusterId, nm);
         } catch (Exception e) {
-          Assertions.fail(e.getMessage());
+          fail(e.getMessage());
         }
         mockRMs.put(subClusterId, mockRM);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.server.router.rmadmin;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
@@ -58,7 +60,6 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResp
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -82,7 +83,7 @@ public abstract class BaseRouterRMAdminTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterRMAdminService getRouterRMAdminService() {
-    Assertions.assertNotNull(this.rmAdminService);
+    assertNotNull(this.rmAdminService);
     return this.rmAdminService;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
@@ -57,9 +57,9 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeRequ
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base class for all the RouterRMAdminService test cases. It provides utility
@@ -82,11 +82,11 @@ public abstract class BaseRouterRMAdminTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterRMAdminService getRouterRMAdminService() {
-    Assert.assertNotNull(this.rmAdminService);
+    Assertions.assertNotNull(this.rmAdminService);
     return this.rmAdminService;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.conf = createConfiguration();
     this.dispatcher = new AsyncDispatcher();
@@ -120,7 +120,7 @@ public abstract class BaseRouterRMAdminTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (rmAdminService != null) {
       rmAdminService.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
@@ -81,8 +81,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyCo
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,8 +99,8 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Extends the FederationRMAdminInterceptor and overrides methods to provide a
@@ -151,7 +151,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      Assertions.fail();
     }
 
     DefaultMetricsSystem.setMiniClusterMode(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
@@ -81,7 +81,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyCo
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +102,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Extends the FederationRMAdminInterceptor and overrides methods to provide a
@@ -124,6 +126,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
   private FederationStateStoreTestUtil stateStoreUtil;
   private List<SubClusterId> subClusters;
 
+  @BeforeEach
   @Override
   public void setUp() {
 
@@ -151,7 +154,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assertions.fail();
+      fail();
     }
 
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -177,6 +180,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
     return config;
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.rmadmin;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -37,7 +43,6 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RemoveFromClusterNodeLa
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService.RequestInterceptorChainWrapper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,21 +74,21 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assertions.assertEquals(
+        assertEquals(
             PassThroughRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assertions.assertEquals(MockRMAdminRequestInterceptor.class.getName(),
+        assertEquals(MockRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assertions.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assertions.assertEquals(4
+    assertEquals(4
 ,         index, "The number of interceptors in chain does not match");
   }
 
@@ -99,82 +104,82 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     LOG.info("testRouterRMAdminServiceE2E - Refresh Queues");
 
     RefreshQueuesResponse responseRefreshQueues = refreshQueues(user);
-    Assertions.assertNotNull(responseRefreshQueues);
+    assertNotNull(responseRefreshQueues);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes");
 
     RefreshNodesResponse responseRefreshNodes = refreshNodes(user);
-    Assertions.assertNotNull(responseRefreshNodes);
+    assertNotNull(responseRefreshNodes);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Super User");
 
     RefreshSuperUserGroupsConfigurationResponse responseRefreshSuperUser =
         refreshSuperUserGroupsConfiguration(user);
-    Assertions.assertNotNull(responseRefreshSuperUser);
+    assertNotNull(responseRefreshSuperUser);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh User to Group");
 
     RefreshUserToGroupsMappingsResponse responseRefreshUserToGroup =
         refreshUserToGroupsMappings(user);
-    Assertions.assertNotNull(responseRefreshUserToGroup);
+    assertNotNull(responseRefreshUserToGroup);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Admin Acls");
 
     RefreshAdminAclsResponse responseRefreshAdminAcls = refreshAdminAcls(user);
-    Assertions.assertNotNull(responseRefreshAdminAcls);
+    assertNotNull(responseRefreshAdminAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Service Acls");
 
     RefreshServiceAclsResponse responseRefreshServiceAcls =
         refreshServiceAcls(user);
-    Assertions.assertNotNull(responseRefreshServiceAcls);
+    assertNotNull(responseRefreshServiceAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Update Node Resource");
 
     UpdateNodeResourceResponse responseUpdateNodeResource =
         updateNodeResource(user);
-    Assertions.assertNotNull(responseUpdateNodeResource);
+    assertNotNull(responseUpdateNodeResource);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes Resource");
 
     RefreshNodesResourcesResponse responseRefreshNodesResources =
         refreshNodesResources(user);
-    Assertions.assertNotNull(responseRefreshNodesResources);
+    assertNotNull(responseRefreshNodesResources);
 
     LOG.info("testRouterRMAdminServiceE2E - Add To Cluster NodeLabels");
 
     AddToClusterNodeLabelsResponse responseAddToClusterNodeLabels =
         addToClusterNodeLabels(user);
-    Assertions.assertNotNull(responseAddToClusterNodeLabels);
+    assertNotNull(responseAddToClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Remove To Cluster NodeLabels");
 
     RemoveFromClusterNodeLabelsResponse responseRemoveFromClusterNodeLabels =
         removeFromClusterNodeLabels(user);
-    Assertions.assertNotNull(responseRemoveFromClusterNodeLabels);
+    assertNotNull(responseRemoveFromClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Replace Labels On Node");
 
     ReplaceLabelsOnNodeResponse responseReplaceLabelsOnNode =
         replaceLabelsOnNode(user);
-    Assertions.assertNotNull(responseReplaceLabelsOnNode);
+    assertNotNull(responseReplaceLabelsOnNode);
 
     LOG.info("testRouterRMAdminServiceE2E - Check For Decommissioning Nodes");
 
     CheckForDecommissioningNodesResponse responseCheckForDecom =
         checkForDecommissioningNodes(user);
-    Assertions.assertNotNull(responseCheckForDecom);
+    assertNotNull(responseCheckForDecom);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Cluster Max Priority");
 
     RefreshClusterMaxPriorityResponse responseRefreshClusterMaxPriority =
         refreshClusterMaxPriority(user);
-    Assertions.assertNotNull(responseRefreshClusterMaxPriority);
+    assertNotNull(responseRefreshClusterMaxPriority);
 
     LOG.info("testRouterRMAdminServiceE2E - Get Groups For User");
 
     String[] responseGetGroupsForUser = getGroupsForUser(user);
-    Assertions.assertNotNull(responseGetGroupsForUser);
+    assertNotNull(responseGetGroupsForUser);
 
   }
 
@@ -199,7 +204,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     refreshQueues("test8");
 
     pipelines = super.getRouterRMAdminService().getPipelines();
-    Assertions.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     refreshQueues("test9");
     refreshQueues("test10");
@@ -208,13 +213,13 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assertions.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assertions.assertNotNull(chain, "test1 should not be evicted");
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assertions.assertNull(chain, "test2 should have been evicted");
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -249,7 +254,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
                     getRouterRMAdminService().getInterceptorChain();
                 RMAdminRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assertions.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init rm admin interceptor success for user" + user);
                 return interceptor;
               }
@@ -270,9 +275,9 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     client1.join();
     client2.join();
 
-    Assertions.assertNotNull(client1.interceptor);
-    Assertions.assertNotNull(client2.interceptor);
-    Assertions.assertTrue(client1.interceptor == client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RemoveFromClusterNodeLa
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService.RequestInterceptorChainWrapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,22 +69,22 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(
+        Assertions.assertEquals(
             PassThroughRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockRMAdminRequestInterceptor.class.getName(),
+        Assertions.assertEquals(MockRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        Assertions.fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    Assertions.assertEquals(4
+,         index, "The number of interceptors in chain does not match");
   }
 
   /**
@@ -99,82 +99,82 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     LOG.info("testRouterRMAdminServiceE2E - Refresh Queues");
 
     RefreshQueuesResponse responseRefreshQueues = refreshQueues(user);
-    Assert.assertNotNull(responseRefreshQueues);
+    Assertions.assertNotNull(responseRefreshQueues);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes");
 
     RefreshNodesResponse responseRefreshNodes = refreshNodes(user);
-    Assert.assertNotNull(responseRefreshNodes);
+    Assertions.assertNotNull(responseRefreshNodes);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Super User");
 
     RefreshSuperUserGroupsConfigurationResponse responseRefreshSuperUser =
         refreshSuperUserGroupsConfiguration(user);
-    Assert.assertNotNull(responseRefreshSuperUser);
+    Assertions.assertNotNull(responseRefreshSuperUser);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh User to Group");
 
     RefreshUserToGroupsMappingsResponse responseRefreshUserToGroup =
         refreshUserToGroupsMappings(user);
-    Assert.assertNotNull(responseRefreshUserToGroup);
+    Assertions.assertNotNull(responseRefreshUserToGroup);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Admin Acls");
 
     RefreshAdminAclsResponse responseRefreshAdminAcls = refreshAdminAcls(user);
-    Assert.assertNotNull(responseRefreshAdminAcls);
+    Assertions.assertNotNull(responseRefreshAdminAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Service Acls");
 
     RefreshServiceAclsResponse responseRefreshServiceAcls =
         refreshServiceAcls(user);
-    Assert.assertNotNull(responseRefreshServiceAcls);
+    Assertions.assertNotNull(responseRefreshServiceAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Update Node Resource");
 
     UpdateNodeResourceResponse responseUpdateNodeResource =
         updateNodeResource(user);
-    Assert.assertNotNull(responseUpdateNodeResource);
+    Assertions.assertNotNull(responseUpdateNodeResource);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes Resource");
 
     RefreshNodesResourcesResponse responseRefreshNodesResources =
         refreshNodesResources(user);
-    Assert.assertNotNull(responseRefreshNodesResources);
+    Assertions.assertNotNull(responseRefreshNodesResources);
 
     LOG.info("testRouterRMAdminServiceE2E - Add To Cluster NodeLabels");
 
     AddToClusterNodeLabelsResponse responseAddToClusterNodeLabels =
         addToClusterNodeLabels(user);
-    Assert.assertNotNull(responseAddToClusterNodeLabels);
+    Assertions.assertNotNull(responseAddToClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Remove To Cluster NodeLabels");
 
     RemoveFromClusterNodeLabelsResponse responseRemoveFromClusterNodeLabels =
         removeFromClusterNodeLabels(user);
-    Assert.assertNotNull(responseRemoveFromClusterNodeLabels);
+    Assertions.assertNotNull(responseRemoveFromClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Replace Labels On Node");
 
     ReplaceLabelsOnNodeResponse responseReplaceLabelsOnNode =
         replaceLabelsOnNode(user);
-    Assert.assertNotNull(responseReplaceLabelsOnNode);
+    Assertions.assertNotNull(responseReplaceLabelsOnNode);
 
     LOG.info("testRouterRMAdminServiceE2E - Check For Decommissioning Nodes");
 
     CheckForDecommissioningNodesResponse responseCheckForDecom =
         checkForDecommissioningNodes(user);
-    Assert.assertNotNull(responseCheckForDecom);
+    Assertions.assertNotNull(responseCheckForDecom);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Cluster Max Priority");
 
     RefreshClusterMaxPriorityResponse responseRefreshClusterMaxPriority =
         refreshClusterMaxPriority(user);
-    Assert.assertNotNull(responseRefreshClusterMaxPriority);
+    Assertions.assertNotNull(responseRefreshClusterMaxPriority);
 
     LOG.info("testRouterRMAdminServiceE2E - Get Groups For User");
 
     String[] responseGetGroupsForUser = getGroupsForUser(user);
-    Assert.assertNotNull(responseGetGroupsForUser);
+    Assertions.assertNotNull(responseGetGroupsForUser);
 
   }
 
@@ -199,7 +199,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     refreshQueues("test8");
 
     pipelines = super.getRouterRMAdminService().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    Assertions.assertEquals(8, pipelines.size());
 
     refreshQueues("test9");
     refreshQueues("test10");
@@ -208,13 +208,13 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    Assertions.assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    Assertions.assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    Assertions.assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -249,7 +249,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
                     getRouterRMAdminService().getInterceptorChain();
                 RMAdminRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                Assertions.assertNotNull(interceptor);
                 LOG.info("init rm admin interceptor success for user" + user);
                 return interceptor;
               }
@@ -270,9 +270,9 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertTrue(client1.interceptor == client2.interceptor);
+    Assertions.assertNotNull(client1.interceptor);
+    Assertions.assertNotNull(client2.interceptor);
+    Assertions.assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -112,6 +112,8 @@ public abstract class AbstractSecureRouterTest {
     conf.set(YarnConfiguration.ROUTER_PRINCIPAL, ROUTER_LOCALHOST_REALM);
     conf.set(YarnConfiguration.ROUTER_KEYTAB, routerKeytab.getAbsolutePath());
 
+    conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);
+
     DefaultMetricsSystem.setMiniClusterMode(true);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.server.resourcemanager.TestRMRestart;
 import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,9 +41,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class AbstractSecureRouterTest {
 
@@ -91,7 +91,7 @@ public abstract class AbstractSecureRouterTest {
   private static ConcurrentHashMap<SubClusterId, MockRM> mockRMs =
       new ConcurrentHashMap<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeSecureRouterTestClass() throws Exception {
     // Sets up the KDC and Principals.
     setupKDCAndPrincipals();
@@ -163,9 +163,9 @@ public abstract class AbstractSecureRouterTest {
    * @throws Exception an error occurred.
    */
   public static File createKeytab(String principal, String filename) throws Exception {
-    assertTrue("empty principal", StringUtils.isNotBlank(principal));
-    assertTrue("empty host", StringUtils.isNotBlank(filename));
-    assertNotNull("null KDC", kdc);
+    assertTrue(StringUtils.isNotBlank(principal), "empty principal");
+    assertTrue(StringUtils.isNotBlank(filename), "empty host");
+    assertNotNull(kdc, "null KDC");
     File keytab = new File(kdcWorkDir, filename);
     kdc.createPrincipal(keytab,
         principal,
@@ -180,7 +180,7 @@ public abstract class AbstractSecureRouterTest {
    * @throws Exception an error occurred.
    */
   public synchronized void startSecureRouter() {
-    assertNull("Router is already running", router);
+    assertNull(router, "Router is already running");
     MemoryFederationStateStore stateStore = new MemoryFederationStateStore();
     stateStore.init(getConf());
     FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore, getConf());
@@ -219,7 +219,7 @@ public abstract class AbstractSecureRouterTest {
    *
    * @throws Exception an error occurred.
    */
-  @AfterClass
+  @AfterAll
   public static void afterSecureRouterTest() throws Exception {
     LOG.info("teardown of kdc instance.");
     teardownKDC();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
@@ -25,16 +25,16 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TestRouterDelegationTokenSecretManager extends AbstractSecureRouterTest {
 
@@ -117,7 +117,7 @@ public class TestRouterDelegationTokenSecretManager extends AbstractSecureRouter
         new Text("owner1"), new Text("renewer1"), new Text("realuser1"));
     dtId2.setSequenceNumber(sequenceNumber);
     RMDelegationTokenIdentifier dtId3 = secretManager.getTokenByRouterStoreToken(dtId2);
-    Assert.assertEquals(dtId1, dtId3);
+    Assertions.assertEquals(dtId1, dtId3);
 
     // query rm-token2 not exists
     sequenceNumber++;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,7 +116,7 @@ public class TestRouterDelegationTokenSecretManager extends AbstractSecureRouter
         new Text("owner1"), new Text("renewer1"), new Text("realuser1"));
     dtId2.setSequenceNumber(sequenceNumber);
     RMDelegationTokenIdentifier dtId3 = secretManager.getTokenByRouterStoreToken(dtId2);
-    Assertions.assertEquals(dtId1, dtId3);
+    assertEquals(dtId1, dtId3);
 
     // query rm-token2 not exists
     sequenceNumber++;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router.secure;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.apache.commons.collections4.MapUtils;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
@@ -35,7 +38,6 @@ import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.rmadmin.DefaultRMAdminRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
 
   @Test
   public void testHasRealm() throws Throwable {
-    Assertions.assertNotNull(getRealm());
+    assertNotNull(getRealm());
     LOG.info("Router principal = {}", getPrincipalAndRealm(ROUTER_LOCALHOST));
   }
 
@@ -58,8 +60,8 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     startSecureRouter();
 
     List<Service> services = this.getRouter().getServices();
-    Assertions.assertNotNull(services);
-    Assertions.assertEquals(3, services.size());
+    assertNotNull(services);
+    assertEquals(3, services.size());
 
     stopSecureRouter();
   }
@@ -78,10 +80,10 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     GetClusterMetricsRequest metricsRequest = GetClusterMetricsRequest.newInstance();
     GetClusterMetricsResponse metricsResponse =
         routerClientRMService.getClusterMetrics(metricsRequest);
-    Assertions.assertNotNull(metricsResponse);
+    assertNotNull(metricsResponse);
     YarnClusterMetrics clusterMetrics = metricsResponse.getClusterMetrics();
-    Assertions.assertEquals(4, clusterMetrics.getNumNodeManagers());
-    Assertions.assertEquals(0, clusterMetrics.getNumLostNodeManagers());
+    assertEquals(4, clusterMetrics.getNumNodeManagers());
+    assertEquals(0, clusterMetrics.getNumLostNodeManagers());
 
     // Stop the Router in Secure Mode
     stopSecureRouter();
@@ -101,7 +103,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     RefreshNodesRequest refreshNodesRequest = RefreshNodesRequest.newInstance();
     RefreshNodesResponse refreshNodesResponse =
         routerRMAdminService.refreshNodes(refreshNodesRequest);
-    Assertions.assertNotNull(refreshNodesResponse);
+    assertNotNull(refreshNodesResponse);
 
     // Stop the Router in Secure Mode
     stopSecureRouter();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.rmadmin.DefaultRMAdminRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
 
   @Test
   public void testHasRealm() throws Throwable {
-    Assert.assertNotNull(getRealm());
+    Assertions.assertNotNull(getRealm());
     LOG.info("Router principal = {}", getPrincipalAndRealm(ROUTER_LOCALHOST));
   }
 
@@ -58,8 +58,8 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     startSecureRouter();
 
     List<Service> services = this.getRouter().getServices();
-    Assert.assertNotNull(services);
-    Assert.assertEquals(3, services.size());
+    Assertions.assertNotNull(services);
+    Assertions.assertEquals(3, services.size());
 
     stopSecureRouter();
   }
@@ -78,10 +78,10 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     GetClusterMetricsRequest metricsRequest = GetClusterMetricsRequest.newInstance();
     GetClusterMetricsResponse metricsResponse =
         routerClientRMService.getClusterMetrics(metricsRequest);
-    Assert.assertNotNull(metricsResponse);
+    Assertions.assertNotNull(metricsResponse);
     YarnClusterMetrics clusterMetrics = metricsResponse.getClusterMetrics();
-    Assert.assertEquals(4, clusterMetrics.getNumNodeManagers());
-    Assert.assertEquals(0, clusterMetrics.getNumLostNodeManagers());
+    Assertions.assertEquals(4, clusterMetrics.getNumNodeManagers());
+    Assertions.assertEquals(0, clusterMetrics.getNumLostNodeManagers());
 
     // Stop the Router in Secure Mode
     stopSecureRouter();
@@ -101,7 +101,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     RefreshNodesRequest refreshNodesRequest = RefreshNodesRequest.newInstance();
     RefreshNodesResponse refreshNodesResponse =
         routerRMAdminService.refreshNodes(refreshNodesRequest);
-    Assert.assertNotNull(refreshNodesResponse);
+    Assertions.assertNotNull(refreshNodesResponse);
 
     // Stop the Router in Secure Mode
     stopSecureRouter();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
@@ -74,7 +74,7 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.AP
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.RESERVATION_NEW;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.ADD_NODE_LABELS;
 import static org.apache.hadoop.yarn.server.router.webapp.TestRouterWebServicesREST.waitWebAppRunning;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFederationSubCluster {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
@@ -58,9 +58,9 @@ import org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterUserInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationSchedulerTypeInfo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -105,9 +105,9 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.RE
 import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster.format;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.POST;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.PUT;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestYarnFederationWithCapacityScheduler {
 
@@ -117,7 +117,7 @@ public class TestYarnFederationWithCapacityScheduler {
   private static final String SC1_RM_WEB_ADDRESS = "http://localhost:18088";
   private static final String SC2_RM_WEB_ADDRESS = "http://localhost:28088";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp()
       throws IOException, InterruptedException, YarnException, TimeoutException {
     testFederationSubCluster = new TestFederationSubCluster();
@@ -130,7 +130,7 @@ public class TestYarnFederationWithCapacityScheduler {
     subClusters.add("SC-2");
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDown() throws Exception {
     testFederationSubCluster.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/fair/TestYarnFederationWithFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/fair/TestYarnFederationWithFairScheduler.java
@@ -64,9 +64,9 @@ import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterUserInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationSchedulerTypeInfo;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -113,9 +113,9 @@ import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubC
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.POST;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.PUT;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestYarnFederationWithFairScheduler {
   private static TestFederationSubCluster testFederationSubCluster;
@@ -124,7 +124,7 @@ public class TestYarnFederationWithFairScheduler {
   private static final String SC1_RM_WEB_ADDRESS = "http://localhost:38088";
   private static final String SC2_RM_WEB_ADDRESS = "http://localhost:48088";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp()
       throws IOException, InterruptedException, YarnException, TimeoutException {
     testFederationSubCluster = new TestFederationSubCluster();
@@ -137,7 +137,7 @@ public class TestYarnFederationWithFairScheduler {
     subClusters.add("SC-2");
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDown() throws Exception {
     testFederationSubCluster.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -60,7 +61,6 @@ import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
@@ -137,7 +137,7 @@ public abstract class BaseRouterWebServicesTest {
   }
 
   protected RouterWebServices getRouterWebServices() {
-    Assertions.assertNotNull(this.routerWebService);
+    assertNotNull(this.routerWebService);
     return this.routerWebService;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
@@ -59,9 +59,9 @@ import org.apache.hadoop.yarn.server.router.webapp.RouterWebServices.RequestInte
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
 /**
@@ -89,7 +89,7 @@ public abstract class BaseRouterWebServicesTest {
 
   private RouterWebServices routerWebService;
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException, IOException {
 
     this.conf = createConfiguration();
@@ -121,7 +121,7 @@ public abstract class BaseRouterWebServicesTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (router != null) {
       router.stop();
@@ -137,7 +137,7 @@ public abstract class BaseRouterWebServicesTest {
   }
 
   protected RouterWebServices getRouterWebServices() {
-    Assert.assertNotNull(this.routerWebService);
+    Assertions.assertNotNull(this.routerWebService);
     return this.routerWebService;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
@@ -217,7 +217,10 @@ public class MockDefaultRequestInterceptorREST
             applicationCounter.incrementAndGet());
     NewApplication appId =
         new NewApplication(applicationId.toString(), new ResourceInfo());
-    return Response.status(Status.OK).entity(appId).build();
+    Response response = Mockito.mock(Response.class);
+    Mockito.when(response.readEntity(NewApplication.class)).thenReturn(appId);
+    Mockito.when(response.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+    return response;
   }
 
   @Override
@@ -315,7 +318,7 @@ public class MockDefaultRequestInterceptorREST
     NodeInfo node = null;
     SubClusterId subCluster = getSubClusterId();
     String subClusterId = subCluster.getId();
-    if (nodeId.contains(subClusterId) || nodeId.contains("test")) {
+    if (nodeId == null || nodeId.contains(subClusterId) || nodeId.contains("test")) {
       node = new NodeInfo();
       node.setId(nodeId);
       node.setLastHealthUpdate(Integer.parseInt(getSubClusterId().getId()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -143,8 +143,8 @@ import org.apache.hadoop.yarn.webapp.dao.ConfInfo;
 import org.apache.hadoop.yarn.webapp.dao.QueueConfigInfo;
 import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.RM_DELEGATION_KEY_UPDATE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.RM_DELEGATION_KEY_UPDATE_INTERVAL_KEY;
@@ -285,12 +285,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response = interceptor.createNewApplication(null);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     NewApplication ci = (NewApplication) response.getEntity();
-    Assert.assertNotNull(ci);
+    Assertions.assertNotNull(ci);
     ApplicationId appId = ApplicationId.fromString(ci.getApplicationId());
-    Assert.assertTrue(appId.getClusterTimestamp() < NUM_SUBCLUSTER);
-    Assert.assertTrue(appId.getClusterTimestamp() >= 0);
+    Assertions.assertTrue(appId.getClusterTimestamp() < NUM_SUBCLUSTER);
+    Assertions.assertTrue(appId.getClusterTimestamp() >= 0);
   }
 
   /**
@@ -309,14 +309,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(ACCEPTED, response.getStatus());
+    Assertions.assertEquals(ACCEPTED, response.getStatus());
     SubClusterId ci = (SubClusterId) response.getEntity();
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult);
-    Assert.assertTrue(subClusters.contains(scIdResult));
-    Assert.assertEquals(ci, scIdResult);
+    Assertions.assertNotNull(scIdResult);
+    Assertions.assertTrue(subClusters.contains(scIdResult));
+    Assertions.assertEquals(ci, scIdResult);
   }
 
   /**
@@ -336,20 +336,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // First attempt
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(ACCEPTED, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(ACCEPTED, response.getStatus());
 
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult);
+    Assertions.assertNotNull(scIdResult);
 
     // First retry
     response = interceptor.submitApplication(context, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(ACCEPTED, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(ACCEPTED, response.getStatus());
     SubClusterId scIdResult2 = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assert.assertNotNull(scIdResult2);
-    Assert.assertEquals(scIdResult, scIdResult2);
+    Assertions.assertNotNull(scIdResult2);
+    Assertions.assertEquals(scIdResult, scIdResult2);
   }
 
   /**
@@ -362,18 +362,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // ApplicationSubmissionContextInfo null
     Response response = interceptor.submitApplication(null, null);
 
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
 
     // ApplicationSubmissionContextInfo empty
     response = interceptor
         .submitApplication(new ApplicationSubmissionContextInfo(), null);
 
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
 
     ApplicationSubmissionContextInfo context =
         new ApplicationSubmissionContextInfo();
     response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -387,7 +387,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
         new ApplicationSubmissionContextInfo();
     context.setApplicationId("Application_wrong_id");
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -407,14 +407,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we are going to kill later
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppState appState = new AppState("KILLED");
 
     Response responseKill =
         interceptor.updateAppState(appState, null, appId.toString());
-    Assert.assertNotNull(responseKill);
+    Assertions.assertNotNull(responseKill);
   }
 
   /**
@@ -431,7 +431,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateAppState(appState, null, appId.toString());
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
 
   }
 
@@ -446,7 +446,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     AppState appState = new AppState("KILLED");
     Response response =
         interceptor.updateAppState(appState, null, "Application_wrong_id");
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -468,7 +468,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateAppState(null, null, appId.toString());
-    Assert.assertEquals(BAD_REQUEST, response.getStatus());
+    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
 
   }
 
@@ -489,12 +489,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppInfo responseGet = interceptor.getApp(null, appId.toString(), null);
 
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
   }
 
   /**
@@ -509,7 +509,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppInfo response = interceptor.getApp(null, appId.toString(), null);
 
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -521,7 +521,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppInfo response = interceptor.getApp(null, "Application_wrong_id", null);
 
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -534,8 +534,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     AppsInfo responseGet = interceptor.getApps(null, null, null, null, null,
         null, null, null, null, null, null, null, null, null, null);
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertEquals(NUM_SUBCLUSTER, responseGet.getApps().size());
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertEquals(NUM_SUBCLUSTER, responseGet.getApps().size());
     // The merged operations is tested in TestRouterWebServiceUtil
   }
 
@@ -550,8 +550,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     NodeInfo responseGet = interceptor.getNode("testGetNode");
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertEquals(NUM_SUBCLUSTER - 1, responseGet.getLastHealthUpdate());
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertEquals(NUM_SUBCLUSTER - 1, responseGet.getLastHealthUpdate());
   }
 
   /**
@@ -563,8 +563,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     NodesInfo responseGet = interceptor.getNodes(null);
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertEquals(NUM_SUBCLUSTER, responseGet.getNodes().size());
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertEquals(NUM_SUBCLUSTER, responseGet.getNodes().size());
     // The remove duplicate operations is tested in TestRouterWebServiceUtil
   }
 
@@ -574,16 +574,16 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testUpdateNodeResource() {
     List<NodeInfo> nodes = interceptor.getNodes(null).getNodes();
-    Assert.assertFalse(nodes.isEmpty());
+    Assertions.assertFalse(nodes.isEmpty());
     final String nodeId = nodes.get(0).getNodeId();
     ResourceOptionInfo resourceOption = new ResourceOptionInfo(
         ResourceOption.newInstance(
             Resource.newInstance(2048, 3), 1000));
     ResourceInfo resource = interceptor.updateNodeResource(
         null, nodeId, resourceOption);
-    Assert.assertNotNull(resource);
-    Assert.assertEquals(2048, resource.getMemorySize());
-    Assert.assertEquals(3, resource.getvCores());
+    Assertions.assertNotNull(resource);
+    Assertions.assertEquals(2048, resource.getMemorySize());
+    Assertions.assertEquals(3, resource.getvCores());
   }
 
   /**
@@ -597,12 +597,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     ClusterMetricsInfo responseGet = interceptor.getClusterMetricsInfo();
 
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
     int expectedAppSubmitted = 0;
     for (int i = 0; i < NUM_SUBCLUSTER; i++) {
       expectedAppSubmitted += i;
     }
-    Assert.assertEquals(expectedAppSubmitted, responseGet.getAppsSubmitted());
+    Assertions.assertEquals(expectedAppSubmitted, responseGet.getAppsSubmitted());
     // The merge operations is tested in TestRouterWebServiceUtil
   }
 
@@ -623,13 +623,13 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppState responseGet = interceptor.getAppState(null, appId.toString());
 
-    Assert.assertNotNull(responseGet);
-    Assert.assertEquals(MockDefaultRequestInterceptorREST.APP_STATE_RUNNING,
+    Assertions.assertNotNull(responseGet);
+    Assertions.assertEquals(MockDefaultRequestInterceptorREST.APP_STATE_RUNNING,
         responseGet.getState());
   }
 
@@ -645,7 +645,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppState response = interceptor.getAppState(null, appId.toString());
 
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -658,7 +658,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppState response = interceptor.getAppState(null, "Application_wrong_id");
 
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -670,14 +670,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     SubClusterId subClusterId = SubClusterId.newInstance(Integer.toString(0));
 
     interceptor.getClusterMetricsInfo();
-    Assert.assertEquals("http://1.2.3.4:4", interceptor
+    Assertions.assertEquals("http://1.2.3.4:4", interceptor
             .getInterceptorForSubCluster(subClusterId).getWebAppAddress());
 
     //Register the first subCluster with secondRM simulating RMSwitchover
     registerSubClusterWithSwitchoverRM(subClusterId);
 
     interceptor.getClusterMetricsInfo();
-    Assert.assertEquals("http://5.6.7.8:8", interceptor
+    Assertions.assertEquals("http://5.6.7.8:8", interceptor
             .getInterceptorForSubCluster(subClusterId).getWebAppAddress());
   }
 
@@ -708,15 +708,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     ApplicationAttemptId appAttempt = ApplicationAttemptId.newInstance(appId, 1);
 
     ContainersInfo responseGet = interceptor.getContainers(
         null, null, appId.toString(), appAttempt.toString());
 
-    Assert.assertEquals(4, responseGet.getContainers().size());
+    Assertions.assertEquals(4, responseGet.getContainers().size());
   }
 
   @Test
@@ -748,86 +748,86 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetNodeToLabels() throws IOException {
     NodeToLabelsInfo info = interceptor.getNodeToLabels(null);
     HashMap<String, NodeLabelsInfo> map = info.getNodeToLabels();
-    Assert.assertNotNull(map);
-    Assert.assertEquals(2, map.size());
+    Assertions.assertNotNull(map);
+    Assertions.assertEquals(2, map.size());
 
     NodeLabelsInfo node1Value = map.getOrDefault("node1", null);
-    Assert.assertNotNull(node1Value);
-    Assert.assertEquals(1, node1Value.getNodeLabelsName().size());
-    Assert.assertEquals("CPU", node1Value.getNodeLabelsName().get(0));
+    Assertions.assertNotNull(node1Value);
+    Assertions.assertEquals(1, node1Value.getNodeLabelsName().size());
+    Assertions.assertEquals("CPU", node1Value.getNodeLabelsName().get(0));
 
     NodeLabelsInfo node2Value = map.getOrDefault("node2", null);
-    Assert.assertNotNull(node2Value);
-    Assert.assertEquals(1, node2Value.getNodeLabelsName().size());
-    Assert.assertEquals("GPU", node2Value.getNodeLabelsName().get(0));
+    Assertions.assertNotNull(node2Value);
+    Assertions.assertEquals(1, node2Value.getNodeLabelsName().size());
+    Assertions.assertEquals("GPU", node2Value.getNodeLabelsName().get(0));
   }
 
   @Test
   public void testGetLabelsToNodes() throws Exception {
     LabelsToNodesInfo labelsToNodesInfo = interceptor.getLabelsToNodes(null);
     Map<NodeLabelInfo, NodeIDsInfo> map = labelsToNodesInfo.getLabelsToNodes();
-    Assert.assertNotNull(map);
-    Assert.assertEquals(3, map.size());
+    Assertions.assertNotNull(map);
+    Assertions.assertEquals(3, map.size());
 
     NodeLabel labelX = NodeLabel.newInstance("x", false);
     NodeLabelInfo nodeLabelInfoX = new NodeLabelInfo(labelX);
     NodeIDsInfo nodeIDsInfoX = map.get(nodeLabelInfoX);
-    Assert.assertNotNull(nodeIDsInfoX);
-    Assert.assertEquals(2, nodeIDsInfoX.getNodeIDs().size());
+    Assertions.assertNotNull(nodeIDsInfoX);
+    Assertions.assertEquals(2, nodeIDsInfoX.getNodeIDs().size());
     Resource resourceX =
         nodeIDsInfoX.getPartitionInfo().getResourceAvailable().getResource();
-    Assert.assertNotNull(resourceX);
-    Assert.assertEquals(4*10, resourceX.getVirtualCores());
-    Assert.assertEquals(4*20*1024, resourceX.getMemorySize());
+    Assertions.assertNotNull(resourceX);
+    Assertions.assertEquals(4*10, resourceX.getVirtualCores());
+    Assertions.assertEquals(4*20*1024, resourceX.getMemorySize());
 
     NodeLabel labelY = NodeLabel.newInstance("y", false);
     NodeLabelInfo nodeLabelInfoY = new NodeLabelInfo(labelY);
     NodeIDsInfo nodeIDsInfoY = map.get(nodeLabelInfoY);
-    Assert.assertNotNull(nodeIDsInfoY);
-    Assert.assertEquals(2, nodeIDsInfoY.getNodeIDs().size());
+    Assertions.assertNotNull(nodeIDsInfoY);
+    Assertions.assertEquals(2, nodeIDsInfoY.getNodeIDs().size());
     Resource resourceY =
         nodeIDsInfoY.getPartitionInfo().getResourceAvailable().getResource();
-    Assert.assertNotNull(resourceY);
-    Assert.assertEquals(4*20, resourceY.getVirtualCores());
-    Assert.assertEquals(4*40*1024, resourceY.getMemorySize());
+    Assertions.assertNotNull(resourceY);
+    Assertions.assertEquals(4*20, resourceY.getVirtualCores());
+    Assertions.assertEquals(4*40*1024, resourceY.getMemorySize());
   }
 
   @Test
   public void testGetClusterNodeLabels() throws Exception {
     NodeLabelsInfo nodeLabelsInfo = interceptor.getClusterNodeLabels(null);
-    Assert.assertNotNull(nodeLabelsInfo);
-    Assert.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
+    Assertions.assertNotNull(nodeLabelsInfo);
+    Assertions.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
 
     List<String> nodeLabelsName = nodeLabelsInfo.getNodeLabelsName();
-    Assert.assertNotNull(nodeLabelsName);
-    Assert.assertTrue(nodeLabelsName.contains("cpu"));
-    Assert.assertTrue(nodeLabelsName.contains("gpu"));
+    Assertions.assertNotNull(nodeLabelsName);
+    Assertions.assertTrue(nodeLabelsName.contains("cpu"));
+    Assertions.assertTrue(nodeLabelsName.contains("gpu"));
 
     ArrayList<NodeLabelInfo> nodeLabelInfos = nodeLabelsInfo.getNodeLabelsInfo();
-    Assert.assertNotNull(nodeLabelInfos);
-    Assert.assertEquals(2, nodeLabelInfos.size());
+    Assertions.assertNotNull(nodeLabelInfos);
+    Assertions.assertEquals(2, nodeLabelInfos.size());
     NodeLabelInfo cpuNodeLabelInfo = new NodeLabelInfo("cpu", false);
-    Assert.assertTrue(nodeLabelInfos.contains(cpuNodeLabelInfo));
+    Assertions.assertTrue(nodeLabelInfos.contains(cpuNodeLabelInfo));
     NodeLabelInfo gpuNodeLabelInfo = new NodeLabelInfo("gpu", false);
-    Assert.assertTrue(nodeLabelInfos.contains(gpuNodeLabelInfo));
+    Assertions.assertTrue(nodeLabelInfos.contains(gpuNodeLabelInfo));
   }
 
   @Test
   public void testGetLabelsOnNode() throws Exception {
     NodeLabelsInfo nodeLabelsInfo = interceptor.getLabelsOnNode(null, "node1");
-    Assert.assertNotNull(nodeLabelsInfo);
-    Assert.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
+    Assertions.assertNotNull(nodeLabelsInfo);
+    Assertions.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
 
     List<String> nodeLabelsName = nodeLabelsInfo.getNodeLabelsName();
-    Assert.assertNotNull(nodeLabelsName);
-    Assert.assertTrue(nodeLabelsName.contains("x"));
-    Assert.assertTrue(nodeLabelsName.contains("y"));
+    Assertions.assertNotNull(nodeLabelsName);
+    Assertions.assertTrue(nodeLabelsName.contains("x"));
+    Assertions.assertTrue(nodeLabelsName.contains("y"));
 
     // null request
     interceptor.setAllowPartialResult(false);
     NodeLabelsInfo nodeLabelsInfo2 = interceptor.getLabelsOnNode(null, "node2");
-    Assert.assertNotNull(nodeLabelsInfo2);
-    Assert.assertEquals(0, nodeLabelsInfo2.getNodeLabelsName().size());
+    Assertions.assertNotNull(nodeLabelsInfo2);
+    Assertions.assertEquals(0, nodeLabelsInfo2.getNodeLabelsName().size());
   }
 
   @Test
@@ -843,7 +843,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit application to multiSubCluster
     ApplicationSubmissionContextInfo context = new ApplicationSubmissionContextInfo();
     context.setApplicationId(applicationId);
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     // Test Case1: Wrong ContainerId
     LambdaTestUtils.intercept(IllegalArgumentException.class, "Invalid ContainerId prefix: 0",
@@ -853,7 +853,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     ContainerInfo containerInfo = interceptor.getContainer(null, null, applicationId,
         attemptId, containerId);
-    Assert.assertNotNull(containerInfo);
+    Assertions.assertNotNull(containerInfo);
   }
 
   @Test
@@ -863,28 +863,28 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     ApplicationSubmissionContextInfo context = new ApplicationSubmissionContextInfo();
     context.setApplicationId(appId.toString());
 
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     AppAttemptsInfo appAttemptsInfo = interceptor.getAppAttempts(null, appId.toString());
-    Assert.assertNotNull(appAttemptsInfo);
+    Assertions.assertNotNull(appAttemptsInfo);
 
     ArrayList<AppAttemptInfo> attemptLists = appAttemptsInfo.getAttempts();
-    Assert.assertNotNull(appAttemptsInfo);
-    Assert.assertEquals(2, attemptLists.size());
+    Assertions.assertNotNull(appAttemptsInfo);
+    Assertions.assertEquals(2, attemptLists.size());
 
     AppAttemptInfo attemptInfo1 = attemptLists.get(0);
-    Assert.assertNotNull(attemptInfo1);
-    Assert.assertEquals(0, attemptInfo1.getAttemptId());
-    Assert.assertEquals("AppAttemptId_0", attemptInfo1.getAppAttemptId());
-    Assert.assertEquals("LogLink_0", attemptInfo1.getLogsLink());
-    Assert.assertEquals(1659621705L, attemptInfo1.getFinishedTime());
+    Assertions.assertNotNull(attemptInfo1);
+    Assertions.assertEquals(0, attemptInfo1.getAttemptId());
+    Assertions.assertEquals("AppAttemptId_0", attemptInfo1.getAppAttemptId());
+    Assertions.assertEquals("LogLink_0", attemptInfo1.getLogsLink());
+    Assertions.assertEquals(1659621705L, attemptInfo1.getFinishedTime());
 
     AppAttemptInfo attemptInfo2 = attemptLists.get(1);
-    Assert.assertNotNull(attemptInfo2);
-    Assert.assertEquals(0, attemptInfo2.getAttemptId());
-    Assert.assertEquals("AppAttemptId_1", attemptInfo2.getAppAttemptId());
-    Assert.assertEquals("LogLink_1", attemptInfo2.getLogsLink());
-    Assert.assertEquals(1659621705L, attemptInfo2.getFinishedTime());
+    Assertions.assertNotNull(attemptInfo2);
+    Assertions.assertEquals(0, attemptInfo2.getAttemptId());
+    Assertions.assertEquals("AppAttemptId_1", attemptInfo2.getAppAttemptId());
+    Assertions.assertEquals("LogLink_1", attemptInfo2.getLogsLink());
+    Assertions.assertEquals(1659621705L, attemptInfo2.getFinishedTime());
   }
 
   @Test
@@ -896,19 +896,19 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
     ApplicationAttemptId expectAppAttemptId = ApplicationAttemptId.newInstance(appId, 1);
     String appAttemptId = expectAppAttemptId.toString();
 
     org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo
         appAttemptInfo = interceptor.getAppAttempt(null, null, appId.toString(), appAttemptId);
 
-    Assert.assertNotNull(appAttemptInfo);
-    Assert.assertEquals(expectAppAttemptId.toString(), appAttemptInfo.getAppAttemptId());
-    Assert.assertEquals("url", appAttemptInfo.getTrackingUrl());
-    Assert.assertEquals("oUrl", appAttemptInfo.getOriginalTrackingUrl());
-    Assert.assertEquals(124, appAttemptInfo.getRpcPort());
-    Assert.assertEquals("host", appAttemptInfo.getHost());
+    Assertions.assertNotNull(appAttemptInfo);
+    Assertions.assertEquals(expectAppAttemptId.toString(), appAttemptInfo.getAppAttemptId());
+    Assertions.assertEquals("url", appAttemptInfo.getTrackingUrl());
+    Assertions.assertEquals("oUrl", appAttemptInfo.getOriginalTrackingUrl());
+    Assertions.assertEquals(124, appAttemptInfo.getRpcPort());
+    Assertions.assertEquals("host", appAttemptInfo.getHost());
   }
 
   @Test
@@ -920,15 +920,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     ApplicationTimeoutType appTimeoutType = ApplicationTimeoutType.LIFETIME;
     AppTimeoutInfo appTimeoutInfo =
         interceptor.getAppTimeout(null, appId.toString(), appTimeoutType.toString());
-    Assert.assertNotNull(appTimeoutInfo);
-    Assert.assertEquals(10, appTimeoutInfo.getRemainingTimeInSec());
-    Assert.assertEquals("UNLIMITED", appTimeoutInfo.getExpireTime());
-    Assert.assertEquals(appTimeoutType, appTimeoutInfo.getTimeoutType());
+    Assertions.assertNotNull(appTimeoutInfo);
+    Assertions.assertEquals(10, appTimeoutInfo.getRemainingTimeInSec());
+    Assertions.assertEquals("UNLIMITED", appTimeoutInfo.getExpireTime());
+    Assertions.assertEquals(appTimeoutType, appTimeoutInfo.getTimeoutType());
   }
 
   @Test
@@ -940,20 +940,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     AppTimeoutsInfo appTimeoutsInfo = interceptor.getAppTimeouts(null, appId.toString());
-    Assert.assertNotNull(appTimeoutsInfo);
+    Assertions.assertNotNull(appTimeoutsInfo);
 
     List<AppTimeoutInfo> timeouts = appTimeoutsInfo.getAppTimeouts();
-    Assert.assertNotNull(timeouts);
-    Assert.assertEquals(1, timeouts.size());
+    Assertions.assertNotNull(timeouts);
+    Assertions.assertEquals(1, timeouts.size());
 
     AppTimeoutInfo resultAppTimeout = timeouts.get(0);
-    Assert.assertNotNull(resultAppTimeout);
-    Assert.assertEquals(10, resultAppTimeout.getRemainingTimeInSec());
-    Assert.assertEquals("UNLIMITED", resultAppTimeout.getExpireTime());
-    Assert.assertEquals(ApplicationTimeoutType.LIFETIME, resultAppTimeout.getTimeoutType());
+    Assertions.assertNotNull(resultAppTimeout);
+    Assertions.assertEquals(10, resultAppTimeout.getRemainingTimeInSec());
+    Assertions.assertEquals("UNLIMITED", resultAppTimeout.getExpireTime());
+    Assertions.assertEquals(ApplicationTimeoutType.LIFETIME, resultAppTimeout.getTimeoutType());
   }
 
   @Test
@@ -966,7 +966,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     long newLifetime = 10L;
     // update 10L seconds more to timeout
@@ -979,12 +979,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateApplicationTimeout(paramAppTimeOut, null, appId.toString());
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     AppTimeoutInfo entity = (AppTimeoutInfo) response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertEquals(paramAppTimeOut.getExpireTime(), entity.getExpireTime());
-    Assert.assertEquals(paramAppTimeOut.getTimeoutType(), entity.getTimeoutType());
-    Assert.assertEquals(paramAppTimeOut.getRemainingTimeInSec(), entity.getRemainingTimeInSec());
+    Assertions.assertNotNull(entity);
+    Assertions.assertEquals(paramAppTimeOut.getExpireTime(), entity.getExpireTime());
+    Assertions.assertEquals(paramAppTimeOut.getTimeoutType(), entity.getTimeoutType());
+    Assertions.assertEquals(paramAppTimeOut.getRemainingTimeInSec(), entity.getRemainingTimeInSec());
   }
 
   @Test
@@ -998,17 +998,17 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setPriority(20);
 
     // Submit the application we are going to kill later
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     int iPriority = 10;
     // Set Priority for application
     Response response = interceptor.updateApplicationPriority(
         new AppPriority(iPriority), null, appId.toString());
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     AppPriority entity = (AppPriority) response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertEquals(iPriority, entity.getPriority());
+    Assertions.assertNotNull(entity);
+    Assertions.assertEquals(iPriority, entity.getPriority());
   }
 
   @Test
@@ -1022,12 +1022,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setPriority(priority);
 
     // Submit the application we are going to kill later
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     // Set Priority for application
     AppPriority appPriority = interceptor.getAppPriority(null, appId.toString());
-    Assert.assertNotNull(appPriority);
-    Assert.assertEquals(priority, appPriority.getPriority());
+    Assertions.assertNotNull(appPriority);
+    Assertions.assertEquals(priority, appPriority.getPriority());
   }
 
   @Test
@@ -1044,20 +1044,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setQueue(oldQueue);
 
     // Submit the application
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     // Set New Queue for application
     Response response = interceptor.updateAppQueue(new AppQueue(newQueue),
         null, appId.toString());
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     AppQueue appQueue = (AppQueue) response.getEntity();
-    Assert.assertEquals(newQueue, appQueue.getQueue());
+    Assertions.assertEquals(newQueue, appQueue.getQueue());
 
     // Get AppQueue by application
     AppQueue queue = interceptor.getAppQueue(null, appId.toString());
-    Assert.assertNotNull(queue);
-    Assert.assertEquals(newQueue, queue.getQueue());
+    Assertions.assertNotNull(queue);
+    Assertions.assertEquals(newQueue, queue.getQueue());
   }
 
   @Test
@@ -1070,12 +1070,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
     context.setQueue(queueName);
 
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     // Get Queue by application
     AppQueue queue = interceptor.getAppQueue(null, appId.toString());
-    Assert.assertNotNull(queue);
-    Assert.assertEquals(queueName, queue.getQueue());
+    Assertions.assertNotNull(queue);
+    Assertions.assertEquals(queueName, queue.getQueue());
   }
 
   @Test
@@ -1083,21 +1083,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppsInfo responseGet = interceptor.getApps(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-    Assert.assertNotNull(responseGet);
+    Assertions.assertNotNull(responseGet);
 
     RouterAppInfoCacheKey cacheKey = RouterAppInfoCacheKey.newInstance(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
     LRUCacheHashMap<RouterAppInfoCacheKey, AppsInfo> appsInfoCache =
         interceptor.getAppInfosCaches();
-    Assert.assertNotNull(appsInfoCache);
-    Assert.assertFalse(appsInfoCache.isEmpty());
-    Assert.assertEquals(1, appsInfoCache.size());
-    Assert.assertTrue(appsInfoCache.containsKey(cacheKey));
+    Assertions.assertNotNull(appsInfoCache);
+    Assertions.assertFalse(appsInfoCache.isEmpty());
+    Assertions.assertEquals(1, appsInfoCache.size());
+    Assertions.assertTrue(appsInfoCache.containsKey(cacheKey));
 
     AppsInfo cacheResult = appsInfoCache.get(cacheKey);
-    Assert.assertNotNull(cacheResult);
-    Assert.assertEquals(responseGet, cacheResult);
+    Assertions.assertNotNull(cacheResult);
+    Assertions.assertEquals(responseGet, cacheResult);
   }
 
   @Test
@@ -1110,14 +1110,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationType("MapReduce");
     context.setQueue("queue");
 
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
 
     GetApplicationHomeSubClusterRequest request =
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse response =
         stateStore.getApplicationHomeSubCluster(request);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     ApplicationHomeSubCluster homeSubCluster = response.getApplicationHomeSubCluster();
 
     DefaultRequestInterceptorREST interceptorREST =
@@ -1137,13 +1137,13 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     ApplicationStatisticsInfo response2 =
         interceptor.getAppStatistics(null, stateQueries, typeQueries);
 
-    Assert.assertNotNull(response2);
-    Assert.assertFalse(response2.getStatItems().isEmpty());
+    Assertions.assertNotNull(response2);
+    Assertions.assertFalse(response2.getStatItems().isEmpty());
 
     StatisticsItemInfo result = response2.getStatItems().get(0);
-    Assert.assertEquals(1, result.getCount());
-    Assert.assertEquals(YarnApplicationState.RUNNING, result.getState());
-    Assert.assertEquals("MapReduce", result.getType());
+    Assertions.assertEquals(1, result.getCount());
+    Assertions.assertEquals(YarnApplicationState.RUNNING, result.getState());
+    Assertions.assertEquals("MapReduce", result.getType());
   }
 
   @Test
@@ -1155,7 +1155,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationType("MapReduce");
     context.setQueue("queue");
 
-    Assert.assertNotNull(interceptor.submitApplication(context, null));
+    Assertions.assertNotNull(interceptor.submitApplication(context, null));
     Set<String> prioritiesSet = Collections.singleton("0");
     Set<String> allocationRequestIdsSet = Collections.singleton("0");
 
@@ -1163,9 +1163,9 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
         interceptor.getAppActivities(null, appId.toString(), String.valueOf(Time.now()),
         prioritiesSet, allocationRequestIdsSet, null, "-1", null, false);
 
-    Assert.assertNotNull(appActivitiesInfo);
-    Assert.assertEquals(appId.toString(), appActivitiesInfo.getApplicationId());
-    Assert.assertEquals(10, appActivitiesInfo.getAllocations().size());
+    Assertions.assertNotNull(appActivitiesInfo);
+    Assertions.assertEquals(appId.toString(), appActivitiesInfo.getApplicationId());
+    Assertions.assertEquals(10, appActivitiesInfo.getAllocations().size());
   }
 
   @Test
@@ -1179,63 +1179,63 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String applyReservationId = reservationId.toString();
     Response listReservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assert.assertNotNull(listReservationResponse);
-    Assert.assertNotNull(listReservationResponse.getStatus());
+    Assertions.assertNotNull(listReservationResponse);
+    Assertions.assertNotNull(listReservationResponse.getStatus());
     Status status = Status.fromStatusCode(listReservationResponse.getStatus());
-    Assert.assertEquals(Status.OK, status);
+    Assertions.assertEquals(Status.OK, status);
 
     Object entity = listReservationResponse.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertNotNull(entity instanceof ReservationListInfo);
+    Assertions.assertNotNull(entity);
+    Assertions.assertNotNull(entity instanceof ReservationListInfo);
 
-    Assert.assertTrue(entity instanceof ReservationListInfo);
+    Assertions.assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assert.assertNotNull(listInfo);
+    Assertions.assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfoList = listInfo.getReservations();
-    Assert.assertNotNull(reservationInfoList);
-    Assert.assertEquals(1, reservationInfoList.size());
+    Assertions.assertNotNull(reservationInfoList);
+    Assertions.assertEquals(1, reservationInfoList.size());
 
     ReservationInfo reservationInfo = reservationInfoList.get(0);
-    Assert.assertNotNull(reservationInfo);
-    Assert.assertEquals(applyReservationId, reservationInfo.getReservationId());
+    Assertions.assertNotNull(reservationInfo);
+    Assertions.assertEquals(applyReservationId, reservationInfo.getReservationId());
 
     ReservationDefinitionInfo definitionInfo = reservationInfo.getReservationDefinition();
-    Assert.assertNotNull(definitionInfo);
+    Assertions.assertNotNull(definitionInfo);
 
     ReservationRequestsInfo reservationRequestsInfo = definitionInfo.getReservationRequests();
-    Assert.assertNotNull(reservationRequestsInfo);
+    Assertions.assertNotNull(reservationRequestsInfo);
 
     ArrayList<ReservationRequestInfo> reservationRequestInfoList =
         reservationRequestsInfo.getReservationRequest();
-    Assert.assertNotNull(reservationRequestInfoList);
-    Assert.assertEquals(1, reservationRequestInfoList.size());
+    Assertions.assertNotNull(reservationRequestInfoList);
+    Assertions.assertEquals(1, reservationRequestInfoList.size());
 
     ReservationRequestInfo reservationRequestInfo = reservationRequestInfoList.get(0);
-    Assert.assertNotNull(reservationRequestInfo);
-    Assert.assertEquals(4, reservationRequestInfo.getNumContainers());
+    Assertions.assertNotNull(reservationRequestInfo);
+    Assertions.assertEquals(4, reservationRequestInfo.getNumContainers());
 
     ResourceInfo resourceInfo = reservationRequestInfo.getCapability();
-    Assert.assertNotNull(resourceInfo);
+    Assertions.assertNotNull(resourceInfo);
 
     int vCore = resourceInfo.getvCores();
     long memory = resourceInfo.getMemorySize();
-    Assert.assertEquals(1, vCore);
-    Assert.assertEquals(1024, memory);
+    Assertions.assertEquals(1, vCore);
+    Assertions.assertEquals(1024, memory);
   }
 
   @Test
   public void testCreateNewReservation() throws Exception {
     Response response = interceptor.createNewReservation(null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof NewReservation);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof NewReservation);
 
     NewReservation newReservation = (NewReservation) entity;
-    Assert.assertNotNull(newReservation);
-    Assert.assertTrue(newReservation.getReservationId().contains("reservation"));
+    Assertions.assertNotNull(newReservation);
+    Assertions.assertTrue(newReservation.getReservationId().contains("reservation"));
   }
 
   @Test
@@ -1244,29 +1244,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 2);
     Response response = submitReservation(reservationId);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     String applyReservationId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assert.assertNotNull(reservationResponse);
+    Assertions.assertNotNull(reservationResponse);
 
     Object entity = reservationResponse.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertNotNull(entity instanceof ReservationListInfo);
+    Assertions.assertNotNull(entity);
+    Assertions.assertNotNull(entity instanceof ReservationListInfo);
 
-    Assert.assertTrue(entity instanceof ReservationListInfo);
+    Assertions.assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assert.assertNotNull(listInfo);
+    Assertions.assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfos = listInfo.getReservations();
-    Assert.assertNotNull(reservationInfos);
-    Assert.assertEquals(1, reservationInfos.size());
+    Assertions.assertNotNull(reservationInfos);
+    Assertions.assertEquals(1, reservationInfos.size());
 
     ReservationInfo reservationInfo = reservationInfos.get(0);
-    Assert.assertNotNull(reservationInfo);
-    Assert.assertEquals(reservationInfo.getReservationId(), applyReservationId);
+    Assertions.assertNotNull(reservationInfo);
+    Assertions.assertEquals(reservationInfo.getReservationId(), applyReservationId);
   }
 
   @Test
@@ -1274,8 +1274,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 3);
     Response response = submitReservation(reservationId);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     // update reservation
     ReservationSubmissionRequest resSubRequest =
@@ -1288,52 +1288,52 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     updateRequestInfo.setReservationId(reservationId.toString());
     updateRequestInfo.setReservationDefinition(reservationDefinitionInfo);
     Response updateReservationResp = interceptor.updateReservation(updateRequestInfo, null);
-    Assert.assertNotNull(updateReservationResp);
-    Assert.assertEquals(Status.OK.getStatusCode(), updateReservationResp.getStatus());
+    Assertions.assertNotNull(updateReservationResp);
+    Assertions.assertEquals(Status.OK.getStatusCode(), updateReservationResp.getStatus());
 
     String applyReservationId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
             QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assert.assertNotNull(reservationResponse);
+    Assertions.assertNotNull(reservationResponse);
 
     Object entity = reservationResponse.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertNotNull(entity instanceof ReservationListInfo);
+    Assertions.assertNotNull(entity);
+    Assertions.assertNotNull(entity instanceof ReservationListInfo);
 
-    Assert.assertTrue(entity instanceof ReservationListInfo);
+    Assertions.assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assert.assertNotNull(listInfo);
+    Assertions.assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfos = listInfo.getReservations();
-    Assert.assertNotNull(reservationInfos);
-    Assert.assertEquals(1, reservationInfos.size());
+    Assertions.assertNotNull(reservationInfos);
+    Assertions.assertEquals(1, reservationInfos.size());
 
     ReservationInfo reservationInfo = reservationInfos.get(0);
-    Assert.assertNotNull(reservationInfo);
-    Assert.assertEquals(reservationInfo.getReservationId(), applyReservationId);
+    Assertions.assertNotNull(reservationInfo);
+    Assertions.assertEquals(reservationInfo.getReservationId(), applyReservationId);
 
     ReservationDefinitionInfo resDefinitionInfo = reservationInfo.getReservationDefinition();
-    Assert.assertNotNull(resDefinitionInfo);
+    Assertions.assertNotNull(resDefinitionInfo);
 
     ReservationRequestsInfo reservationRequestsInfo = resDefinitionInfo.getReservationRequests();
-    Assert.assertNotNull(reservationRequestsInfo);
+    Assertions.assertNotNull(reservationRequestsInfo);
 
     ArrayList<ReservationRequestInfo> reservationRequestInfoList =
             reservationRequestsInfo.getReservationRequest();
-    Assert.assertNotNull(reservationRequestInfoList);
-    Assert.assertEquals(1, reservationRequestInfoList.size());
+    Assertions.assertNotNull(reservationRequestInfoList);
+    Assertions.assertEquals(1, reservationRequestInfoList.size());
 
     ReservationRequestInfo reservationRequestInfo = reservationRequestInfoList.get(0);
-    Assert.assertNotNull(reservationRequestInfo);
-    Assert.assertEquals(6, reservationRequestInfo.getNumContainers());
+    Assertions.assertNotNull(reservationRequestInfo);
+    Assertions.assertEquals(6, reservationRequestInfo.getNumContainers());
 
     ResourceInfo resourceInfo = reservationRequestInfo.getCapability();
-    Assert.assertNotNull(resourceInfo);
+    Assertions.assertNotNull(resourceInfo);
 
     int vCore = resourceInfo.getvCores();
     long memory = resourceInfo.getMemorySize();
-    Assert.assertEquals(2, vCore);
-    Assert.assertEquals(2048, memory);
+    Assertions.assertEquals(2, vCore);
+    Assertions.assertEquals(2048, memory);
   }
 
   @Test
@@ -1341,19 +1341,19 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 4);
     Response response = submitReservation(reservationId);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     String applyResId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyResId, -1, -1, false, null);
-    Assert.assertNotNull(reservationResponse);
+    Assertions.assertNotNull(reservationResponse);
 
     ReservationDeleteRequestInfo deleteRequestInfo =
         new ReservationDeleteRequestInfo();
     deleteRequestInfo.setReservationId(applyResId);
     Response delResponse = interceptor.deleteReservation(deleteRequestInfo, null);
-    Assert.assertNotNull(delResponse);
+    Assertions.assertNotNull(delResponse);
 
     LambdaTestUtils.intercept(Exception.class,
         "reservationId with id: " + reservationId + " not found",
@@ -1425,7 +1425,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String expectedHttpWebAddress = "http://0.0.0.0:8000";
     String webAppAddressWithScheme =
         WebAppUtils.getHttpSchemePrefix(this.getConf()) + webAppAddress;
-    Assert.assertEquals(expectedHttpWebAddress, webAppAddressWithScheme);
+    Assertions.assertEquals(expectedHttpWebAddress, webAppAddressWithScheme);
 
     // 2. We try to enable Https，at this point we should get the following link:
     // https://0.0.0.0:8000
@@ -1435,7 +1435,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String expectedHttpsWebAddress = "https://0.0.0.0:8000";
     String webAppAddressWithScheme2 =
         WebAppUtils.getHttpSchemePrefix(this.getConf()) + webAppAddress;
-    Assert.assertEquals(expectedHttpsWebAddress, webAppAddressWithScheme2);
+    Assertions.assertEquals(expectedHttpsWebAddress, webAppAddressWithScheme2);
   }
 
   @Test
@@ -1481,14 +1481,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     HttpServletRequest mockHsr = mockHttpServletRequestByUserName(mockUser);
     RMQueueAclInfo aclInfo =
         interceptor.checkUserAccessToQueue(queue, userName, queueACL.name(), mockHsr);
-    Assert.assertNotNull(aclInfo);
-    Assert.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
+    Assertions.assertNotNull(aclInfo);
+    Assertions.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
     FederationRMQueueAclInfo fedAclInfo = (FederationRMQueueAclInfo) aclInfo;
     List<RMQueueAclInfo> aclInfos = fedAclInfo.getList();
-    Assert.assertNotNull(aclInfos);
-    Assert.assertEquals(4, aclInfos.size());
+    Assertions.assertNotNull(aclInfos);
+    Assertions.assertEquals(4, aclInfos.size());
     for (RMQueueAclInfo rMQueueAclInfo : aclInfos) {
-      Assert.assertTrue(rMQueueAclInfo.isAllowed());
+      Assertions.assertTrue(rMQueueAclInfo.isAllowed());
     }
   }
 
@@ -1497,17 +1497,17 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     HttpServletRequest mockHsr = mockHttpServletRequestByUserName(mockUser);
     RMQueueAclInfo aclInfo =
         interceptor.checkUserAccessToQueue(queue, userName, queueACL.name(), mockHsr);
-    Assert.assertNotNull(aclInfo);
-    Assert.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
+    Assertions.assertNotNull(aclInfo);
+    Assertions.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
     FederationRMQueueAclInfo fedAclInfo = (FederationRMQueueAclInfo) aclInfo;
     List<RMQueueAclInfo> aclInfos = fedAclInfo.getList();
-    Assert.assertNotNull(aclInfos);
-    Assert.assertEquals(4, aclInfos.size());
+    Assertions.assertNotNull(aclInfos);
+    Assertions.assertEquals(4, aclInfos.size());
     for (RMQueueAclInfo rMQueueAclInfo : aclInfos) {
-      Assert.assertFalse(rMQueueAclInfo.isAllowed());
+      Assertions.assertFalse(rMQueueAclInfo.isAllowed());
       String expectDiagnostics = "User=" + userName +
           " doesn't have access to queue=queue with acl-type=" + queueACL.name();
-      Assert.assertEquals(expectDiagnostics, rMQueueAclInfo.getDiagnostics());
+      Assertions.assertEquals(expectDiagnostics, rMQueueAclInfo.getDiagnostics());
     }
   }
 
@@ -1534,9 +1534,9 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     DefaultRequestInterceptorREST interceptorREST =
         rest.getOrCreateInterceptorForSubCluster(subClusterId, webAppSocket);
 
-    Assert.assertNotNull(interceptorREST);
-    Assert.assertNotNull(interceptorREST.getClient());
-    Assert.assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
+    Assertions.assertNotNull(interceptorREST);
+    Assertions.assertNotNull(interceptorREST.getClient());
+    Assertions.assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
   }
 
   @Test
@@ -1552,18 +1552,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // of the multi-thread call can match the node data
     Map<SubClusterInfo, NodesInfo> subClusterInfoNodesInfoMap =
         interceptor.invokeConcurrentGetNodeLabel();
-    Assert.assertNotNull(subClusterInfoNodesInfoMap);
-    Assert.assertEquals(4, subClusterInfoNodesInfoMap.size());
+    Assertions.assertNotNull(subClusterInfoNodesInfoMap);
+    Assertions.assertEquals(4, subClusterInfoNodesInfoMap.size());
 
     subClusterInfoNodesInfoMap.forEach((subClusterInfo, nodesInfo) -> {
       String subClusterId = subClusterInfo.getSubClusterId().getId();
       List<NodeInfo> nodeInfos = nodesInfo.getNodes();
-      Assert.assertNotNull(nodeInfos);
-      Assert.assertEquals(1, nodeInfos.size());
+      Assertions.assertNotNull(nodeInfos);
+      Assertions.assertEquals(1, nodeInfos.size());
 
       String expectNodeId = "Node " + subClusterId;
       String nodeId = nodeInfos.get(0).getNodeId();
-      Assert.assertEquals(expectNodeId, nodeId);
+      Assertions.assertEquals(expectNodeId, nodeId);
     });
   }
 
@@ -1571,54 +1571,54 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetSchedulerInfo() {
     // In this test case, we will get the return results of 4 sub-clusters.
     SchedulerTypeInfo typeInfo = interceptor.getSchedulerInfo();
-    Assert.assertNotNull(typeInfo);
-    Assert.assertTrue(typeInfo instanceof FederationSchedulerTypeInfo);
+    Assertions.assertNotNull(typeInfo);
+    Assertions.assertTrue(typeInfo instanceof FederationSchedulerTypeInfo);
 
     FederationSchedulerTypeInfo federationSchedulerTypeInfo =
         (FederationSchedulerTypeInfo) typeInfo;
-    Assert.assertNotNull(federationSchedulerTypeInfo);
+    Assertions.assertNotNull(federationSchedulerTypeInfo);
     List<SchedulerTypeInfo> schedulerTypeInfos = federationSchedulerTypeInfo.getList();
-    Assert.assertNotNull(schedulerTypeInfos);
-    Assert.assertEquals(4, schedulerTypeInfos.size());
+    Assertions.assertNotNull(schedulerTypeInfos);
+    Assertions.assertEquals(4, schedulerTypeInfos.size());
     List<String> subClusterIds = subClusters.stream().map(SubClusterId::getId).
         collect(Collectors.toList());
 
     for (SchedulerTypeInfo schedulerTypeInfo : schedulerTypeInfos) {
-      Assert.assertNotNull(schedulerTypeInfo);
+      Assertions.assertNotNull(schedulerTypeInfo);
 
       // 1. Whether the returned subClusterId is in the subCluster list
       String subClusterId = schedulerTypeInfo.getSubClusterId();
-      Assert.assertTrue(subClusterIds.contains(subClusterId));
+      Assertions.assertTrue(subClusterIds.contains(subClusterId));
 
       // 2. We test CapacityScheduler, the returned type should be CapacityScheduler.
       SchedulerInfo schedulerInfo = schedulerTypeInfo.getSchedulerInfo();
-      Assert.assertNotNull(schedulerInfo);
-      Assert.assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
+      Assertions.assertNotNull(schedulerInfo);
+      Assertions.assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
       CapacitySchedulerInfo capacitySchedulerInfo = (CapacitySchedulerInfo) schedulerInfo;
-      Assert.assertNotNull(capacitySchedulerInfo);
+      Assertions.assertNotNull(capacitySchedulerInfo);
 
       // 3. The parent queue name should be root
       String queueName = capacitySchedulerInfo.getQueueName();
-      Assert.assertEquals("root", queueName);
+      Assertions.assertEquals("root", queueName);
 
       // 4. schedulerType should be CapacityScheduler
       String schedulerType = capacitySchedulerInfo.getSchedulerType();
-      Assert.assertEquals("Capacity Scheduler", schedulerType);
+      Assertions.assertEquals("Capacity Scheduler", schedulerType);
 
       // 5. queue path should be root
       String queuePath = capacitySchedulerInfo.getQueuePath();
-      Assert.assertEquals("root", queuePath);
+      Assertions.assertEquals("root", queuePath);
 
       // 6. mockRM has 2 test queues, [root.a, root.b]
       List<String> queues = Lists.newArrayList("root.a", "root.b");
       CapacitySchedulerQueueInfoList csSchedulerQueueInfoList = capacitySchedulerInfo.getQueues();
-      Assert.assertNotNull(csSchedulerQueueInfoList);
+      Assertions.assertNotNull(csSchedulerQueueInfoList);
       List<CapacitySchedulerQueueInfo> csQueueInfoList =
           csSchedulerQueueInfoList.getQueueInfoList();
-      Assert.assertEquals(2, csQueueInfoList.size());
+      Assertions.assertEquals(2, csQueueInfoList.size());
       for (CapacitySchedulerQueueInfo csQueueInfo : csQueueInfoList) {
-        Assert.assertNotNull(csQueueInfo);
-        Assert.assertTrue(queues.contains(csQueueInfo.getQueuePath()));
+        Assertions.assertNotNull(csQueueInfo);
+        Assertions.assertTrue(queues.contains(csQueueInfo.getQueuePath()));
       }
     }
   }
@@ -1653,15 +1653,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // If we don't set the authentication type, we will get error message.
     Response response = interceptor.postDelegationToken(token, request);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(response.getStatus(), Status.FORBIDDEN.getStatusCode());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(response.getStatus(), Status.FORBIDDEN.getStatusCode());
     String errMsg = "Delegation token operations can only be carried out on a " +
         "Kerberos authenticated channel. Expected auth type is kerberos, got type null";
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof String);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof String);
     String entityMsg = String.valueOf(entity);
-    Assert.assertTrue(errMsg.contains(entityMsg));
+    Assertions.assertTrue(errMsg.contains(entityMsg));
   }
 
   @Test
@@ -1680,18 +1680,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof DelegationToken);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof DelegationToken);
 
     DelegationToken dtoken = (DelegationToken) entity;
-    Assert.assertEquals(TEST_RENEWER, dtoken.getRenewer());
-    Assert.assertEquals(TEST_RENEWER, dtoken.getOwner());
-    Assert.assertEquals("RM_DELEGATION_TOKEN", dtoken.getKind());
-    Assert.assertNotNull(dtoken.getToken());
-    Assert.assertTrue(dtoken.getNextExpirationTime() > now);
+    Assertions.assertEquals(TEST_RENEWER, dtoken.getRenewer());
+    Assertions.assertEquals(TEST_RENEWER, dtoken.getOwner());
+    Assertions.assertEquals("RM_DELEGATION_TOKEN", dtoken.getKind());
+    Assertions.assertNotNull(dtoken.getToken());
+    Assertions.assertTrue(dtoken.getNextExpirationTime() > now);
   }
 
   @Test
@@ -1731,28 +1731,28 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof DelegationToken);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof DelegationToken);
     DelegationToken dtoken = (DelegationToken) entity;
 
     final String yarnTokenHeader = "Hadoop-YARN-RM-Delegation-Token";
     when(request.getHeader(yarnTokenHeader)).thenReturn(dtoken.getToken());
 
     Response renewResponse = interceptor.postDelegationTokenExpiration(request);
-    Assert.assertNotNull(renewResponse);
+    Assertions.assertNotNull(renewResponse);
 
     Object renewEntity = renewResponse.getEntity();
-    Assert.assertNotNull(renewEntity);
-    Assert.assertTrue(renewEntity instanceof DelegationToken);
+    Assertions.assertNotNull(renewEntity);
+    Assertions.assertTrue(renewEntity instanceof DelegationToken);
 
     // renewDelegation, we only return renewDate, other values are NULL.
     DelegationToken renewDToken = (DelegationToken) renewEntity;
-    Assert.assertNull(renewDToken.getRenewer());
-    Assert.assertNull(renewDToken.getOwner());
-    Assert.assertNull(renewDToken.getKind());
-    Assert.assertTrue(renewDToken.getNextExpirationTime() > dtoken.getNextExpirationTime());
+    Assertions.assertNull(renewDToken.getRenewer());
+    Assertions.assertNull(renewDToken.getOwner());
+    Assertions.assertNull(renewDToken.getKind());
+    Assertions.assertTrue(renewDToken.getNextExpirationTime() > dtoken.getNextExpirationTime());
   }
 
   @Test
@@ -1769,18 +1769,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof DelegationToken);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof DelegationToken);
     DelegationToken dtoken = (DelegationToken) entity;
 
     final String yarnTokenHeader = "Hadoop-YARN-RM-Delegation-Token";
     when(request.getHeader(yarnTokenHeader)).thenReturn(dtoken.getToken());
 
     Response cancelResponse = interceptor.cancelDelegationToken(request);
-    Assert.assertNotNull(cancelResponse);
-    Assert.assertEquals(response.getStatus(), Status.OK.getStatusCode());
+    Assertions.assertNotNull(cancelResponse);
+    Assertions.assertEquals(response.getStatus(), Status.OK.getStatusCode());
   }
 
   @Test
@@ -1805,20 +1805,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // subCluster#0:Success;subCluster#1:Success;subCluster#3:Success;subCluster#2:Success;
     // We can't confirm the complete return order.
     Response response = interceptor.replaceLabelsOnNodes(nodeToLabelsEntryList, null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(200, response.getStatus());
 
     Object entityObject = response.getEntity();
-    Assert.assertNotNull(entityObject);
+    Assertions.assertNotNull(entityObject);
 
     String entityValue = String.valueOf(entityObject);
     String[] entities = entityValue.split(",");
-    Assert.assertNotNull(entities);
-    Assert.assertEquals(4, entities.length);
+    Assertions.assertNotNull(entities);
+    Assertions.assertEquals(4, entities.length);
     String expectValue =
         "subCluster-0:Success,subCluster-1:Success,subCluster-2:Success,subCluster-3:Success,";
     for (String entity : entities) {
-      Assert.assertTrue(expectValue.contains(entity));
+      Assertions.assertTrue(expectValue.contains(entity));
     }
   }
 
@@ -1845,15 +1845,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // We expect the following result: subCluster#3:Success;
     String expectValue = "subCluster#3:Success;";
     Response response = interceptor.replaceLabelsOnNode(labels, null, nodeId);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(200, response.getStatus());
 
     Object entityObject = response.getEntity();
-    Assert.assertNotNull(entityObject);
+    Assertions.assertNotNull(entityObject);
 
     String entityValue = String.valueOf(entityObject);
-    Assert.assertNotNull(entityValue);
-    Assert.assertEquals(expectValue, entityValue);
+    Assertions.assertNotNull(entityValue);
+    Assertions.assertEquals(expectValue, entityValue);
   }
 
   @Test
@@ -1886,11 +1886,11 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // We cannot guarantee the calling order of the sub-clusters,
     // We guarantee that the returned result contains the information of each subCluster.
-    Assert.assertNotNull(dumpSchedulerLogsMsg);
+    Assertions.assertNotNull(dumpSchedulerLogsMsg);
     subClusters.forEach(subClusterId -> {
       String subClusterMsg =
           "subClusterId" + subClusterId + " : Capacity scheduler logs are being created.; ";
-      Assert.assertTrue(dumpSchedulerLogsMsg.contains(subClusterMsg));
+      Assertions.assertTrue(dumpSchedulerLogsMsg.contains(subClusterMsg));
     });
   }
 
@@ -1917,22 +1917,22 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testGetActivitiesNormal() {
     ActivitiesInfo activitiesInfo = interceptor.getActivities(null, "1", "DIAGNOSTIC");
-    Assert.assertNotNull(activitiesInfo);
+    Assertions.assertNotNull(activitiesInfo);
 
     String nodeId = activitiesInfo.getNodeId();
-    Assert.assertNotNull(nodeId);
-    Assert.assertEquals("1", nodeId);
+    Assertions.assertNotNull(nodeId);
+    Assertions.assertEquals("1", nodeId);
 
     String diagnostic = activitiesInfo.getDiagnostic();
-    Assert.assertNotNull(diagnostic);
-    Assert.assertTrue(StringUtils.contains(diagnostic, "Diagnostic"));
+    Assertions.assertNotNull(diagnostic);
+    Assertions.assertTrue(StringUtils.contains(diagnostic, "Diagnostic"));
 
     long timestamp = activitiesInfo.getTimestamp();
-    Assert.assertEquals(1673081972L, timestamp);
+    Assertions.assertEquals(1673081972L, timestamp);
 
     List<NodeAllocationInfo> allocationInfos = activitiesInfo.getAllocations();
-    Assert.assertNotNull(allocationInfos);
-    Assert.assertEquals(1, allocationInfos.size());
+    Assertions.assertNotNull(allocationInfos);
+    Assertions.assertEquals(1, allocationInfos.size());
   }
 
   @Test
@@ -1957,23 +1957,23 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetBulkActivitiesNormal() throws InterruptedException {
     BulkActivitiesInfo bulkActivitiesInfo =
         interceptor.getBulkActivities(null, "DIAGNOSTIC", 5);
-    Assert.assertNotNull(bulkActivitiesInfo);
+    Assertions.assertNotNull(bulkActivitiesInfo);
 
-    Assert.assertTrue(bulkActivitiesInfo instanceof FederationBulkActivitiesInfo);
+    Assertions.assertTrue(bulkActivitiesInfo instanceof FederationBulkActivitiesInfo);
 
     FederationBulkActivitiesInfo federationBulkActivitiesInfo =
         (FederationBulkActivitiesInfo) bulkActivitiesInfo;
-    Assert.assertNotNull(federationBulkActivitiesInfo);
+    Assertions.assertNotNull(federationBulkActivitiesInfo);
 
     List<BulkActivitiesInfo> activitiesInfos = federationBulkActivitiesInfo.getList();
-    Assert.assertNotNull(activitiesInfos);
-    Assert.assertEquals(4, activitiesInfos.size());
+    Assertions.assertNotNull(activitiesInfos);
+    Assertions.assertEquals(4, activitiesInfos.size());
 
     for (BulkActivitiesInfo activitiesInfo : activitiesInfos) {
-      Assert.assertNotNull(activitiesInfo);
+      Assertions.assertNotNull(activitiesInfo);
       List<ActivitiesInfo> activitiesInfoList = activitiesInfo.getActivities();
-      Assert.assertNotNull(activitiesInfoList);
-      Assert.assertEquals(5, activitiesInfoList.size());
+      Assertions.assertNotNull(activitiesInfoList);
+      Assertions.assertEquals(5, activitiesInfoList.size());
     }
   }
 
@@ -2003,21 +2003,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     nodeLabelsInfo.getNodeLabelsInfo().add(nodeLabelInfo);
 
     Response response = interceptor.addToClusterNodeLabels(nodeLabelsInfo, null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assert.assertNotNull(entityObj);
+    Assertions.assertNotNull(entityObj);
 
     String entity = String.valueOf(entityObj);
     String[] entities = StringUtils.split(entity, ",");
-    Assert.assertNotNull(entities);
-    Assert.assertEquals(4, entities.length);
+    Assertions.assertNotNull(entities);
+    Assertions.assertEquals(4, entities.length);
 
     // The order in which the cluster returns messages is uncertain,
     // we confirm the result by contains
     String expectedMsg =
         "SubCluster-0:SUCCESS,SubCluster-1:SUCCESS,SubCluster-2:SUCCESS,SubCluster-3:SUCCESS";
-    Arrays.stream(entities).forEach(item -> Assert.assertTrue(expectedMsg.contains(item)));
+    Arrays.stream(entities).forEach(item -> Assertions.assertTrue(expectedMsg.contains(item)));
   }
 
   @Test
@@ -2029,14 +2029,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     nodeLabelsInfo.getNodeLabelsInfo().add(nodeLabelInfo);
 
     Response response = interceptor.addToClusterNodeLabels(nodeLabelsInfo, null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assert.assertNotNull(entityObj);
+    Assertions.assertNotNull(entityObj);
 
     String expectedValue = "SubCluster-0:SUCCESS,";
     String entity = String.valueOf(entityObj);
-    Assert.assertTrue(entity.contains(expectedValue));
+    Assertions.assertTrue(entity.contains(expectedValue));
   }
 
   @Test
@@ -2066,21 +2066,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     oldNodeLabels.add("ALL");
 
     Response response = interceptor.removeFromClusterNodeLabels(oldNodeLabels, null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assert.assertNotNull(entityObj);
+    Assertions.assertNotNull(entityObj);
 
     String entity = String.valueOf(entityObj);
     String[] entities = StringUtils.split(entity, ",");
-    Assert.assertNotNull(entities);
-    Assert.assertEquals(4, entities.length);
+    Assertions.assertNotNull(entities);
+    Assertions.assertEquals(4, entities.length);
 
     // The order in which the cluster returns messages is uncertain,
     // we confirm the result by contains
     String expectedMsg =
         "SubCluster-0:SUCCESS,SubCluster-1:SUCCESS,SubCluster-2:SUCCESS,SubCluster-3:SUCCESS";
-    Arrays.stream(entities).forEach(item -> Assert.assertTrue(expectedMsg.contains(item)));
+    Arrays.stream(entities).forEach(item -> Assertions.assertTrue(expectedMsg.contains(item)));
   }
 
   @Test
@@ -2089,14 +2089,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     oldNodeLabels.add("A0");
 
     Response response = interceptor.removeFromClusterNodeLabels(oldNodeLabels, null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assert.assertNotNull(entityObj);
+    Assertions.assertNotNull(entityObj);
 
     String expectedValue = "SubCluster-0:SUCCESS,";
     String entity = String.valueOf(entityObj);
-    Assert.assertTrue(entity.contains(expectedValue));
+    Assertions.assertTrue(entity.contains(expectedValue));
   }
 
   @Test
@@ -2122,29 +2122,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testGetSchedulerConfiguration() throws Exception {
     Response response = interceptor.getSchedulerConfiguration(null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(OK, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(OK, response.getStatus());
 
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
-    Assert.assertTrue(entity instanceof FederationConfInfo);
+    Assertions.assertNotNull(entity);
+    Assertions.assertTrue(entity instanceof FederationConfInfo);
 
     FederationConfInfo federationConfInfo = FederationConfInfo.class.cast(entity);
     List<ConfInfo> confInfos = federationConfInfo.getList();
-    Assert.assertNotNull(confInfos);
-    Assert.assertEquals(4, confInfos.size());
+    Assertions.assertNotNull(confInfos);
+    Assertions.assertEquals(4, confInfos.size());
 
     List<String> errors = federationConfInfo.getErrorMsgs();
-    Assert.assertEquals(0, errors.size());
+    Assertions.assertEquals(0, errors.size());
 
     Set<String> subClusterSet = subClusters.stream()
         .map(subClusterId -> subClusterId.getId()).collect(Collectors.toSet());
 
     for (ConfInfo confInfo : confInfos) {
       List<ConfInfo.ConfItem> confItems = confInfo.getItems();
-      Assert.assertNotNull(confItems);
-      Assert.assertTrue(confItems.size() > 0);
-      Assert.assertTrue(subClusterSet.contains(confInfo.getSubClusterId()));
+      Assertions.assertNotNull(confItems);
+      Assertions.assertTrue(confItems.size() > 0);
+      Assertions.assertTrue(subClusterSet.contains(confInfo.getSubClusterId()));
     }
   }
 
@@ -2155,15 +2155,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(hsr.getRemoteUser()).thenReturn(requestUserName);
     ClusterUserInfo clusterUserInfo = interceptor.getClusterUserInfo(hsr);
 
-    Assert.assertNotNull(clusterUserInfo);
-    Assert.assertTrue(clusterUserInfo instanceof FederationClusterUserInfo);
+    Assertions.assertNotNull(clusterUserInfo);
+    Assertions.assertTrue(clusterUserInfo instanceof FederationClusterUserInfo);
 
     FederationClusterUserInfo federationClusterUserInfo =
         (FederationClusterUserInfo) clusterUserInfo;
 
     List<ClusterUserInfo> fedClusterUserInfoList = federationClusterUserInfo.getList();
-    Assert.assertNotNull(fedClusterUserInfoList);
-    Assert.assertEquals(4, fedClusterUserInfoList.size());
+    Assertions.assertNotNull(fedClusterUserInfoList);
+    Assertions.assertEquals(4, fedClusterUserInfoList.size());
 
     List<String> subClusterIds = subClusters.stream().map(
         subClusterId -> subClusterId.getId()).collect(Collectors.toList());
@@ -2172,18 +2172,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     for (ClusterUserInfo fedClusterUserInfo : fedClusterUserInfoList) {
       // Check subClusterId
       String subClusterId = fedClusterUserInfo.getSubClusterId();
-      Assert.assertNotNull(subClusterId);
-      Assert.assertTrue(subClusterIds.contains(subClusterId));
+      Assertions.assertNotNull(subClusterId);
+      Assertions.assertTrue(subClusterIds.contains(subClusterId));
 
       // Check requestedUser
       String requestedUser = fedClusterUserInfo.getRequestedUser();
-      Assert.assertNotNull(requestedUser);
-      Assert.assertEquals(requestUserName, requestedUser);
+      Assertions.assertNotNull(requestedUser);
+      Assertions.assertEquals(requestUserName, requestedUser);
 
       // Check rmLoginUser
       String rmLoginUser = fedClusterUserInfo.getRmLoginUser();
-      Assert.assertNotNull(rmLoginUser);
-      Assert.assertEquals(mockRM.getRMLoginUser(), rmLoginUser);
+      Assertions.assertNotNull(rmLoginUser);
+      Assertions.assertEquals(mockRM.getRMLoginUser(), rmLoginUser);
     }
   }
 
@@ -2211,29 +2211,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     updateInfo.getUpdateQueueInfo().add(goodUpdateInfo);
     Response response = interceptor.updateSchedulerConfiguration(updateInfo, null);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(OK, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(OK, response.getStatus());
 
     String expectMsg = "Configuration change successfully applied.";
     Object entity = response.getEntity();
-    Assert.assertNotNull(entity);
+    Assertions.assertNotNull(entity);
 
     String entityMsg = String.valueOf(entity);
-    Assert.assertEquals(expectMsg, entityMsg);
+    Assertions.assertEquals(expectMsg, entityMsg);
   }
 
   @Test
   public void testGetClusterInfo() {
     ClusterInfo clusterInfos = interceptor.getClusterInfo();
-    Assert.assertNotNull(clusterInfos);
-    Assert.assertTrue(clusterInfos instanceof FederationClusterInfo);
+    Assertions.assertNotNull(clusterInfos);
+    Assertions.assertTrue(clusterInfos instanceof FederationClusterInfo);
 
     FederationClusterInfo federationClusterInfos =
         (FederationClusterInfo) (clusterInfos);
 
     List<ClusterInfo> fedClusterInfosList = federationClusterInfos.getList();
-    Assert.assertNotNull(fedClusterInfosList);
-    Assert.assertEquals(4, fedClusterInfosList.size());
+    Assertions.assertNotNull(fedClusterInfosList);
+    Assertions.assertEquals(4, fedClusterInfosList.size());
 
     List<String> subClusterIds = subClusters.stream().map(
         subClusterId -> subClusterId.getId()).collect(Collectors.toList());
@@ -2244,23 +2244,23 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     for (ClusterInfo clusterInfo : fedClusterInfosList) {
       String subClusterId = clusterInfo.getSubClusterId();
       // Check subClusterId
-      Assert.assertTrue(subClusterIds.contains(subClusterId));
+      Assertions.assertTrue(subClusterIds.contains(subClusterId));
 
       // Check state
       String clusterState = mockRM.getServiceState().toString();
-      Assert.assertEquals(clusterState, clusterInfo.getState());
+      Assertions.assertEquals(clusterState, clusterInfo.getState());
 
       // Check rmStateStoreName
       String rmStateStoreName =
           mockRM.getRMContext().getStateStore().getClass().getName();
-      Assert.assertEquals(rmStateStoreName, clusterInfo.getRMStateStore());
+      Assertions.assertEquals(rmStateStoreName, clusterInfo.getRMStateStore());
 
       // Check RM Version
-      Assert.assertEquals(yarnVersion, clusterInfo.getRMVersion());
+      Assertions.assertEquals(yarnVersion, clusterInfo.getRMVersion());
 
       // Check haZooKeeperConnectionState
       String rmHAZookeeperConnectionState = mockRM.getRMContext().getHAZookeeperConnectionState();
-      Assert.assertEquals(rmHAZookeeperConnectionState,
+      Assertions.assertEquals(rmHAZookeeperConnectionState,
           clusterInfo.getHAZookeeperConnectionState());
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -143,7 +143,8 @@ import org.apache.hadoop.yarn.webapp.dao.ConfInfo;
 import org.apache.hadoop.yarn.webapp.dao.QueueConfigInfo;
 import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.RM_DELEGATION_KEY_UPDATE_INTERVAL_DEFAULT;
@@ -157,6 +158,11 @@ import static org.apache.hadoop.yarn.conf.YarnConfiguration.RM_DELEGATION_TOKEN_
 
 import static org.apache.hadoop.yarn.server.router.webapp.MockDefaultRequestInterceptorREST.DURATION;
 import static org.apache.hadoop.yarn.server.router.webapp.MockDefaultRequestInterceptorREST.NUM_CONTAINERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -181,6 +187,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   private List<SubClusterId> subClusters;
   private static final String TEST_RENEWER = "test-renewer";
 
+  @BeforeEach
   public void setUp() throws YarnException, IOException {
 
     super.setUpConfig();
@@ -240,6 +247,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();
@@ -285,12 +293,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response = interceptor.createNewApplication(null);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     NewApplication ci = (NewApplication) response.getEntity();
-    Assertions.assertNotNull(ci);
+    assertNotNull(ci);
     ApplicationId appId = ApplicationId.fromString(ci.getApplicationId());
-    Assertions.assertTrue(appId.getClusterTimestamp() < NUM_SUBCLUSTER);
-    Assertions.assertTrue(appId.getClusterTimestamp() >= 0);
+    assertTrue(appId.getClusterTimestamp() < NUM_SUBCLUSTER);
+    assertTrue(appId.getClusterTimestamp() >= 0);
   }
 
   /**
@@ -309,14 +317,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assertions.assertEquals(ACCEPTED, response.getStatus());
+    assertEquals(ACCEPTED, response.getStatus());
     SubClusterId ci = (SubClusterId) response.getEntity();
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult);
-    Assertions.assertTrue(subClusters.contains(scIdResult));
-    Assertions.assertEquals(ci, scIdResult);
+    assertNotNull(scIdResult);
+    assertTrue(subClusters.contains(scIdResult));
+    assertEquals(ci, scIdResult);
   }
 
   /**
@@ -336,20 +344,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // First attempt
     Response response = interceptor.submitApplication(context, null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(ACCEPTED, response.getStatus());
+    assertNotNull(response);
+    assertEquals(ACCEPTED, response.getStatus());
 
     SubClusterId scIdResult = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult);
+    assertNotNull(scIdResult);
 
     // First retry
     response = interceptor.submitApplication(context, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(ACCEPTED, response.getStatus());
+    assertNotNull(response);
+    assertEquals(ACCEPTED, response.getStatus());
     SubClusterId scIdResult2 = stateStoreUtil.queryApplicationHomeSC(appId);
-    Assertions.assertNotNull(scIdResult2);
-    Assertions.assertEquals(scIdResult, scIdResult2);
+    assertNotNull(scIdResult2);
+    assertEquals(scIdResult, scIdResult2);
   }
 
   /**
@@ -362,18 +370,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // ApplicationSubmissionContextInfo null
     Response response = interceptor.submitApplication(null, null);
 
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
 
     // ApplicationSubmissionContextInfo empty
     response = interceptor
         .submitApplication(new ApplicationSubmissionContextInfo(), null);
 
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
 
     ApplicationSubmissionContextInfo context =
         new ApplicationSubmissionContextInfo();
     response = interceptor.submitApplication(context, null);
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -387,7 +395,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
         new ApplicationSubmissionContextInfo();
     context.setApplicationId("Application_wrong_id");
     Response response = interceptor.submitApplication(context, null);
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -407,14 +415,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we are going to kill later
     Response response = interceptor.submitApplication(context, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppState appState = new AppState("KILLED");
 
     Response responseKill =
         interceptor.updateAppState(appState, null, appId.toString());
-    Assertions.assertNotNull(responseKill);
+    assertNotNull(responseKill);
   }
 
   /**
@@ -431,7 +439,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateAppState(appState, null, appId.toString());
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
 
   }
 
@@ -446,7 +454,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     AppState appState = new AppState("KILLED");
     Response response =
         interceptor.updateAppState(appState, null, "Application_wrong_id");
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
   }
 
   /**
@@ -468,7 +476,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateAppState(null, null, appId.toString());
-    Assertions.assertEquals(BAD_REQUEST, response.getStatus());
+    assertEquals(BAD_REQUEST, response.getStatus());
 
   }
 
@@ -489,12 +497,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppInfo responseGet = interceptor.getApp(null, appId.toString(), null);
 
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
   }
 
   /**
@@ -509,7 +517,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppInfo response = interceptor.getApp(null, appId.toString(), null);
 
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -521,7 +529,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppInfo response = interceptor.getApp(null, "Application_wrong_id", null);
 
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -534,8 +542,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     AppsInfo responseGet = interceptor.getApps(null, null, null, null, null,
         null, null, null, null, null, null, null, null, null, null);
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertEquals(NUM_SUBCLUSTER, responseGet.getApps().size());
+    assertNotNull(responseGet);
+    assertEquals(NUM_SUBCLUSTER, responseGet.getApps().size());
     // The merged operations is tested in TestRouterWebServiceUtil
   }
 
@@ -550,8 +558,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     NodeInfo responseGet = interceptor.getNode("testGetNode");
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertEquals(NUM_SUBCLUSTER - 1, responseGet.getLastHealthUpdate());
+    assertNotNull(responseGet);
+    assertEquals(NUM_SUBCLUSTER - 1, responseGet.getLastHealthUpdate());
   }
 
   /**
@@ -563,8 +571,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     NodesInfo responseGet = interceptor.getNodes(null);
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertEquals(NUM_SUBCLUSTER, responseGet.getNodes().size());
+    assertNotNull(responseGet);
+    assertEquals(NUM_SUBCLUSTER, responseGet.getNodes().size());
     // The remove duplicate operations is tested in TestRouterWebServiceUtil
   }
 
@@ -574,16 +582,16 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testUpdateNodeResource() {
     List<NodeInfo> nodes = interceptor.getNodes(null).getNodes();
-    Assertions.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
     final String nodeId = nodes.get(0).getNodeId();
     ResourceOptionInfo resourceOption = new ResourceOptionInfo(
         ResourceOption.newInstance(
             Resource.newInstance(2048, 3), 1000));
     ResourceInfo resource = interceptor.updateNodeResource(
         null, nodeId, resourceOption);
-    Assertions.assertNotNull(resource);
-    Assertions.assertEquals(2048, resource.getMemorySize());
-    Assertions.assertEquals(3, resource.getvCores());
+    assertNotNull(resource);
+    assertEquals(2048, resource.getMemorySize());
+    assertEquals(3, resource.getvCores());
   }
 
   /**
@@ -597,12 +605,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     ClusterMetricsInfo responseGet = interceptor.getClusterMetricsInfo();
 
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
     int expectedAppSubmitted = 0;
     for (int i = 0; i < NUM_SUBCLUSTER; i++) {
       expectedAppSubmitted += i;
     }
-    Assertions.assertEquals(expectedAppSubmitted, responseGet.getAppsSubmitted());
+    assertEquals(expectedAppSubmitted, responseGet.getAppsSubmitted());
     // The merge operations is tested in TestRouterWebServiceUtil
   }
 
@@ -623,13 +631,13 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     AppState responseGet = interceptor.getAppState(null, appId.toString());
 
-    Assertions.assertNotNull(responseGet);
-    Assertions.assertEquals(MockDefaultRequestInterceptorREST.APP_STATE_RUNNING,
+    assertNotNull(responseGet);
+    assertEquals(MockDefaultRequestInterceptorREST.APP_STATE_RUNNING,
         responseGet.getState());
   }
 
@@ -645,7 +653,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppState response = interceptor.getAppState(null, appId.toString());
 
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -658,7 +666,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppState response = interceptor.getAppState(null, "Application_wrong_id");
 
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -670,14 +678,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     SubClusterId subClusterId = SubClusterId.newInstance(Integer.toString(0));
 
     interceptor.getClusterMetricsInfo();
-    Assertions.assertEquals("http://1.2.3.4:4", interceptor
+    assertEquals("http://1.2.3.4:4", interceptor
             .getInterceptorForSubCluster(subClusterId).getWebAppAddress());
 
     //Register the first subCluster with secondRM simulating RMSwitchover
     registerSubClusterWithSwitchoverRM(subClusterId);
 
     interceptor.getClusterMetricsInfo();
-    Assertions.assertEquals("http://5.6.7.8:8", interceptor
+    assertEquals("http://5.6.7.8:8", interceptor
             .getInterceptorForSubCluster(subClusterId).getWebAppAddress());
   }
 
@@ -708,15 +716,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit the application we want the report later
     Response response = interceptor.submitApplication(context, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertNotNull(stateStoreUtil.queryApplicationHomeSC(appId));
 
     ApplicationAttemptId appAttempt = ApplicationAttemptId.newInstance(appId, 1);
 
     ContainersInfo responseGet = interceptor.getContainers(
         null, null, appId.toString(), appAttempt.toString());
 
-    Assertions.assertEquals(4, responseGet.getContainers().size());
+    assertEquals(4, responseGet.getContainers().size());
   }
 
   @Test
@@ -748,86 +756,86 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetNodeToLabels() throws IOException {
     NodeToLabelsInfo info = interceptor.getNodeToLabels(null);
     HashMap<String, NodeLabelsInfo> map = info.getNodeToLabels();
-    Assertions.assertNotNull(map);
-    Assertions.assertEquals(2, map.size());
+    assertNotNull(map);
+    assertEquals(2, map.size());
 
     NodeLabelsInfo node1Value = map.getOrDefault("node1", null);
-    Assertions.assertNotNull(node1Value);
-    Assertions.assertEquals(1, node1Value.getNodeLabelsName().size());
-    Assertions.assertEquals("CPU", node1Value.getNodeLabelsName().get(0));
+    assertNotNull(node1Value);
+    assertEquals(1, node1Value.getNodeLabelsName().size());
+    assertEquals("CPU", node1Value.getNodeLabelsName().get(0));
 
     NodeLabelsInfo node2Value = map.getOrDefault("node2", null);
-    Assertions.assertNotNull(node2Value);
-    Assertions.assertEquals(1, node2Value.getNodeLabelsName().size());
-    Assertions.assertEquals("GPU", node2Value.getNodeLabelsName().get(0));
+    assertNotNull(node2Value);
+    assertEquals(1, node2Value.getNodeLabelsName().size());
+    assertEquals("GPU", node2Value.getNodeLabelsName().get(0));
   }
 
   @Test
   public void testGetLabelsToNodes() throws Exception {
     LabelsToNodesInfo labelsToNodesInfo = interceptor.getLabelsToNodes(null);
     Map<NodeLabelInfo, NodeIDsInfo> map = labelsToNodesInfo.getLabelsToNodes();
-    Assertions.assertNotNull(map);
-    Assertions.assertEquals(3, map.size());
+    assertNotNull(map);
+    assertEquals(3, map.size());
 
     NodeLabel labelX = NodeLabel.newInstance("x", false);
     NodeLabelInfo nodeLabelInfoX = new NodeLabelInfo(labelX);
     NodeIDsInfo nodeIDsInfoX = map.get(nodeLabelInfoX);
-    Assertions.assertNotNull(nodeIDsInfoX);
-    Assertions.assertEquals(2, nodeIDsInfoX.getNodeIDs().size());
+    assertNotNull(nodeIDsInfoX);
+    assertEquals(2, nodeIDsInfoX.getNodeIDs().size());
     Resource resourceX =
         nodeIDsInfoX.getPartitionInfo().getResourceAvailable().getResource();
-    Assertions.assertNotNull(resourceX);
-    Assertions.assertEquals(4*10, resourceX.getVirtualCores());
-    Assertions.assertEquals(4*20*1024, resourceX.getMemorySize());
+    assertNotNull(resourceX);
+    assertEquals(4*10, resourceX.getVirtualCores());
+    assertEquals(4*20*1024, resourceX.getMemorySize());
 
     NodeLabel labelY = NodeLabel.newInstance("y", false);
     NodeLabelInfo nodeLabelInfoY = new NodeLabelInfo(labelY);
     NodeIDsInfo nodeIDsInfoY = map.get(nodeLabelInfoY);
-    Assertions.assertNotNull(nodeIDsInfoY);
-    Assertions.assertEquals(2, nodeIDsInfoY.getNodeIDs().size());
+    assertNotNull(nodeIDsInfoY);
+    assertEquals(2, nodeIDsInfoY.getNodeIDs().size());
     Resource resourceY =
         nodeIDsInfoY.getPartitionInfo().getResourceAvailable().getResource();
-    Assertions.assertNotNull(resourceY);
-    Assertions.assertEquals(4*20, resourceY.getVirtualCores());
-    Assertions.assertEquals(4*40*1024, resourceY.getMemorySize());
+    assertNotNull(resourceY);
+    assertEquals(4*20, resourceY.getVirtualCores());
+    assertEquals(4*40*1024, resourceY.getMemorySize());
   }
 
   @Test
   public void testGetClusterNodeLabels() throws Exception {
     NodeLabelsInfo nodeLabelsInfo = interceptor.getClusterNodeLabels(null);
-    Assertions.assertNotNull(nodeLabelsInfo);
-    Assertions.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
+    assertNotNull(nodeLabelsInfo);
+    assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
 
     List<String> nodeLabelsName = nodeLabelsInfo.getNodeLabelsName();
-    Assertions.assertNotNull(nodeLabelsName);
-    Assertions.assertTrue(nodeLabelsName.contains("cpu"));
-    Assertions.assertTrue(nodeLabelsName.contains("gpu"));
+    assertNotNull(nodeLabelsName);
+    assertTrue(nodeLabelsName.contains("cpu"));
+    assertTrue(nodeLabelsName.contains("gpu"));
 
     ArrayList<NodeLabelInfo> nodeLabelInfos = nodeLabelsInfo.getNodeLabelsInfo();
-    Assertions.assertNotNull(nodeLabelInfos);
-    Assertions.assertEquals(2, nodeLabelInfos.size());
+    assertNotNull(nodeLabelInfos);
+    assertEquals(2, nodeLabelInfos.size());
     NodeLabelInfo cpuNodeLabelInfo = new NodeLabelInfo("cpu", false);
-    Assertions.assertTrue(nodeLabelInfos.contains(cpuNodeLabelInfo));
+    assertTrue(nodeLabelInfos.contains(cpuNodeLabelInfo));
     NodeLabelInfo gpuNodeLabelInfo = new NodeLabelInfo("gpu", false);
-    Assertions.assertTrue(nodeLabelInfos.contains(gpuNodeLabelInfo));
+    assertTrue(nodeLabelInfos.contains(gpuNodeLabelInfo));
   }
 
   @Test
   public void testGetLabelsOnNode() throws Exception {
     NodeLabelsInfo nodeLabelsInfo = interceptor.getLabelsOnNode(null, "node1");
-    Assertions.assertNotNull(nodeLabelsInfo);
-    Assertions.assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
+    assertNotNull(nodeLabelsInfo);
+    assertEquals(2, nodeLabelsInfo.getNodeLabelsName().size());
 
     List<String> nodeLabelsName = nodeLabelsInfo.getNodeLabelsName();
-    Assertions.assertNotNull(nodeLabelsName);
-    Assertions.assertTrue(nodeLabelsName.contains("x"));
-    Assertions.assertTrue(nodeLabelsName.contains("y"));
+    assertNotNull(nodeLabelsName);
+    assertTrue(nodeLabelsName.contains("x"));
+    assertTrue(nodeLabelsName.contains("y"));
 
     // null request
     interceptor.setAllowPartialResult(false);
     NodeLabelsInfo nodeLabelsInfo2 = interceptor.getLabelsOnNode(null, "node2");
-    Assertions.assertNotNull(nodeLabelsInfo2);
-    Assertions.assertEquals(0, nodeLabelsInfo2.getNodeLabelsName().size());
+    assertNotNull(nodeLabelsInfo2);
+    assertEquals(0, nodeLabelsInfo2.getNodeLabelsName().size());
   }
 
   @Test
@@ -843,7 +851,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // Submit application to multiSubCluster
     ApplicationSubmissionContextInfo context = new ApplicationSubmissionContextInfo();
     context.setApplicationId(applicationId);
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     // Test Case1: Wrong ContainerId
     LambdaTestUtils.intercept(IllegalArgumentException.class, "Invalid ContainerId prefix: 0",
@@ -853,7 +861,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     ContainerInfo containerInfo = interceptor.getContainer(null, null, applicationId,
         attemptId, containerId);
-    Assertions.assertNotNull(containerInfo);
+    assertNotNull(containerInfo);
   }
 
   @Test
@@ -863,28 +871,28 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     ApplicationSubmissionContextInfo context = new ApplicationSubmissionContextInfo();
     context.setApplicationId(appId.toString());
 
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     AppAttemptsInfo appAttemptsInfo = interceptor.getAppAttempts(null, appId.toString());
-    Assertions.assertNotNull(appAttemptsInfo);
+    assertNotNull(appAttemptsInfo);
 
     ArrayList<AppAttemptInfo> attemptLists = appAttemptsInfo.getAttempts();
-    Assertions.assertNotNull(appAttemptsInfo);
-    Assertions.assertEquals(2, attemptLists.size());
+    assertNotNull(appAttemptsInfo);
+    assertEquals(2, attemptLists.size());
 
     AppAttemptInfo attemptInfo1 = attemptLists.get(0);
-    Assertions.assertNotNull(attemptInfo1);
-    Assertions.assertEquals(0, attemptInfo1.getAttemptId());
-    Assertions.assertEquals("AppAttemptId_0", attemptInfo1.getAppAttemptId());
-    Assertions.assertEquals("LogLink_0", attemptInfo1.getLogsLink());
-    Assertions.assertEquals(1659621705L, attemptInfo1.getFinishedTime());
+    assertNotNull(attemptInfo1);
+    assertEquals(0, attemptInfo1.getAttemptId());
+    assertEquals("AppAttemptId_0", attemptInfo1.getAppAttemptId());
+    assertEquals("LogLink_0", attemptInfo1.getLogsLink());
+    assertEquals(1659621705L, attemptInfo1.getFinishedTime());
 
     AppAttemptInfo attemptInfo2 = attemptLists.get(1);
-    Assertions.assertNotNull(attemptInfo2);
-    Assertions.assertEquals(0, attemptInfo2.getAttemptId());
-    Assertions.assertEquals("AppAttemptId_1", attemptInfo2.getAppAttemptId());
-    Assertions.assertEquals("LogLink_1", attemptInfo2.getLogsLink());
-    Assertions.assertEquals(1659621705L, attemptInfo2.getFinishedTime());
+    assertNotNull(attemptInfo2);
+    assertEquals(0, attemptInfo2.getAttemptId());
+    assertEquals("AppAttemptId_1", attemptInfo2.getAppAttemptId());
+    assertEquals("LogLink_1", attemptInfo2.getLogsLink());
+    assertEquals(1659621705L, attemptInfo2.getFinishedTime());
   }
 
   @Test
@@ -896,19 +904,19 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
     ApplicationAttemptId expectAppAttemptId = ApplicationAttemptId.newInstance(appId, 1);
     String appAttemptId = expectAppAttemptId.toString();
 
     org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo
         appAttemptInfo = interceptor.getAppAttempt(null, null, appId.toString(), appAttemptId);
 
-    Assertions.assertNotNull(appAttemptInfo);
-    Assertions.assertEquals(expectAppAttemptId.toString(), appAttemptInfo.getAppAttemptId());
-    Assertions.assertEquals("url", appAttemptInfo.getTrackingUrl());
-    Assertions.assertEquals("oUrl", appAttemptInfo.getOriginalTrackingUrl());
-    Assertions.assertEquals(124, appAttemptInfo.getRpcPort());
-    Assertions.assertEquals("host", appAttemptInfo.getHost());
+    assertNotNull(appAttemptInfo);
+    assertEquals(expectAppAttemptId.toString(), appAttemptInfo.getAppAttemptId());
+    assertEquals("url", appAttemptInfo.getTrackingUrl());
+    assertEquals("oUrl", appAttemptInfo.getOriginalTrackingUrl());
+    assertEquals(124, appAttemptInfo.getRpcPort());
+    assertEquals("host", appAttemptInfo.getHost());
   }
 
   @Test
@@ -920,15 +928,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     ApplicationTimeoutType appTimeoutType = ApplicationTimeoutType.LIFETIME;
     AppTimeoutInfo appTimeoutInfo =
         interceptor.getAppTimeout(null, appId.toString(), appTimeoutType.toString());
-    Assertions.assertNotNull(appTimeoutInfo);
-    Assertions.assertEquals(10, appTimeoutInfo.getRemainingTimeInSec());
-    Assertions.assertEquals("UNLIMITED", appTimeoutInfo.getExpireTime());
-    Assertions.assertEquals(appTimeoutType, appTimeoutInfo.getTimeoutType());
+    assertNotNull(appTimeoutInfo);
+    assertEquals(10, appTimeoutInfo.getRemainingTimeInSec());
+    assertEquals("UNLIMITED", appTimeoutInfo.getExpireTime());
+    assertEquals(appTimeoutType, appTimeoutInfo.getTimeoutType());
   }
 
   @Test
@@ -940,20 +948,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     AppTimeoutsInfo appTimeoutsInfo = interceptor.getAppTimeouts(null, appId.toString());
-    Assertions.assertNotNull(appTimeoutsInfo);
+    assertNotNull(appTimeoutsInfo);
 
     List<AppTimeoutInfo> timeouts = appTimeoutsInfo.getAppTimeouts();
-    Assertions.assertNotNull(timeouts);
-    Assertions.assertEquals(1, timeouts.size());
+    assertNotNull(timeouts);
+    assertEquals(1, timeouts.size());
 
     AppTimeoutInfo resultAppTimeout = timeouts.get(0);
-    Assertions.assertNotNull(resultAppTimeout);
-    Assertions.assertEquals(10, resultAppTimeout.getRemainingTimeInSec());
-    Assertions.assertEquals("UNLIMITED", resultAppTimeout.getExpireTime());
-    Assertions.assertEquals(ApplicationTimeoutType.LIFETIME, resultAppTimeout.getTimeoutType());
+    assertNotNull(resultAppTimeout);
+    assertEquals(10, resultAppTimeout.getRemainingTimeInSec());
+    assertEquals("UNLIMITED", resultAppTimeout.getExpireTime());
+    assertEquals(ApplicationTimeoutType.LIFETIME, resultAppTimeout.getTimeoutType());
   }
 
   @Test
@@ -966,7 +974,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
 
     // Generate ApplicationAttemptId information
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     long newLifetime = 10L;
     // update 10L seconds more to timeout
@@ -979,12 +987,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     Response response =
         interceptor.updateApplicationTimeout(paramAppTimeOut, null, appId.toString());
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     AppTimeoutInfo entity = (AppTimeoutInfo) response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertEquals(paramAppTimeOut.getExpireTime(), entity.getExpireTime());
-    Assertions.assertEquals(paramAppTimeOut.getTimeoutType(), entity.getTimeoutType());
-    Assertions.assertEquals(paramAppTimeOut.getRemainingTimeInSec(), entity.getRemainingTimeInSec());
+    assertNotNull(entity);
+    assertEquals(paramAppTimeOut.getExpireTime(), entity.getExpireTime());
+    assertEquals(paramAppTimeOut.getTimeoutType(), entity.getTimeoutType());
+    assertEquals(paramAppTimeOut.getRemainingTimeInSec(), entity.getRemainingTimeInSec());
   }
 
   @Test
@@ -998,17 +1006,17 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setPriority(20);
 
     // Submit the application we are going to kill later
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     int iPriority = 10;
     // Set Priority for application
     Response response = interceptor.updateApplicationPriority(
         new AppPriority(iPriority), null, appId.toString());
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     AppPriority entity = (AppPriority) response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertEquals(iPriority, entity.getPriority());
+    assertNotNull(entity);
+    assertEquals(iPriority, entity.getPriority());
   }
 
   @Test
@@ -1022,12 +1030,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setPriority(priority);
 
     // Submit the application we are going to kill later
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     // Set Priority for application
     AppPriority appPriority = interceptor.getAppPriority(null, appId.toString());
-    Assertions.assertNotNull(appPriority);
-    Assertions.assertEquals(priority, appPriority.getPriority());
+    assertNotNull(appPriority);
+    assertEquals(priority, appPriority.getPriority());
   }
 
   @Test
@@ -1044,20 +1052,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setQueue(oldQueue);
 
     // Submit the application
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     // Set New Queue for application
     Response response = interceptor.updateAppQueue(new AppQueue(newQueue),
         null, appId.toString());
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     AppQueue appQueue = (AppQueue) response.getEntity();
-    Assertions.assertEquals(newQueue, appQueue.getQueue());
+    assertEquals(newQueue, appQueue.getQueue());
 
     // Get AppQueue by application
     AppQueue queue = interceptor.getAppQueue(null, appId.toString());
-    Assertions.assertNotNull(queue);
-    Assertions.assertEquals(newQueue, queue.getQueue());
+    assertNotNull(queue);
+    assertEquals(newQueue, queue.getQueue());
   }
 
   @Test
@@ -1070,12 +1078,12 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationId(appId.toString());
     context.setQueue(queueName);
 
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     // Get Queue by application
     AppQueue queue = interceptor.getAppQueue(null, appId.toString());
-    Assertions.assertNotNull(queue);
-    Assertions.assertEquals(queueName, queue.getQueue());
+    assertNotNull(queue);
+    assertEquals(queueName, queue.getQueue());
   }
 
   @Test
@@ -1083,21 +1091,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     AppsInfo responseGet = interceptor.getApps(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-    Assertions.assertNotNull(responseGet);
+    assertNotNull(responseGet);
 
     RouterAppInfoCacheKey cacheKey = RouterAppInfoCacheKey.newInstance(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
     LRUCacheHashMap<RouterAppInfoCacheKey, AppsInfo> appsInfoCache =
         interceptor.getAppInfosCaches();
-    Assertions.assertNotNull(appsInfoCache);
-    Assertions.assertFalse(appsInfoCache.isEmpty());
-    Assertions.assertEquals(1, appsInfoCache.size());
-    Assertions.assertTrue(appsInfoCache.containsKey(cacheKey));
+    assertNotNull(appsInfoCache);
+    assertFalse(appsInfoCache.isEmpty());
+    assertEquals(1, appsInfoCache.size());
+    assertTrue(appsInfoCache.containsKey(cacheKey));
 
     AppsInfo cacheResult = appsInfoCache.get(cacheKey);
-    Assertions.assertNotNull(cacheResult);
-    Assertions.assertEquals(responseGet, cacheResult);
+    assertNotNull(cacheResult);
+    assertEquals(responseGet, cacheResult);
   }
 
   @Test
@@ -1110,14 +1118,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationType("MapReduce");
     context.setQueue("queue");
 
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
 
     GetApplicationHomeSubClusterRequest request =
         GetApplicationHomeSubClusterRequest.newInstance(appId);
     GetApplicationHomeSubClusterResponse response =
         stateStore.getApplicationHomeSubCluster(request);
 
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     ApplicationHomeSubCluster homeSubCluster = response.getApplicationHomeSubCluster();
 
     DefaultRequestInterceptorREST interceptorREST =
@@ -1137,13 +1145,13 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     ApplicationStatisticsInfo response2 =
         interceptor.getAppStatistics(null, stateQueries, typeQueries);
 
-    Assertions.assertNotNull(response2);
-    Assertions.assertFalse(response2.getStatItems().isEmpty());
+    assertNotNull(response2);
+    assertFalse(response2.getStatItems().isEmpty());
 
     StatisticsItemInfo result = response2.getStatItems().get(0);
-    Assertions.assertEquals(1, result.getCount());
-    Assertions.assertEquals(YarnApplicationState.RUNNING, result.getState());
-    Assertions.assertEquals("MapReduce", result.getType());
+    assertEquals(1, result.getCount());
+    assertEquals(YarnApplicationState.RUNNING, result.getState());
+    assertEquals("MapReduce", result.getType());
   }
 
   @Test
@@ -1155,7 +1163,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     context.setApplicationType("MapReduce");
     context.setQueue("queue");
 
-    Assertions.assertNotNull(interceptor.submitApplication(context, null));
+    assertNotNull(interceptor.submitApplication(context, null));
     Set<String> prioritiesSet = Collections.singleton("0");
     Set<String> allocationRequestIdsSet = Collections.singleton("0");
 
@@ -1163,9 +1171,9 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
         interceptor.getAppActivities(null, appId.toString(), String.valueOf(Time.now()),
         prioritiesSet, allocationRequestIdsSet, null, "-1", null, false);
 
-    Assertions.assertNotNull(appActivitiesInfo);
-    Assertions.assertEquals(appId.toString(), appActivitiesInfo.getApplicationId());
-    Assertions.assertEquals(10, appActivitiesInfo.getAllocations().size());
+    assertNotNull(appActivitiesInfo);
+    assertEquals(appId.toString(), appActivitiesInfo.getApplicationId());
+    assertEquals(10, appActivitiesInfo.getAllocations().size());
   }
 
   @Test
@@ -1179,63 +1187,63 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String applyReservationId = reservationId.toString();
     Response listReservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assertions.assertNotNull(listReservationResponse);
-    Assertions.assertNotNull(listReservationResponse.getStatus());
+    assertNotNull(listReservationResponse);
+    assertNotNull(listReservationResponse.getStatus());
     Status status = Status.fromStatusCode(listReservationResponse.getStatus());
-    Assertions.assertEquals(Status.OK, status);
+    assertEquals(Status.OK, status);
 
     Object entity = listReservationResponse.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertNotNull(entity instanceof ReservationListInfo);
+    assertNotNull(entity);
+    assertNotNull(entity instanceof ReservationListInfo);
 
-    Assertions.assertTrue(entity instanceof ReservationListInfo);
+    assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assertions.assertNotNull(listInfo);
+    assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfoList = listInfo.getReservations();
-    Assertions.assertNotNull(reservationInfoList);
-    Assertions.assertEquals(1, reservationInfoList.size());
+    assertNotNull(reservationInfoList);
+    assertEquals(1, reservationInfoList.size());
 
     ReservationInfo reservationInfo = reservationInfoList.get(0);
-    Assertions.assertNotNull(reservationInfo);
-    Assertions.assertEquals(applyReservationId, reservationInfo.getReservationId());
+    assertNotNull(reservationInfo);
+    assertEquals(applyReservationId, reservationInfo.getReservationId());
 
     ReservationDefinitionInfo definitionInfo = reservationInfo.getReservationDefinition();
-    Assertions.assertNotNull(definitionInfo);
+    assertNotNull(definitionInfo);
 
     ReservationRequestsInfo reservationRequestsInfo = definitionInfo.getReservationRequests();
-    Assertions.assertNotNull(reservationRequestsInfo);
+    assertNotNull(reservationRequestsInfo);
 
     ArrayList<ReservationRequestInfo> reservationRequestInfoList =
         reservationRequestsInfo.getReservationRequest();
-    Assertions.assertNotNull(reservationRequestInfoList);
-    Assertions.assertEquals(1, reservationRequestInfoList.size());
+    assertNotNull(reservationRequestInfoList);
+    assertEquals(1, reservationRequestInfoList.size());
 
     ReservationRequestInfo reservationRequestInfo = reservationRequestInfoList.get(0);
-    Assertions.assertNotNull(reservationRequestInfo);
-    Assertions.assertEquals(4, reservationRequestInfo.getNumContainers());
+    assertNotNull(reservationRequestInfo);
+    assertEquals(4, reservationRequestInfo.getNumContainers());
 
     ResourceInfo resourceInfo = reservationRequestInfo.getCapability();
-    Assertions.assertNotNull(resourceInfo);
+    assertNotNull(resourceInfo);
 
     int vCore = resourceInfo.getvCores();
     long memory = resourceInfo.getMemorySize();
-    Assertions.assertEquals(1, vCore);
-    Assertions.assertEquals(1024, memory);
+    assertEquals(1, vCore);
+    assertEquals(1024, memory);
   }
 
   @Test
   public void testCreateNewReservation() throws Exception {
     Response response = interceptor.createNewReservation(null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof NewReservation);
+    assertNotNull(entity);
+    assertTrue(entity instanceof NewReservation);
 
     NewReservation newReservation = (NewReservation) entity;
-    Assertions.assertNotNull(newReservation);
-    Assertions.assertTrue(newReservation.getReservationId().contains("reservation"));
+    assertNotNull(newReservation);
+    assertTrue(newReservation.getReservationId().contains("reservation"));
   }
 
   @Test
@@ -1244,29 +1252,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 2);
     Response response = submitReservation(reservationId);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    assertNotNull(response);
+    assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     String applyReservationId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assertions.assertNotNull(reservationResponse);
+    assertNotNull(reservationResponse);
 
     Object entity = reservationResponse.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertNotNull(entity instanceof ReservationListInfo);
+    assertNotNull(entity);
+    assertNotNull(entity instanceof ReservationListInfo);
 
-    Assertions.assertTrue(entity instanceof ReservationListInfo);
+    assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assertions.assertNotNull(listInfo);
+    assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfos = listInfo.getReservations();
-    Assertions.assertNotNull(reservationInfos);
-    Assertions.assertEquals(1, reservationInfos.size());
+    assertNotNull(reservationInfos);
+    assertEquals(1, reservationInfos.size());
 
     ReservationInfo reservationInfo = reservationInfos.get(0);
-    Assertions.assertNotNull(reservationInfo);
-    Assertions.assertEquals(reservationInfo.getReservationId(), applyReservationId);
+    assertNotNull(reservationInfo);
+    assertEquals(reservationInfo.getReservationId(), applyReservationId);
   }
 
   @Test
@@ -1274,8 +1282,8 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 3);
     Response response = submitReservation(reservationId);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    assertNotNull(response);
+    assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     // update reservation
     ReservationSubmissionRequest resSubRequest =
@@ -1288,52 +1296,52 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     updateRequestInfo.setReservationId(reservationId.toString());
     updateRequestInfo.setReservationDefinition(reservationDefinitionInfo);
     Response updateReservationResp = interceptor.updateReservation(updateRequestInfo, null);
-    Assertions.assertNotNull(updateReservationResp);
-    Assertions.assertEquals(Status.OK.getStatusCode(), updateReservationResp.getStatus());
+    assertNotNull(updateReservationResp);
+    assertEquals(Status.OK.getStatusCode(), updateReservationResp.getStatus());
 
     String applyReservationId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
             QUEUE_DEDICATED_FULL, applyReservationId, -1, -1, false, null);
-    Assertions.assertNotNull(reservationResponse);
+    assertNotNull(reservationResponse);
 
     Object entity = reservationResponse.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertNotNull(entity instanceof ReservationListInfo);
+    assertNotNull(entity);
+    assertNotNull(entity instanceof ReservationListInfo);
 
-    Assertions.assertTrue(entity instanceof ReservationListInfo);
+    assertTrue(entity instanceof ReservationListInfo);
     ReservationListInfo listInfo = (ReservationListInfo) entity;
-    Assertions.assertNotNull(listInfo);
+    assertNotNull(listInfo);
 
     List<ReservationInfo> reservationInfos = listInfo.getReservations();
-    Assertions.assertNotNull(reservationInfos);
-    Assertions.assertEquals(1, reservationInfos.size());
+    assertNotNull(reservationInfos);
+    assertEquals(1, reservationInfos.size());
 
     ReservationInfo reservationInfo = reservationInfos.get(0);
-    Assertions.assertNotNull(reservationInfo);
-    Assertions.assertEquals(reservationInfo.getReservationId(), applyReservationId);
+    assertNotNull(reservationInfo);
+    assertEquals(reservationInfo.getReservationId(), applyReservationId);
 
     ReservationDefinitionInfo resDefinitionInfo = reservationInfo.getReservationDefinition();
-    Assertions.assertNotNull(resDefinitionInfo);
+    assertNotNull(resDefinitionInfo);
 
     ReservationRequestsInfo reservationRequestsInfo = resDefinitionInfo.getReservationRequests();
-    Assertions.assertNotNull(reservationRequestsInfo);
+    assertNotNull(reservationRequestsInfo);
 
     ArrayList<ReservationRequestInfo> reservationRequestInfoList =
             reservationRequestsInfo.getReservationRequest();
-    Assertions.assertNotNull(reservationRequestInfoList);
-    Assertions.assertEquals(1, reservationRequestInfoList.size());
+    assertNotNull(reservationRequestInfoList);
+    assertEquals(1, reservationRequestInfoList.size());
 
     ReservationRequestInfo reservationRequestInfo = reservationRequestInfoList.get(0);
-    Assertions.assertNotNull(reservationRequestInfo);
-    Assertions.assertEquals(6, reservationRequestInfo.getNumContainers());
+    assertNotNull(reservationRequestInfo);
+    assertEquals(6, reservationRequestInfo.getNumContainers());
 
     ResourceInfo resourceInfo = reservationRequestInfo.getCapability();
-    Assertions.assertNotNull(resourceInfo);
+    assertNotNull(resourceInfo);
 
     int vCore = resourceInfo.getvCores();
     long memory = resourceInfo.getMemorySize();
-    Assertions.assertEquals(2, vCore);
-    Assertions.assertEquals(2048, memory);
+    assertEquals(2, vCore);
+    assertEquals(2048, memory);
   }
 
   @Test
@@ -1341,19 +1349,19 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // submit reservation
     ReservationId reservationId = ReservationId.newInstance(Time.now(), 4);
     Response response = submitReservation(reservationId);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+    assertNotNull(response);
+    assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
 
     String applyResId = reservationId.toString();
     Response reservationResponse = interceptor.listReservation(
         QUEUE_DEDICATED_FULL, applyResId, -1, -1, false, null);
-    Assertions.assertNotNull(reservationResponse);
+    assertNotNull(reservationResponse);
 
     ReservationDeleteRequestInfo deleteRequestInfo =
         new ReservationDeleteRequestInfo();
     deleteRequestInfo.setReservationId(applyResId);
     Response delResponse = interceptor.deleteReservation(deleteRequestInfo, null);
-    Assertions.assertNotNull(delResponse);
+    assertNotNull(delResponse);
 
     LambdaTestUtils.intercept(Exception.class,
         "reservationId with id: " + reservationId + " not found",
@@ -1425,7 +1433,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String expectedHttpWebAddress = "http://0.0.0.0:8000";
     String webAppAddressWithScheme =
         WebAppUtils.getHttpSchemePrefix(this.getConf()) + webAppAddress;
-    Assertions.assertEquals(expectedHttpWebAddress, webAppAddressWithScheme);
+    assertEquals(expectedHttpWebAddress, webAppAddressWithScheme);
 
     // 2. We try to enable Https，at this point we should get the following link:
     // https://0.0.0.0:8000
@@ -1435,7 +1443,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     String expectedHttpsWebAddress = "https://0.0.0.0:8000";
     String webAppAddressWithScheme2 =
         WebAppUtils.getHttpSchemePrefix(this.getConf()) + webAppAddress;
-    Assertions.assertEquals(expectedHttpsWebAddress, webAppAddressWithScheme2);
+    assertEquals(expectedHttpsWebAddress, webAppAddressWithScheme2);
   }
 
   @Test
@@ -1481,14 +1489,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     HttpServletRequest mockHsr = mockHttpServletRequestByUserName(mockUser);
     RMQueueAclInfo aclInfo =
         interceptor.checkUserAccessToQueue(queue, userName, queueACL.name(), mockHsr);
-    Assertions.assertNotNull(aclInfo);
-    Assertions.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
+    assertNotNull(aclInfo);
+    assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
     FederationRMQueueAclInfo fedAclInfo = (FederationRMQueueAclInfo) aclInfo;
     List<RMQueueAclInfo> aclInfos = fedAclInfo.getList();
-    Assertions.assertNotNull(aclInfos);
-    Assertions.assertEquals(4, aclInfos.size());
+    assertNotNull(aclInfos);
+    assertEquals(4, aclInfos.size());
     for (RMQueueAclInfo rMQueueAclInfo : aclInfos) {
-      Assertions.assertTrue(rMQueueAclInfo.isAllowed());
+      assertTrue(rMQueueAclInfo.isAllowed());
     }
   }
 
@@ -1497,17 +1505,17 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     HttpServletRequest mockHsr = mockHttpServletRequestByUserName(mockUser);
     RMQueueAclInfo aclInfo =
         interceptor.checkUserAccessToQueue(queue, userName, queueACL.name(), mockHsr);
-    Assertions.assertNotNull(aclInfo);
-    Assertions.assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
+    assertNotNull(aclInfo);
+    assertTrue(aclInfo instanceof FederationRMQueueAclInfo);
     FederationRMQueueAclInfo fedAclInfo = (FederationRMQueueAclInfo) aclInfo;
     List<RMQueueAclInfo> aclInfos = fedAclInfo.getList();
-    Assertions.assertNotNull(aclInfos);
-    Assertions.assertEquals(4, aclInfos.size());
+    assertNotNull(aclInfos);
+    assertEquals(4, aclInfos.size());
     for (RMQueueAclInfo rMQueueAclInfo : aclInfos) {
-      Assertions.assertFalse(rMQueueAclInfo.isAllowed());
+      assertFalse(rMQueueAclInfo.isAllowed());
       String expectDiagnostics = "User=" + userName +
           " doesn't have access to queue=queue with acl-type=" + queueACL.name();
-      Assertions.assertEquals(expectDiagnostics, rMQueueAclInfo.getDiagnostics());
+      assertEquals(expectDiagnostics, rMQueueAclInfo.getDiagnostics());
     }
   }
 
@@ -1534,9 +1542,9 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     DefaultRequestInterceptorREST interceptorREST =
         rest.getOrCreateInterceptorForSubCluster(subClusterId, webAppSocket);
 
-    Assertions.assertNotNull(interceptorREST);
-    Assertions.assertNotNull(interceptorREST.getClient());
-    Assertions.assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
+    assertNotNull(interceptorREST);
+    assertNotNull(interceptorREST.getClient());
+    assertEquals(webAppAddress, interceptorREST.getWebAppAddress());
   }
 
   @Test
@@ -1552,18 +1560,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // of the multi-thread call can match the node data
     Map<SubClusterInfo, NodesInfo> subClusterInfoNodesInfoMap =
         interceptor.invokeConcurrentGetNodeLabel();
-    Assertions.assertNotNull(subClusterInfoNodesInfoMap);
-    Assertions.assertEquals(4, subClusterInfoNodesInfoMap.size());
+    assertNotNull(subClusterInfoNodesInfoMap);
+    assertEquals(4, subClusterInfoNodesInfoMap.size());
 
     subClusterInfoNodesInfoMap.forEach((subClusterInfo, nodesInfo) -> {
       String subClusterId = subClusterInfo.getSubClusterId().getId();
       List<NodeInfo> nodeInfos = nodesInfo.getNodes();
-      Assertions.assertNotNull(nodeInfos);
-      Assertions.assertEquals(1, nodeInfos.size());
+      assertNotNull(nodeInfos);
+      assertEquals(1, nodeInfos.size());
 
       String expectNodeId = "Node " + subClusterId;
       String nodeId = nodeInfos.get(0).getNodeId();
-      Assertions.assertEquals(expectNodeId, nodeId);
+      assertEquals(expectNodeId, nodeId);
     });
   }
 
@@ -1571,54 +1579,54 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetSchedulerInfo() {
     // In this test case, we will get the return results of 4 sub-clusters.
     SchedulerTypeInfo typeInfo = interceptor.getSchedulerInfo();
-    Assertions.assertNotNull(typeInfo);
-    Assertions.assertTrue(typeInfo instanceof FederationSchedulerTypeInfo);
+    assertNotNull(typeInfo);
+    assertTrue(typeInfo instanceof FederationSchedulerTypeInfo);
 
     FederationSchedulerTypeInfo federationSchedulerTypeInfo =
         (FederationSchedulerTypeInfo) typeInfo;
-    Assertions.assertNotNull(federationSchedulerTypeInfo);
+    assertNotNull(federationSchedulerTypeInfo);
     List<SchedulerTypeInfo> schedulerTypeInfos = federationSchedulerTypeInfo.getList();
-    Assertions.assertNotNull(schedulerTypeInfos);
-    Assertions.assertEquals(4, schedulerTypeInfos.size());
+    assertNotNull(schedulerTypeInfos);
+    assertEquals(4, schedulerTypeInfos.size());
     List<String> subClusterIds = subClusters.stream().map(SubClusterId::getId).
         collect(Collectors.toList());
 
     for (SchedulerTypeInfo schedulerTypeInfo : schedulerTypeInfos) {
-      Assertions.assertNotNull(schedulerTypeInfo);
+      assertNotNull(schedulerTypeInfo);
 
       // 1. Whether the returned subClusterId is in the subCluster list
       String subClusterId = schedulerTypeInfo.getSubClusterId();
-      Assertions.assertTrue(subClusterIds.contains(subClusterId));
+      assertTrue(subClusterIds.contains(subClusterId));
 
       // 2. We test CapacityScheduler, the returned type should be CapacityScheduler.
       SchedulerInfo schedulerInfo = schedulerTypeInfo.getSchedulerInfo();
-      Assertions.assertNotNull(schedulerInfo);
-      Assertions.assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
+      assertNotNull(schedulerInfo);
+      assertTrue(schedulerInfo instanceof CapacitySchedulerInfo);
       CapacitySchedulerInfo capacitySchedulerInfo = (CapacitySchedulerInfo) schedulerInfo;
-      Assertions.assertNotNull(capacitySchedulerInfo);
+      assertNotNull(capacitySchedulerInfo);
 
       // 3. The parent queue name should be root
       String queueName = capacitySchedulerInfo.getQueueName();
-      Assertions.assertEquals("root", queueName);
+      assertEquals("root", queueName);
 
       // 4. schedulerType should be CapacityScheduler
       String schedulerType = capacitySchedulerInfo.getSchedulerType();
-      Assertions.assertEquals("Capacity Scheduler", schedulerType);
+      assertEquals("Capacity Scheduler", schedulerType);
 
       // 5. queue path should be root
       String queuePath = capacitySchedulerInfo.getQueuePath();
-      Assertions.assertEquals("root", queuePath);
+      assertEquals("root", queuePath);
 
       // 6. mockRM has 2 test queues, [root.a, root.b]
       List<String> queues = Lists.newArrayList("root.a", "root.b");
       CapacitySchedulerQueueInfoList csSchedulerQueueInfoList = capacitySchedulerInfo.getQueues();
-      Assertions.assertNotNull(csSchedulerQueueInfoList);
+      assertNotNull(csSchedulerQueueInfoList);
       List<CapacitySchedulerQueueInfo> csQueueInfoList =
           csSchedulerQueueInfoList.getQueueInfoList();
-      Assertions.assertEquals(2, csQueueInfoList.size());
+      assertEquals(2, csQueueInfoList.size());
       for (CapacitySchedulerQueueInfo csQueueInfo : csQueueInfoList) {
-        Assertions.assertNotNull(csQueueInfo);
-        Assertions.assertTrue(queues.contains(csQueueInfo.getQueuePath()));
+        assertNotNull(csQueueInfo);
+        assertTrue(queues.contains(csQueueInfo.getQueuePath()));
       }
     }
   }
@@ -1653,15 +1661,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // If we don't set the authentication type, we will get error message.
     Response response = interceptor.postDelegationToken(token, request);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(response.getStatus(), Status.FORBIDDEN.getStatusCode());
+    assertNotNull(response);
+    assertEquals(response.getStatus(), Status.FORBIDDEN.getStatusCode());
     String errMsg = "Delegation token operations can only be carried out on a " +
         "Kerberos authenticated channel. Expected auth type is kerberos, got type null";
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof String);
+    assertNotNull(entity);
+    assertTrue(entity instanceof String);
     String entityMsg = String.valueOf(entity);
-    Assertions.assertTrue(errMsg.contains(entityMsg));
+    assertTrue(errMsg.contains(entityMsg));
   }
 
   @Test
@@ -1680,18 +1688,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof DelegationToken);
+    assertNotNull(entity);
+    assertTrue(entity instanceof DelegationToken);
 
     DelegationToken dtoken = (DelegationToken) entity;
-    Assertions.assertEquals(TEST_RENEWER, dtoken.getRenewer());
-    Assertions.assertEquals(TEST_RENEWER, dtoken.getOwner());
-    Assertions.assertEquals("RM_DELEGATION_TOKEN", dtoken.getKind());
-    Assertions.assertNotNull(dtoken.getToken());
-    Assertions.assertTrue(dtoken.getNextExpirationTime() > now);
+    assertEquals(TEST_RENEWER, dtoken.getRenewer());
+    assertEquals(TEST_RENEWER, dtoken.getOwner());
+    assertEquals("RM_DELEGATION_TOKEN", dtoken.getKind());
+    assertNotNull(dtoken.getToken());
+    assertTrue(dtoken.getNextExpirationTime() > now);
   }
 
   @Test
@@ -1731,28 +1739,28 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof DelegationToken);
+    assertNotNull(entity);
+    assertTrue(entity instanceof DelegationToken);
     DelegationToken dtoken = (DelegationToken) entity;
 
     final String yarnTokenHeader = "Hadoop-YARN-RM-Delegation-Token";
     when(request.getHeader(yarnTokenHeader)).thenReturn(dtoken.getToken());
 
     Response renewResponse = interceptor.postDelegationTokenExpiration(request);
-    Assertions.assertNotNull(renewResponse);
+    assertNotNull(renewResponse);
 
     Object renewEntity = renewResponse.getEntity();
-    Assertions.assertNotNull(renewEntity);
-    Assertions.assertTrue(renewEntity instanceof DelegationToken);
+    assertNotNull(renewEntity);
+    assertTrue(renewEntity instanceof DelegationToken);
 
     // renewDelegation, we only return renewDate, other values are NULL.
     DelegationToken renewDToken = (DelegationToken) renewEntity;
-    Assertions.assertNull(renewDToken.getRenewer());
-    Assertions.assertNull(renewDToken.getOwner());
-    Assertions.assertNull(renewDToken.getKind());
-    Assertions.assertTrue(renewDToken.getNextExpirationTime() > dtoken.getNextExpirationTime());
+    assertNull(renewDToken.getRenewer());
+    assertNull(renewDToken.getOwner());
+    assertNull(renewDToken.getKind());
+    assertTrue(renewDToken.getNextExpirationTime() > dtoken.getNextExpirationTime());
   }
 
   @Test
@@ -1769,18 +1777,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(request.getAuthType()).thenReturn("kerberos");
 
     Response response = interceptor.postDelegationToken(token, request);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof DelegationToken);
+    assertNotNull(entity);
+    assertTrue(entity instanceof DelegationToken);
     DelegationToken dtoken = (DelegationToken) entity;
 
     final String yarnTokenHeader = "Hadoop-YARN-RM-Delegation-Token";
     when(request.getHeader(yarnTokenHeader)).thenReturn(dtoken.getToken());
 
     Response cancelResponse = interceptor.cancelDelegationToken(request);
-    Assertions.assertNotNull(cancelResponse);
-    Assertions.assertEquals(response.getStatus(), Status.OK.getStatusCode());
+    assertNotNull(cancelResponse);
+    assertEquals(response.getStatus(), Status.OK.getStatusCode());
   }
 
   @Test
@@ -1805,20 +1813,20 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // subCluster#0:Success;subCluster#1:Success;subCluster#3:Success;subCluster#2:Success;
     // We can't confirm the complete return order.
     Response response = interceptor.replaceLabelsOnNodes(nodeToLabelsEntryList, null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(200, response.getStatus());
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
 
     Object entityObject = response.getEntity();
-    Assertions.assertNotNull(entityObject);
+    assertNotNull(entityObject);
 
     String entityValue = String.valueOf(entityObject);
     String[] entities = entityValue.split(",");
-    Assertions.assertNotNull(entities);
-    Assertions.assertEquals(4, entities.length);
+    assertNotNull(entities);
+    assertEquals(4, entities.length);
     String expectValue =
         "subCluster-0:Success,subCluster-1:Success,subCluster-2:Success,subCluster-3:Success,";
     for (String entity : entities) {
-      Assertions.assertTrue(expectValue.contains(entity));
+      assertTrue(expectValue.contains(entity));
     }
   }
 
@@ -1845,15 +1853,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     // We expect the following result: subCluster#3:Success;
     String expectValue = "subCluster#3:Success;";
     Response response = interceptor.replaceLabelsOnNode(labels, null, nodeId);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(200, response.getStatus());
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
 
     Object entityObject = response.getEntity();
-    Assertions.assertNotNull(entityObject);
+    assertNotNull(entityObject);
 
     String entityValue = String.valueOf(entityObject);
-    Assertions.assertNotNull(entityValue);
-    Assertions.assertEquals(expectValue, entityValue);
+    assertNotNull(entityValue);
+    assertEquals(expectValue, entityValue);
   }
 
   @Test
@@ -1886,11 +1894,11 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     // We cannot guarantee the calling order of the sub-clusters,
     // We guarantee that the returned result contains the information of each subCluster.
-    Assertions.assertNotNull(dumpSchedulerLogsMsg);
+    assertNotNull(dumpSchedulerLogsMsg);
     subClusters.forEach(subClusterId -> {
       String subClusterMsg =
           "subClusterId" + subClusterId + " : Capacity scheduler logs are being created.; ";
-      Assertions.assertTrue(dumpSchedulerLogsMsg.contains(subClusterMsg));
+      assertTrue(dumpSchedulerLogsMsg.contains(subClusterMsg));
     });
   }
 
@@ -1917,22 +1925,22 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testGetActivitiesNormal() {
     ActivitiesInfo activitiesInfo = interceptor.getActivities(null, "1", "DIAGNOSTIC");
-    Assertions.assertNotNull(activitiesInfo);
+    assertNotNull(activitiesInfo);
 
     String nodeId = activitiesInfo.getNodeId();
-    Assertions.assertNotNull(nodeId);
-    Assertions.assertEquals("1", nodeId);
+    assertNotNull(nodeId);
+    assertEquals("1", nodeId);
 
     String diagnostic = activitiesInfo.getDiagnostic();
-    Assertions.assertNotNull(diagnostic);
-    Assertions.assertTrue(StringUtils.contains(diagnostic, "Diagnostic"));
+    assertNotNull(diagnostic);
+    assertTrue(StringUtils.contains(diagnostic, "Diagnostic"));
 
     long timestamp = activitiesInfo.getTimestamp();
-    Assertions.assertEquals(1673081972L, timestamp);
+    assertEquals(1673081972L, timestamp);
 
     List<NodeAllocationInfo> allocationInfos = activitiesInfo.getAllocations();
-    Assertions.assertNotNull(allocationInfos);
-    Assertions.assertEquals(1, allocationInfos.size());
+    assertNotNull(allocationInfos);
+    assertEquals(1, allocationInfos.size());
   }
 
   @Test
@@ -1957,23 +1965,23 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   public void testGetBulkActivitiesNormal() throws InterruptedException {
     BulkActivitiesInfo bulkActivitiesInfo =
         interceptor.getBulkActivities(null, "DIAGNOSTIC", 5);
-    Assertions.assertNotNull(bulkActivitiesInfo);
+    assertNotNull(bulkActivitiesInfo);
 
-    Assertions.assertTrue(bulkActivitiesInfo instanceof FederationBulkActivitiesInfo);
+    assertTrue(bulkActivitiesInfo instanceof FederationBulkActivitiesInfo);
 
     FederationBulkActivitiesInfo federationBulkActivitiesInfo =
         (FederationBulkActivitiesInfo) bulkActivitiesInfo;
-    Assertions.assertNotNull(federationBulkActivitiesInfo);
+    assertNotNull(federationBulkActivitiesInfo);
 
     List<BulkActivitiesInfo> activitiesInfos = federationBulkActivitiesInfo.getList();
-    Assertions.assertNotNull(activitiesInfos);
-    Assertions.assertEquals(4, activitiesInfos.size());
+    assertNotNull(activitiesInfos);
+    assertEquals(4, activitiesInfos.size());
 
     for (BulkActivitiesInfo activitiesInfo : activitiesInfos) {
-      Assertions.assertNotNull(activitiesInfo);
+      assertNotNull(activitiesInfo);
       List<ActivitiesInfo> activitiesInfoList = activitiesInfo.getActivities();
-      Assertions.assertNotNull(activitiesInfoList);
-      Assertions.assertEquals(5, activitiesInfoList.size());
+      assertNotNull(activitiesInfoList);
+      assertEquals(5, activitiesInfoList.size());
     }
   }
 
@@ -2003,21 +2011,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     nodeLabelsInfo.getNodeLabelsInfo().add(nodeLabelInfo);
 
     Response response = interceptor.addToClusterNodeLabels(nodeLabelsInfo, null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assertions.assertNotNull(entityObj);
+    assertNotNull(entityObj);
 
     String entity = String.valueOf(entityObj);
     String[] entities = StringUtils.split(entity, ",");
-    Assertions.assertNotNull(entities);
-    Assertions.assertEquals(4, entities.length);
+    assertNotNull(entities);
+    assertEquals(4, entities.length);
 
     // The order in which the cluster returns messages is uncertain,
     // we confirm the result by contains
     String expectedMsg =
         "SubCluster-0:SUCCESS,SubCluster-1:SUCCESS,SubCluster-2:SUCCESS,SubCluster-3:SUCCESS";
-    Arrays.stream(entities).forEach(item -> Assertions.assertTrue(expectedMsg.contains(item)));
+    Arrays.stream(entities).forEach(item -> assertTrue(expectedMsg.contains(item)));
   }
 
   @Test
@@ -2029,14 +2037,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     nodeLabelsInfo.getNodeLabelsInfo().add(nodeLabelInfo);
 
     Response response = interceptor.addToClusterNodeLabels(nodeLabelsInfo, null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assertions.assertNotNull(entityObj);
+    assertNotNull(entityObj);
 
     String expectedValue = "SubCluster-0:SUCCESS,";
     String entity = String.valueOf(entityObj);
-    Assertions.assertTrue(entity.contains(expectedValue));
+    assertTrue(entity.contains(expectedValue));
   }
 
   @Test
@@ -2066,21 +2074,21 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     oldNodeLabels.add("ALL");
 
     Response response = interceptor.removeFromClusterNodeLabels(oldNodeLabels, null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assertions.assertNotNull(entityObj);
+    assertNotNull(entityObj);
 
     String entity = String.valueOf(entityObj);
     String[] entities = StringUtils.split(entity, ",");
-    Assertions.assertNotNull(entities);
-    Assertions.assertEquals(4, entities.length);
+    assertNotNull(entities);
+    assertEquals(4, entities.length);
 
     // The order in which the cluster returns messages is uncertain,
     // we confirm the result by contains
     String expectedMsg =
         "SubCluster-0:SUCCESS,SubCluster-1:SUCCESS,SubCluster-2:SUCCESS,SubCluster-3:SUCCESS";
-    Arrays.stream(entities).forEach(item -> Assertions.assertTrue(expectedMsg.contains(item)));
+    Arrays.stream(entities).forEach(item -> assertTrue(expectedMsg.contains(item)));
   }
 
   @Test
@@ -2089,14 +2097,14 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     oldNodeLabels.add("A0");
 
     Response response = interceptor.removeFromClusterNodeLabels(oldNodeLabels, null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     Object entityObj = response.getEntity();
-    Assertions.assertNotNull(entityObj);
+    assertNotNull(entityObj);
 
     String expectedValue = "SubCluster-0:SUCCESS,";
     String entity = String.valueOf(entityObj);
-    Assertions.assertTrue(entity.contains(expectedValue));
+    assertTrue(entity.contains(expectedValue));
   }
 
   @Test
@@ -2122,29 +2130,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
   @Test
   public void testGetSchedulerConfiguration() throws Exception {
     Response response = interceptor.getSchedulerConfiguration(null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(OK, response.getStatus());
+    assertNotNull(response);
+    assertEquals(OK, response.getStatus());
 
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
-    Assertions.assertTrue(entity instanceof FederationConfInfo);
+    assertNotNull(entity);
+    assertTrue(entity instanceof FederationConfInfo);
 
     FederationConfInfo federationConfInfo = FederationConfInfo.class.cast(entity);
     List<ConfInfo> confInfos = federationConfInfo.getList();
-    Assertions.assertNotNull(confInfos);
-    Assertions.assertEquals(4, confInfos.size());
+    assertNotNull(confInfos);
+    assertEquals(4, confInfos.size());
 
     List<String> errors = federationConfInfo.getErrorMsgs();
-    Assertions.assertEquals(0, errors.size());
+    assertEquals(0, errors.size());
 
     Set<String> subClusterSet = subClusters.stream()
         .map(subClusterId -> subClusterId.getId()).collect(Collectors.toSet());
 
     for (ConfInfo confInfo : confInfos) {
       List<ConfInfo.ConfItem> confItems = confInfo.getItems();
-      Assertions.assertNotNull(confItems);
-      Assertions.assertTrue(confItems.size() > 0);
-      Assertions.assertTrue(subClusterSet.contains(confInfo.getSubClusterId()));
+      assertNotNull(confItems);
+      assertTrue(confItems.size() > 0);
+      assertTrue(subClusterSet.contains(confInfo.getSubClusterId()));
     }
   }
 
@@ -2155,15 +2163,15 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     when(hsr.getRemoteUser()).thenReturn(requestUserName);
     ClusterUserInfo clusterUserInfo = interceptor.getClusterUserInfo(hsr);
 
-    Assertions.assertNotNull(clusterUserInfo);
-    Assertions.assertTrue(clusterUserInfo instanceof FederationClusterUserInfo);
+    assertNotNull(clusterUserInfo);
+    assertTrue(clusterUserInfo instanceof FederationClusterUserInfo);
 
     FederationClusterUserInfo federationClusterUserInfo =
         (FederationClusterUserInfo) clusterUserInfo;
 
     List<ClusterUserInfo> fedClusterUserInfoList = federationClusterUserInfo.getList();
-    Assertions.assertNotNull(fedClusterUserInfoList);
-    Assertions.assertEquals(4, fedClusterUserInfoList.size());
+    assertNotNull(fedClusterUserInfoList);
+    assertEquals(4, fedClusterUserInfoList.size());
 
     List<String> subClusterIds = subClusters.stream().map(
         subClusterId -> subClusterId.getId()).collect(Collectors.toList());
@@ -2172,18 +2180,18 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     for (ClusterUserInfo fedClusterUserInfo : fedClusterUserInfoList) {
       // Check subClusterId
       String subClusterId = fedClusterUserInfo.getSubClusterId();
-      Assertions.assertNotNull(subClusterId);
-      Assertions.assertTrue(subClusterIds.contains(subClusterId));
+      assertNotNull(subClusterId);
+      assertTrue(subClusterIds.contains(subClusterId));
 
       // Check requestedUser
       String requestedUser = fedClusterUserInfo.getRequestedUser();
-      Assertions.assertNotNull(requestedUser);
-      Assertions.assertEquals(requestUserName, requestedUser);
+      assertNotNull(requestedUser);
+      assertEquals(requestUserName, requestedUser);
 
       // Check rmLoginUser
       String rmLoginUser = fedClusterUserInfo.getRmLoginUser();
-      Assertions.assertNotNull(rmLoginUser);
-      Assertions.assertEquals(mockRM.getRMLoginUser(), rmLoginUser);
+      assertNotNull(rmLoginUser);
+      assertEquals(mockRM.getRMLoginUser(), rmLoginUser);
     }
   }
 
@@ -2211,29 +2219,29 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     updateInfo.getUpdateQueueInfo().add(goodUpdateInfo);
     Response response = interceptor.updateSchedulerConfiguration(updateInfo, null);
 
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(OK, response.getStatus());
+    assertNotNull(response);
+    assertEquals(OK, response.getStatus());
 
     String expectMsg = "Configuration change successfully applied.";
     Object entity = response.getEntity();
-    Assertions.assertNotNull(entity);
+    assertNotNull(entity);
 
     String entityMsg = String.valueOf(entity);
-    Assertions.assertEquals(expectMsg, entityMsg);
+    assertEquals(expectMsg, entityMsg);
   }
 
   @Test
   public void testGetClusterInfo() {
     ClusterInfo clusterInfos = interceptor.getClusterInfo();
-    Assertions.assertNotNull(clusterInfos);
-    Assertions.assertTrue(clusterInfos instanceof FederationClusterInfo);
+    assertNotNull(clusterInfos);
+    assertTrue(clusterInfos instanceof FederationClusterInfo);
 
     FederationClusterInfo federationClusterInfos =
         (FederationClusterInfo) (clusterInfos);
 
     List<ClusterInfo> fedClusterInfosList = federationClusterInfos.getList();
-    Assertions.assertNotNull(fedClusterInfosList);
-    Assertions.assertEquals(4, fedClusterInfosList.size());
+    assertNotNull(fedClusterInfosList);
+    assertEquals(4, fedClusterInfosList.size());
 
     List<String> subClusterIds = subClusters.stream().map(
         subClusterId -> subClusterId.getId()).collect(Collectors.toList());
@@ -2244,23 +2252,23 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
     for (ClusterInfo clusterInfo : fedClusterInfosList) {
       String subClusterId = clusterInfo.getSubClusterId();
       // Check subClusterId
-      Assertions.assertTrue(subClusterIds.contains(subClusterId));
+      assertTrue(subClusterIds.contains(subClusterId));
 
       // Check state
       String clusterState = mockRM.getServiceState().toString();
-      Assertions.assertEquals(clusterState, clusterInfo.getState());
+      assertEquals(clusterState, clusterInfo.getState());
 
       // Check rmStateStoreName
       String rmStateStoreName =
           mockRM.getRMContext().getStateStore().getClass().getName();
-      Assertions.assertEquals(rmStateStoreName, clusterInfo.getRMStateStore());
+      assertEquals(rmStateStoreName, clusterInfo.getRMStateStore());
 
       // Check RM Version
-      Assertions.assertEquals(yarnVersion, clusterInfo.getRMVersion());
+      assertEquals(yarnVersion, clusterInfo.getRMVersion());
 
       // Check haZooKeeperConnectionState
       String rmHAZookeeperConnectionState = mockRM.getRMContext().getHAZookeeperConnectionState();
-      Assertions.assertEquals(rmHAZookeeperConnectionState,
+      assertEquals(rmHAZookeeperConnectionState,
           clusterInfo.getHAZookeeperConnectionState());
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -20,10 +20,12 @@ package org.apache.hadoop.yarn.server.router.webapp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,7 +34,6 @@ import java.util.List;
 import javax.ws.rs.core.Response;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -315,7 +316,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    assertNull(response);
+    assertNotNull(response);
+    assertTrue(response.getApps().isEmpty());
   }
 
   /**
@@ -329,7 +331,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    assertNull(response);
+    assertNotNull(response);
+    assertTrue(response.getApps().isEmpty());
   }
 
   /**
@@ -378,7 +381,8 @@ public class TestFederationInterceptorRESTRetry
       interceptor.getNode("testGetNodeTwoBadSCs");
       fail();
     } catch (NotFoundException e) {
-      assertTrue(e.getMessage()
+      String stackTraceAsString = getStackTraceAsString(e);
+      assertTrue(stackTraceAsString
           .contains("nodeId, testGetNodeTwoBadSCs, is not found"));
     }
   }
@@ -408,8 +412,11 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -421,8 +428,11 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(bad1, bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -433,8 +443,11 @@ public class TestFederationInterceptorRESTRetry
   public void testGetNodesOneBadOneGood() throws Exception {
     setupCluster(Arrays.asList(good, bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -586,5 +599,12 @@ public class TestFederationInterceptorRESTRetry
     interceptor.setAllowPartialResult(false);
 
     setupCluster(Arrays.asList(good, bad2));
+  }
+
+  private String getStackTraceAsString(Exception e) {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    e.printStackTrace(pw);
+    return sw.toString();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -47,8 +47,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodesInfo;
 import org.apache.hadoop.yarn.server.router.clientrm.PassThroughClientRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.clientrm.TestableFederationClientInterceptor;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +133,7 @@ public class TestFederationInterceptorRESTRetry
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -176,8 +176,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -194,8 +194,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -211,16 +211,16 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(good, bad2));
     Response response = interceptor.createNewApplication(null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(OK, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(OK, response.getStatus());
 
     NewApplication newApp = (NewApplication) response.getEntity();
-    Assert.assertNotNull(newApp);
+    Assertions.assertNotNull(newApp);
 
     ApplicationId appId = ApplicationId.fromString(newApp.getApplicationId());
-    Assert.assertNotNull(appId);
+    Assertions.assertNotNull(appId);
 
-    Assert.assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
+    Assertions.assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
   }
 
   /**
@@ -242,8 +242,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -263,8 +263,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -285,9 +285,9 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertEquals(ACCEPTED, response.getStatus());
+    Assertions.assertEquals(ACCEPTED, response.getStatus());
 
-    Assert.assertEquals(good,
+    Assertions.assertEquals(good,
         stateStore
             .getApplicationHomeSubCluster(
                 GetApplicationHomeSubClusterRequest.newInstance(appId))
@@ -306,7 +306,7 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -320,7 +320,7 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNull(response);
+    Assertions.assertNull(response);
   }
 
   /**
@@ -334,8 +334,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(1, response.getApps().size());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(1, response.getApps().size());
   }
 
   /**
@@ -349,9 +349,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
     try {
       interceptor.getNode("testGetNodeOneBadSC");
-      Assert.fail();
+      Assertions.fail();
     } catch (NotFoundException e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
     }
   }
@@ -367,9 +367,9 @@ public class TestFederationInterceptorRESTRetry
 
     try {
       interceptor.getNode("testGetNodeTwoBadSCs");
-      Assert.fail();
+      Assertions.fail();
     } catch (NotFoundException e) {
-      Assert.assertTrue(e.getMessage()
+      Assertions.assertTrue(e.getMessage()
           .contains("nodeId, testGetNodeTwoBadSCs, is not found"));
     }
   }
@@ -384,9 +384,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodeInfo response = interceptor.getNode(null);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     // Check if the only node came from Good SubCluster
-    Assert.assertEquals(good.getId(),
+    Assertions.assertEquals(good.getId(),
         Long.toString(response.getLastHealthUpdate()));
   }
 
@@ -439,7 +439,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     // check if we got an empty metrics
     checkEmptyMetrics(response);
   }
@@ -455,9 +455,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     // check if we got an empty metrics
-    Assert.assertEquals(0, response.getAppsSubmitted());
+    Assertions.assertEquals(0, response.getAppsSubmitted());
   }
 
   /**
@@ -473,56 +473,56 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     checkMetricsFromGoodSC(response);
     // The merge operations is tested in TestRouterWebServiceUtil
   }
 
   private void checkMetricsFromGoodSC(ClusterMetricsInfo response) {
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsSubmitted());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsCompleted());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsPending());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsRunning());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsFailed());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    Assertions.assertEquals(Integer.parseInt(good.getId()),
         response.getAppsKilled());
   }
 
   private void checkEmptyMetrics(ClusterMetricsInfo response) {
-    Assert.assertEquals(0, response.getAppsSubmitted());
-    Assert.assertEquals(0, response.getAppsCompleted());
-    Assert.assertEquals(0, response.getAppsPending());
-    Assert.assertEquals(0, response.getAppsRunning());
-    Assert.assertEquals(0, response.getAppsFailed());
-    Assert.assertEquals(0, response.getAppsKilled());
+    Assertions.assertEquals(0, response.getAppsSubmitted());
+    Assertions.assertEquals(0, response.getAppsCompleted());
+    Assertions.assertEquals(0, response.getAppsPending());
+    Assertions.assertEquals(0, response.getAppsRunning());
+    Assertions.assertEquals(0, response.getAppsFailed());
+    Assertions.assertEquals(0, response.getAppsKilled());
 
-    Assert.assertEquals(0, response.getReservedMB());
-    Assert.assertEquals(0, response.getAvailableMB());
-    Assert.assertEquals(0, response.getAllocatedMB());
+    Assertions.assertEquals(0, response.getReservedMB());
+    Assertions.assertEquals(0, response.getAvailableMB());
+    Assertions.assertEquals(0, response.getAllocatedMB());
 
-    Assert.assertEquals(0, response.getReservedVirtualCores());
-    Assert.assertEquals(0, response.getAvailableVirtualCores());
-    Assert.assertEquals(0, response.getAllocatedVirtualCores());
+    Assertions.assertEquals(0, response.getReservedVirtualCores());
+    Assertions.assertEquals(0, response.getAvailableVirtualCores());
+    Assertions.assertEquals(0, response.getAllocatedVirtualCores());
 
-    Assert.assertEquals(0, response.getContainersAllocated());
-    Assert.assertEquals(0, response.getReservedContainers());
-    Assert.assertEquals(0, response.getPendingContainers());
+    Assertions.assertEquals(0, response.getContainersAllocated());
+    Assertions.assertEquals(0, response.getReservedContainers());
+    Assertions.assertEquals(0, response.getPendingContainers());
 
-    Assert.assertEquals(0, response.getTotalMB());
-    Assert.assertEquals(0, response.getTotalVirtualCores());
-    Assert.assertEquals(0, response.getTotalNodes());
-    Assert.assertEquals(0, response.getLostNodes());
-    Assert.assertEquals(0, response.getUnhealthyNodes());
-    Assert.assertEquals(0, response.getDecommissioningNodes());
-    Assert.assertEquals(0, response.getDecommissionedNodes());
-    Assert.assertEquals(0, response.getRebootedNodes());
-    Assert.assertEquals(0, response.getActiveNodes());
-    Assert.assertEquals(0, response.getShutdownNodes());
+    Assertions.assertEquals(0, response.getTotalMB());
+    Assertions.assertEquals(0, response.getTotalVirtualCores());
+    Assertions.assertEquals(0, response.getTotalNodes());
+    Assertions.assertEquals(0, response.getLostNodes());
+    Assertions.assertEquals(0, response.getUnhealthyNodes());
+    Assertions.assertEquals(0, response.getDecommissioningNodes());
+    Assertions.assertEquals(0, response.getDecommissionedNodes());
+    Assertions.assertEquals(0, response.getRebootedNodes());
+    Assertions.assertEquals(0, response.getActiveNodes());
+    Assertions.assertEquals(0, response.getShutdownNodes());
   }
 
   @Test
@@ -535,7 +535,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assert.assertNotNull(nodesInfo);
+    Assertions.assertNotNull(nodesInfo);
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -551,7 +551,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assert.assertNotNull(nodesInfo);
+    Assertions.assertNotNull(nodesInfo);
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -566,10 +566,10 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodesInfo response = interceptor.getNodes(null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(1, response.getNodes().size());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(1, response.getNodes().size());
     // Check if the only node came from Good SubCluster
-    Assert.assertEquals(good.getId(),
+    Assertions.assertEquals(good.getId(),
         Long.toString(response.getNodes().get(0).getLastHealthUpdate()));
 
     // allowPartialResult = false,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +53,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodesInfo;
 import org.apache.hadoop.yarn.server.router.clientrm.PassThroughClientRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.clientrm.TestableFederationClientInterceptor;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +87,7 @@ public class TestFederationInterceptorRESTRetry
   private FederationStateStoreTestUtil stateStoreUtil;
   private String user = "test-user";
 
+  @BeforeEach
   @Override
   public void setUp() {
     super.setUpConfig();
@@ -115,6 +123,7 @@ public class TestFederationInterceptorRESTRetry
     interceptor.registerBadSubCluster(bad2);
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();
@@ -133,7 +142,7 @@ public class TestFederationInterceptorRESTRetry
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assertions.fail();
+      fail();
     }
   }
 
@@ -176,8 +185,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -194,8 +203,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -211,16 +220,16 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(good, bad2));
     Response response = interceptor.createNewApplication(null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(OK, response.getStatus());
+    assertNotNull(response);
+    assertEquals(OK, response.getStatus());
 
     NewApplication newApp = (NewApplication) response.getEntity();
-    Assertions.assertNotNull(newApp);
+    assertNotNull(newApp);
 
     ApplicationId appId = ApplicationId.fromString(newApp.getApplicationId());
-    Assertions.assertNotNull(appId);
+    assertNotNull(appId);
 
-    Assertions.assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
+    assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
   }
 
   /**
@@ -242,8 +251,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -263,8 +272,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assertions.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assertions.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -285,9 +294,9 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
     Response response = interceptor.submitApplication(context, null);
 
-    Assertions.assertEquals(ACCEPTED, response.getStatus());
+    assertEquals(ACCEPTED, response.getStatus());
 
-    Assertions.assertEquals(good,
+    assertEquals(good,
         stateStore
             .getApplicationHomeSubCluster(
                 GetApplicationHomeSubClusterRequest.newInstance(appId))
@@ -306,7 +315,7 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -320,7 +329,7 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assertions.assertNull(response);
+    assertNull(response);
   }
 
   /**
@@ -334,8 +343,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(1, response.getApps().size());
+    assertNotNull(response);
+    assertEquals(1, response.getApps().size());
   }
 
   /**
@@ -349,9 +358,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
     try {
       interceptor.getNode("testGetNodeOneBadSC");
-      Assertions.fail();
+      fail();
     } catch (NotFoundException e) {
-      Assertions.assertTrue(
+      assertTrue(
           e.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
     }
   }
@@ -367,9 +376,9 @@ public class TestFederationInterceptorRESTRetry
 
     try {
       interceptor.getNode("testGetNodeTwoBadSCs");
-      Assertions.fail();
+      fail();
     } catch (NotFoundException e) {
-      Assertions.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("nodeId, testGetNodeTwoBadSCs, is not found"));
     }
   }
@@ -384,9 +393,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodeInfo response = interceptor.getNode(null);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     // Check if the only node came from Good SubCluster
-    Assertions.assertEquals(good.getId(),
+    assertEquals(good.getId(),
         Long.toString(response.getLastHealthUpdate()));
   }
 
@@ -439,7 +448,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     // check if we got an empty metrics
     checkEmptyMetrics(response);
   }
@@ -455,9 +464,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     // check if we got an empty metrics
-    Assertions.assertEquals(0, response.getAppsSubmitted());
+    assertEquals(0, response.getAppsSubmitted());
   }
 
   /**
@@ -473,56 +482,56 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
     checkMetricsFromGoodSC(response);
     // The merge operations is tested in TestRouterWebServiceUtil
   }
 
   private void checkMetricsFromGoodSC(ClusterMetricsInfo response) {
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsSubmitted());
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsCompleted());
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsPending());
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsRunning());
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsFailed());
-    Assertions.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsKilled());
   }
 
   private void checkEmptyMetrics(ClusterMetricsInfo response) {
-    Assertions.assertEquals(0, response.getAppsSubmitted());
-    Assertions.assertEquals(0, response.getAppsCompleted());
-    Assertions.assertEquals(0, response.getAppsPending());
-    Assertions.assertEquals(0, response.getAppsRunning());
-    Assertions.assertEquals(0, response.getAppsFailed());
-    Assertions.assertEquals(0, response.getAppsKilled());
+    assertEquals(0, response.getAppsSubmitted());
+    assertEquals(0, response.getAppsCompleted());
+    assertEquals(0, response.getAppsPending());
+    assertEquals(0, response.getAppsRunning());
+    assertEquals(0, response.getAppsFailed());
+    assertEquals(0, response.getAppsKilled());
 
-    Assertions.assertEquals(0, response.getReservedMB());
-    Assertions.assertEquals(0, response.getAvailableMB());
-    Assertions.assertEquals(0, response.getAllocatedMB());
+    assertEquals(0, response.getReservedMB());
+    assertEquals(0, response.getAvailableMB());
+    assertEquals(0, response.getAllocatedMB());
 
-    Assertions.assertEquals(0, response.getReservedVirtualCores());
-    Assertions.assertEquals(0, response.getAvailableVirtualCores());
-    Assertions.assertEquals(0, response.getAllocatedVirtualCores());
+    assertEquals(0, response.getReservedVirtualCores());
+    assertEquals(0, response.getAvailableVirtualCores());
+    assertEquals(0, response.getAllocatedVirtualCores());
 
-    Assertions.assertEquals(0, response.getContainersAllocated());
-    Assertions.assertEquals(0, response.getReservedContainers());
-    Assertions.assertEquals(0, response.getPendingContainers());
+    assertEquals(0, response.getContainersAllocated());
+    assertEquals(0, response.getReservedContainers());
+    assertEquals(0, response.getPendingContainers());
 
-    Assertions.assertEquals(0, response.getTotalMB());
-    Assertions.assertEquals(0, response.getTotalVirtualCores());
-    Assertions.assertEquals(0, response.getTotalNodes());
-    Assertions.assertEquals(0, response.getLostNodes());
-    Assertions.assertEquals(0, response.getUnhealthyNodes());
-    Assertions.assertEquals(0, response.getDecommissioningNodes());
-    Assertions.assertEquals(0, response.getDecommissionedNodes());
-    Assertions.assertEquals(0, response.getRebootedNodes());
-    Assertions.assertEquals(0, response.getActiveNodes());
-    Assertions.assertEquals(0, response.getShutdownNodes());
+    assertEquals(0, response.getTotalMB());
+    assertEquals(0, response.getTotalVirtualCores());
+    assertEquals(0, response.getTotalNodes());
+    assertEquals(0, response.getLostNodes());
+    assertEquals(0, response.getUnhealthyNodes());
+    assertEquals(0, response.getDecommissioningNodes());
+    assertEquals(0, response.getDecommissionedNodes());
+    assertEquals(0, response.getRebootedNodes());
+    assertEquals(0, response.getActiveNodes());
+    assertEquals(0, response.getShutdownNodes());
   }
 
   @Test
@@ -535,7 +544,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assertions.assertNotNull(nodesInfo);
+    assertNotNull(nodesInfo);
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -551,7 +560,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assertions.assertNotNull(nodesInfo);
+    assertNotNull(nodesInfo);
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -566,10 +575,10 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodesInfo response = interceptor.getNodes(null);
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(1, response.getNodes().size());
+    assertNotNull(response);
+    assertEquals(1, response.getNodes().size());
     // Check if the only node came from Good SubCluster
-    Assertions.assertEquals(good.getId(),
+    assertEquals(good.getId(),
         Long.toString(response.getNodes().get(0).getLastHealthUpdate()));
 
     // allowPartialResult = false,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -360,8 +360,8 @@ public class TestFederationInterceptorRESTRetry
       interceptor.getNode("testGetNodeOneBadSC");
       fail();
     } catch (NotFoundException e) {
-      assertTrue(
-          e.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
+      Throwable cause = e.getCause();
+      assertTrue(cause.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationWebApp.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
@@ -44,8 +44,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class TestRouterWebAppProxy {
@@ -79,7 +80,7 @@ public class TestRouterWebAppProxy {
   /**
    * Simple http server. Server should send answer with status 200
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     mockServer = new Server(0);
     ((QueuedThreadPool) mockServer.getThreadPool()).setMaxThreads(20);
@@ -96,7 +97,8 @@ public class TestRouterWebAppProxy {
     LOG.info("Running embedded servlet container at: http://localhost:" + mockServerPort);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testRouterWebAppProxyFed() throws Exception {
 
     Configuration conf = new Configuration();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -39,11 +39,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ApplicationStatisticsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.StatisticsItemInfo;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -105,8 +107,8 @@ public class TestRouterWebServiceUtil {
     apps.add(app4);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(4, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(4, result.getApps().size());
 
     List<String> appIds = new ArrayList<String>();
     AppInfo appInfo1 = null, appInfo2 = null, appInfo3 = null, appInfo4 = null;
@@ -126,28 +128,28 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assertions.assertTrue(appIds.contains(APPID1.toString()));
-    Assertions.assertTrue(appIds.contains(APPID2.toString()));
-    Assertions.assertTrue(appIds.contains(APPID3.toString()));
-    Assertions.assertTrue(appIds.contains(APPID4.toString()));
+    assertTrue(appIds.contains(APPID1.toString()));
+    assertTrue(appIds.contains(APPID2.toString()));
+    assertTrue(appIds.contains(APPID3.toString()));
+    assertTrue(appIds.contains(APPID4.toString()));
 
     // Check preservations APP1
-    Assertions.assertEquals(app1.getState(), appInfo1.getState());
-    Assertions.assertEquals(app1.getNumAMContainerPreempted(),
+    assertEquals(app1.getState(), appInfo1.getState());
+    assertEquals(app1.getNumAMContainerPreempted(),
         appInfo1.getNumAMContainerPreempted());
 
     // Check preservations APP2
-    Assertions.assertEquals(app2.getState(), appInfo2.getState());
-    Assertions.assertEquals(app3.getAllocatedVCores(),
+    assertEquals(app2.getState(), appInfo2.getState());
+    assertEquals(app3.getAllocatedVCores(),
         appInfo3.getAllocatedVCores());
 
     // Check preservations APP3
-    Assertions.assertEquals(app3.getState(), appInfo3.getState());
-    Assertions.assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
+    assertEquals(app3.getState(), appInfo3.getState());
+    assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
 
     // Check preservations APP3
-    Assertions.assertEquals(app4.getState(), appInfo4.getState());
-    Assertions.assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
+    assertEquals(app4.getState(), appInfo4.getState());
+    assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
   }
 
   /**
@@ -186,19 +188,19 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assertions.assertEquals(APPID1.toString(), app.getAppId());
-    Assertions.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assertions.assertEquals(value * 3, app.getPreemptedResourceMB());
-    Assertions.assertEquals(value * 3, app.getPreemptedResourceVCores());
-    Assertions.assertEquals(value * 3, app.getNumNonAMContainerPreempted());
-    Assertions.assertEquals(value * 3, app.getNumAMContainerPreempted());
-    Assertions.assertEquals(value * 3, app.getPreemptedMemorySeconds());
-    Assertions.assertEquals(value * 3, app.getPreemptedVcoreSeconds());
+    assertEquals(APPID1.toString(), app.getAppId());
+    assertEquals(amHost, app.getAMHostHttpAddress());
+    assertEquals(value * 3, app.getPreemptedResourceMB());
+    assertEquals(value * 3, app.getPreemptedResourceVCores());
+    assertEquals(value * 3, app.getNumNonAMContainerPreempted());
+    assertEquals(value * 3, app.getNumAMContainerPreempted());
+    assertEquals(value * 3, app.getPreemptedMemorySeconds());
+    assertEquals(value * 3, app.getPreemptedVcoreSeconds());
   }
 
   private void setAppInfoFinished(AppInfo am, int value) {
@@ -248,21 +250,21 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assertions.assertEquals(APPID2.toString(), app.getAppId());
-    Assertions.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assertions.assertEquals(value * 3, app.getAllocatedMB());
-    Assertions.assertEquals(value * 3, app.getAllocatedVCores());
-    Assertions.assertEquals(value * 3, app.getReservedMB());
-    Assertions.assertEquals(value * 3, app.getReservedVCores());
-    Assertions.assertEquals(value * 3, app.getRunningContainers());
-    Assertions.assertEquals(value * 3, app.getMemorySeconds());
-    Assertions.assertEquals(value * 3, app.getVcoreSeconds());
-    Assertions.assertEquals(3, app.getResourceRequests().size());
+    assertEquals(APPID2.toString(), app.getAppId());
+    assertEquals(amHost, app.getAMHostHttpAddress());
+    assertEquals(value * 3, app.getAllocatedMB());
+    assertEquals(value * 3, app.getAllocatedVCores());
+    assertEquals(value * 3, app.getReservedMB());
+    assertEquals(value * 3, app.getReservedVCores());
+    assertEquals(value * 3, app.getRunningContainers());
+    assertEquals(value * 3, app.getMemorySeconds());
+    assertEquals(value * 3, app.getVcoreSeconds());
+    assertEquals(3, app.getResourceRequests().size());
   }
 
   private void setAppInfoRunning(AppInfo am, int value) {
@@ -300,15 +302,15 @@ public class TestRouterWebServiceUtil {
     apps.add(app2);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(0, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(0, result.getApps().size());
 
     // By enabling partial result, the expected result would be a partial report
     // of the 2 UAMs
     AppsInfo result2 = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), true);
-    Assertions.assertNotNull(result2);
-    Assertions.assertEquals(1, result2.getApps().size());
-    Assertions.assertEquals(YarnApplicationState.RUNNING,
+    assertNotNull(result2);
+    assertEquals(1, result2.getApps().size());
+    assertEquals(YarnApplicationState.RUNNING,
         result2.getApps().get(0).getState());
   }
 
@@ -329,8 +331,8 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
   }
 
   /**
@@ -361,8 +363,8 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(4, result.getNodes().size());
+    assertNotNull(result);
+    assertEquals(4, result.getNodes().size());
 
     List<String> nodesIds = new ArrayList<String>();
 
@@ -370,10 +372,10 @@ public class TestRouterWebServiceUtil {
       nodesIds.add(node.getNodeId());
     }
 
-    Assertions.assertTrue(nodesIds.contains(NODE1));
-    Assertions.assertTrue(nodesIds.contains(NODE2));
-    Assertions.assertTrue(nodesIds.contains(NODE3));
-    Assertions.assertTrue(nodesIds.contains(NODE4));
+    assertTrue(nodesIds.contains(NODE1));
+    assertTrue(nodesIds.contains(NODE2));
+    assertTrue(nodesIds.contains(NODE3));
+    assertTrue(nodesIds.contains(NODE4));
   }
 
   /**
@@ -404,13 +406,13 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(1, result.getNodes().size());
+    assertNotNull(result);
+    assertEquals(1, result.getNodes().size());
 
     NodeInfo node = result.getNodes().get(0);
 
-    Assertions.assertEquals(NODE1, node.getNodeId());
-    Assertions.assertEquals(2, node.getLastHealthUpdate());
+    assertEquals(NODE1, node.getNodeId());
+    assertEquals(2, node.getLastHealthUpdate());
   }
 
   /**
@@ -431,98 +433,98 @@ public class TestRouterWebServiceUtil {
     ClusterMetricsInfo metricsClone = createClusterMetricsClone(metrics);
     RouterWebServiceUtil.mergeMetrics(metrics, metricsResponse);
 
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsSubmitted() + metricsClone.getAppsSubmitted(),
         metrics.getAppsSubmitted());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsCompleted() + metricsClone.getAppsCompleted(),
         metrics.getAppsCompleted());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsPending() + metricsClone.getAppsPending(),
         metrics.getAppsPending());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsRunning() + metricsClone.getAppsRunning(),
         metrics.getAppsRunning());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsFailed() + metricsClone.getAppsFailed(),
         metrics.getAppsFailed());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAppsKilled() + metricsClone.getAppsKilled(),
         metrics.getAppsKilled());
 
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getReservedMB() + metricsClone.getReservedMB(),
         metrics.getReservedMB());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAvailableMB() + metricsClone.getAvailableMB(),
         metrics.getAvailableMB());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAllocatedMB() + metricsClone.getAllocatedMB(),
         metrics.getAllocatedMB());
 
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getReservedVirtualCores()
             + metricsClone.getReservedVirtualCores(),
         metrics.getReservedVirtualCores());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAvailableVirtualCores()
             + metricsClone.getAvailableVirtualCores(),
         metrics.getAvailableVirtualCores());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getAllocatedVirtualCores()
             + metricsClone.getAllocatedVirtualCores(),
         metrics.getAllocatedVirtualCores());
 
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getContainersAllocated()
             + metricsClone.getContainersAllocated(),
         metrics.getContainersAllocated());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getReservedContainers()
             + metricsClone.getReservedContainers(),
         metrics.getReservedContainers());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getPendingContainers()
             + metricsClone.getPendingContainers(),
         metrics.getPendingContainers());
 
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getTotalMB() + metricsClone.getTotalMB(),
         metrics.getTotalMB());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getUtilizedMB() + metricsClone.getUtilizedMB(),
         metrics.getUtilizedMB());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getTotalVirtualCores()
             + metricsClone.getTotalVirtualCores(),
         metrics.getTotalVirtualCores());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getUtilizedVirtualCores() + metricsClone.getUtilizedVirtualCores(),
         metrics.getUtilizedVirtualCores());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getTotalNodes() + metricsClone.getTotalNodes(),
         metrics.getTotalNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getLostNodes() + metricsClone.getLostNodes(),
         metrics.getLostNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getUnhealthyNodes() + metricsClone.getUnhealthyNodes(),
         metrics.getUnhealthyNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getDecommissioningNodes()
             + metricsClone.getDecommissioningNodes(),
         metrics.getDecommissioningNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getDecommissionedNodes()
             + metricsClone.getDecommissionedNodes(),
         metrics.getDecommissionedNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getRebootedNodes() + metricsClone.getRebootedNodes(),
         metrics.getRebootedNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getActiveNodes() + metricsClone.getActiveNodes(),
         metrics.getActiveNodes());
-    Assertions.assertEquals(
+    assertEquals(
         metricsResponse.getShutdownNodes() + metricsClone.getShutdownNodes(),
         metrics.getShutdownNodes());
   }
@@ -629,14 +631,14 @@ public class TestRouterWebServiceUtil {
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
     ArrayList<StatisticsItemInfo> statItem = mergeInfo.getStatItems();
 
-    Assertions.assertNotNull(statItem);
-    Assertions.assertEquals(1, statItem.size());
+    assertNotNull(statItem);
+    assertEquals(1, statItem.size());
 
     StatisticsItemInfo first = statItem.get(0);
 
-    Assertions.assertEquals(item1.getCount() + item2.getCount(), first.getCount());
-    Assertions.assertEquals(item1.getType(), first.getType());
-    Assertions.assertEquals(item1.getState(), first.getState());
+    assertEquals(item1.getCount() + item2.getCount(), first.getCount());
+    assertEquals(item1.getType(), first.getType());
+    assertEquals(item1.getState(), first.getState());
   }
 
   @Test
@@ -662,7 +664,7 @@ public class TestRouterWebServiceUtil {
     ApplicationStatisticsInfo mergeInfo =
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
 
-    Assertions.assertEquals(3, mergeInfo.getStatItems().size());
+    assertEquals(3, mergeInfo.getStatItems().size());
     List<StatisticsItemInfo> mergeInfoStatItems = mergeInfo.getStatItems();
 
     StatisticsItemInfo item1Result = null;
@@ -686,12 +688,12 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assertions.assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
-    Assertions.assertEquals(item1.getCount(), item1Result.getCount());
-    Assertions.assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
-    Assertions.assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
-    Assertions.assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
-    Assertions.assertEquals(item4.getCount(), item3Result.getCount());
+    assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
+    assertEquals(item1.getCount(), item1Result.getCount());
+    assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
+    assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
+    assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
+    assertEquals(item4.getCount(), item3Result.getCount());
   }
 
   @Test
@@ -702,8 +704,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties = client01.getConfiguration().getProperties();
     int readTimeOut = (int) properties.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut = (int) properties.get(ClientProperties.CONNECT_TIMEOUT);
-    Assertions.assertEquals(30000, readTimeOut);
-    Assertions.assertEquals(30000, connectTimeOut);
+    assertEquals(30000, readTimeOut);
+    assertEquals(30000, connectTimeOut);
     client01.close();
 
     // Case2, set a negative timeout, We'll get the default timeout(30s)
@@ -714,8 +716,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties02 = client02.getConfiguration().getProperties();
     int readTimeOut02 = (int) properties02.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut02 =  (int) properties02.get(ClientProperties.CONNECT_TIMEOUT);
-    Assertions.assertEquals(30000, readTimeOut02);
-    Assertions.assertEquals(30000, connectTimeOut02);
+    assertEquals(30000, readTimeOut02);
+    assertEquals(30000, connectTimeOut02);
     client02.close();
 
     // Case3, Set the maximum value that exceeds the integer
@@ -730,8 +732,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties03 = client03.getConfiguration().getProperties();
     int readTimeOut03 = (int) properties03.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut03 = (int) properties03.get(ClientProperties.CONNECT_TIMEOUT);
-    Assertions.assertEquals(30000, readTimeOut03);
-    Assertions.assertEquals(30000, connectTimeOut03);
+    assertEquals(30000, readTimeOut03);
+    assertEquals(30000, connectTimeOut03);
     client03.close();
   }
 
@@ -748,8 +750,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout = (int) getTimeDuration(conf,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assertions.assertEquals(-1, connectTimeOut);
-    Assertions.assertEquals(-1, readTimeout);
+    assertEquals(-1, connectTimeOut);
+    assertEquals(-1, readTimeout);
 
     // Case2, Set the maximum value that exceeds the integer.
     // Converted to int, there will be a value out of bounds.
@@ -765,8 +767,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout1 = (int) getTimeDuration(conf1,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assertions.assertEquals(-2147483648, connectTimeOut1);
-    Assertions.assertEquals(-2147483648, readTimeout1);
+    assertEquals(-2147483648, connectTimeOut1);
+    assertEquals(-2147483648, readTimeout1);
   }
 
   private long getTimeDuration(YarnConfiguration conf, String varName, long defaultValue) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -39,8 +39,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ApplicationStatisticsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.StatisticsItemInfo;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,8 +105,8 @@ public class TestRouterWebServiceUtil {
     apps.add(app4);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(4, result.getApps().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(4, result.getApps().size());
 
     List<String> appIds = new ArrayList<String>();
     AppInfo appInfo1 = null, appInfo2 = null, appInfo3 = null, appInfo4 = null;
@@ -126,28 +126,28 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assert.assertTrue(appIds.contains(APPID1.toString()));
-    Assert.assertTrue(appIds.contains(APPID2.toString()));
-    Assert.assertTrue(appIds.contains(APPID3.toString()));
-    Assert.assertTrue(appIds.contains(APPID4.toString()));
+    Assertions.assertTrue(appIds.contains(APPID1.toString()));
+    Assertions.assertTrue(appIds.contains(APPID2.toString()));
+    Assertions.assertTrue(appIds.contains(APPID3.toString()));
+    Assertions.assertTrue(appIds.contains(APPID4.toString()));
 
     // Check preservations APP1
-    Assert.assertEquals(app1.getState(), appInfo1.getState());
-    Assert.assertEquals(app1.getNumAMContainerPreempted(),
+    Assertions.assertEquals(app1.getState(), appInfo1.getState());
+    Assertions.assertEquals(app1.getNumAMContainerPreempted(),
         appInfo1.getNumAMContainerPreempted());
 
     // Check preservations APP2
-    Assert.assertEquals(app2.getState(), appInfo2.getState());
-    Assert.assertEquals(app3.getAllocatedVCores(),
+    Assertions.assertEquals(app2.getState(), appInfo2.getState());
+    Assertions.assertEquals(app3.getAllocatedVCores(),
         appInfo3.getAllocatedVCores());
 
     // Check preservations APP3
-    Assert.assertEquals(app3.getState(), appInfo3.getState());
-    Assert.assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
+    Assertions.assertEquals(app3.getState(), appInfo3.getState());
+    Assertions.assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
 
     // Check preservations APP3
-    Assert.assertEquals(app4.getState(), appInfo4.getState());
-    Assert.assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
+    Assertions.assertEquals(app4.getState(), appInfo4.getState());
+    Assertions.assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
   }
 
   /**
@@ -186,19 +186,19 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assert.assertEquals(APPID1.toString(), app.getAppId());
-    Assert.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assert.assertEquals(value * 3, app.getPreemptedResourceMB());
-    Assert.assertEquals(value * 3, app.getPreemptedResourceVCores());
-    Assert.assertEquals(value * 3, app.getNumNonAMContainerPreempted());
-    Assert.assertEquals(value * 3, app.getNumAMContainerPreempted());
-    Assert.assertEquals(value * 3, app.getPreemptedMemorySeconds());
-    Assert.assertEquals(value * 3, app.getPreemptedVcoreSeconds());
+    Assertions.assertEquals(APPID1.toString(), app.getAppId());
+    Assertions.assertEquals(amHost, app.getAMHostHttpAddress());
+    Assertions.assertEquals(value * 3, app.getPreemptedResourceMB());
+    Assertions.assertEquals(value * 3, app.getPreemptedResourceVCores());
+    Assertions.assertEquals(value * 3, app.getNumNonAMContainerPreempted());
+    Assertions.assertEquals(value * 3, app.getNumAMContainerPreempted());
+    Assertions.assertEquals(value * 3, app.getPreemptedMemorySeconds());
+    Assertions.assertEquals(value * 3, app.getPreemptedVcoreSeconds());
   }
 
   private void setAppInfoFinished(AppInfo am, int value) {
@@ -248,21 +248,21 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assert.assertEquals(APPID2.toString(), app.getAppId());
-    Assert.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assert.assertEquals(value * 3, app.getAllocatedMB());
-    Assert.assertEquals(value * 3, app.getAllocatedVCores());
-    Assert.assertEquals(value * 3, app.getReservedMB());
-    Assert.assertEquals(value * 3, app.getReservedVCores());
-    Assert.assertEquals(value * 3, app.getRunningContainers());
-    Assert.assertEquals(value * 3, app.getMemorySeconds());
-    Assert.assertEquals(value * 3, app.getVcoreSeconds());
-    Assert.assertEquals(3, app.getResourceRequests().size());
+    Assertions.assertEquals(APPID2.toString(), app.getAppId());
+    Assertions.assertEquals(amHost, app.getAMHostHttpAddress());
+    Assertions.assertEquals(value * 3, app.getAllocatedMB());
+    Assertions.assertEquals(value * 3, app.getAllocatedVCores());
+    Assertions.assertEquals(value * 3, app.getReservedMB());
+    Assertions.assertEquals(value * 3, app.getReservedVCores());
+    Assertions.assertEquals(value * 3, app.getRunningContainers());
+    Assertions.assertEquals(value * 3, app.getMemorySeconds());
+    Assertions.assertEquals(value * 3, app.getVcoreSeconds());
+    Assertions.assertEquals(3, app.getResourceRequests().size());
   }
 
   private void setAppInfoRunning(AppInfo am, int value) {
@@ -300,15 +300,15 @@ public class TestRouterWebServiceUtil {
     apps.add(app2);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(0, result.getApps().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(0, result.getApps().size());
 
     // By enabling partial result, the expected result would be a partial report
     // of the 2 UAMs
     AppsInfo result2 = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), true);
-    Assert.assertNotNull(result2);
-    Assert.assertEquals(1, result2.getApps().size());
-    Assert.assertEquals(YarnApplicationState.RUNNING,
+    Assertions.assertNotNull(result2);
+    Assertions.assertEquals(1, result2.getApps().size());
+    Assertions.assertEquals(YarnApplicationState.RUNNING,
         result2.getApps().get(0).getState());
   }
 
@@ -329,8 +329,8 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getApps().size());
   }
 
   /**
@@ -361,8 +361,8 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assert.assertNotNull(result);
-    Assert.assertEquals(4, result.getNodes().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(4, result.getNodes().size());
 
     List<String> nodesIds = new ArrayList<String>();
 
@@ -370,10 +370,10 @@ public class TestRouterWebServiceUtil {
       nodesIds.add(node.getNodeId());
     }
 
-    Assert.assertTrue(nodesIds.contains(NODE1));
-    Assert.assertTrue(nodesIds.contains(NODE2));
-    Assert.assertTrue(nodesIds.contains(NODE3));
-    Assert.assertTrue(nodesIds.contains(NODE4));
+    Assertions.assertTrue(nodesIds.contains(NODE1));
+    Assertions.assertTrue(nodesIds.contains(NODE2));
+    Assertions.assertTrue(nodesIds.contains(NODE3));
+    Assertions.assertTrue(nodesIds.contains(NODE4));
   }
 
   /**
@@ -404,13 +404,13 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getNodes().size());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1, result.getNodes().size());
 
     NodeInfo node = result.getNodes().get(0);
 
-    Assert.assertEquals(NODE1, node.getNodeId());
-    Assert.assertEquals(2, node.getLastHealthUpdate());
+    Assertions.assertEquals(NODE1, node.getNodeId());
+    Assertions.assertEquals(2, node.getLastHealthUpdate());
   }
 
   /**
@@ -431,98 +431,98 @@ public class TestRouterWebServiceUtil {
     ClusterMetricsInfo metricsClone = createClusterMetricsClone(metrics);
     RouterWebServiceUtil.mergeMetrics(metrics, metricsResponse);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsSubmitted() + metricsClone.getAppsSubmitted(),
         metrics.getAppsSubmitted());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsCompleted() + metricsClone.getAppsCompleted(),
         metrics.getAppsCompleted());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsPending() + metricsClone.getAppsPending(),
         metrics.getAppsPending());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsRunning() + metricsClone.getAppsRunning(),
         metrics.getAppsRunning());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsFailed() + metricsClone.getAppsFailed(),
         metrics.getAppsFailed());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAppsKilled() + metricsClone.getAppsKilled(),
         metrics.getAppsKilled());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getReservedMB() + metricsClone.getReservedMB(),
         metrics.getReservedMB());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAvailableMB() + metricsClone.getAvailableMB(),
         metrics.getAvailableMB());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAllocatedMB() + metricsClone.getAllocatedMB(),
         metrics.getAllocatedMB());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getReservedVirtualCores()
             + metricsClone.getReservedVirtualCores(),
         metrics.getReservedVirtualCores());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAvailableVirtualCores()
             + metricsClone.getAvailableVirtualCores(),
         metrics.getAvailableVirtualCores());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getAllocatedVirtualCores()
             + metricsClone.getAllocatedVirtualCores(),
         metrics.getAllocatedVirtualCores());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getContainersAllocated()
             + metricsClone.getContainersAllocated(),
         metrics.getContainersAllocated());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getReservedContainers()
             + metricsClone.getReservedContainers(),
         metrics.getReservedContainers());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getPendingContainers()
             + metricsClone.getPendingContainers(),
         metrics.getPendingContainers());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getTotalMB() + metricsClone.getTotalMB(),
         metrics.getTotalMB());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getUtilizedMB() + metricsClone.getUtilizedMB(),
         metrics.getUtilizedMB());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getTotalVirtualCores()
             + metricsClone.getTotalVirtualCores(),
         metrics.getTotalVirtualCores());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getUtilizedVirtualCores() + metricsClone.getUtilizedVirtualCores(),
         metrics.getUtilizedVirtualCores());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getTotalNodes() + metricsClone.getTotalNodes(),
         metrics.getTotalNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getLostNodes() + metricsClone.getLostNodes(),
         metrics.getLostNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getUnhealthyNodes() + metricsClone.getUnhealthyNodes(),
         metrics.getUnhealthyNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getDecommissioningNodes()
             + metricsClone.getDecommissioningNodes(),
         metrics.getDecommissioningNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getDecommissionedNodes()
             + metricsClone.getDecommissionedNodes(),
         metrics.getDecommissionedNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getRebootedNodes() + metricsClone.getRebootedNodes(),
         metrics.getRebootedNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getActiveNodes() + metricsClone.getActiveNodes(),
         metrics.getActiveNodes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricsResponse.getShutdownNodes() + metricsClone.getShutdownNodes(),
         metrics.getShutdownNodes());
   }
@@ -629,14 +629,14 @@ public class TestRouterWebServiceUtil {
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
     ArrayList<StatisticsItemInfo> statItem = mergeInfo.getStatItems();
 
-    Assert.assertNotNull(statItem);
-    Assert.assertEquals(1, statItem.size());
+    Assertions.assertNotNull(statItem);
+    Assertions.assertEquals(1, statItem.size());
 
     StatisticsItemInfo first = statItem.get(0);
 
-    Assert.assertEquals(item1.getCount() + item2.getCount(), first.getCount());
-    Assert.assertEquals(item1.getType(), first.getType());
-    Assert.assertEquals(item1.getState(), first.getState());
+    Assertions.assertEquals(item1.getCount() + item2.getCount(), first.getCount());
+    Assertions.assertEquals(item1.getType(), first.getType());
+    Assertions.assertEquals(item1.getState(), first.getState());
   }
 
   @Test
@@ -662,7 +662,7 @@ public class TestRouterWebServiceUtil {
     ApplicationStatisticsInfo mergeInfo =
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
 
-    Assert.assertEquals(3, mergeInfo.getStatItems().size());
+    Assertions.assertEquals(3, mergeInfo.getStatItems().size());
     List<StatisticsItemInfo> mergeInfoStatItems = mergeInfo.getStatItems();
 
     StatisticsItemInfo item1Result = null;
@@ -686,12 +686,12 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assert.assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
-    Assert.assertEquals(item1.getCount(), item1Result.getCount());
-    Assert.assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
-    Assert.assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
-    Assert.assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
-    Assert.assertEquals(item4.getCount(), item3Result.getCount());
+    Assertions.assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
+    Assertions.assertEquals(item1.getCount(), item1Result.getCount());
+    Assertions.assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
+    Assertions.assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
+    Assertions.assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
+    Assertions.assertEquals(item4.getCount(), item3Result.getCount());
   }
 
   @Test
@@ -702,8 +702,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties = client01.getConfiguration().getProperties();
     int readTimeOut = (int) properties.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut = (int) properties.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut);
-    Assert.assertEquals(30000, connectTimeOut);
+    Assertions.assertEquals(30000, readTimeOut);
+    Assertions.assertEquals(30000, connectTimeOut);
     client01.close();
 
     // Case2, set a negative timeout, We'll get the default timeout(30s)
@@ -714,8 +714,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties02 = client02.getConfiguration().getProperties();
     int readTimeOut02 = (int) properties02.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut02 =  (int) properties02.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut02);
-    Assert.assertEquals(30000, connectTimeOut02);
+    Assertions.assertEquals(30000, readTimeOut02);
+    Assertions.assertEquals(30000, connectTimeOut02);
     client02.close();
 
     // Case3, Set the maximum value that exceeds the integer
@@ -730,8 +730,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties03 = client03.getConfiguration().getProperties();
     int readTimeOut03 = (int) properties03.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut03 = (int) properties03.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut03);
-    Assert.assertEquals(30000, connectTimeOut03);
+    Assertions.assertEquals(30000, readTimeOut03);
+    Assertions.assertEquals(30000, connectTimeOut03);
     client03.close();
   }
 
@@ -748,8 +748,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout = (int) getTimeDuration(conf,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assert.assertEquals(-1, connectTimeOut);
-    Assert.assertEquals(-1, readTimeout);
+    Assertions.assertEquals(-1, connectTimeOut);
+    Assertions.assertEquals(-1, readTimeout);
 
     // Case2, Set the maximum value that exceeds the integer.
     // Converted to int, there will be a value out of bounds.
@@ -765,8 +765,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout1 = (int) getTimeDuration(conf1,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assert.assertEquals(-2147483648, connectTimeOut1);
-    Assert.assertEquals(-2147483648, readTimeout1);
+    Assertions.assertEquals(-2147483648, connectTimeOut1);
+    Assertions.assertEquals(-2147483648, readTimeout1);
   }
 
   private long getTimeDuration(YarnConfiguration conf, String varName, long defaultValue) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
@@ -49,8 +49,8 @@ import org.apache.hadoop.yarn.server.router.webapp.RouterWebServices.RequestInte
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,140 +72,140 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
   public void testRouterWebServicesE2E() throws Exception {
 
     ClusterInfo clusterInfo = get(user);
-    Assert.assertNotNull(clusterInfo);
+    Assertions.assertNotNull(clusterInfo);
 
     ClusterInfo clusterInfo2 = getClusterInfo(user);
-    Assert.assertNotNull(clusterInfo2);
+    Assertions.assertNotNull(clusterInfo2);
 
     ClusterMetricsInfo clusterMetricsInfo = getClusterMetricsInfo(user);
-    Assert.assertNotNull(clusterMetricsInfo);
+    Assertions.assertNotNull(clusterMetricsInfo);
 
     SchedulerTypeInfo schedulerTypeInfo = getSchedulerInfo(user);
-    Assert.assertNotNull(schedulerTypeInfo);
+    Assertions.assertNotNull(schedulerTypeInfo);
 
     String dumpResult = dumpSchedulerLogs(user);
-    Assert.assertNotNull(dumpResult);
+    Assertions.assertNotNull(dumpResult);
 
     NodesInfo nodesInfo = getNodes(user);
-    Assert.assertNotNull(nodesInfo);
+    Assertions.assertNotNull(nodesInfo);
 
     NodeInfo nodeInfo = getNode(user);
-    Assert.assertNotNull(nodeInfo);
+    Assertions.assertNotNull(nodeInfo);
 
     AppsInfo appsInfo = getApps(user);
-    Assert.assertNotNull(appsInfo);
+    Assertions.assertNotNull(appsInfo);
 
     ActivitiesInfo activitiesInfo = getActivities(user);
-    Assert.assertNotNull(activitiesInfo);
+    Assertions.assertNotNull(activitiesInfo);
 
     AppActivitiesInfo appActiviesInfo = getAppActivities(user);
-    Assert.assertNotNull(appActiviesInfo);
+    Assertions.assertNotNull(appActiviesInfo);
 
     ApplicationStatisticsInfo applicationStatisticsInfo =
         getAppStatistics(user);
-    Assert.assertNotNull(applicationStatisticsInfo);
+    Assertions.assertNotNull(applicationStatisticsInfo);
 
     AppInfo appInfo = getApp(user);
-    Assert.assertNotNull(appInfo);
+    Assertions.assertNotNull(appInfo);
 
     AppState appState = getAppState(user);
-    Assert.assertNotNull(appState);
+    Assertions.assertNotNull(appState);
 
     Response response = updateAppState(user);
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     NodeToLabelsInfo nodeToLabelsInfo = getNodeToLabels(user);
-    Assert.assertNotNull(nodeToLabelsInfo);
+    Assertions.assertNotNull(nodeToLabelsInfo);
 
     LabelsToNodesInfo labelsToNodesInfo = getLabelsToNodes(user);
-    Assert.assertNotNull(labelsToNodesInfo);
+    Assertions.assertNotNull(labelsToNodesInfo);
 
     Response response2 = replaceLabelsOnNodes(user);
-    Assert.assertNotNull(response2);
+    Assertions.assertNotNull(response2);
 
     Response response3 = replaceLabelsOnNode(user);
-    Assert.assertNotNull(response3);
+    Assertions.assertNotNull(response3);
 
     NodeLabelsInfo nodeLabelsInfo = getClusterNodeLabels(user);
-    Assert.assertNotNull(nodeLabelsInfo);
+    Assertions.assertNotNull(nodeLabelsInfo);
 
     Response response4 = addToClusterNodeLabels(user);
-    Assert.assertNotNull(response4);
+    Assertions.assertNotNull(response4);
 
     Response response5 = removeFromClusterNodeLabels(user);
-    Assert.assertNotNull(response5);
+    Assertions.assertNotNull(response5);
 
     NodeLabelsInfo nodeLabelsInfo2 = getLabelsOnNode(user);
-    Assert.assertNotNull(nodeLabelsInfo2);
+    Assertions.assertNotNull(nodeLabelsInfo2);
 
     AppPriority appPriority = getAppPriority(user);
-    Assert.assertNotNull(appPriority);
+    Assertions.assertNotNull(appPriority);
 
     Response response6 = updateApplicationPriority(user);
-    Assert.assertNotNull(response6);
+    Assertions.assertNotNull(response6);
 
     AppQueue appQueue = getAppQueue(user);
-    Assert.assertNotNull(appQueue);
+    Assertions.assertNotNull(appQueue);
 
     Response response7 = updateAppQueue(user);
-    Assert.assertNotNull(response7);
+    Assertions.assertNotNull(response7);
 
     Response response8 = createNewApplication(user);
-    Assert.assertNotNull(response8);
+    Assertions.assertNotNull(response8);
 
     Response response9 = submitApplication(user);
-    Assert.assertNotNull(response9);
+    Assertions.assertNotNull(response9);
 
     Response response10 = postDelegationToken(user);
-    Assert.assertNotNull(response10);
+    Assertions.assertNotNull(response10);
 
     Response response11 = postDelegationTokenExpiration(user);
-    Assert.assertNotNull(response11);
+    Assertions.assertNotNull(response11);
 
     Response response12 = cancelDelegationToken(user);
-    Assert.assertNotNull(response12);
+    Assertions.assertNotNull(response12);
 
     Response response13 = createNewReservation(user);
-    Assert.assertNotNull(response13);
+    Assertions.assertNotNull(response13);
 
     Response response14 = submitReservation(user);
-    Assert.assertNotNull(response14);
+    Assertions.assertNotNull(response14);
 
     Response response15 = updateReservation(user);
-    Assert.assertNotNull(response15);
+    Assertions.assertNotNull(response15);
 
     Response response16 = deleteReservation(user);
-    Assert.assertNotNull(response16);
+    Assertions.assertNotNull(response16);
 
     Response response17 = listReservation(user);
-    Assert.assertNotNull(response17);
+    Assertions.assertNotNull(response17);
 
     AppTimeoutInfo appTimeoutInfo = getAppTimeout(user);
-    Assert.assertNotNull(appTimeoutInfo);
+    Assertions.assertNotNull(appTimeoutInfo);
 
     AppTimeoutsInfo appTimeoutsInfo = getAppTimeouts(user);
-    Assert.assertNotNull(appTimeoutsInfo);
+    Assertions.assertNotNull(appTimeoutsInfo);
 
     Response response18 = updateApplicationTimeout(user);
-    Assert.assertNotNull(response18);
+    Assertions.assertNotNull(response18);
 
     AppAttemptsInfo appAttemptsInfo = getAppAttempts(user);
-    Assert.assertNotNull(appAttemptsInfo);
+    Assertions.assertNotNull(appAttemptsInfo);
 
     AppAttemptInfo appAttemptInfo = getAppAttempt(user);
-    Assert.assertNotNull(appAttemptInfo);
+    Assertions.assertNotNull(appAttemptInfo);
 
     ContainersInfo containersInfo = getContainers(user);
-    Assert.assertNotNull(containersInfo);
+    Assertions.assertNotNull(containersInfo);
 
     ContainerInfo containerInfo = getContainer(user);
-    Assert.assertNotNull(containerInfo);
+    Assertions.assertNotNull(containerInfo);
 
     Response response19 = updateSchedulerConfiguration(user);
-    Assert.assertNotNull(response19);
+    Assertions.assertNotNull(response19);
 
     Response response20 = getSchedulerConfiguration(user);
-    Assert.assertNotNull(response20);
+    Assertions.assertNotNull(response20);
   }
 
   /**
@@ -227,21 +227,21 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
+        Assertions.assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockRESTRequestInterceptor.class.getName(),
+        Assertions.assertEquals(MockRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        Assertions.fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    Assertions.assertEquals(4
+,         index, "The number of interceptors in chain does not match");
   }
 
   /**
@@ -262,7 +262,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
 
     Map<String, RequestInterceptorChainWrapper> pipelines =
         getRouterWebServices().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    Assertions.assertEquals(8, pipelines.size());
 
     getInterceptorChain("test9");
     getInterceptorChain("test10");
@@ -270,13 +270,13 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     getInterceptorChain("test11");
 
     // The cache max size is defined in TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    Assertions.assertEquals(10, pipelines.size());
 
     RequestInterceptorChainWrapper chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    Assertions.assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    Assertions.assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -311,7 +311,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
                     getInterceptorChain(user);
                 RESTRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                Assertions.assertNotNull(interceptor);
                 LOG.info("init web interceptor success for user" + user);
                 return interceptor;
               }
@@ -332,9 +332,9 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertSame(client1.interceptor, client2.interceptor);
+    Assertions.assertNotNull(client1.interceptor);
+    Assertions.assertNotNull(client2.interceptor);
+    Assertions.assertSame(client1.interceptor, client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -49,7 +55,6 @@ import org.apache.hadoop.yarn.server.router.webapp.RouterWebServices.RequestInte
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,140 +77,140 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
   public void testRouterWebServicesE2E() throws Exception {
 
     ClusterInfo clusterInfo = get(user);
-    Assertions.assertNotNull(clusterInfo);
+    assertNotNull(clusterInfo);
 
     ClusterInfo clusterInfo2 = getClusterInfo(user);
-    Assertions.assertNotNull(clusterInfo2);
+    assertNotNull(clusterInfo2);
 
     ClusterMetricsInfo clusterMetricsInfo = getClusterMetricsInfo(user);
-    Assertions.assertNotNull(clusterMetricsInfo);
+    assertNotNull(clusterMetricsInfo);
 
     SchedulerTypeInfo schedulerTypeInfo = getSchedulerInfo(user);
-    Assertions.assertNotNull(schedulerTypeInfo);
+    assertNotNull(schedulerTypeInfo);
 
     String dumpResult = dumpSchedulerLogs(user);
-    Assertions.assertNotNull(dumpResult);
+    assertNotNull(dumpResult);
 
     NodesInfo nodesInfo = getNodes(user);
-    Assertions.assertNotNull(nodesInfo);
+    assertNotNull(nodesInfo);
 
     NodeInfo nodeInfo = getNode(user);
-    Assertions.assertNotNull(nodeInfo);
+    assertNotNull(nodeInfo);
 
     AppsInfo appsInfo = getApps(user);
-    Assertions.assertNotNull(appsInfo);
+    assertNotNull(appsInfo);
 
     ActivitiesInfo activitiesInfo = getActivities(user);
-    Assertions.assertNotNull(activitiesInfo);
+    assertNotNull(activitiesInfo);
 
     AppActivitiesInfo appActiviesInfo = getAppActivities(user);
-    Assertions.assertNotNull(appActiviesInfo);
+    assertNotNull(appActiviesInfo);
 
     ApplicationStatisticsInfo applicationStatisticsInfo =
         getAppStatistics(user);
-    Assertions.assertNotNull(applicationStatisticsInfo);
+    assertNotNull(applicationStatisticsInfo);
 
     AppInfo appInfo = getApp(user);
-    Assertions.assertNotNull(appInfo);
+    assertNotNull(appInfo);
 
     AppState appState = getAppState(user);
-    Assertions.assertNotNull(appState);
+    assertNotNull(appState);
 
     Response response = updateAppState(user);
-    Assertions.assertNotNull(response);
+    assertNotNull(response);
 
     NodeToLabelsInfo nodeToLabelsInfo = getNodeToLabels(user);
-    Assertions.assertNotNull(nodeToLabelsInfo);
+    assertNotNull(nodeToLabelsInfo);
 
     LabelsToNodesInfo labelsToNodesInfo = getLabelsToNodes(user);
-    Assertions.assertNotNull(labelsToNodesInfo);
+    assertNotNull(labelsToNodesInfo);
 
     Response response2 = replaceLabelsOnNodes(user);
-    Assertions.assertNotNull(response2);
+    assertNotNull(response2);
 
     Response response3 = replaceLabelsOnNode(user);
-    Assertions.assertNotNull(response3);
+    assertNotNull(response3);
 
     NodeLabelsInfo nodeLabelsInfo = getClusterNodeLabels(user);
-    Assertions.assertNotNull(nodeLabelsInfo);
+    assertNotNull(nodeLabelsInfo);
 
     Response response4 = addToClusterNodeLabels(user);
-    Assertions.assertNotNull(response4);
+    assertNotNull(response4);
 
     Response response5 = removeFromClusterNodeLabels(user);
-    Assertions.assertNotNull(response5);
+    assertNotNull(response5);
 
     NodeLabelsInfo nodeLabelsInfo2 = getLabelsOnNode(user);
-    Assertions.assertNotNull(nodeLabelsInfo2);
+    assertNotNull(nodeLabelsInfo2);
 
     AppPriority appPriority = getAppPriority(user);
-    Assertions.assertNotNull(appPriority);
+    assertNotNull(appPriority);
 
     Response response6 = updateApplicationPriority(user);
-    Assertions.assertNotNull(response6);
+    assertNotNull(response6);
 
     AppQueue appQueue = getAppQueue(user);
-    Assertions.assertNotNull(appQueue);
+    assertNotNull(appQueue);
 
     Response response7 = updateAppQueue(user);
-    Assertions.assertNotNull(response7);
+    assertNotNull(response7);
 
     Response response8 = createNewApplication(user);
-    Assertions.assertNotNull(response8);
+    assertNotNull(response8);
 
     Response response9 = submitApplication(user);
-    Assertions.assertNotNull(response9);
+    assertNotNull(response9);
 
     Response response10 = postDelegationToken(user);
-    Assertions.assertNotNull(response10);
+    assertNotNull(response10);
 
     Response response11 = postDelegationTokenExpiration(user);
-    Assertions.assertNotNull(response11);
+    assertNotNull(response11);
 
     Response response12 = cancelDelegationToken(user);
-    Assertions.assertNotNull(response12);
+    assertNotNull(response12);
 
     Response response13 = createNewReservation(user);
-    Assertions.assertNotNull(response13);
+    assertNotNull(response13);
 
     Response response14 = submitReservation(user);
-    Assertions.assertNotNull(response14);
+    assertNotNull(response14);
 
     Response response15 = updateReservation(user);
-    Assertions.assertNotNull(response15);
+    assertNotNull(response15);
 
     Response response16 = deleteReservation(user);
-    Assertions.assertNotNull(response16);
+    assertNotNull(response16);
 
     Response response17 = listReservation(user);
-    Assertions.assertNotNull(response17);
+    assertNotNull(response17);
 
     AppTimeoutInfo appTimeoutInfo = getAppTimeout(user);
-    Assertions.assertNotNull(appTimeoutInfo);
+    assertNotNull(appTimeoutInfo);
 
     AppTimeoutsInfo appTimeoutsInfo = getAppTimeouts(user);
-    Assertions.assertNotNull(appTimeoutsInfo);
+    assertNotNull(appTimeoutsInfo);
 
     Response response18 = updateApplicationTimeout(user);
-    Assertions.assertNotNull(response18);
+    assertNotNull(response18);
 
     AppAttemptsInfo appAttemptsInfo = getAppAttempts(user);
-    Assertions.assertNotNull(appAttemptsInfo);
+    assertNotNull(appAttemptsInfo);
 
     AppAttemptInfo appAttemptInfo = getAppAttempt(user);
-    Assertions.assertNotNull(appAttemptInfo);
+    assertNotNull(appAttemptInfo);
 
     ContainersInfo containersInfo = getContainers(user);
-    Assertions.assertNotNull(containersInfo);
+    assertNotNull(containersInfo);
 
     ContainerInfo containerInfo = getContainer(user);
-    Assertions.assertNotNull(containerInfo);
+    assertNotNull(containerInfo);
 
     Response response19 = updateSchedulerConfiguration(user);
-    Assertions.assertNotNull(response19);
+    assertNotNull(response19);
 
     Response response20 = getSchedulerConfiguration(user);
-    Assertions.assertNotNull(response20);
+    assertNotNull(response20);
   }
 
   /**
@@ -227,21 +232,20 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assertions.assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
+        assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assertions.assertEquals(MockRESTRequestInterceptor.class.getName(),
+        assertEquals(MockRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assertions.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assertions.assertEquals(4
-,         index, "The number of interceptors in chain does not match");
+    assertEquals(4, index, "The number of interceptors in chain does not match");
   }
 
   /**
@@ -262,7 +266,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
 
     Map<String, RequestInterceptorChainWrapper> pipelines =
         getRouterWebServices().getPipelines();
-    Assertions.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     getInterceptorChain("test9");
     getInterceptorChain("test10");
@@ -270,13 +274,13 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     getInterceptorChain("test11");
 
     // The cache max size is defined in TEST_MAX_CACHE_SIZE
-    Assertions.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     RequestInterceptorChainWrapper chain = pipelines.get("test1");
-    Assertions.assertNotNull(chain, "test1 should not be evicted");
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assertions.assertNull(chain, "test2 should have been evicted");
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -311,7 +315,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
                     getInterceptorChain(user);
                 RESTRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assertions.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init web interceptor success for user" + user);
                 return interceptor;
               }
@@ -332,9 +336,9 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     client1.join();
     client2.join();
 
-    Assertions.assertNotNull(client1.interceptor);
-    Assertions.assertNotNull(client2.interceptor);
-    Assertions.assertSame(client1.interceptor, client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertSame(client1.interceptor, client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
@@ -69,9 +69,9 @@ import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseS
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getNMWebAppURLWithoutScheme;
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getRMWebAppURLWithScheme;
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getRouterWebAppURLWithScheme;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -129,9 +129,10 @@ import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.server.webapp.WebServices;
 import org.apache.hadoop.yarn.server.webapp.dao.AppsInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -202,7 +203,7 @@ public class TestRouterWebServicesREST {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new YarnConfiguration();
 
@@ -231,7 +232,7 @@ public class TestRouterWebServicesREST {
     waitWebAppRunning(nmAddress, "/ws/v1/node");
   }
 
-  @AfterClass
+  @AfterAll
   public static void stop() throws Exception {
     if (nm != null) {
       nm.stop();
@@ -332,7 +333,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link RMWebServiceProtocol#get()}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testInfoXML() throws Exception {
 
     List<ClusterInfo> responses = performGetCalls(
@@ -353,7 +355,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testClusterInfoXML() throws Exception {
 
     List<ClusterInfo> responses = performGetCalls(
@@ -374,7 +377,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterMetricsInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testMetricsInfoXML() throws Exception {
 
     List<ClusterMetricsInfo> responses = performGetCalls(
@@ -395,7 +399,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getSchedulerInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSchedulerInfoXML() throws Exception {
 
     List<SchedulerTypeInfo> responses = performGetCalls(
@@ -416,7 +421,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodes(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodesEmptyXML() throws Exception {
 
     List<NodesInfo> responses = performGetCalls(
@@ -437,7 +443,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodes(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodesXML() throws Exception {
 
     List<NodesInfo> responses = performGetCalls(
@@ -458,7 +465,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNode(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodeXML() throws Exception {
 
     List<NodeInfo> responses = performGetCalls(
@@ -520,7 +528,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getActivities(HttpServletRequest, String, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testActiviesXML() throws Exception {
 
     List<ActivitiesInfo> responses = performGetCalls(
@@ -538,7 +547,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppActivities} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppActivitiesXML() throws Exception {
 
     String appId = submitApplication();
@@ -558,7 +568,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppStatistics} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppStatisticsXML() throws Exception {
 
     submitApplication();
@@ -582,7 +593,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#dumpSchedulerLogs} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testDumpSchedulerLogsXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -605,7 +617,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#createNewApplication} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNewApplicationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -629,7 +642,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#submitApplication} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSubmitApplicationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -655,7 +669,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getApps} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppsXML() throws Exception {
 
     submitApplication();
@@ -678,7 +693,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getApp} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppXML() throws Exception {
 
     String appId = submitApplication();
@@ -702,7 +718,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppAttempts} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppAttemptXML() throws Exception {
 
     String appId = submitApplication();
@@ -726,7 +743,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppState} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppStateXML() throws Exception {
 
     String appId = submitApplication();
@@ -750,7 +768,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#updateAppState} inside Router.
    */
-  @Test(timeout = 20000000)
+  @Test
+  @Timeout(value = 20000)
   public void testUpdateAppStateXML() throws Exception {
 
     String appId = submitApplication();
@@ -778,7 +797,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppPriority} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppPriorityXML() throws Exception {
 
     String appId = submitApplication();
@@ -801,7 +821,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateApplicationPriority(
    *     AppPriority, HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppPriorityXML() throws Exception {
 
     String appId = submitApplication();
@@ -829,7 +850,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppQueue(HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppQueueXML() throws Exception {
 
     String appId = submitApplication();
@@ -852,7 +874,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateAppQueue(AppQueue, HttpServletRequest, String)}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppQueueXML() throws Exception {
 
     String appId = submitApplication();
@@ -880,7 +903,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppTimeouts} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppTimeoutsXML() throws Exception {
 
     String appId = submitApplication();
@@ -904,7 +928,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppTimeout} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppTimeoutXML() throws Exception {
 
     String appId = submitApplication();
@@ -928,7 +953,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateApplicationTimeout}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppTimeoutsXML() throws Exception {
 
     String appId = submitApplication();
@@ -956,7 +982,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#createNewReservation(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNewReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -981,7 +1008,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#submitReservation(
    *     ReservationSubmissionRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSubmitReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1010,7 +1038,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateReservation(
    *     ReservationUpdateRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1037,7 +1066,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#deleteReservation(
    *     ReservationDeleteRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testDeleteReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1063,7 +1093,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodeToLabels(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetNodeToLabelsXML() throws Exception {
 
     List<NodeToLabelsInfo> responses = performGetCalls(
@@ -1085,7 +1116,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterNodeLabels(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetClusterNodeLabelsXML() throws Exception {
 
     List<NodeLabelsInfo> responses = performGetCalls(
@@ -1107,7 +1139,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsOnNode(HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsOnNodeXML() throws Exception {
 
     List<NodeLabelsInfo> responses = performGetCalls(
@@ -1129,7 +1162,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsToNodes(Set<String>)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsMappingEmptyXML() throws Exception {
 
     List<LabelsToNodesInfo> responses = performGetCalls(
@@ -1151,7 +1185,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsToNodes(Set<String>)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsMappingXML() throws Exception {
 
     List<LabelsToNodesInfo> responses = performGetCalls(
@@ -1174,7 +1209,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#addToClusterNodeLabels(
    *     NodeLabelsInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAddToClusterNodeLabelsXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1202,7 +1238,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#removeFromClusterNodeLabels} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testRemoveFromClusterNodeLabelsXML()
       throws Exception {
 
@@ -1228,7 +1265,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#replaceLabelsOnNodes} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testReplaceLabelsOnNodesXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1255,7 +1293,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#replaceLabelsOnNode} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testReplaceLabelsOnNodeXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1281,7 +1320,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link WebServices#getAppAttempt}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetAppAttemptXML() throws Exception {
 
     String appId = submitApplication();
@@ -1305,7 +1345,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link WebServices#getContainers}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetContainersXML() throws Exception {
 
     String appId = submitApplication();
@@ -1326,7 +1367,8 @@ public class TestRouterWebServicesREST {
         routerResponse.getContainers().size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetAppsMultiThread() throws Exception {
     final int iniNumApps = getNumApps();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/resources/yarn-site.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/resources/yarn-site.xml
@@ -41,7 +41,7 @@
   </property>
   <property>
     <name>yarn.federation.policy-manager-params</name>
-    <value>{"routerPolicyWeights":{"entry":[{"key":{"id":"SC-2"},"value":"0.3"},{"key":{"id":"SC-1"},"value":"0.7"}]},"amrmPolicyWeights":{"entry":[{"key":{"id":"SC-2"},"value":"0.4"},{"key":{"id":"SC-1"},"value":"0.6"}]},"headroomAlpha":"1.0"}</value>
+    <value>{"routerPolicyWeights":{"SC-2":"0.3","SC-1":"0.7"},"amrmPolicyWeights":{"SC-2":"0.4", "SC-1":"0.6"},"headroomAlpha":"1.0"}</value>
   </property>
   <property>
     <name>yarn.resourcemanager.cluster-id</name>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11267. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-router.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

