### PR TITLE
MAPREDUCE-7495. Broken sort for numeric columns in UI.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/TaskPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/TaskPage.java
@@ -225,10 +225,10 @@ public class TaskPage extends AppView {
     .append("\n, {'sType':'natural', 'aTargets': [ 0 ]")
     .append(", 'mRender': parseHadoopID }")
 
-    .append("\n, {'sType':'numeric', 'aTargets': [ 6, 7")
+    .append("\n, {'sType':'num', 'aTargets': [ 6, 7")
     .append(" ], 'mRender': renderHadoopDate }")
 
-    .append("\n, {'sType':'numeric', 'aTargets': [ 8")
+    .append("\n, {'sType':'num', 'aTargets': [ 8")
     .append(" ], 'mRender': renderHadoopElapsedTime }]")
 
     // Sort by id upon page load

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/TasksPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/TasksPage.java
@@ -46,14 +46,14 @@ public class TasksPage extends AppView {
       .append("{'sType':'natural', 'aTargets': [0]")
       .append(", 'mRender': parseHadoopID }")
 
-      .append("\n, {'sType':'numeric', bSearchable:false, 'aTargets': [1]")
+      .append("\n, {'sType':'num', bSearchable:false, 'aTargets': [1]")
       .append(", 'mRender': parseHadoopProgress }")
 
 
-      .append("\n, {'sType':'numeric', 'aTargets': [4, 5]")
+      .append("\n, {'sType':'num', 'aTargets': [4, 5]")
       .append(", 'mRender': renderHadoopDate }")
 
-      .append("\n, {'sType':'numeric', 'aTargets': [6]")
+      .append("\n, {'sType':'num', 'aTargets': [6]")
       .append(", 'mRender': renderHadoopElapsedTime }]")
 
       // Sort by id upon page load

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTaskPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTaskPage.java
@@ -313,12 +313,12 @@ public class HsTaskPage extends HsView {
       .append("\n, {'sType':'natural', 'aTargets': [ 0 ]")
       .append(", 'mRender': parseHadoopID }")
 
-      .append("\n, {'sType':'numeric', 'aTargets': [ 5, 6")
+      .append("\n, {'sType':'num', 'aTargets': [ 5, 6")
       //Column numbers are different for maps and reduces
       .append(type == TaskType.REDUCE ? ", 7, 8" : "")
       .append(" ], 'mRender': renderHadoopDate }")
 
-      .append("\n, {'sType':'numeric', 'aTargets': [")
+      .append("\n, {'sType':'num', 'aTargets': [")
       .append(type == TaskType.REDUCE ? "9, 10, 11, 12" : "7")
       .append(" ], 'mRender': renderHadoopElapsedTime }]")
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTasksPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTasksPage.java
@@ -79,11 +79,11 @@ public class HsTasksPage extends HsView {
     .append("{'sType':'natural', 'aTargets': [ 0 ]")
     .append(", 'mRender': parseHadoopID }")
 
-    .append(", {'sType':'numeric', 'aTargets': [ 4")
+    .append(", {'sType':'num', 'aTargets': [ 4")
     .append(type == TaskType.REDUCE ? ", 9, 10, 11, 12" : ", 7")
     .append(" ], 'mRender': renderHadoopElapsedTime }")
 
-    .append("\n, {'sType':'numeric', 'aTargets': [ 2, 3, 5")
+    .append("\n, {'sType':'num', 'aTargets': [ 2, 3, 5")
     .append(type == TaskType.REDUCE ? ", 6, 7, 8" : ", 6")
     .append(" ], 'mRender': renderHadoopDate }]")
 


### PR DESCRIPTION
Change datatable type from 'numeric' to 'num' in Mapreduce client App and HS


### Description of PR

JIRA: MAPREDUCE-7495. Broken sort for numeric columns in UI.

Since the use of datatables 1.10, the 'numeric' type doesn't exist anymore and has been replaced by 'num'. The numeric fields (especially the elapsed times) were sorted in alphabetical order in the Mapreduce Job History Server and in the AM interface, making the UI unusable to analyse the performances of a Mapreduce job.


### How was this patch tested?
Running a Mapreduce job and a Job History server. No additional unit test was written.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

