### PR TITLE
HADOOP-19464. S3A: Restore Compatibility with EMRFS FileSystem

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2605,8 +2605,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           path,
           true,
           includeSelf
-              ? Listing.ACCEPT_ALL_OBJECTS
-              : new Listing.AcceptAllButSelf(path),
+              ? Listing.ACCEPT_ALL_BUT_S3N
+              : new Listing.AcceptAllButSelfAndS3nDirs(path),
           status
       );
     }
@@ -2651,7 +2651,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           listing.createFileStatusListingIterator(path,
               createListObjectsRequest(key, null),
               ACCEPT_ALL,
-              Listing.ACCEPT_ALL_OBJECTS,
+              Listing.ACCEPT_ALL_BUT_S3N,
               auditSpan));
     }
 
@@ -3679,7 +3679,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         return listing.createProvidedFileStatusIterator(
                 stats,
                 ACCEPT_ALL,
-                Listing.ACCEPT_ALL_OBJECTS);
+                Listing.ACCEPT_ALL_BUT_S3N);
       }
     }
     // Here we have a directory which may or may not be empty.
@@ -3863,7 +3863,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     @Override
     public RemoteIterator<S3ALocatedFileStatus> listFilesIterator(final Path path,
         final boolean recursive) throws IOException {
-      return S3AFileSystem.this.innerListFiles(path, recursive, Listing.ACCEPT_ALL_OBJECTS, null);
+      return S3AFileSystem.this.innerListFiles(path, recursive, Listing.ACCEPT_ALL_BUT_S3N, null);
     }
   }
 
@@ -5090,7 +5090,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     final Path path = qualify(f);
     return trackDurationAndSpan(INVOCATION_LIST_FILES, path, () ->
         innerListFiles(path, recursive,
-            Listing.ACCEPT_ALL_OBJECTS,
+            Listing.ACCEPT_ALL_BUT_S3N,
             null));
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2605,8 +2605,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           path,
           true,
           includeSelf
-              ? Listing.ACCEPT_ALL_BUT_S3N
-              : new Listing.AcceptAllButSelfAndS3nDirs(path),
+              ? Listing.ACCEPT_ALL_OBJECTS
+              : new Listing.AcceptAllButSelf(path),
           status
       );
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
@@ -32,37 +31,38 @@ import static org.apache.hadoop.fs.s3a.Constants.S3N_FOLDER_SUFFIX;
  * S3A works as expected.
  */
 public class ITestEMRFSCompatibility extends AbstractS3ATestBase {
-
-  private Path basePath;
-  private static final String FILE_NAME = "file1.txt";
-
-  @Override
-  public void setup() throws Exception {
-    super.setup();
-    S3AFileSystem fs = getFileSystem();
-    basePath = methodPath();
-
-    // define the paths and create them.
-    describe("Creating test directories and files");
-
-    // write an empty S3N folder marker object
-    Path folderMarker = new Path(basePath, S3N_FOLDER_SUFFIX);
-    touch(fs, folderMarker);
-
-    // write an empty object
-    Path file = new Path(basePath, FILE_NAME);
-    touch(fs, file);
-  }
+  private static final String SRC_DIR = "src";
+  private static final String DEST_DIR = "dest";
+  private static final String SUBDIR = "subdir";
 
   @Test
-  public void testSkipS3NFolderMarker() throws Throwable {
+  public void testFileSystemOperationWithS3NFolderMarker() throws Throwable {
     S3AFileSystem fs = getFileSystem();
-    FileStatus[] fileStatus = fs.listStatus(basePath);
-    Assertions.assertThat(fileStatus.length)
-        .describedAs("The expected number of files did not match")
-        .isEqualTo(1);
-    Assertions.assertThat(fileStatus[0].getPath().getName())
-        .describedAs("The expected name does not match")
-        .isEqualTo(FILE_NAME);
+    Path basePath = methodPath();
+    Path src = new Path(basePath, SRC_DIR);
+    Path dest = new Path(basePath, DEST_DIR);
+    Path subdir = new Path(src, SUBDIR);
+    Path folderMarker = new Path(subdir, S3N_FOLDER_SUFFIX);
+
+    // write an empty S3N folder marker object
+    touch(fs, folderMarker);
+
+    // verify initial state
+    Assertions.assertThat(fs.listStatus(subdir))
+        .describedAs("No objects are expected to be listed")
+        .isEmpty();
+
+    // rename the src folder.
+    fs.rename(src, dest);
+
+    //verify destination folder exists
+    Assertions.assertThat(fs.exists(new Path(dest, "subdir")))
+        .describedAs("Destination folder should exist")
+        .isTrue();
+
+    // verify src folder does not exists
+    Assertions.assertThat(fs.exists(src))
+        .describedAs("Source folder should not exist after rename")
+        .isFalse();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
+import static org.apache.hadoop.fs.s3a.Constants.S3N_FOLDER_SUFFIX;
+
+/**
+ * This test verifies that the EMRFS or legacy S3N filesystem compatibility with
+ * S3A works as expected.
+ */
+public class ITestEMRFSCompatibility extends AbstractS3ATestBase {
+
+  private Path basePath;
+  private static final String FILE_NAME = "file1.txt";
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    S3AFileSystem fs = getFileSystem();
+    basePath = methodPath();
+
+    // define the paths and create them.
+    describe("Creating test directories and files");
+
+    // write an empty S3N folder marker object
+    Path folderMarker = new Path(basePath, S3N_FOLDER_SUFFIX);
+    touch(fs, folderMarker);
+
+    // write an empty object
+    Path file = new Path(basePath, FILE_NAME);
+    touch(fs, file);
+  }
+
+  @Test
+  public void testSkipS3NFolderMarker() throws Throwable {
+    S3AFileSystem fs = getFileSystem();
+    FileStatus[] fileStatus = fs.listStatus(basePath);
+    Assertions.assertThat(fileStatus.length)
+        .describedAs("The expected number of files did not match")
+        .isEqualTo(1);
+    Assertions.assertThat(fileStatus[0].getPath().getName())
+        .describedAs("The expected name does not match")
+        .isEqualTo(FILE_NAME);
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

After [HADOOP-19278](https://issues.apache.org/jira/browse/HADOOP-19278) , The S3N folder marker _$folder$ is not skipped during listing of S3 directories leading to S3A filesystem not able to read data written by legacy Hadoop S3N filesystem and AWS EMR's EMRFS (S3 filesystem) leading to compatibility issues and possible migration risks to S3A filesystem.

### How was this patch tested?

Added integration test `ITestEMRFSCompatibility` and ran other UT/IT in `us-east-1 `region

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

