### PR TITLE
HADOOP-19469. Set Curator Connection Timeout.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ZKCuratorManager.java
@@ -207,6 +207,7 @@ public final class ZKCuratorManager {
                 conf.get(CommonConfigurationKeys.ZK_KERBEROS_PRINCIPAL),
                 conf.get(CommonConfigurationKeys.ZK_KERBEROS_KEYTAB), sslEnabled,
                 new TruststoreKeystore(conf))).zkClientConfig(zkClientConfig)
+        .connectionTimeoutMs(zkSessionTimeout)
         .sessionTimeoutMs(zkSessionTimeout).retryPolicy(retryPolicy)
         .authorization(authInfos).build();
     client.start();


### PR DESCRIPTION
JIRA: HADOOP-19469. Set Curator Connection Timeout.

Curator 5.2.0 has a default "connection timeout" of 15s:

https://github.com/apache/curator/blob/apache-curator-5.2.0/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java#L63

And it will throw a warning if the Zookeeper session timeout is less than the Curator connection timeout:

https://github.com/apache/curator/blob/apache-curator-5.2.0/curator-client/src/main/java/org/apache/curator/CuratorZookeeperClient.java#L117-L120

The Hadoop default for ZK timeout is set to 10s:

https://github.com/apache/hadoop/blob/0dd9bf8/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java#L414-L416

Which means without setting the "connection timeout" a default installation will keep warning about the connection timeout for Curator being lower than the requested session timeout. This sets both timeout values to override the Curator default.

Another option is to change the default Hadoop ZK timeout from 10s to 15s.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

