### PR TITLE
 MAPREDUCE-7500. Support optimistic file renames in the commit protocol

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -508,7 +508,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
               }
             }
 
-            // The delete call succeeded. Try and rename the file again. 
+            // The delete call succeeded. Try and rename the file again.
             if (!fs.rename(from.getPath(), to)) {
               throw new IOException("Failed retry of rename " + from + " to " + to);
             }
@@ -524,11 +524,11 @@ public class FileOutputCommitter extends PathOutputCommitter {
 
           if (!fs.rename(from.getPath(), to)) {
             throw new IOException("Failed to rename " + from + " to " + to);
-          } 
+          }
         }
       } else if (from.isDirectory()) {
         FileStatus toStat = getFileStatus(fs, to);
-        
+
         if (toStat != null) {
           if (!toStat.isDirectory()) {
             if (!fs.delete(to, true)) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -490,7 +490,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
 
       if (from.isFile()) {
         if (useOptimisticFileMerge) {
-          // This first assumes that there is no object in the destination.
+          // This assumes that there is no object in the destination.
           // If the rename succeeds this saves a getFileStatus call.
           // If the rename fails then it attempts to delete the object and tries
           // again.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -100,11 +100,17 @@ public class FileOutputCommitter extends PathOutputCommitter {
   public static final boolean
       FILEOUTPUTCOMMITTER_TASK_CLEANUP_ENABLED_DEFAULT = false;
 
+  public static final String FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED =
+      "mapreduce.fileoutputcommitter.optimistic.file.commit.enabled";
+  public static final boolean
+      FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED_DEFAULT = false;
+
   private Path outputPath = null;
   private Path workPath = null;
   private final int algorithmVersion;
   private final boolean skipCleanup;
   private final boolean ignoreCleanupFailures;
+  private final boolean useOptimisticFileMerge;
 
   /**
    * Create a file output committer
@@ -162,6 +168,10 @@ public class FileOutputCommitter extends PathOutputCommitter {
       FileSystem fs = outputPath.getFileSystem(context.getConfiguration());
       this.outputPath = fs.makeQualified(outputPath);
     }
+
+    useOptimisticFileMerge = conf.getBoolean(
+        FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED,
+        FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED_DEFAULT);
   }
   
   /**
@@ -446,6 +456,24 @@ public class FileOutputCommitter extends PathOutputCommitter {
   }
 
   /**
+   * Gets the file status for the path
+   * @param fs The file system to use
+   * @param p The path to get the status of
+   * @return The file status, or null if the path does not exist
+   * @throws IOException
+   */
+  private static FileStatus getFileStatus(FileSystem fs, Path p) throws IOException {
+    FileStatus stat;
+    try {
+      stat = fs.getFileStatus(p);
+    } catch (FileNotFoundException fnfe) {
+      stat = null;
+    }
+
+    return stat;
+  }
+
+  /**
    * Merge two paths together.  Anything in from will be moved into to, if there
    * are any name conflicts while merging the files or directories in from win.
    * @param fs the File System to use
@@ -459,24 +487,48 @@ public class FileOutputCommitter extends PathOutputCommitter {
         false,
         "Merging data from %s to %s", from, to)) {
       reportProgress(context);
-      FileStatus toStat;
-      try {
-        toStat = fs.getFileStatus(to);
-      } catch (FileNotFoundException fnfe) {
-        toStat = null;
-      }
 
       if (from.isFile()) {
-        if (toStat != null) {
-          if (!fs.delete(to, true)) {
-            throw new IOException("Failed to delete " + to);
-          }
-        }
+        if (useOptimisticFileMerge) {
+          // This first assumes that there is no object in the destination.
+          // If the rename succeeds this saves a getFileStatus call.
+          // If the rename fails then it attempts to delete the object and tries
+          // again.
+          if (!fs.rename(from.getPath(), to)) {
+            // There may be an object in the destination. Try and delete it.
+            if (!fs.delete(to, true)) {
+              // If the delete call did not succeed it means the rename
+              // did not fail from the case of a file/dir in the destination location with ACLs that allows
+              // for this client to delete it. Check the file status to give a failure that aligns with the
+              // non-optimistic file commit path.
+              if (getFileStatus(fs, to) != null) {
+                throw new IOException("Failed to delete " + to);
+              } else {
+                throw new IOException("Failed to rename " + from + " to " + to);
+              }
+            }
 
-        if (!fs.rename(from.getPath(), to)) {
-          throw new IOException("Failed to rename " + from + " to " + to);
+            // The delete call succeeded. Try and rename the file again. 
+            if (!fs.rename(from.getPath(), to)) {
+              throw new IOException("Failed retry of rename " + from + " to " + to);
+            }
+          }
+        } else {
+          FileStatus toStat = getFileStatus(fs, to);
+          
+          if (toStat != null) {
+            if (!fs.delete(to, true)) {
+              throw new IOException("Failed to delete " + to);
+            }
+          }
+
+          if (!fs.rename(from.getPath(), to)) {
+            throw new IOException("Failed to rename " + from + " to " + to);
+          } 
         }
       } else if (from.isDirectory()) {
+        FileStatus toStat = getFileStatus(fs, to);
+        
         if (toStat != null) {
           if (!toStat.isDirectory()) {
             if (!fs.delete(to, true)) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -456,7 +456,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
   }
 
   /**
-   * Gets the file status for the path
+   * Gets the file status for the path.
    * @param fs The file system to use
    * @param p The path to get the status of
    * @return The file status, or null if the path does not exist
@@ -498,9 +498,9 @@ public class FileOutputCommitter extends PathOutputCommitter {
             // There may be an object in the destination. Try and delete it.
             if (!fs.delete(to, true)) {
               // If the delete call did not succeed it means the rename
-              // did not fail from the case of a file/dir in the destination location with ACLs that allows
-              // for this client to delete it. Check the file status to give a failure that aligns with the
-              // non-optimistic file commit path.
+              // did not fail from the case of a file/dir in the destination location with ACLs
+              // that allows for this client to delete it. Check the file status to give a
+              // failure that aligns with the non-optimistic file commit path.
               if (getFileStatus(fs, to) != null) {
                 throw new IOException("Failed to delete " + to);
               } else {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -515,7 +515,7 @@ public class FileOutputCommitter extends PathOutputCommitter {
           }
         } else {
           FileStatus toStat = getFileStatus(fs, to);
-          
+
           if (toStat != null) {
             if (!fs.delete(to, true)) {
               throw new IOException("Failed to delete " + to);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -97,12 +97,12 @@ public class TestFileOutputCommitter {
 
     // Default configs
     testCases.add(Arguments.of(job.getConfiguration()));
-    
+
     // Optimistic file commits
     Configuration configOptimisticFileCommits = job.getConfiguration();
     configOptimisticFileCommits.set(FileOutputCommitter.FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED, "true");
     testCases.add(Arguments.of(configOptimisticFileCommits));
-    
+
     return testCases;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -142,11 +142,12 @@ public class TestFileOutputCommitter {
     }
   }
   
-  private void testRecoveryInternal(int commitVersion, int recoveryVersion)
+  private void testRecoveryInternal(int commitVersion, int recoveryVersion, Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(MRJobConfig.APPLICATION_ATTEMPT_ID, 1);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
@@ -179,6 +180,7 @@ public class TestFileOutputCommitter {
     //now while running the second app attempt, 
     //recover the task output from first attempt
     Configuration conf2 = job.getConfiguration();
+    conf2.addResource(additionalConfigs);
     conf2.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf2.setInt(MRJobConfig.APPLICATION_ATTEMPT_ID, 2);
     conf2.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
@@ -263,11 +265,12 @@ public class TestFileOutputCommitter {
     assert(dataFileFound && indexFileFound);
   }
 
-  private void testCommitterInternal(int version, boolean taskCleanup)
+  private void testCommitterInternal(int version, boolean taskCleanup, Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(
         FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
@@ -343,11 +346,12 @@ public class TestFileOutputCommitter {
     testCommitterWithDuplicatedCommitInternal(2);
   }
 
-  private void testCommitterWithDuplicatedCommitInternal(int version) throws
+  private void testCommitterWithDuplicatedCommitInternal(int version, Configuration additionalConfigs) throws
       Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
@@ -397,11 +401,12 @@ public class TestFileOutputCommitter {
     testCommitterWithFailureInternal(2, 2);
   }
 
-  private void testCommitterWithFailureInternal(int version, int maxAttempts)
+  private void testCommitterWithFailureInternal(int version, int maxAttempts, Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
@@ -442,10 +447,11 @@ public class TestFileOutputCommitter {
   }
 
   @Test
-  public void testProgressDuringMerge() throws Exception {
+  public void testProgressDuringMerge(Configuration additionalConfigs) throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         2);
@@ -481,11 +487,12 @@ public class TestFileOutputCommitter {
   }
 
   // retry committer for 2 times.
-  private void testCommitterRetryInternal(int version)
+  private void testCommitterRetryInternal(int version, Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
@@ -536,11 +543,12 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  private void testMapFileOutputCommitterInternal(int version)
+  private void testMapFileOutputCommitterInternal(int version, Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
@@ -585,10 +593,11 @@ public class TestFileOutputCommitter {
   }
 
   @Test
-  public void testInvalidVersionNumber() throws IOException {
+  public void testInvalidVersionNumber(Configuration additionalConfigs) throws IOException {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION, 3);
     TaskAttemptContext tContext = new TaskAttemptContextImpl(conf, taskID);
@@ -600,11 +609,12 @@ public class TestFileOutputCommitter {
     }
   }
 
-  private void testAbortInternal(int version)
+  private void testAbortInternal(int version, Configuration additionalConfigs)
       throws IOException, InterruptedException {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);
@@ -662,10 +672,11 @@ public class TestFileOutputCommitter {
   }
 
 
-  private void testFailAbortInternal(int version)
+  private void testFailAbortInternal(int version, Configuration additionalConfigs)
       throws IOException, InterruptedException {
     Job job = Job.getInstance();
     Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, "faildel:///");
     conf.setClass("fs.faildel.impl", FakeFileSystem.class, FileSystem.class);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
@@ -749,11 +760,12 @@ public class TestFileOutputCommitter {
     }
   }
 
-  private void testConcurrentCommitTaskWithSubDir(int version)
+  private void testConcurrentCommitTaskWithSubDir(int version, Configuration additionalConfigs)
       throws Exception {
     final Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
     final Configuration conf = job.getConfiguration();
+    conf.addResource(additionalConfigs);
     conf.set(MRJobConfig.TASK_ATTEMPT_ID, attempt);
     conf.setInt(FileOutputCommitter.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION,
         version);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -24,13 +24,17 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -86,6 +90,21 @@ public class TestFileOutputCommitter {
 
   private static final String attempt1 = "attempt_200707121733_0001_m_000001_0";
   private static final TaskAttemptID taskID1 = TaskAttemptID.forName(attempt1);
+
+  static List<Arguments> configurationProvider() throws IOException {
+    List<Arguments> testCases = new ArrayList<>();
+    Job job = Job.getInstance();
+
+    // Default configs
+    testCases.add(Arguments.of(job.getConfiguration()));
+    
+    // Optimistic file commits
+    Configuration configOptimisticFileCommits = job.getConfiguration();
+    configOptimisticFileCommits.set(FileOutputCommitter.FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED, "true");
+    testCases.add(Arguments.of(configOptimisticFileCommits));
+    
+    return testCases;
+  }
 
   private Text key1 = new Text("key1");
   private Text key2 = new Text("key2");
@@ -208,19 +227,22 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
-  public void testRecoveryV1() throws Exception {
-    testRecoveryInternal(1, 1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testRecoveryV1(Configuration additionalConfigs) throws Exception {
+    testRecoveryInternal(1, 1, additionalConfigs);
   }
 
-  @Test
-  public void testRecoveryV2() throws Exception {
-    testRecoveryInternal(2, 2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testRecoveryV2(Configuration additionalConfigs) throws Exception {
+    testRecoveryInternal(2, 2, additionalConfigs);
   }
 
-  @Test
-  public void testRecoveryUpgradeV1V2() throws Exception {
-    testRecoveryInternal(1, 2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testRecoveryUpgradeV1V2(Configuration additionalConfigs) throws Exception {
+    testRecoveryInternal(1, 2, additionalConfigs);
   }
 
   private void validateContent(Path dir) throws IOException {
@@ -321,29 +343,34 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
-  public void testCommitterV1() throws Exception {
-    testCommitterInternal(1, false);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterV1(Configuration additionalConfigs) throws Exception {
+    testCommitterInternal(1, false, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterV2() throws Exception {
-    testCommitterInternal(2, false);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterV2(Configuration additionalConfigs) throws Exception {
+    testCommitterInternal(2, false, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterV2TaskCleanupEnabled() throws Exception {
-    testCommitterInternal(2, true);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterV2TaskCleanupEnabled(Configuration additionalConfigs) throws Exception {
+    testCommitterInternal(2, true, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterWithDuplicatedCommitV1() throws Exception {
-    testCommitterWithDuplicatedCommitInternal(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterWithDuplicatedCommitV1(Configuration additionalConfigs) throws Exception {
+    testCommitterWithDuplicatedCommitInternal(1, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterWithDuplicatedCommitV2() throws Exception {
-    testCommitterWithDuplicatedCommitInternal(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterWithDuplicatedCommitV2(Configuration additionalConfigs) throws Exception {
+    testCommitterWithDuplicatedCommitInternal(2, additionalConfigs);
   }
 
   private void testCommitterWithDuplicatedCommitInternal(int version, Configuration additionalConfigs) throws
@@ -389,16 +416,18 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
-  public void testCommitterWithFailureV1() throws Exception {
-    testCommitterWithFailureInternal(1, 1);
-    testCommitterWithFailureInternal(1, 2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterWithFailureV1(Configuration additionalConfigs) throws Exception {
+    testCommitterWithFailureInternal(1, 1, additionalConfigs);
+    testCommitterWithFailureInternal(1, 2, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterWithFailureV2() throws Exception {
-    testCommitterWithFailureInternal(2, 1);
-    testCommitterWithFailureInternal(2, 2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterWithFailureV2(Configuration additionalConfigs) throws Exception {
+    testCommitterWithFailureInternal(2, 1, additionalConfigs);
+    testCommitterWithFailureInternal(2, 2, additionalConfigs);
   }
 
   private void testCommitterWithFailureInternal(int version, int maxAttempts, Configuration additionalConfigs)
@@ -446,7 +475,8 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
   public void testProgressDuringMerge(Configuration additionalConfigs) throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -476,14 +506,16 @@ public class TestFileOutputCommitter {
     verify(tContext, atLeast(2)).progress();
   }
 
-  @Test
-  public void testCommitterRepeatableV1() throws Exception {
-    testCommitterRetryInternal(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterRepeatableV1(Configuration additionalConfigs) throws Exception {
+    testCommitterRetryInternal(1, additionalConfigs);
   }
 
-  @Test
-  public void testCommitterRepeatableV2() throws Exception {
-    testCommitterRetryInternal(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testCommitterRepeatableV2(Configuration additionalConfigs) throws Exception {
+    testCommitterRetryInternal(2, additionalConfigs);
   }
 
   // retry committer for 2 times.
@@ -582,17 +614,20 @@ public class TestFileOutputCommitter {
     }
   }
 
-  @Test
-  public void testMapFileOutputCommitterV1() throws Exception {
-    testMapFileOutputCommitterInternal(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testMapFileOutputCommitterV1(Configuration additionalConfigs) throws Exception {
+    testMapFileOutputCommitterInternal(1, additionalConfigs);
   }
 
-  @Test
-  public void testMapFileOutputCommitterV2() throws Exception {
-    testMapFileOutputCommitterInternal(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testMapFileOutputCommitterV2(Configuration additionalConfigs) throws Exception {
+    testMapFileOutputCommitterInternal(2, additionalConfigs);
   }
 
-  @Test
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
   public void testInvalidVersionNumber(Configuration additionalConfigs) throws IOException {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -646,14 +681,16 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
-  public void testAbortV1() throws IOException, InterruptedException {
-    testAbortInternal(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testAbortV1(Configuration additionalConfigs) throws IOException, InterruptedException {
+    testAbortInternal(1, additionalConfigs);
   }
 
-  @Test
-  public void testAbortV2() throws IOException, InterruptedException {
-    testAbortInternal(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testAbortV2(Configuration additionalConfigs) throws IOException, InterruptedException {
+    testAbortInternal(2, additionalConfigs);
   }
 
   public static class FakeFileSystem extends RawLocalFileSystem {
@@ -728,14 +765,16 @@ public class TestFileOutputCommitter {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 
-  @Test
-  public void testFailAbortV1() throws Exception {
-    testFailAbortInternal(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testFailAbortV1(Configuration additionalConfigs) throws Exception {
+    testFailAbortInternal(1, additionalConfigs);
   }
 
-  @Test
-  public void testFailAbortV2() throws Exception {
-    testFailAbortInternal(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testFailAbortV2(Configuration additionalConfigs) throws Exception {
+    testFailAbortInternal(2, additionalConfigs);
   }
 
   static class RLFS extends RawLocalFileSystem {
@@ -840,14 +879,16 @@ public class TestFileOutputCommitter {
     }
   }
 
-  @Test
-  public void testConcurrentCommitTaskWithSubDirV1() throws Exception {
-    testConcurrentCommitTaskWithSubDir(1);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testConcurrentCommitTaskWithSubDirV1(Configuration additionalConfigs) throws Exception {
+    testConcurrentCommitTaskWithSubDir(1, additionalConfigs);
   }
 
-  @Test
-  public void testConcurrentCommitTaskWithSubDirV2() throws Exception {
-    testConcurrentCommitTaskWithSubDir(2);
+  @ParameterizedTest
+  @MethodSource("configurationProvider")
+  public void testConcurrentCommitTaskWithSubDirV2(Configuration additionalConfigs) throws Exception {
+    testConcurrentCommitTaskWithSubDir(2, additionalConfigs);
   }
 
   public static String slurp(File f) throws IOException {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestFileOutputCommitter.java
@@ -100,7 +100,8 @@ public class TestFileOutputCommitter {
 
     // Optimistic file commits
     Configuration configOptimisticFileCommits = job.getConfiguration();
-    configOptimisticFileCommits.set(FileOutputCommitter.FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED, "true");
+    configOptimisticFileCommits.set(
+        FileOutputCommitter.FILEOUTPUTCOMMITTER_OPTIMISTIC_FILE_COMMIT_ENABLED, "true");
     testCases.add(Arguments.of(configOptimisticFileCommits));
 
     return testCases;
@@ -161,7 +162,8 @@ public class TestFileOutputCommitter {
     }
   }
   
-  private void testRecoveryInternal(int commitVersion, int recoveryVersion, Configuration additionalConfigs)
+  private void testRecoveryInternal(int commitVersion, int recoveryVersion,
+      Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -287,7 +289,8 @@ public class TestFileOutputCommitter {
     assert(dataFileFound && indexFileFound);
   }
 
-  private void testCommitterInternal(int version, boolean taskCleanup, Configuration additionalConfigs)
+  private void testCommitterInternal(int version, boolean taskCleanup,
+      Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -363,17 +366,20 @@ public class TestFileOutputCommitter {
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testCommitterWithDuplicatedCommitV1(Configuration additionalConfigs) throws Exception {
+  public void testCommitterWithDuplicatedCommitV1(
+      Configuration additionalConfigs) throws Exception {
     testCommitterWithDuplicatedCommitInternal(1, additionalConfigs);
   }
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testCommitterWithDuplicatedCommitV2(Configuration additionalConfigs) throws Exception {
+  public void testCommitterWithDuplicatedCommitV2(
+      Configuration additionalConfigs) throws Exception {
     testCommitterWithDuplicatedCommitInternal(2, additionalConfigs);
   }
 
-  private void testCommitterWithDuplicatedCommitInternal(int version, Configuration additionalConfigs) throws
+  private void testCommitterWithDuplicatedCommitInternal(int version,
+      Configuration additionalConfigs) throws
       Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -430,7 +436,8 @@ public class TestFileOutputCommitter {
     testCommitterWithFailureInternal(2, 2, additionalConfigs);
   }
 
-  private void testCommitterWithFailureInternal(int version, int maxAttempts, Configuration additionalConfigs)
+  private void testCommitterWithFailureInternal(int version, int maxAttempts,
+      Configuration additionalConfigs)
       throws Exception {
     Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -683,13 +690,15 @@ public class TestFileOutputCommitter {
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testAbortV1(Configuration additionalConfigs) throws IOException, InterruptedException {
+  public void testAbortV1(
+      Configuration additionalConfigs) throws IOException, InterruptedException {
     testAbortInternal(1, additionalConfigs);
   }
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testAbortV2(Configuration additionalConfigs) throws IOException, InterruptedException {
+  public void testAbortV2(
+      Configuration additionalConfigs) throws IOException, InterruptedException {
     testAbortInternal(2, additionalConfigs);
   }
 
@@ -799,7 +808,8 @@ public class TestFileOutputCommitter {
     }
   }
 
-  private void testConcurrentCommitTaskWithSubDir(int version, Configuration additionalConfigs)
+  private void testConcurrentCommitTaskWithSubDir(int version,
+      Configuration additionalConfigs)
       throws Exception {
     final Job job = Job.getInstance();
     FileOutputFormat.setOutputPath(job, outDir);
@@ -881,13 +891,15 @@ public class TestFileOutputCommitter {
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testConcurrentCommitTaskWithSubDirV1(Configuration additionalConfigs) throws Exception {
+  public void testConcurrentCommitTaskWithSubDirV1(
+      Configuration additionalConfigs) throws Exception {
     testConcurrentCommitTaskWithSubDir(1, additionalConfigs);
   }
 
   @ParameterizedTest
   @MethodSource("configurationProvider")
-  public void testConcurrentCommitTaskWithSubDirV2(Configuration additionalConfigs) throws Exception {
+  public void testConcurrentCommitTaskWithSubDirV2(
+      Configuration additionalConfigs) throws Exception {
     testConcurrentCommitTaskWithSubDir(2, additionalConfigs);
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR adds a new feature to commit files optimistically (assumes no conflicting file/dir in the destination) to avoid a `FileSystem.getFileStatus` RPC. The default behavior has not been changed. To use this feature this config must be set `mapreduce.fileoutputcommitter.optimistic.file.commit.enabled=true`.

This is useful for cases like Spark where no destination conflict is expected and the `FileSystem.getFileStatus` RPC is wasted time. When I profiled the commit time for a Spark job before this enhancement, it showed this call was taking 50% of the time (HDFS with intermittent latency in our environment).

### How was this patch tested?
**Correctness**
I modified all tests in `FileOutputCommitter` tests to run with and without this configuration. I modified the test class to use parameterized tests using the default configs and this change enabled. There may also be an opportunity to move the v1/v2 algorithm tests into the parameterized test, but I opted to leave that refactor for later to minimize unnecessary changes.

```
[INFO] Running org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.946 s - in org.apache.hadoop.mapreduce.lib.output.TestFileOutputCommitter
```

**Performance**
I tested the performance of the changes using Spark writing to HDFS for partitioned and non-partitioned datasets. The summary of the improvement is:
- For the non-partitioned commit, the average commit time decreased from 16.6min to 4.8min (71% improvement).
- For the partitioned commit, the average commit time decreased from 4.3min to 1.5min (65% improvement).

![image](https://github.com/user-attachments/assets/18c426da-61a4-4cef-9950-438e8f2bf0e0)

Non-partitioned test Spark script:
```scala
val fileCount = 5000
val path = "/path/temp_data_no_part"

spark.range(0, fileCount, 1, fileCount).write
  .mode(SaveMode.Overwrite)
  .option("path", path)
  .save()
```

Partitioned test Spark script:
```scala
val fileCount = 1000
val partitionCount = 5
val path = "/path/temp_data_part"

spark
  .range(0, fileCount, 1, fileCount)
  .withColumn("part", $"id" % lit(partitionCount))
  .write
  .mode(SaveMode.Overwrite)
  .option("path", path)
  .partitionBy("part")
  .save()
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

