### PR TITLE
HDFS-17732. addExpectedReplicasToPending should add EC block expectedStorages in PendingReconstructionBlocks.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -1252,30 +1252,21 @@ public class BlockManager implements BlockStatsMXBean {
   /**
    * If IBR is not sent from expected locations yet, add the datanodes to
    * pendingReconstruction in order to keep RedundancyMonitor from scheduling
-   * the block. In case of erasure coding blocks, adds only in case there
-   * isn't any missing node.
+   * the block.
    */
   public void addExpectedReplicasToPending(BlockInfo blk) {
-    boolean addForStriped = false;
     DatanodeStorageInfo[] expectedStorages =
         blk.getUnderConstructionFeature().getExpectedStorageLocations();
-    if (blk.isStriped()) {
-      BlockInfoStriped blkStriped = (BlockInfoStriped) blk;
-      addForStriped =
-          blkStriped.getRealTotalBlockNum() == expectedStorages.length;
-    }
-    if (!blk.isStriped() || addForStriped) {
-      if (expectedStorages.length - blk.numNodes() > 0) {
-        ArrayList<DatanodeStorageInfo> pendingNodes = new ArrayList<>();
-        for (DatanodeStorageInfo storage : expectedStorages) {
-          DatanodeDescriptor dnd = storage.getDatanodeDescriptor();
-          if (blk.findStorageInfo(dnd) == null) {
-            pendingNodes.add(storage);
-          }
+    if (expectedStorages.length - blk.numNodes() > 0) {
+      ArrayList<DatanodeStorageInfo> pendingNodes = new ArrayList<>();
+      for (DatanodeStorageInfo storage : expectedStorages) {
+        DatanodeDescriptor dnd = storage.getDatanodeDescriptor();
+        if (blk.findStorageInfo(dnd) == null) {
+          pendingNodes.add(storage);
         }
-        pendingReconstruction.increment(blk,
-            pendingNodes.toArray(new DatanodeStorageInfo[pendingNodes.size()]));
       }
+      pendingReconstruction.increment(blk,
+          pendingNodes.toArray(new DatanodeStorageInfo[pendingNodes.size()]));
     }
   }
 
@@ -3868,6 +3859,10 @@ public class BlockManager implements BlockStatsMXBean {
       processExtraRedundancyBlock(storedBlock, fileRedundancy, node,
           delNodeHint);
     }
+    if (storedBlock.isStriped() && storedBlock.isComplete() && hasEnoughEffectiveReplicas(
+        storedBlock, num, 0)) {
+      pendingReconstruction.remove(storedBlock);
+    }
     // If the file redundancy has reached desired value
     // we can remove any corrupt replicas the block may have
     int corruptReplicasCount = corruptReplicas.numCorruptReplicas(storedBlock);
@@ -5048,6 +5043,9 @@ public class BlockManager implements BlockStatsMXBean {
             n.readOnlyReplicas(), n.outOfServiceReplicas(), expected);
       } else if (shouldProcessExtraRedundancy(n, expected)) {
         processExtraRedundancyBlock(block, expected, null, null);
+      }
+      if (block.isStriped() && hasEnoughEffectiveReplicas(block, n, 0)) {
+        pendingReconstruction.remove(block);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdfs;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeys.FS_CLIENT_TOPOLOGY_RESOLUTION_ENABLED;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_FILE_CLOSE_NUM_COMMITTED_ALLOWED_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RECONSTRUCTION_PENDING_TIMEOUT_SEC_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsAdmin.TRASH_PERMISSION;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,10 +109,15 @@ import org.apache.hadoop.hdfs.protocol.HdfsConstants.RollingUpgradeAction;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.SafeModeAction;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants.StoragePolicySatisfierMode;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocol.OpenFileEntry;
 import org.apache.hadoop.hdfs.protocol.OpenFilesIterator;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoStriped;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerTestUtil;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyRackFaultTolerant;
+import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
@@ -2777,6 +2784,56 @@ public class TestDistributedFileSystem {
           () ->
           DFSTestUtil.createFile(fs, new Path("/testFile"),
               1024L, (short) 3, 1024L));
+    }
+  }
+
+  @Test(timeout = 60000)
+  public void testECAddExpectedReplicasToPending() throws Exception {
+    HdfsConfiguration conf = new HdfsConfiguration();
+    conf.setInt(DFS_NAMENODE_FILE_CLOSE_NUM_COMMITTED_ALLOWED_KEY, 0);
+    conf.setInt(DFS_NAMENODE_RECONSTRUCTION_PENDING_TIMEOUT_SEC_KEY, 10);
+    conf.setInt(DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 3);
+    try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build()) {
+      cluster.waitActive();
+      final DistributedFileSystem dfs = cluster.getFileSystem();
+      Path dir = new Path("/dir");
+      dfs.mkdirs(dir);
+      dfs.enableErasureCodingPolicy("XOR-2-1-1024k");
+      dfs.setErasureCodingPolicy(dir, "XOR-2-1-1024k");
+
+      try (FSDataOutputStream str = dfs.create(new Path("/dir/file"));) {
+        DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(0));
+        DataNodeTestUtils.pauseIBR(cluster.getDataNodes().get(1));
+        Thread.sleep(1000);
+        for (int i = 0; i < 1024 * 1024; i++) {
+          str.write(i);
+        }
+        str.flush();
+        // Wait for dn2 IBR.
+        Thread.sleep(2000);
+      }
+
+      LocatedBlocks locatedBlocks = dfs.getClient().getBlockLocations("/dir/file", 1024 * 1024);
+      BlockManager blockManager = cluster.getNamesystem().getBlockManager();
+      BlockInfoStriped blockInfo = (BlockInfoStriped) blockManager.getStoredBlock(
+          locatedBlocks.getLocatedBlocks().get(0).getBlock().getLocalBlock());
+      assertEquals(1, blockInfo.numNodes());
+      int pendingNum =
+          BlockManagerTestUtil.getNumReplicasInPendingReconstruction(blockManager, blockInfo);
+      assertEquals(2, pendingNum);
+
+      DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(0));
+      DataNodeTestUtils.resumeIBR(cluster.getDataNodes().get(1));
+      // Wait for dn0 dn1 IBR.
+      Thread.sleep(2000);
+      pendingNum =
+          BlockManagerTestUtil.getNumReplicasInPendingReconstruction(blockManager, blockInfo);
+      assertEquals(0, pendingNum);
+
+      blockInfo = (BlockInfoStriped) blockManager.getStoredBlock(
+          locatedBlocks.getLocatedBlocks().get(0).getBlock().getLocalBlock());
+      assertEquals(2, blockInfo.numNodes());
+      assertEquals(BlockUCState.COMPLETE, blockInfo.getBlockUCState());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
@@ -172,6 +172,11 @@ public class BlockManagerTestUtil {
     blockManager.pendingReconstruction.getTimerThread().interrupt();
   }
 
+  public static int getNumReplicasInPendingReconstruction(final BlockManager blockManager,
+      BlockInfo blockInfo) {
+    return blockManager.pendingReconstruction.getNumReplicas(blockInfo);
+  }
+
   public static HeartbeatManager getHeartbeatManager(
       final BlockManager blockManager) {
     return blockManager.getDatanodeManager().getHeartbeatManager();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: HDFS-17732. addExpectedReplicasToPending should add EC block expectedStorages in PendingReconstructionBlocks.

Now when a block commit , it should add expectedStorages into PendingReconstructionBlocks if datanode ibr is not sent from expected locations.  And for a ec block group , only  blkStriped.getRealTotalBlockNum() == expectedStorages.length will be added into PendingReconstructionBlocks.
 
The problem is that  when an ec file size <= ecPolicy.getCellSize *(ecPolicy.getNumDataUnits()-1),  it always will be blkStriped.getRealTotalBlockNum() < expectedStorages.length.   This will lead to namenode generation reconstruction task first if other ibrs comme later.


For example:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/ed1f726e-2ae8-4564-84e2-bf227a73b1f9" />


(1)   A EC file with XOR-2-1-1024k，file size <=1024k
(2)  The file has one ec block  and 3 replics (blk0,blk1,blk2) , and only blk0,blk2 has data because of file size <=1024k
(3)  Namenode recived IBR0
(4)  Client close file,  now the file reach MinStorage and ec block commit
(5)  Now blkStriped.getRealTotalBlockNum()=1  expectedStorages.length=3  ,so blk1,blk2 cannot add into PendingReconstructionBlocks
(6)  Ec block complete and file close, because it has missing block so add into neededReconstruction 
(7)  Namenode generation ec reconstruction task and deliver to the datanode DN2
(8)  Namenode recived IBR2 (DN2 blk2) 
(9)  Namenode recived  new block (DN2 ec reconstruction task    blk2')
(10) For ecPolicy, DN2 has two  block   blk2 ,blk2' , this increases the risk of data loss
(11) For other ecPolicy, on a same datanode may has two different replicas on  one ec block group , and namenode will only record the later replica.

 

So the right way is:
(1) addExpectedReplicasToPending should add EC block expectedStorages in PendingReconstructionBlocks
(2) In order to reduce PendingReconstructionBlocks timeout, when a file close or ibr commes, we should remove block which has enough replicas from  PendingReconstructionBlocks
