### PR TITLE
HADOOP-19259. Upgrade to jackson 2.14.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -505,7 +505,6 @@ javax.cache:cache-api:1.1.1
 javax.servlet:javax.servlet-api:3.1.0
 javax.servlet.jsp:jsp-api:2.1
 javax.websocket:javax.websocket-api:1.0
-javax.ws.rs:jsr311-api:1.1.1
 javax.xml.bind:jaxb-api:2.3.1
 
 Eclipse Distribution License (EDL) 1.0

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -218,12 +218,12 @@ com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
-com.fasterxml.jackson.core:jackson-annotations:2.12.7
-com.fasterxml.jackson.core:jackson-core:2.12.7
-com.fasterxml.jackson.core:jackson-databind:2.12.7.1
-com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.12.7
-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.7
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.7
+com.fasterxml.jackson.core:jackson-annotations:2.14.3
+com.fasterxml.jackson.core:jackson-core:2.14.3
+com.fasterxml.jackson.core:jackson-databind:2.14.3
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.14.3
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.14.3
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.14.3
 com.fasterxml.uuid:java-uuid-generator:3.1.4
 com.fasterxml.woodstox:woodstox-core:5.4.0
 com.github.ben-manes.caffeine:caffeine:2.9.3
@@ -506,7 +506,7 @@ javax.servlet:javax.servlet-api:3.1.0
 javax.servlet.jsp:jsp-api:2.1
 javax.websocket:javax.websocket-api:1.0
 javax.ws.rs:jsr311-api:1.1.1
-javax.xml.bind:jaxb-api:2.2.11
+javax.xml.bind:jaxb-api:2.3.1
 
 Eclipse Distribution License (EDL) 1.0
 --------------------------

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -46,10 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.net.SocketFactory;
 
-import org.apache.hadoop.security.AccessControlException;
-import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
-import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
-
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -58,9 +54,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ipc.VersionedProtocol;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Preconditions;
+import org.apache.hadoop.util.dynamic.DynConstructors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1114,7 +1114,7 @@ public class NetUtils {
 
   /**
    * Return an @{@link InetAddress} to bind to. If bindWildCardAddress is true
-   * than returns null.
+   * then returns null.
    *
    * @param localAddr local addr.
    * @param bindWildCardAddress bind wildcard address.
@@ -1126,5 +1126,50 @@ public class NetUtils {
       return localAddr;
     }
     return null;
+  }
+
+  /**
+   * Return an @{@link IOException} of the same type as the input exception but with
+   * a modified exception message that includes the node name.
+   *
+   * @param ioe existing exception.
+   * @param nodeName name of the node.
+   * @return IOException
+   */
+  public static IOException addNodeNameToIOException(final IOException ioe, final String nodeName) {
+    try {
+      final Throwable cause = ioe.getCause();
+      IOException newIoe = null;
+      if (cause != null) {
+        try {
+          DynConstructors.Ctor<? extends IOException> ctor =
+              new DynConstructors.Builder()
+                  .impl(ioe.getClass(), String.class, Throwable.class)
+                  .buildChecked();
+          newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage(), cause);
+        } catch (NoSuchMethodException e) {
+          // no matching constructor - try next approach below
+        }
+      }
+      if (newIoe == null) {
+        DynConstructors.Ctor<? extends IOException> ctor =
+            new DynConstructors.Builder()
+                .impl(ioe.getClass(), String.class)
+                .buildChecked();
+        newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage());
+        if (cause != null) {
+          try {
+            newIoe.initCause(cause);
+          } catch (Exception e) {
+            // Unable to initCause. Ignore the exception.
+          }
+        }
+      }
+      newIoe.setStackTrace(ioe.getStackTrace());
+      return newIoe;
+    } catch (Exception e) {
+      // Unable to create new exception. Return the original exception.
+      return ioe;
+    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/NetUtils.java
@@ -21,7 +21,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Constructor;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -941,10 +940,59 @@ public class NetUtils {
 
       }
     } catch (IOException ex) {
-      return (IOException) new IOException("Failed on local exception: "
-          + exception + "; Host Details : "
-          + getHostDetailsAsString(destHost, destPort, localHost))
-          .initCause(exception);
+      try {
+        return new IOException("Failed on local exception: "
+            + exception + "; Host Details : "
+            + getHostDetailsAsString(destHost, destPort, localHost), exception);
+      } catch (Exception ignore) {
+        // in worst case, return the original exception
+        return exception;
+      }
+    }
+  }
+
+  /**
+   * Return an @{@link IOException} of the same type as the input exception but with
+   * a modified exception message that includes the node name.
+   *
+   * @param ioe existing exception.
+   * @param nodeName name of the node.
+   * @return IOException
+   */
+  public static IOException addNodeNameToIOException(final IOException ioe, final String nodeName) {
+    try {
+      final Throwable cause = ioe.getCause();
+      IOException newIoe = null;
+      if (cause != null) {
+        try {
+          DynConstructors.Ctor<? extends IOException> ctor =
+              new DynConstructors.Builder()
+                  .impl(ioe.getClass(), String.class, Throwable.class)
+                  .buildChecked();
+          newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage(), cause);
+        } catch (NoSuchMethodException e) {
+          // no matching constructor - try next approach below
+        }
+      }
+      if (newIoe == null) {
+        DynConstructors.Ctor<? extends IOException> ctor =
+            new DynConstructors.Builder()
+                .impl(ioe.getClass(), String.class)
+                .buildChecked();
+        newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage());
+        if (cause != null) {
+          try {
+            newIoe.initCause(cause);
+          } catch (Exception e) {
+            // Unable to initCause. Ignore the exception.
+          }
+        }
+      }
+      newIoe.setStackTrace(ioe.getStackTrace());
+      return newIoe;
+    } catch (Exception e) {
+      // Unable to create new exception. Return the original exception.
+      return ioe;
     }
   }
 
@@ -957,9 +1005,22 @@ public class NetUtils {
       T exception, String msg) throws T {
     Class<? extends Throwable> clazz = exception.getClass();
     try {
-      Constructor<? extends Throwable> ctor = clazz.getConstructor(String.class);
-      Throwable t = ctor.newInstance(msg);
-      return (T)(t.initCause(exception));
+      try {
+        DynConstructors.Ctor<T> ctor =
+            new DynConstructors.Builder()
+                .impl(clazz, String.class, Throwable.class)
+                .buildChecked();
+        return ctor.newInstance(msg, exception);
+      } catch (NoSuchMethodException e) {
+        // no matching constructor - try next approach below
+      }
+      DynConstructors.Ctor<T> ctor =
+          new DynConstructors.Builder()
+              .impl(clazz, String.class)
+              .buildChecked();
+      T newException = ctor.newInstance(msg);
+      newException.initCause(exception);
+      return newException;
     } catch (NoSuchMethodException e) {
       return exception;
     } catch (Throwable e) {
@@ -1126,50 +1187,5 @@ public class NetUtils {
       return localAddr;
     }
     return null;
-  }
-
-  /**
-   * Return an @{@link IOException} of the same type as the input exception but with
-   * a modified exception message that includes the node name.
-   *
-   * @param ioe existing exception.
-   * @param nodeName name of the node.
-   * @return IOException
-   */
-  public static IOException addNodeNameToIOException(final IOException ioe, final String nodeName) {
-    try {
-      final Throwable cause = ioe.getCause();
-      IOException newIoe = null;
-      if (cause != null) {
-        try {
-          DynConstructors.Ctor<? extends IOException> ctor =
-              new DynConstructors.Builder()
-                  .impl(ioe.getClass(), String.class, Throwable.class)
-                  .buildChecked();
-          newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage(), cause);
-        } catch (NoSuchMethodException e) {
-          // no matching constructor - try next approach below
-        }
-      }
-      if (newIoe == null) {
-        DynConstructors.Ctor<? extends IOException> ctor =
-            new DynConstructors.Builder()
-                .impl(ioe.getClass(), String.class)
-                .buildChecked();
-        newIoe = ctor.newInstance(nodeName + ": " + ioe.getMessage());
-        if (cause != null) {
-          try {
-            newIoe.initCause(cause);
-          } catch (Exception e) {
-            // Unable to initCause. Ignore the exception.
-          }
-        }
-      }
-      newIoe.setStackTrace(ioe.getStackTrace());
-      return newIoe;
-    } catch (Exception e) {
-      // Unable to create new exception. Return the original exception.
-      return ioe;
-    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -799,6 +800,48 @@ public class TestNetUtils {
         .bindToLocalAddress(NetUtils.getLocalInetAddress("127.0.0.1"), false));
     assertNull(NetUtils
         .bindToLocalAddress(NetUtils.getLocalInetAddress("127.0.0.1"), true));
+  }
+
+  public static class WrappedIOException extends IOException {
+    public WrappedIOException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+  }
+
+  private static class PrivateIOException extends IOException {
+    PrivateIOException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+  }
+
+  @Test
+  public void testAddNodeNameToIOException() {
+    IOException e0 = new IOException("test123");
+    assertNull(e0.getCause());
+    IOException new0 = NetUtils.addNodeNameToIOException(e0, "node123");
+    assertNull(new0.getCause());
+    assertEquals("node123: test123", new0.getMessage());
+
+    IOException e1 = new IOException("test456", new IllegalStateException("deliberate"));
+    IOException new1 = NetUtils.addNodeNameToIOException(e1, "node456");
+    assertEquals(e1.getCause(), new1.getCause());
+    assertEquals("node456: test456", new1.getMessage());
+
+    ZipException e2 = new ZipException("test789");
+    assertNull(e2.getCause());
+    IOException new2 = NetUtils.addNodeNameToIOException(e2, "node789");
+    assertNull(new2.getCause());
+    assertEquals("node789: test789", new2.getMessage());
+
+    WrappedIOException e3 = new WrappedIOException("test987", new IllegalStateException("deliberate"));
+    IOException new3 = NetUtils.addNodeNameToIOException(e3, "node987");
+    assertEquals(e3.getCause(), new3.getCause());
+    assertEquals("node987: test987", new3.getMessage());
+
+    // addNodeNameToIOException will return the original exception if the class is not accessible
+    PrivateIOException e4 = new PrivateIOException("test654", new IllegalStateException("deliberate"));
+    IOException new4 = NetUtils.addNodeNameToIOException(e4, "node654");
+    assertEquals(e4, new4);
   }
 
   private <T> void assertBetterArrayEquals(T[] expect, T[]got) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -834,13 +834,15 @@ public class TestNetUtils {
     assertNullCause(new2);
     assertEquals("node789: test789", new2.getMessage());
 
-    WrappedIOException e3 = new WrappedIOException("test987", new IllegalStateException("deliberate"));
+    WrappedIOException e3 = new WrappedIOException("test987",
+        new IllegalStateException("deliberate"));
     IOException new3 = NetUtils.addNodeNameToIOException(e3, "node987");
     assertSame(e3.getCause(), new3.getCause());
     assertEquals("node987: test987", new3.getMessage());
 
     // addNodeNameToIOException will return the original exception if the class is not accessible
-    PrivateIOException e4 = new PrivateIOException("test654", new IllegalStateException("deliberate"));
+    PrivateIOException e4 = new PrivateIOException("test654",
+        new IllegalStateException("deliberate"));
     IOException new4 = NetUtils.addNodeNameToIOException(e4, "node654");
     assertSame(e4, new4);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -817,36 +818,40 @@ public class TestNetUtils {
   @Test
   public void testAddNodeNameToIOException() {
     IOException e0 = new IOException("test123");
-    assertNull(e0.getCause());
+    assertNullCause(e0);
     IOException new0 = NetUtils.addNodeNameToIOException(e0, "node123");
-    assertNull(new0.getCause());
+    assertNullCause(new0);
     assertEquals("node123: test123", new0.getMessage());
 
     IOException e1 = new IOException("test456", new IllegalStateException("deliberate"));
     IOException new1 = NetUtils.addNodeNameToIOException(e1, "node456");
-    assertEquals(e1.getCause(), new1.getCause());
+    assertSame(e1.getCause(), new1.getCause());
     assertEquals("node456: test456", new1.getMessage());
 
     ZipException e2 = new ZipException("test789");
-    assertNull(e2.getCause());
+    assertNullCause(e2);
     IOException new2 = NetUtils.addNodeNameToIOException(e2, "node789");
-    assertNull(new2.getCause());
+    assertNullCause(new2);
     assertEquals("node789: test789", new2.getMessage());
 
     WrappedIOException e3 = new WrappedIOException("test987", new IllegalStateException("deliberate"));
     IOException new3 = NetUtils.addNodeNameToIOException(e3, "node987");
-    assertEquals(e3.getCause(), new3.getCause());
+    assertSame(e3.getCause(), new3.getCause());
     assertEquals("node987: test987", new3.getMessage());
 
     // addNodeNameToIOException will return the original exception if the class is not accessible
     PrivateIOException e4 = new PrivateIOException("test654", new IllegalStateException("deliberate"));
     IOException new4 = NetUtils.addNodeNameToIOException(e4, "node654");
-    assertEquals(e4, new4);
+    assertSame(e4, new4);
   }
 
   private <T> void assertBetterArrayEquals(T[] expect, T[]got) {
     String expectStr = StringUtils.join(expect, ", ");
     String gotStr = StringUtils.join(got, ", ");
     assertEquals(expectStr, gotStr);
+  }
+
+  private void assertNullCause(Exception e) {
+    assertNull(e.getCause(), "Expected exception to have null cause");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -31,7 +31,6 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -133,6 +132,7 @@ import org.apache.hadoop.util.KMSUtil;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.dynamic.DynConstructors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -846,14 +846,36 @@ public class WebHdfsFileSystem extends FileSystem
             node = url.getAuthority();
           }
           try {
-            IOException newIoe = ioe.getClass().getConstructor(String.class)
-                .newInstance(node + ": " + ioe.getMessage());
-            newIoe.initCause(ioe.getCause());
+            final Throwable cause = ioe.getCause();
+            IOException newIoe = null;
+            if (cause != null) {
+              try {
+                DynConstructors.Ctor<? extends IOException> ctor =
+                    new DynConstructors.Builder()
+                        .impl(ioe.getClass(), String.class, Throwable.class)
+                        .buildChecked();
+                newIoe = ctor.newInstance(node + ": " + ioe.getMessage(), cause);
+              } catch (NoSuchMethodException e) {
+                // no matching constructor - try next approach below
+              }
+            }
+            if (newIoe == null) {
+              DynConstructors.Ctor<? extends IOException> ctor =
+                  new DynConstructors.Builder()
+                      .impl(ioe.getClass(), String.class)
+                      .buildChecked();
+              newIoe = ctor.newInstance(node + ": " + ioe.getMessage());
+              if (cause != null) {
+                try {
+                  newIoe.initCause(cause);
+                } catch (Exception e) {
+                  // Unable to initCause. Ignore the exception.
+                }
+              }
+            }
             newIoe.setStackTrace(ioe.getStackTrace());
             ioe = newIoe;
-          } catch (NoSuchMethodException | SecurityException 
-                   | InstantiationException | IllegalAccessException
-                   | IllegalArgumentException | InvocationTargetException e) {
+          } catch (NoSuchMethodException | SecurityException | IllegalArgumentException e) {
           }
           shouldRetry(ioe, retry);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -875,7 +875,7 @@ public class WebHdfsFileSystem extends FileSystem
             }
             newIoe.setStackTrace(ioe.getStackTrace());
             ioe = newIoe;
-          } catch (NoSuchMethodException | SecurityException | IllegalArgumentException e) {
+          } catch (Exception e) {
           }
           shouldRetry(ioe, retry);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -132,7 +132,6 @@ import org.apache.hadoop.util.KMSUtil;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.dynamic.DynConstructors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -845,38 +844,7 @@ public class WebHdfsFileSystem extends FileSystem
           if (node == null) {
             node = url.getAuthority();
           }
-          try {
-            final Throwable cause = ioe.getCause();
-            IOException newIoe = null;
-            if (cause != null) {
-              try {
-                DynConstructors.Ctor<? extends IOException> ctor =
-                    new DynConstructors.Builder()
-                        .impl(ioe.getClass(), String.class, Throwable.class)
-                        .buildChecked();
-                newIoe = ctor.newInstance(node + ": " + ioe.getMessage(), cause);
-              } catch (NoSuchMethodException e) {
-                // no matching constructor - try next approach below
-              }
-            }
-            if (newIoe == null) {
-              DynConstructors.Ctor<? extends IOException> ctor =
-                  new DynConstructors.Builder()
-                      .impl(ioe.getClass(), String.class)
-                      .buildChecked();
-              newIoe = ctor.newInstance(node + ": " + ioe.getMessage());
-              if (cause != null) {
-                try {
-                  newIoe.initCause(cause);
-                } catch (Exception e) {
-                  // Unable to initCause. Ignore the exception.
-                }
-              }
-            }
-            newIoe.setStackTrace(ioe.getStackTrace());
-            ioe = newIoe;
-          } catch (Exception e) {
-          }
+          ioe = NetUtils.addNodeNameToIOException(ioe, node);
           shouldRetry(ioe, retry);
         }
       }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -68,9 +68,6 @@
     <!-- jersey version -->
     <jersey2.version>2.46</jersey2.version>
 
-    <!-- jaxb version -->
-    <jaxb.version>2.3.1</jaxb.version>
-
     <!-- jackson versions -->
     <jackson2.version>2.14.3</jackson2.version>
     <jackson2.databind.version>2.14.3</jackson2.databind.version>
@@ -2138,11 +2135,6 @@
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jettison</artifactId>
         <version>${jersey2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>net.jodah</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -1284,12 +1284,6 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson2.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -68,9 +68,12 @@
     <!-- jersey version -->
     <jersey2.version>2.46</jersey2.version>
 
+    <!-- jaxb version -->
+    <jaxb.version>2.3.1</jaxb.version>
+
     <!-- jackson versions -->
-    <jackson2.version>2.12.7</jackson2.version>
-    <jackson2.databind.version>2.12.7.1</jackson2.databind.version>
+    <jackson2.version>2.14.3</jackson2.version>
+    <jackson2.databind.version>2.14.3</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.13</httpclient.version>
@@ -1281,6 +1284,12 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson2.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -2135,6 +2144,11 @@
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jettison</artifactId>
         <version>${jersey2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>net.jodah</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -205,10 +205,6 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
     </dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -205,6 +205,10 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
     </dependency>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Hitting issues in jackson 2.18 and there is a bug in jackson 2.18.2 that I want to avoid. I think it is useful to upgrade to jackson 2.14.3 first. It has some security hardening and bug fixes but avoids some major changes in jackson 2.15+.

Replacement for #7022

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

