### PR TITLE
HDFS-17729. Inconsistent mtime in the results of -stat and -ls command due to different TimeZone.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Stat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Stat.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedList;
-import java.util.TimeZone;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Stat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Stat.java
@@ -73,7 +73,6 @@ class Stat extends FsCommand {
   protected final SimpleDateFormat timeFmt;
   {
     timeFmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    timeFmt.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   // default format string


### PR DESCRIPTION
### Description of PR
The problem is shown in below picture. It's caused by different TimeZone of these two commands.

![image](https://github.com/user-attachments/assets/614c1092-7a65-4fab-95c5-de0a46157846)

After fixing:

![image](https://github.com/user-attachments/assets/f96a4394-36cb-48ef-ba13-7f4da25e4af6)
