### PR TITLE
HDFS-17737. Implement Backoff Retry for ErasureCoding reads

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/pom.xml
@@ -190,6 +190,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <source>8</source>
           <excludePackageNames>org.apache.hadoop.hdfs.protocol.proto</excludePackageNames>
         </configuration>
       </plugin>

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.classification.VisibleForTesting;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -68,7 +68,7 @@ public class DFSClientFaultInjector {
 
   public void delayWhenRenewLeaseTimeout() {}
 
-  public void onCreateBlockReader(LocatedBlock block, int chunkIndex, long offset, long length) {}
+  public void onCreateBlockReader(LocatedBlock block, int chunkIndex, long offset, long length) throws IOException {}
 
   public void failCreateBlockReader() throws InvalidBlockTokenException {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -69,7 +69,8 @@ public class DFSClientFaultInjector {
 
   public void delayWhenRenewLeaseTimeout() {}
 
-  public void onCreateBlockReader(LocatedBlock block, int chunkIndex, long offset, long length) throws IOException {}
+  public void onCreateBlockReader(LocatedBlock block, int chunkIndex,
+      long offset, long length) throws IOException {}
 
   public void failCreateBlockReader() throws InvalidBlockTokenException {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 
 import org.apache.hadoop.io.erasurecode.ErasureCoderOptions;
 import org.apache.hadoop.io.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.hadoop.util.Time;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -51,10 +52,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdfs.util.IOUtilsClient.updateReadStatistics;
 
@@ -76,6 +80,8 @@ public class DFSStripedInputStream extends DFSInputStream {
   protected ByteBuffer parityBuf;
   private final ErasureCodingPolicy ecPolicy;
   private RawErasureDecoder decoder;
+  private final ConcurrentHashMap<DatanodeInfo, RetryTimeoutPair> sleepingNodes =
+      new ConcurrentHashMap<>();
 
   /**
    * Indicate the start/end offset of the current buffered stripe in the
@@ -232,6 +238,102 @@ public class DFSStripedInputStream extends DFSInputStream {
     return pos - currentLocatedBlock.getStartOffset();
   }
 
+  private static class RetryTimeoutPair {
+    private int attempts = 0;
+    private long sleepTimestamp = 0;
+  }
+
+  /**
+   * Gets the list of nodes that are waiting to be retried.
+   * @return The list of sleeping nodes
+   */
+  protected Collection<DatanodeInfo> checkSleepingNodes() {
+    return sleepingNodes.entrySet().stream().filter(entry ->
+        entry.getValue().sleepTimestamp > Time.monotonicNow())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+  }
+
+  private long getSleepingTimestamp(int attempts) {
+    // Introducing a random factor to the wait time before another retry.
+    // The wait time is dependent on # of failures and a random factor.
+    // At the first time of getting a BlockMissingException, the wait time
+    // is a random number between 0..3000 ms. If the first retry
+    // still fails, we will wait 3000 ms grace period before the 2nd retry.
+    // Also at the second retry, the waiting window is expanded to 6000 ms
+    // alleviating the request rate from the server. Similarly the 3rd retry
+    // will wait 6000ms grace period before retry and the waiting window is
+    // expanded to 9000ms.
+    // grace period for the last round of attempt
+    double waitTime = dfsClient.getConf().getTimeWindow() * attempts +
+        // expanding time window for each failure
+        dfsClient.getConf().getTimeWindow() * attempts *
+            ThreadLocalRandom.current().nextDouble();
+    return Time.monotonicNow() + (long)waitTime;
+  }
+
+  /**
+   * Checks whether the {@param block} is on a sleeping node.
+   * @param block the block to check
+   * @return True if the {@param block} is on a sleeping node, otherwise false.
+   */
+  protected boolean isBlockOnSleepingNode(LocatedBlock block) {
+    Collection<DatanodeInfo> sleepingNodes = checkSleepingNodes();
+    DNAddrPair dnInfo = getBestNodeDNAddrPair(block, null);
+    return dnInfo != null && sleepingNodes.contains(dnInfo.info);
+  }
+
+  /**
+   * Sleeps the thread until the next retry can be attempted.
+   */
+  protected void sleepUntilRetry() {
+    long sleepTimestamp = 0;
+    int countSleepingNodes = 0;
+    for (RetryTimeoutPair rt : sleepingNodes.values()) {
+      if (rt.sleepTimestamp > Time.monotonicNow()) {
+        countSleepingNodes++;
+        if (sleepTimestamp == 0) {
+          sleepTimestamp = rt.sleepTimestamp;
+        } else {
+          sleepTimestamp = Math.min(sleepTimestamp, rt.sleepTimestamp);
+        }
+      }
+    }
+    long duration = sleepTimestamp - Time.monotonicNow();
+    try {
+      DFSClient.LOG.warn("Failed to acquire {}/{} blocks, will wait " +
+                             "for {} msec and try again", countSleepingNodes,
+          dataBlkNum + parityBlkNum, duration);
+      Thread.sleep(duration);
+    } catch (InterruptedException e) {
+      DFSClient.LOG.warn("Error read retry backoff interrupted");
+    }
+  }
+
+  /**
+   * Update the {@param dnInfo} node with a new sleepTimestamp if it has any
+   * retries left, otherwise put it into the deadNodes list.
+   * @param dnInfo Update the sleeping information for this node.
+   * @return True if the node {@param dnInfo} will be retried, otherwise false.
+   */
+  protected boolean updateSleepingNodes(DatanodeInfo dnInfo) {
+    // Ignore nodes that are already in the deadNodes list.
+    if (!getLocalDeadNodes().containsKey(dnInfo)) {
+      RetryTimeoutPair rt = sleepingNodes.computeIfAbsent(dnInfo,
+          k -> new RetryTimeoutPair());
+      rt.attempts++;
+      if (rt.attempts > dfsClient.getConf().getMaxBlockAcquireFailures()) {
+        // If we are out of retries, then put the node into the deadNodes list
+        sleepingNodes.remove(dnInfo);
+        addToLocalDeadNodes(dnInfo);
+      } else {
+        rt.sleepTimestamp = getSleepingTimestamp(rt.attempts);
+        return true;
+      }
+    }
+    return false;
+  }
+
   boolean createBlockReader(LocatedBlock block, long offsetInBlock,
       LocatedBlock[] targetBlocks, BlockReaderInfo[] readerInfos,
       int chunkIndex, long readTo) throws IOException {
@@ -248,18 +350,18 @@ public class DFSStripedInputStream extends DFSInputStream {
         targetBlocks[chunkIndex] = block;
 
         // internal block has one location, just rule out the deadNodes
-        dnInfo = getBestNodeDNAddrPair(block, null);
+        dnInfo = getBestNodeDNAddrPair(block, checkSleepingNodes());
         if (dnInfo == null) {
           break;
         }
         if (readTo < 0 || readTo > block.getBlockSize()) {
           readTo = block.getBlockSize();
         }
+        DFSClientFaultInjector.get().onCreateBlockReader(block, chunkIndex, offsetInBlock,
+            readTo - offsetInBlock);
         reader = getBlockReader(block, offsetInBlock,
             readTo - offsetInBlock,
             dnInfo.addr, dnInfo.storageType, dnInfo.info);
-        DFSClientFaultInjector.get().onCreateBlockReader(block, chunkIndex, offsetInBlock,
-            readTo - offsetInBlock);
       } catch (IOException e) {
         if (e instanceof InvalidEncryptionKeyException &&
             retry.shouldRefetchEncryptionKey()) {
@@ -273,12 +375,11 @@ public class DFSStripedInputStream extends DFSInputStream {
           fetchBlockAt(block.getStartOffset());
           retry.refetchToken();
         } else {
-          //TODO: handles connection issues
           DFSClient.LOG.warn("Failed to connect to " + dnInfo.addr + " for " +
               "block" + block.getBlock(), e);
           // re-fetch the block in case the block has been moved
           fetchBlockAt(block.getStartOffset());
-          addToLocalDeadNodes(dnInfo.info);
+          updateSleepingNodes(dnInfo.info);
         }
       }
       if (reader != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -52,7 +52,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
@@ -278,9 +277,8 @@ public class DFSStripedInputStream extends DFSInputStream {
    * @return True if the {@param block} is on a sleeping node, otherwise false.
    */
   protected boolean isBlockOnSleepingNode(LocatedBlock block) {
-    Collection<DatanodeInfo> sleepingNodes = checkSleepingNodes();
     DNAddrPair dnInfo = getBestNodeDNAddrPair(block, null);
-    return dnInfo != null && sleepingNodes.contains(dnInfo.info);
+    return dnInfo != null && checkSleepingNodes().contains(dnInfo.info);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PositionStripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/PositionStripeReader.java
@@ -56,14 +56,14 @@ class PositionStripeReader extends StripeReader {
   @Override
   boolean prepareParityChunk(int index) {
     Preconditions.checkState(index >= dataBlkNum &&
-        alignedStripe.chunks[index] == null);
+        alignedStripe.isNull(index));
 
     int bufLen = (int) alignedStripe.getSpanInBlock();
     decodeInputs[index] = new ECChunk(codingBuffer.duplicate(), index * bufLen,
         bufLen);
 
-    alignedStripe.chunks[index] =
-        new StripingChunk(decodeInputs[index].getBuffer());
+    alignedStripe.setChunk(index,
+        new StripingChunk(decodeInputs[index].getBuffer()));
 
     return true;
   }
@@ -86,9 +86,9 @@ class PositionStripeReader extends StripeReader {
     }
 
     for (int i = 0; i < dataBlkNum; i++) {
-      if (alignedStripe.chunks[i] == null) {
-        alignedStripe.chunks[i] =
-            new StripingChunk(decodeInputs[i].getBuffer());
+      if (alignedStripe.isNull(i)) {
+        alignedStripe.setChunk(i,
+            new StripingChunk(decodeInputs[i].getBuffer()));
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ReadStatistics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ReadStatistics.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdfs;
 
 import org.apache.hadoop.hdfs.protocol.BlockType;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A utility class that maintains statistics for reading.
  */
@@ -29,7 +31,7 @@ public class ReadStatistics {
   private long totalZeroCopyBytesRead;
 
   private BlockType blockType = BlockType.CONTIGUOUS;
-  private long totalEcDecodingTimeMillis;
+  private long totalEcDecodingTimeNanos;
 
   public ReadStatistics() {
     clear();
@@ -92,7 +94,14 @@ public class ReadStatistics {
    * Return the total time in milliseconds used for erasure coding decoding.
    */
   public synchronized long getTotalEcDecodingTimeMillis() {
-    return totalEcDecodingTimeMillis;
+    return TimeUnit.NANOSECONDS.toMillis(totalEcDecodingTimeNanos);
+  }
+
+  /**
+   * Return the total time in nanoseconds used for erasure coding decoding.
+   */
+  public synchronized long getTotalEcDecodingTimeNanos() {
+    return totalEcDecodingTimeNanos;
   }
 
   public synchronized void addRemoteBytes(long amt) {
@@ -117,8 +126,8 @@ public class ReadStatistics {
     this.totalZeroCopyBytesRead += amt;
   }
 
-  public synchronized void addErasureCodingDecodingTime(long millis) {
-    this.totalEcDecodingTimeMillis += millis;
+  public synchronized void addErasureCodingDecodingTime(long nanos) {
+    this.totalEcDecodingTimeNanos += nanos;
   }
 
   synchronized void setBlockType(BlockType blockType) {
@@ -130,6 +139,6 @@ public class ReadStatistics {
     this.totalLocalBytesRead = 0;
     this.totalShortCircuitBytesRead = 0;
     this.totalZeroCopyBytesRead = 0;
-    this.totalEcDecodingTimeMillis = 0;
+    this.totalEcDecodingTimeNanos = 0;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StatefulStripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StatefulStripeReader.java
@@ -63,9 +63,9 @@ class StatefulStripeReader extends StripeReader {
       cur.position(pos);
       cur.limit(pos + bufLen);
       decodeInputs[i] = new ECChunk(cur.slice(), 0, bufLen);
-      if (alignedStripe.chunks[i] == null) {
-        alignedStripe.chunks[i] =
-            new StripingChunk(decodeInputs[i].getBuffer());
+      if (alignedStripe.isNull(i)) {
+        alignedStripe.setChunk(i,
+            new StripingChunk(decodeInputs[i].getBuffer()));
       }
     }
   }
@@ -73,15 +73,15 @@ class StatefulStripeReader extends StripeReader {
   @Override
   boolean prepareParityChunk(int index) {
     Preconditions.checkState(index >= dataBlkNum
-        && alignedStripe.chunks[index] == null);
+        && alignedStripe.isNull(index));
     final int parityIndex = index - dataBlkNum;
     ByteBuffer buf = dfsStripedInputStream.getParityBuffer().duplicate();
     buf.position(cellSize * parityIndex);
     buf.limit(cellSize * parityIndex + (int) alignedStripe.range.spanInBlock);
     decodeInputs[index] =
         new ECChunk(buf.slice(), 0, (int) alignedStripe.range.spanInBlock);
-    alignedStripe.chunks[index] =
-        new StripingChunk(decodeInputs[index].getBuffer());
+    alignedStripe.setChunk(index,
+        new StripingChunk(decodeInputs[index].getBuffer()));
     return true;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -316,7 +316,7 @@ abstract class StripeReader {
   }
 
   /**
-   * Decide which chunks to transition from READY to REQUESTED
+   * Decide which chunks to transition from READY to REQUESTED.
    */
   private void requestChunks() throws IOException {
     if (alignedStripe.getReadyChunksNum() > 0 &&
@@ -408,8 +408,8 @@ abstract class StripeReader {
             alignedStripe.setFetched(r.index);
             updateState4SuccessRead(r);
           } else {
-            if (r.exception instanceof ExecutionException &&
-                !(r.exception.getCause() instanceof ChecksumException)) {
+            if (r.getException() instanceof ExecutionException &&
+                !(r.getException().getCause() instanceof ChecksumException)) {
               if (dfsStripedInputStream.updateSleepingNodes(
                   readerInfos[r.index].datanode)) {
                 alignedStripe.setSleeping(r.index);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -41,8 +41,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
+
+import static org.apache.hadoop.hdfs.util.StripedBlockUtil.ChunkByteBuffer;
 
 /**
  * The reader for reading a complete {@link StripedBlockUtil.AlignedStripe}.
@@ -113,6 +116,7 @@ abstract class StripeReader {
   protected final LocatedBlock[] targetBlocks;
   protected final CorruptedBlocks corruptedBlocks;
   protected final BlockReaderInfo[] readerInfos;
+  private boolean decodeInputsPrepared = false;
   protected final ErasureCodingPolicy ecPolicy;
   protected final short dataBlkNum;
   protected final short parityBlkNum;
@@ -173,57 +177,27 @@ abstract class StripeReader {
   }
 
   private void checkMissingBlocks() throws IOException {
-    if (alignedStripe.missingChunksNum > parityBlkNum) {
+    if (alignedStripe.getMissingChunksNum() > parityBlkNum) {
       clearFutures();
-      throw new IOException(alignedStripe.missingChunksNum
+      throw new IOException(alignedStripe.getMissingChunksNum()
           + " missing blocks, the stripe is: " + alignedStripe
           + "; locatedBlocks is: " + dfsStripedInputStream.getLocatedBlocks());
     }
   }
 
-  /**
-   * We need decoding. Thus go through all the data chunks and make sure we
-   * submit read requests for all of them.
-   */
-  private void readDataForDecoding() throws IOException {
-    prepareDecodeInputs();
-    for (int i = 0; i < dataBlkNum; i++) {
-      Preconditions.checkNotNull(alignedStripe.chunks[i]);
-      if (alignedStripe.chunks[i].state == StripingChunk.REQUESTED) {
-        if (!readChunk(targetBlocks[i], i)) {
-          alignedStripe.missingChunksNum++;
-        }
-      }
-    }
-    checkMissingBlocks();
-  }
-
-  void readParityChunks(int num) throws IOException {
-    for (int i = dataBlkNum, j = 0; i < dataBlkNum + parityBlkNum && j < num;
-         i++) {
-      if (alignedStripe.chunks[i] == null) {
-        if (prepareParityChunk(i) && readChunk(targetBlocks[i], i)) {
-          j++;
-        } else {
-          alignedStripe.missingChunksNum++;
-        }
-      }
-    }
-    checkMissingBlocks();
-  }
-
-  private ByteBufferStrategy[] getReadStrategies(StripingChunk chunk) {
-    if (chunk.useByteBuffer()) {
+  private ByteBufferStrategy[] getReadStrategies(int chunkIndex) {
+    if (alignedStripe.useByteBuffer(chunkIndex)) {
       ByteBufferStrategy strategy = new ByteBufferStrategy(
-          chunk.getByteBuffer(), dfsStripedInputStream.getReadStatistics(),
+          alignedStripe.getByteBuffer(chunkIndex),
+          dfsStripedInputStream.getReadStatistics(),
           dfsStripedInputStream.getDFSClient());
       return new ByteBufferStrategy[]{strategy};
     }
-
+    ChunkByteBuffer buf = alignedStripe.getChunkBuffer(chunkIndex);
     ByteBufferStrategy[] strategies =
-        new ByteBufferStrategy[chunk.getChunkBuffer().getSlices().size()];
+        new ByteBufferStrategy[buf.getSlices().size()];
     for (int i = 0; i < strategies.length; i++) {
-      ByteBuffer buffer = chunk.getChunkBuffer().getSlice(i);
+      ByteBuffer buffer = buf.getSlice(i);
       strategies[i] = new ByteBufferStrategy(buffer,
               dfsStripedInputStream.getReadStatistics(),
               dfsStripedInputStream.getDFSClient());
@@ -298,113 +272,176 @@ abstract class StripeReader {
     };
   }
 
-  boolean readChunk(final LocatedBlock block, int chunkIndex)
+  void readChunk(final LocatedBlock block, int chunkIndex)
       throws IOException {
-    final StripingChunk chunk = alignedStripe.chunks[chunkIndex];
+    Preconditions.checkState(alignedStripe.isRequested(chunkIndex));
     if (block == null) {
-      chunk.state = StripingChunk.MISSING;
-      return false;
+      alignedStripe.setMissing(chunkIndex);
+      return;
     }
 
     if (readerInfos[chunkIndex] == null) {
       if (!dfsStripedInputStream.createBlockReader(block,
-          alignedStripe.getOffsetInBlock(), targetBlocks,
-          readerInfos, chunkIndex, readTo)) {
-        chunk.state = StripingChunk.MISSING;
-        return false;
+              alignedStripe.getOffsetInBlock(), targetBlocks,
+              readerInfos, chunkIndex, readTo)) {
+        if (dfsStripedInputStream.isBlockOnSleepingNode(block)) {
+          alignedStripe.setSleeping(chunkIndex);
+        } else {
+          alignedStripe.setMissing(chunkIndex);
+        }
+        return;
       }
     } else if (readerInfos[chunkIndex].shouldSkip) {
-      chunk.state = StripingChunk.MISSING;
-      return false;
+      alignedStripe.setMissing(chunkIndex);
+      return;
     }
 
-    chunk.state = StripingChunk.PENDING;
+    alignedStripe.setPending(chunkIndex);
     Callable<BlockReadStats> readCallable =
         readCells(readerInfos[chunkIndex].reader,
         readerInfos[chunkIndex].datanode,
         readerInfos[chunkIndex].blockReaderOffset,
-        alignedStripe.getOffsetInBlock(), getReadStrategies(chunk),
+        alignedStripe.getOffsetInBlock(), getReadStrategies(chunkIndex),
         block.getBlock());
 
     Future<BlockReadStats> request = service.submit(readCallable);
     futures.put(request, chunkIndex);
-    return true;
+  }
+
+  private synchronized void prepareDecodeInputsInternal() {
+    if (!decodeInputsPrepared) {
+      prepareDecodeInputs();
+      decodeInputsPrepared = true;
+    }
+  }
+
+  /**
+   * Decide which chunks to transition from READY to REQUESTED
+   */
+  private void requestChunks() throws IOException {
+    if (alignedStripe.getReadyChunksNum() > 0 &&
+        alignedStripe.getFetchedChunksNum() < dataBlkNum &&
+        alignedStripe.getMissingChunksNum() <= parityBlkNum) {
+      int numToRequest = dataBlkNum - alignedStripe.getFetchedChunksNum();
+      numToRequest -= alignedStripe.getPendingChunksNum();
+      for (int i = 0, requested = 0; i < dataBlkNum + parityBlkNum &&
+          requested < numToRequest; i++) {
+        if (alignedStripe.isReady(i)) {
+          alignedStripe.setRequested(i);
+          readChunk(targetBlocks[i], i);
+          requested++;
+        }
+      }
+    }
+  }
+
+  /**
+   * Prepare parity blocks.
+   * @return True if we need to request chunks for parity blocks, otherwise
+   * false.
+   */
+  private boolean handleParityChunks() {
+    boolean newParityBlocks = false;
+    int parityChunksNeeded = alignedStripe.getMissingChunksNum() +
+        alignedStripe.getSleepingChunksNum();
+    if (parityChunksNeeded > 0) {
+      prepareDecodeInputsInternal();
+      for (int i = dataBlkNum; i < dataBlkNum + parityBlkNum &&
+          parityChunksNeeded > 0; i++) {
+        if (alignedStripe.isNull(i)) {
+          prepareParityChunk(i);
+          newParityBlocks = true;
+        }
+        if (!alignedStripe.isMissing(i) &&
+            !alignedStripe.isSleeping(i)) {
+          parityChunksNeeded--;
+        }
+      }
+    }
+    return newParityBlocks;
+  }
+
+  private void checkSleepingChunks() {
+    for (int i = 0; i < dataBlkNum + parityBlkNum; i++) {
+      if (!alignedStripe.isNull(i)) {
+        if (targetBlocks[i] != null &&
+            dfsStripedInputStream.isBlockOnSleepingNode(targetBlocks[i])) {
+          alignedStripe.setSleeping(i);
+        } else if (alignedStripe.isSleeping(i)) {
+          alignedStripe.setReady(i);
+        }
+      }
+    }
   }
 
   /**
    * read the whole stripe. do decoding if necessary
    */
   void readStripe() throws IOException {
-    try {
-      for (int i = 0; i < dataBlkNum; i++) {
-        if (alignedStripe.chunks[i] != null &&
-                alignedStripe.chunks[i].state != StripingChunk.ALLZERO) {
-          if (!readChunk(targetBlocks[i], i)) {
-            alignedStripe.missingChunksNum++;
+    // Loop until we have fetched the number of blocks needed for reading or
+    // decoding or until there are more missing blocks than we can tolerate
+    while (alignedStripe.getFetchedChunksNum() < dataBlkNum &&
+        alignedStripe.getMissingChunksNum() <= parityBlkNum) {
+      // Check for any chunks that are on sleeping nodes
+      checkSleepingChunks();
+      // Request and start reading from chunks
+      requestChunks();
+      // The first requests might have issues, so we should handle parity blocks
+      if (handleParityChunks()) {
+        // If we need parity blocks then we should request them.
+        continue;
+      }
+      while (!futures.isEmpty()) {
+        try {
+          long beginReadMS = Time.monotonicNow();
+          StripingChunkReadResult r = StripedBlockUtil
+              .getNextCompletedStripedRead(service, futures, 0);
+          long readTimeMS = Time.monotonicNow() - beginReadMS;
+
+          dfsStripedInputStream.updateReadStats(r.getReadStats(), readTimeMS);
+          DFSClient.LOG.debug("Read task returned: {}, for stripe {}",
+              r, alignedStripe);
+          Preconditions.checkState(!alignedStripe.isNull(r.index));
+          Preconditions.checkState(alignedStripe.isPending(r.index));
+
+          if (r.state == StripingChunkReadResult.SUCCESSFUL) {
+            alignedStripe.setFetched(r.index);
+            updateState4SuccessRead(r);
+          } else {
+            if (r.exception instanceof ExecutionException &&
+                !(r.exception.getCause() instanceof ChecksumException)) {
+              if (dfsStripedInputStream.updateSleepingNodes(
+                  readerInfos[r.index].datanode)) {
+                alignedStripe.setSleeping(r.index);
+              } else {
+                alignedStripe.setMissing(r.index);
+              }
+            } else {
+              alignedStripe.setMissing(r.index);
+              // close the corresponding reader
+              dfsStripedInputStream.closeReader(readerInfos[r.index]);
+            }
           }
+        } catch (InterruptedException ie) {
+          String err = "Read request interrupted";
+          DFSClient.LOG.error(err, ie);
+          dfsStripedInputStream.close();
+          clearFutures();
+          // Don't decode if read interrupted
+          throw new InterruptedIOException(err);
         }
       }
-      // There are missing block locations at this stage. Thus we need to read
-      // the full stripe and one more parity block.
-      if (alignedStripe.missingChunksNum > 0) {
-        checkMissingBlocks();
-        readDataForDecoding();
-        // read parity chunks
-        readParityChunks(alignedStripe.missingChunksNum);
-      }
-    } catch (IOException e) {
-      dfsStripedInputStream.close();
-      throw e;
-    }
-    // TODO: for a full stripe we can start reading (dataBlkNum + 1) chunks
-
-    // Input buffers for potential decode operation, which remains null until
-    // first read failure
-    while (!futures.isEmpty()) {
-      try {
-        long beginReadMS = Time.monotonicNow();
-        StripingChunkReadResult r = StripedBlockUtil
-            .getNextCompletedStripedRead(service, futures, 0);
-        long readTimeMS = Time.monotonicNow() - beginReadMS;
-
-        dfsStripedInputStream.updateReadStats(r.getReadStats(), readTimeMS);
-        DFSClient.LOG.debug("Read task returned: {}, for stripe {}",
-            r, alignedStripe);
-        StripingChunk returnedChunk = alignedStripe.chunks[r.index];
-        Preconditions.checkNotNull(returnedChunk);
-        Preconditions.checkState(returnedChunk.state == StripingChunk.PENDING);
-
-        if (r.state == StripingChunkReadResult.SUCCESSFUL) {
-          returnedChunk.state = StripingChunk.FETCHED;
-          alignedStripe.fetchedChunksNum++;
-          updateState4SuccessRead(r);
-          if (alignedStripe.fetchedChunksNum == dataBlkNum) {
-            clearFutures();
-            break;
-          }
-        } else {
-          returnedChunk.state = StripingChunk.MISSING;
-          // close the corresponding reader
-          dfsStripedInputStream.closeReader(readerInfos[r.index]);
-
-          final int missing = alignedStripe.missingChunksNum;
-          alignedStripe.missingChunksNum++;
-          checkMissingBlocks();
-
-          readDataForDecoding();
-          readParityChunks(alignedStripe.missingChunksNum - missing);
-        }
-      } catch (InterruptedException ie) {
-        String err = "Read request interrupted";
-        DFSClient.LOG.error(err, ie);
-        dfsStripedInputStream.close();
-        clearFutures();
-        // Don't decode if read interrupted
-        throw new InterruptedIOException(err);
+      // If there are more sleeping chunks than parity chunks we need to wait
+      // until next node can be retried.
+      if (alignedStripe.getSleepingChunksNum() > parityBlkNum) {
+        dfsStripedInputStream.sleepUntilRetry();
       }
     }
-
-    if (alignedStripe.missingChunksNum > 0) {
+    checkMissingBlocks();
+    // We are done fetching chunks, so we can clear the futures.
+    clearFutures();
+    // If we have not fetched only data blocks, then we need to decode
+    if (alignedStripe.fetchedDataChunkNum() != dataBlkNum) {
       decode();
     }
   }
@@ -418,15 +455,15 @@ abstract class StripeReader {
    */
 
   void finalizeDecodeInputs() {
-    for (int i = 0; i < alignedStripe.chunks.length; i++) {
-      final StripingChunk chunk = alignedStripe.chunks[i];
-      if (chunk != null && chunk.state == StripingChunk.FETCHED) {
-        if (chunk.useChunkBuffer()) {
-          chunk.getChunkBuffer().copyTo(decodeInputs[i].getBuffer());
+    for (int i = 0; i < dataBlkNum + parityBlkNum; i++) {
+      if (alignedStripe.isFetched(i)) {
+        if (alignedStripe.useChunkBuffer(i)) {
+          alignedStripe.getChunkBuffer(i).copyTo(
+              decodeInputs[i].getBuffer());
         } else {
-          chunk.getByteBuffer().flip();
+          alignedStripe.getByteBuffer(i).flip();
         }
-      } else if (chunk != null && chunk.state == StripingChunk.ALLZERO) {
+      } else if (alignedStripe.isAllZero(i)) {
         decodeInputs[i].setAllZero(true);
       }
     }
@@ -446,7 +483,7 @@ abstract class StripeReader {
       decodeInputs[decodeIndices[i]] = null;
     }
 
-    long start = Time.monotonicNow();
+    long start = Time.monotonicNowNanos();
     // Step 2: decode into prepared output buffers
     decoder.decode(decodeInputs, decodeIndices, outputs);
 
@@ -454,13 +491,14 @@ abstract class StripeReader {
     if (fillBuffer) {
       for (int i = 0; i < decodeIndices.length; i++) {
         int missingBlkIdx = decodeIndices[i];
-        StripingChunk chunk = alignedStripe.chunks[missingBlkIdx];
-        if (chunk.state == StripingChunk.MISSING && chunk.useChunkBuffer()) {
-          chunk.getChunkBuffer().copyFrom(outputs[i].getBuffer());
+        if (alignedStripe.isErasedIndex(missingBlkIdx) &&
+            alignedStripe.useChunkBuffer(missingBlkIdx)) {
+          alignedStripe.getChunkBuffer(missingBlkIdx).copyFrom(
+              outputs[i].getBuffer());
         }
       }
     }
-    long end = Time.monotonicNow();
+    long end = Time.monotonicNowNanos();
     // Decoding time includes CPU time on erasure coding and memory copying of
     // decoded data.
     dfsStripedInputStream.readStatistics.addErasureCodingDecodingTime(
@@ -473,9 +511,8 @@ abstract class StripeReader {
   int[] prepareErasedIndices() {
     int[] decodeIndices = new int[parityBlkNum];
     int pos = 0;
-    for (int i = 0; i < alignedStripe.chunks.length; i++) {
-      if (alignedStripe.chunks[i] != null &&
-          alignedStripe.chunks[i].state == StripingChunk.MISSING){
+    for (int i = 0; i < dataBlkNum + parityBlkNum; i++) {
+      if (alignedStripe.isErasedIndex(i)) {
         decodeIndices[pos++] = i;
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
@@ -307,11 +307,11 @@ public class StripedBlockUtil {
     } catch (ExecutionException e) {
       LOG.debug("Exception during striped read task", e);
       return new StripingChunkReadResult(futures.remove(future),
-          StripingChunkReadResult.FAILED);
+          StripingChunkReadResult.FAILED, e);
     } catch (CancellationException e) {
       LOG.debug("Exception during striped read task", e);
       return new StripingChunkReadResult(futures.remove(future),
-          StripingChunkReadResult.CANCELLED);
+          StripingChunkReadResult.CANCELLED, e);
     }
   }
 
@@ -371,11 +371,11 @@ public class StripedBlockUtil {
         long overlapEnd = Math.min(cellEnd, stripeEnd);
         int overLapLen = (int) (overlapEnd - overlapStart + 1);
         if (overLapLen > 0) {
-          Preconditions.checkState(s.chunks[cell.idxInStripe] == null);
+          Preconditions.checkState(s.isNull(cell.idxInStripe));
           final int pos = (int) (bufOffset + overlapStart - cellStart);
           buf.position(pos);
           buf.limit(pos + overLapLen);
-          s.chunks[cell.idxInStripe] = new StripingChunk(buf.slice());
+          s.setChunk(cell.idxInStripe, new StripingChunk(buf.slice()));
         }
       }
       bufOffset += cell.size;
@@ -541,8 +541,8 @@ public class StripedBlockUtil {
     long prev = -1;
     for (long point : stripePoints) {
       if (prev >= 0) {
-        stripes.add(new AlignedStripe(prev, point - prev,
-            dataBlkNum + parityBlkNum));
+        stripes.add(new AlignedStripe(prev, point - prev, dataBlkNum,
+            parityBlkNum));
       }
       prev = point;
     }
@@ -573,7 +573,6 @@ public class StripedBlockUtil {
     for (StripingCell cell : cells) {
       long cellStart = cell.idxInInternalBlk * cellSize + cell.offset;
       long cellEnd = cellStart + cell.size - 1;
-      StripingChunk chunk;
       for (AlignedStripe s : stripes) {
         long stripeEnd = s.getOffsetInBlock() + s.getSpanInBlock() - 1;
         long overlapStart = Math.max(cellStart, s.getOffsetInBlock());
@@ -582,12 +581,10 @@ public class StripedBlockUtil {
         if (overLapLen <= 0) {
           continue;
         }
-        chunk = s.chunks[cell.idxInStripe];
-        if (chunk == null) {
-          chunk = new StripingChunk();
-          s.chunks[cell.idxInStripe] = chunk;
+        if (s.isNull(cell.idxInStripe)) {
+          s.setChunk(cell.idxInStripe, new StripingChunk());
         }
-        chunk.getChunkBuffer().addSlice(buf,
+        s.getChunkBuffer(cell.idxInStripe).addSlice(buf,
             (int) (done + overlapStart - cellStart), overLapLen);
       }
       done += cell.size;
@@ -605,8 +602,8 @@ public class StripedBlockUtil {
         long internalBlkLen = getInternalBlockLength(blockGroup.getBlockSize(),
             cellSize, dataBlkNum, i);
         if (internalBlkLen <= s.getOffsetInBlock()) {
-          Preconditions.checkState(s.chunks[i] == null);
-          s.chunks[i] = new StripingChunk(StripingChunk.ALLZERO);
+          Preconditions.checkState(s.isNull(i));
+          s.setChunk(i, new StripingChunk(StripingChunk.ALLZERO));
         }
       }
     }
@@ -714,16 +711,202 @@ public class StripedBlockUtil {
   public static class AlignedStripe {
     public VerticalRange range;
     /** status of each chunk in the stripe. */
-    public final StripingChunk[] chunks;
-    public int fetchedChunksNum = 0;
-    public int missingChunksNum = 0;
+    private final StripingChunk[] chunks;
+    private final int dataBlkNum;
+    private final int parityBlkNum;
+    private Map<Integer, Integer> dataStateCounts = new HashMap<>();
+    private Map<Integer, Integer> parityStateCounts = new HashMap<>();
 
-    public AlignedStripe(long offsetInBlock, long length, int width) {
+    /**
+     * Get the state of the chunk, or null if the chunk is null
+     * @param chunkIndex The chunk to get the state of
+     * @return The state of the chunk at {@param chunkIndex}, or null if the
+     * chunk at {@param chunkIndex} is null
+     */
+    private Integer getChunkState(int chunkIndex) {
+      if (chunks[chunkIndex] == null) {
+        return null;
+      }
+      return chunks[chunkIndex].state;
+    }
+
+    private void setChunkState(int chunkIndex, int chunkState) {
+      updateStateCount(chunkIndex, getChunkState(chunkIndex), -1);
+      updateStateCount(chunkIndex, chunkState, 1);
+      chunks[chunkIndex].state = chunkState;
+    }
+
+    private int getChunkStateCount(Integer chunkState) {
+      return getParityChunkStateCount(chunkState) +
+                 getDataChunkStateCount(chunkState);
+    }
+
+    private int getDataChunkStateCount(Integer chunkState) {
+      return dataStateCounts.getOrDefault(chunkState, 0);
+    }
+
+    private int getParityChunkStateCount(Integer chunkState) {
+      return parityStateCounts.getOrDefault(chunkState, 0);
+    }
+
+    public void setChunk(int chunkIndex, StripingChunk chunk) {
+      updateStateCount(chunkIndex, getChunkState(chunkIndex), -1);
+      updateStateCount(chunkIndex, chunk.state, 1);
+      chunks[chunkIndex] = chunk;
+    }
+
+
+    private void updateStateCount(int chunkIndex, Integer chunkState,
+        int delta) {
+      if (chunkIndex < dataBlkNum) {
+        dataStateCounts.merge(chunkState, delta, Integer::sum);
+      } else {
+        parityStateCounts.merge(chunkState, delta, Integer::sum);
+      }
+    }
+
+    public boolean useChunkBuffer(int chunkIndex) {
+      return chunks[chunkIndex].useChunkBuffer();
+    }
+
+    public ChunkByteBuffer getChunkBuffer(int chunkIndex) {
+      return chunks[chunkIndex].getChunkBuffer();
+    }
+
+    public boolean useByteBuffer(int chunkIndex) {
+      return chunks[chunkIndex].useByteBuffer();
+    }
+
+    public ByteBuffer getByteBuffer(int chunkIndex) {
+      return chunks[chunkIndex].getByteBuffer();
+    }
+
+    public int getMissingChunksNum() {
+      return getChunkStateCount(StripingChunk.MISSING);
+    }
+
+    /**
+     * Get the number of fetched chunks that have been read into the buffer
+     * and are ready to decode.
+     * @return The number of {@link StripingChunk#FETCHED} and
+     * {@link StripingChunk#ALLZERO} chunks. If we are not attempting to
+     * decode, then we include the null data chunks because they only need to
+     * be fetched if we need to decode.
+     */
+    public int getFetchedChunksNum() {
+      int fetchedChunksNum = fetchedDataChunkNum();
+      fetchedChunksNum += getParityChunkStateCount(StripingChunk.FETCHED);
+      return fetchedChunksNum;
+    }
+
+    public int fetchedDataChunkNum() {
+      int fetchedChunksNum = 0;
+      if (getDataChunkStateCount(StripingChunk.MISSING) == 0 &&
+          getDataChunkStateCount(StripingChunk.SLEEPING) == 0) {
+        // If there are not missing or sleeping data chunks, then we do not
+        // need to fetch the null data chunks for decoding, so they can be
+        // counted as fetched
+        fetchedChunksNum += getDataChunkStateCount(null);
+      }
+      fetchedChunksNum += getDataChunkStateCount(StripingChunk.FETCHED);
+      fetchedChunksNum += getDataChunkStateCount(StripingChunk.ALLZERO);
+      return fetchedChunksNum;
+    }
+
+    public int getSleepingChunksNum() {
+      return getChunkStateCount(StripingChunk.SLEEPING);
+    }
+
+    public int getReadyChunksNum() {
+      return getChunkStateCount(StripingChunk.READY);
+    }
+
+    public int getPendingChunksNum() {
+      return getChunkStateCount(StripingChunk.PENDING);
+    }
+
+    public boolean isNull(int chunkIndex) {
+      return getChunkState(chunkIndex) == null;
+    }
+
+    public boolean isRequested(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.REQUESTED;
+    }
+
+    public void setRequested(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.REQUESTED);
+    }
+
+    public boolean isFetched(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.FETCHED;
+    }
+
+    public void setFetched(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.FETCHED);
+    }
+
+    public boolean isSleeping(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.SLEEPING;
+    }
+
+    public void setSleeping(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.SLEEPING);
+    }
+
+    public boolean isReady(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.READY;
+    }
+
+    public void setReady(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.READY);
+    }
+
+    public boolean isPending(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.PENDING;
+    }
+
+    public void setPending(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.PENDING);
+    }
+
+    public boolean isMissing(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.MISSING;
+    }
+
+    public void setMissing(int chunkIndex) {
+      setChunkState(chunkIndex, StripingChunk.MISSING);
+    }
+
+    public boolean isAllZero(int chunkIndex) {
+      return chunks[chunkIndex] != null &&
+          chunks[chunkIndex].state == StripingChunk.ALLZERO;
+    }
+
+    public boolean isErasedIndex(int chunkIndex) {
+      // Any PENDING, MISSING, SLEEPING, and REQUESTED chunks are considered
+      // erased for decoding purposes
+      return !isNull(chunkIndex) &&
+          !isFetched(chunkIndex) &&
+          !isAllZero(chunkIndex);
+    }
+
+    public AlignedStripe(long offsetInBlock, long length, int dataBlkNum,
+        int parityBlkNum) {
       Preconditions.checkArgument(offsetInBlock >= 0 && length >= 0,
           "OffsetInBlock(%s) and length(%s) must be non-negative",
           offsetInBlock, length);
       this.range = new VerticalRange(offsetInBlock, length);
-      this.chunks = new StripingChunk[width];
+      this.dataBlkNum = dataBlkNum;
+      this.parityBlkNum = parityBlkNum;
+      this.chunks = new StripingChunk[dataBlkNum + parityBlkNum];
+      dataStateCounts.put(null, dataBlkNum);
+      parityStateCounts.put(null, parityBlkNum);
     }
 
     public boolean include(long pos) {
@@ -741,8 +924,8 @@ public class StripedBlockUtil {
     @Override
     public String toString() {
       return "AlignedStripe(Offset=" + range.offsetInBlock + ", length=" +
-          range.spanInBlock + ", fetchedChunksNum=" + fetchedChunksNum +
-          ", missingChunksNum=" + missingChunksNum + ")";
+          range.spanInBlock + ", fetchedChunksNum=" + getFetchedChunksNum() +
+          ", missingChunksNum=" + getMissingChunksNum() + ")";
     }
   }
 
@@ -825,17 +1008,23 @@ public class StripedBlockUtil {
      * all-zero bytes in codec calculations.
      */
     public static final int ALLZERO = 0X0f;
+    /** Chunk fetch was attempted and it is now sleeping until retry **/
+    public static final int SLEEPING = 0xf1;
+    /** Chunk is ready to start reading **/
+    public static final int READY = 0xf2;
 
     /**
-     * If a chunk is completely in requested range, the state transition is:
-     * REQUESTED (when AlignedStripe created) -&gt; PENDING -&gt;
-     * {FETCHED | MISSING}
+     * If a chunk is completely in requested range, the state transition is:<br>
+     * - READY (when AlignedStripe created) -&gt; REQUESTED<br>
+     * - REQUESTED -&gt; {SLEEPING | PENDING}<br>
+     * - SLEEPING -&gt; {REQUESTED | READY}<br>
+     * - PENDING -&gt; {FETCHED | MISSING}<br>
      * If a chunk is completely outside requested range (including parity
      * chunks), state transition is:
-     * null (AlignedStripe created) -&gt;REQUESTED (upon failure) -&gt;
-     * PENDING ...
+     * null (AlignedStripe created) -&gt; READY (upon failure) -&gt; REQUESTED
+     *  -&gt; {SLEEPING | PENDING} ...
      */
-    public int state = REQUESTED;
+    public int state = READY;
 
     private final ChunkByteBuffer chunkBuffer;
     private final ByteBuffer byteBuffer;
@@ -937,6 +1126,7 @@ public class StripedBlockUtil {
 
     public final int index;
     public final int state;
+    public final Exception exception;
     private final BlockReadStats readStats;
 
     public StripingChunkReadResult(int state) {
@@ -945,18 +1135,25 @@ public class StripedBlockUtil {
       this.index = -1;
       this.state = state;
       this.readStats = null;
-    }
-
-    public StripingChunkReadResult(int index, int state) {
-      this(index, state, null);
+      this.exception = null;
     }
 
     public StripingChunkReadResult(int index, int state, BlockReadStats stats) {
+      this(index, state, stats, null);
+    }
+
+    public StripingChunkReadResult(int index, int state, Exception ex) {
+      this(index, state, null, ex);
+    }
+
+    public StripingChunkReadResult(int index, int state, BlockReadStats stats,
+        Exception exception) {
       Preconditions.checkArgument(state != TIMEOUT,
           "Timeout result should return negative index.");
       this.index = index;
       this.state = state;
       this.readStats = stats;
+      this.exception = exception;
     }
 
     public BlockReadStats getReadStats() {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/util/StripedBlockUtil.java
@@ -718,7 +718,7 @@ public class StripedBlockUtil {
     private Map<Integer, Integer> parityStateCounts = new HashMap<>();
 
     /**
-     * Get the state of the chunk, or null if the chunk is null
+     * Get the state of the chunk, or null if the chunk is null.
      * @param chunkIndex The chunk to get the state of
      * @return The state of the chunk at {@param chunkIndex}, or null if the
      * chunk at {@param chunkIndex} is null
@@ -1008,9 +1008,9 @@ public class StripedBlockUtil {
      * all-zero bytes in codec calculations.
      */
     public static final int ALLZERO = 0X0f;
-    /** Chunk fetch was attempted and it is now sleeping until retry **/
+    /** Chunk fetch was attempted and it is now sleeping until retry. **/
     public static final int SLEEPING = 0xf1;
-    /** Chunk is ready to start reading **/
+    /** Chunk is ready to start reading. **/
     public static final int READY = 0xf2;
 
     /**
@@ -1024,7 +1024,15 @@ public class StripedBlockUtil {
      * null (AlignedStripe created) -&gt; READY (upon failure) -&gt; REQUESTED
      *  -&gt; {SLEEPING | PENDING} ...
      */
-    public int state = READY;
+    private int state = READY;
+
+    public int getState() {
+      return state;
+    }
+
+    public void setState(int state) {
+      this.state = state;
+    }
 
     private final ChunkByteBuffer chunkBuffer;
     private final ByteBuffer byteBuffer;
@@ -1126,8 +1134,12 @@ public class StripedBlockUtil {
 
     public final int index;
     public final int state;
-    public final Exception exception;
+    private final Exception exception;
     private final BlockReadStats readStats;
+
+    public Exception getException() {
+      return exception;
+    }
 
     public StripingChunkReadResult(int state) {
       Preconditions.checkArgument(state == TIMEOUT,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4569,6 +4569,7 @@
   <value>3</value>
   <description>
     Maximum failures allowed when trying to get block information from a specific datanode.
+    This is used for both EC and replication.
   </description>
 </property>
 
@@ -4686,6 +4687,7 @@
     Base time window in ms for DFSClient retries.  For each retry attempt,
     this value is extended linearly (e.g. 3000 ms for first attempt and
     first retry, 6000 ms for second retry, 9000 ms for third retry, etc.).
+    This is used for both EC and replication
   </description>
 </property>
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/StripedFileTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/StripedFileTestUtil.java
@@ -90,29 +90,35 @@ public class StripedFileTestUtil {
       byte[] expected, byte[] buf, ErasureCodingPolicy ecPolicy)
       throws IOException {
     try (FSDataInputStream in = fs.open(srcPath)) {
-      int[] startOffsets = {0, 1, ecPolicy.getCellSize() - 102,
-          ecPolicy.getCellSize(), ecPolicy.getCellSize() + 102,
-          ecPolicy.getCellSize() * (ecPolicy.getNumDataUnits() - 1),
-          ecPolicy.getCellSize() * (ecPolicy.getNumDataUnits() - 1) + 102,
-          ecPolicy.getCellSize() * ecPolicy.getNumDataUnits(),
-          fileLength - 102, fileLength - 1};
-      for (int startOffset : startOffsets) {
-        startOffset = Math.max(0, Math.min(startOffset, fileLength - 1));
-        int remaining = fileLength - startOffset;
-        int offset = startOffset;
-        final byte[] result = new byte[remaining];
-        while (remaining > 0) {
-          int target = Math.min(remaining, buf.length);
-          in.readFully(offset, buf, 0, target);
-          System.arraycopy(buf, 0, result, offset - startOffset, target);
-          remaining -= target;
-          offset += target;
-        }
-        for (int i = 0; i < fileLength - startOffset; i++) {
-          assertEquals("Byte at " + (startOffset + i) + " is different, "
-              + "the startOffset is " + startOffset, expected[startOffset + i],
-              result[i]);
-        }
+      verifyPread(in, fileLength, expected, buf, ecPolicy);
+    }
+  }
+
+  static void verifyPread(FSDataInputStream in, int fileLength,
+      byte[] expected, byte[] buf, ErasureCodingPolicy ecPolicy)
+      throws IOException {
+    int[] startOffsets = {0, 1, ecPolicy.getCellSize() - 102,
+        ecPolicy.getCellSize(), ecPolicy.getCellSize() + 102,
+        ecPolicy.getCellSize() * (ecPolicy.getNumDataUnits() - 1),
+        ecPolicy.getCellSize() * (ecPolicy.getNumDataUnits() - 1) + 102,
+        ecPolicy.getCellSize() * ecPolicy.getNumDataUnits(),
+        fileLength - 102, fileLength - 1};
+    for (int startOffset : startOffsets) {
+      startOffset = Math.max(0, Math.min(startOffset, fileLength - 1));
+      int remaining = fileLength - startOffset;
+      int offset = startOffset;
+      final byte[] result = new byte[remaining];
+      while (remaining > 0) {
+        int target = Math.min(remaining, buf.length);
+        in.readFully(offset, buf, 0, target);
+        System.arraycopy(buf, 0, result, offset - startOffset, target);
+        remaining -= target;
+        offset += target;
+      }
+      for (int i = 0; i < fileLength - startOffset; i++) {
+        assertEquals("Byte at " + (startOffset + i) + " is different, "
+                         + "the startOffset is " + startOffset, expected[startOffset + i],
+            result[i]);
       }
     }
   }
@@ -120,16 +126,21 @@ public class StripedFileTestUtil {
   static void verifyStatefulRead(FileSystem fs, Path srcPath, int fileLength,
       byte[] expected, byte[] buf) throws IOException {
     try (FSDataInputStream in = fs.open(srcPath)) {
-      final byte[] result = new byte[fileLength];
-      int readLen = 0;
-      int ret;
-      while ((ret = in.read(buf, 0, buf.length)) >= 0) {
-        System.arraycopy(buf, 0, result, readLen, ret);
-        readLen += ret;
-      }
-      assertEquals("The length of file should be the same to write size", fileLength, readLen);
-      Assert.assertArrayEquals(expected, result);
+      verifyStatefulRead(in, fileLength, expected, buf);
     }
+  }
+
+  static void verifyStatefulRead(FSDataInputStream in, int fileLength,
+      byte[] expected, byte[] buf) throws IOException {
+    final byte[] result = new byte[fileLength];
+    int readLen = 0;
+    int ret;
+    while ((ret = in.read(buf, 0, buf.length)) >= 0) {
+      System.arraycopy(buf, 0, result, readLen, ret);
+      readLen += ret;
+    }
+    assertEquals("The length of file should be the same to write size", fileLength, readLen);
+    Assert.assertArrayEquals(expected, result);
   }
 
   static void verifyStatefulRead(FileSystem fs, Path srcPath, int fileLength,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
@@ -307,13 +307,13 @@ public class TestWriteReadStripedFile {
     Path srcPath = new Path("/ec/testReadBackoff");
     DFSTestUtil.writeFile(fs, srcPath, new String(expected));
 
-    Set<DatanodeInfoWithStorage> busyDns = new TreeSet<>();
+    Set<DatanodeInfoWithStorage> badDns = new TreeSet<>();
     DFSClientFaultInjector.set(new DFSClientFaultInjector() {
       @Override
       public void onCreateBlockReader(LocatedBlock block, int chunkIndex,
           long offset, long length) throws IOException {
-        if (busyDns.contains(block.getLocations()[0])) {
-          throw new IOException("ERROR_BUSY");
+        if (badDns.contains(block.getLocations()[0])) {
+          throw new IOException("FAILED TO CONNECT FOR TEST");
         }
       }
     });
@@ -337,7 +337,7 @@ public class TestWriteReadStripedFile {
       Assert.assertEquals(0, decodingTimeNanos);
     }
 
-    busyDns.add(chunkToDn[0]);
+    badDns.add(chunkToDn[0]);
     try (FSDataInputStream in = fs.open(srcPath)) {
       StripedFileTestUtil
           .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
@@ -355,7 +355,7 @@ public class TestWriteReadStripedFile {
       Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
     }
 
-    busyDns.add(chunkToDn[1]);
+    badDns.add(chunkToDn[1]);
     try (FSDataInputStream in = fs.open(srcPath)) {
       StripedFileTestUtil
           .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
@@ -373,7 +373,7 @@ public class TestWriteReadStripedFile {
       Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
     }
 
-    busyDns.add(chunkToDn[2]);
+    badDns.add(chunkToDn[2]);
     try (FSDataInputStream in = fs.open(srcPath)) {
       long start = Time.monotonicNow();
       Assert.assertThrows(IOException.class, () -> {
@@ -394,7 +394,7 @@ public class TestWriteReadStripedFile {
           LOG.error("Interrupted while waiting to mark the DqlBusyChecker as " +
               "not busy", ex);
         }
-        busyDns.remove(chunkToDn[0]);
+        badDns.remove(chunkToDn[0]);
       });
       long start = Time.monotonicNow();
       StripedFileTestUtil
@@ -408,7 +408,7 @@ public class TestWriteReadStripedFile {
       Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
     }
 
-    busyDns.add(chunkToDn[0]);
+    badDns.add(chunkToDn[0]);
     try (FSDataInputStream in = fs.open(srcPath)) {
       ExecutorService service = Executors.newSingleThreadExecutor();
       // set the DataNode busy status back to false after 10 seconds.
@@ -419,7 +419,7 @@ public class TestWriteReadStripedFile {
           LOG.error("Interrupted while waiting to mark the DqlBusyChecker as " +
               "not busy", ex);
         }
-        busyDns.remove(chunkToDn[0]);
+        badDns.remove(chunkToDn[0]);
       });
       long start = Time.monotonicNow();
       StripedFileTestUtil

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
@@ -377,12 +377,12 @@ public class TestWriteReadStripedFile {
     try (FSDataInputStream in = fs.open(srcPath)) {
       long start = Time.monotonicNow();
       Assert.assertThrows(IOException.class, () -> {
-          StripedFileTestUtil
-              .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+        StripedFileTestUtil
+            .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
       });
       long timeMs = Time.monotonicNow() - start;
       Assert.assertTrue("Read should have been slower than 10 seconds but was "
-                            + timeMs + " ms",timeMs > 10000);
+                            + timeMs + " ms", timeMs > 10000);
     }
     try (FSDataInputStream in = fs.open(srcPath)) {
       ExecutorService service = Executors.newSingleThreadExecutor();
@@ -401,7 +401,7 @@ public class TestWriteReadStripedFile {
           .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
       long timeMs = Time.monotonicNow() - start;
       Assert.assertTrue("Read should have been slower than 10 seconds but was "
-          + timeMs + " ms",timeMs > 10000);
+          + timeMs + " ms", timeMs > 10000);
       long decodingTimeNanos =
           ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
       // Should read without any decoding
@@ -427,7 +427,7 @@ public class TestWriteReadStripedFile {
       // Should read with decoding
       long timeMs = Time.monotonicNow() - start;
       Assert.assertTrue("Read should have been slower than 10 seconds but was "
-          + timeMs + " ms",timeMs > 10000);
+          + timeMs + " ms", timeMs > 10000);
       long decodingTimeNanos =
           ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
       // Should read without any decoding

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestWriteReadStripedFile.java
@@ -17,14 +17,20 @@
  */
 package org.apache.hadoop.hdfs;
 
+import org.apache.hadoop.fs.HdfsBlockLocation;
+import org.apache.hadoop.hdfs.client.HdfsDataInputStream;
+import org.apache.hadoop.hdfs.protocol.DatanodeInfoWithStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
@@ -32,6 +38,7 @@ import org.apache.hadoop.hdfs.web.WebHdfsConstants;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Time;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,6 +50,12 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY;
 
 public class TestWriteReadStripedFile {
   public static final Logger LOG =
@@ -75,7 +88,10 @@ public class TestWriteReadStripedFile {
   @Before
   public void setup() throws IOException {
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
-    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(numDNs).build();
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(numDNs)
+        .storagesPerDatanode(1)
+        .build();
     fs = cluster.getFileSystem();
     fs.enableErasureCodingPolicy(ecPolicy.getName());
     fs.mkdirs(new Path("/ec"));
@@ -277,6 +293,146 @@ public class TestWriteReadStripedFile {
     StripedFileTestUtil
         .verifyStatefulRead(fs, srcPath, fileLength, expected, smallBuf);
     // webhdfs doesn't support bytebuffer read
+  }
+
+  @Test
+  public void testReadBackoffRetry() throws Exception {
+    int fileLength = blockSize * dataBlocks + cellSize + 123;
+
+    fs.getConf().setLong(HdfsClientConfigKeys.Retry.WINDOW_BASE_KEY, 3000);
+    fs.getConf().setLong(DFS_CLIENT_MAX_BLOCK_ACQUIRE_FAILURES_KEY, 3);
+    fs.initDFSClient(fs.getUri(), fs.getConf());
+
+    final byte[] expected = StripedFileTestUtil.generateBytes(fileLength);
+    Path srcPath = new Path("/ec/testReadBackoff");
+    DFSTestUtil.writeFile(fs, srcPath, new String(expected));
+
+    Set<DatanodeInfoWithStorage> busyDns = new TreeSet<>();
+    DFSClientFaultInjector.set(new DFSClientFaultInjector() {
+      @Override
+      public void onCreateBlockReader(LocatedBlock block, int chunkIndex,
+          long offset, long length) throws IOException {
+        if (busyDns.contains(block.getLocations()[0])) {
+          throw new IOException("ERROR_BUSY");
+        }
+      }
+    });
+    DatanodeInfoWithStorage[] chunkToDn =
+        new DatanodeInfoWithStorage[dataBlocks + parityBlocks];
+    HdfsBlockLocation[] locs =
+        (HdfsBlockLocation[])fs.getFileBlockLocations(srcPath, 0, fileLength);
+    LocatedBlock block = locs[0].getLocatedBlock();
+    for (int i = 0; i < block.getLocations().length; i++) {
+      chunkToDn[i] = block.getLocations()[i];
+    }
+
+    StripedFileTestUtil.verifyLength(fs, srcPath, fileLength);
+    byte[] largeBuf = new byte[fileLength + 100];
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      StripedFileTestUtil
+          .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertEquals(0, decodingTimeNanos);
+    }
+
+    busyDns.add(chunkToDn[0]);
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      StripedFileTestUtil
+          .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      StripedFileTestUtil
+          .verifyStatefulRead(in, fileLength, expected, largeBuf);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
+
+    busyDns.add(chunkToDn[1]);
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      StripedFileTestUtil
+          .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      StripedFileTestUtil
+          .verifyStatefulRead(in, fileLength, expected, largeBuf);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
+
+    busyDns.add(chunkToDn[2]);
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      long start = Time.monotonicNow();
+      Assert.assertThrows(IOException.class, () -> {
+          StripedFileTestUtil
+              .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+      });
+      long timeMs = Time.monotonicNow() - start;
+      Assert.assertTrue("Read should have been slower than 10 seconds but was "
+                            + timeMs + " ms",timeMs > 10000);
+    }
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      ExecutorService service = Executors.newSingleThreadExecutor();
+      // set the DataNode busy status back to false after 10 seconds.
+      service.submit(() -> {
+        try {
+          Thread.sleep(10000);
+        } catch (InterruptedException ex) {
+          LOG.error("Interrupted while waiting to mark the DqlBusyChecker as " +
+              "not busy", ex);
+        }
+        busyDns.remove(chunkToDn[0]);
+      });
+      long start = Time.monotonicNow();
+      StripedFileTestUtil
+          .verifyPread(in, fileLength, expected, largeBuf, ecPolicy);
+      long timeMs = Time.monotonicNow() - start;
+      Assert.assertTrue("Read should have been slower than 10 seconds but was "
+          + timeMs + " ms",timeMs > 10000);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
+
+    busyDns.add(chunkToDn[0]);
+    try (FSDataInputStream in = fs.open(srcPath)) {
+      ExecutorService service = Executors.newSingleThreadExecutor();
+      // set the DataNode busy status back to false after 10 seconds.
+      service.submit(() -> {
+        try {
+          Thread.sleep(10000);
+        } catch (InterruptedException ex) {
+          LOG.error("Interrupted while waiting to mark the DqlBusyChecker as " +
+              "not busy", ex);
+        }
+        busyDns.remove(chunkToDn[0]);
+      });
+      long start = Time.monotonicNow();
+      StripedFileTestUtil
+          .verifyStatefulRead(in, fileLength, expected, largeBuf);
+      // Should read with decoding
+      long timeMs = Time.monotonicNow() - start;
+      Assert.assertTrue("Read should have been slower than 10 seconds but was "
+          + timeMs + " ms",timeMs > 10000);
+      long decodingTimeNanos =
+          ((HdfsDataInputStream) in).getReadStatistics().getTotalEcDecodingTimeNanos();
+      // Should read without any decoding
+      Assert.assertTrue("Decoding should have happened", decodingTimeNanos > 0);
+    }
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/client/impl/TestBlockReaderLocal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/client/impl/TestBlockReaderLocal.java
@@ -858,7 +858,7 @@ public class TestBlockReaderLocal {
         Assert.assertEquals(BlockType.STRIPED, stats.getBlockType());
         Assert.assertEquals(length, stats.getTotalLocalBytesRead());
         Assert.assertEquals(length, stats.getTotalBytesRead());
-        Assert.assertTrue(stats.getTotalEcDecodingTimeMillis() > 0);
+        Assert.assertTrue(stats.getTotalEcDecodingTimeNanos() > 0);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestStripedBlockUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestStripedBlockUtil.java
@@ -267,13 +267,13 @@ public class TestStripedBlockUtil {
 
           for (AlignedStripe stripe : stripes) {
             for (int i = 0; i < dataBlocks; i++) {
-              StripingChunk chunk = stripe.chunks[i];
-              if (chunk == null || chunk.state != StripingChunk.REQUESTED) {
+              if (stripe.isNull(i) || !stripe.isReady(i)) {
                 continue;
               }
               int done = 0;
               int len;
-              for (ByteBuffer slice : chunk.getChunkBuffer().getSlices()) {
+              for (ByteBuffer slice :
+                  stripe.getChunkBuffer(i).getSlices()) {
                 len = slice.remaining();
                 slice.put(internalBlkBufs[i],
                     (int) stripe.getOffsetInBlock() + done, len);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently EC Reads are less stable than replication reads because if 4 out of 9 datanodes in the block group are unable to connect, then the whole read fails. Erasure Coding reads need to be able to handle disconnects from DataNodes and retry after a backoff duration to avoid overloading the DataNodes while increasing the stability of the read.

Throttling on server side was another proposed solution, but we prefer this client side backoff for a few main reasons:
1. Throttling on the server would use up thread connections which have a maximum limit.
2. Throttling was originally added only for cohosting scenario to reduce impact on other services
3. Throttling would use up resources on the DataNode which could already be in a bad state.

#### What
The previous implementation followed a 4 phase algorithm to read.
1. Attempt to read chunks from the data blocks
2. Check for missing data chunks. Fail if there are more missing than the number of parity blocks, otherwise read parity blocks and null data blocks
3. Wait for data to be read into the buffers and handle any read errors by reading from more parity blocks
4. Check for missing blocks and either decode or fail.

The new implementation now merges phase 1-3 into a single loop:
1. Loop until we have enough blocks for read or decode, or we have too many missing blocks to succeed
   - Determine the number of chunks we need to fetch. ALLZERO chunks count towards this total. null data chunks also count towards this total unless there are MISSING or SLEEPING data chunks.
   - Read chunks until we have enough pending or fetched to be able to decode or normal read.
faster.
   - Get results from reads and handle exceptions by preparing more reads for decoding the missing data
   - Check if we should sleep before retrying any reads.
2. Check for missing blocks and either decode or fail.

Add two new states to StripingChunk:
- "SLEEPING" to indicate that the node where the chunk is stored has failed and will be retried in the future
- "READY" to indicate that the node where the chunk is stored is ready to be attempted

### How was this patch tested?
Add unit test to `TestWriteReadStripedFile`
- Covers RS(3,2) with 1 chunk on failed nodes, 2 chunks on failed nodes, and 3 chunks on failed nodes.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

