### PR TITLE
YARN-11384: NPE in DelegationTokenRenewer causes all subsequent apps to fail with "Timer already cancelled"

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -807,10 +807,13 @@ public class DelegationTokenRenewer extends AbstractService {
   private void removeFailedDelegationToken(DelegationTokenToRenew t) {
     Collection<ApplicationId> applicationIds = t.referringAppIds;
     synchronized (applicationIds) {
-      LOG.error("removing failed delegation token for appid=" + applicationIds
-          + ";t=" + t.token.getService());
+      LOG.error("removing failed delegation token for appid={};t={}",
+          applicationIds, t.token.getService());
       for (ApplicationId applicationId : applicationIds) {
-        appTokens.get(applicationId).remove(t);
+        Set<DelegationTokenToRenew> tokens = appTokens.get(applicationId);
+        if (tokens != null && !tokens.isEmpty()) {
+          tokens.remove(t);
+        }
       }
     }
     allTokens.remove(t.token);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

As described in YARN-11384, `DelegationTokenRenewer#removeFailedDelegationToken` may throw NPE due to `appTokens.get(applicationId)` returning `null` (I'm not sure how this happened, but it does happen), such an uncaught exception stops the global `renewalTimer` and causes all subsequent apps to fail with "Timer already cancelled", this effectively leads the entire YARN cluster unavailable.

This patch simply adds a null check to prevent the NPE.

### How was this patch tested?

Change is straightforward I'm not sure whether it requires a UT with plenty of mocked stuff.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

