### PR TITLE
YARN-11678. Update CGroupElasticMemoryController for cgroup v2 support

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupElasticMemoryController.java
@@ -45,27 +45,23 @@ import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_ELASTIC_MEMORY_CO
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_ELASTIC_MEMORY_CONTROL_OOM_TIMEOUT_SEC;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_PMEM_CHECK_ENABLED;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.NM_VMEM_CHECK_ENABLED;
-import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES;
-import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_OOM_CONTROL;
-import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES;
-import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_NO_LIMIT;
 
 /**
  * This thread controls memory usage using cgroups. It listens to out of memory
  * events of all the containers together, and if we go over the limit picks
  * a container to kill. The algorithm that picks the container is a plugin.
  */
-public class CGroupElasticMemoryController extends Thread {
+public abstract class AbstractCGroupElasticMemoryController extends Thread {
   protected static final Logger LOG = LoggerFactory
-      .getLogger(CGroupElasticMemoryController.class);
+      .getLogger(AbstractCGroupElasticMemoryController.class);
   private final Clock clock = new MonotonicClock();
   private String yarnCGroupPath;
   private String oomListenerPath;
   private Runnable oomHandler;
-  private CGroupsHandler cgroups;
-  private boolean controlPhysicalMemory;
-  private boolean controlVirtualMemory;
-  private long limit;
+  protected CGroupsHandler cgroups;
+  protected boolean controlPhysicalMemory;
+  protected boolean controlVirtualMemory;
+  protected long limit;
   private Process process = null;
   private boolean stopped = false;
   private int timeoutMS;
@@ -82,7 +78,7 @@ public class CGroupElasticMemoryController extends Thread {
    * @exception YarnException Could not instantiate class
    */
   @VisibleForTesting
-  CGroupElasticMemoryController(Configuration conf,
+  AbstractCGroupElasticMemoryController(Configuration conf,
                                        Context context,
                                        CGroupsHandler cgroups,
                                        boolean controlPhysicalMemory,
@@ -90,7 +86,7 @@ public class CGroupElasticMemoryController extends Thread {
                                        long limit,
                                        Runnable oomHandlerOverride)
       throws YarnException {
-    super("CGroupElasticMemoryController");
+    super("AbstractCGroupElasticMemoryController");
     boolean controlVirtual = controlVirtualMemory && !controlPhysicalMemory;
     Runnable oomHandlerTemp =
         getDefaultOOMHandler(conf, context, oomHandlerOverride, controlVirtual);
@@ -165,7 +161,7 @@ public class CGroupElasticMemoryController extends Thread {
    * @param limit memory limit in bytes
    * @exception YarnException Could not instantiate class
    */
-  public CGroupElasticMemoryController(Configuration conf,
+  public AbstractCGroupElasticMemoryController(Configuration conf,
                                        Context context,
                                        CGroupsHandler cgroups,
                                        boolean controlPhysicalMemory,
@@ -203,23 +199,23 @@ public class CGroupElasticMemoryController extends Thread {
   }
 
   /**
-   * Checks if the CGroupElasticMemoryController is available on this system.
+   * Checks if the AbstractCGroupElasticMemoryController is available on this system.
    * This assumes that Linux container executor is already initialized.
    * We need to have CGroups enabled.
    *
-   * @return True if CGroupElasticMemoryController is available.
+   * @return True if AbstractCGroupElasticMemoryController is available.
    * False otherwise.
    */
   public static boolean isAvailable() {
     try {
       if (!Shell.LINUX) {
-        LOG.info("CGroupElasticMemoryController currently is supported only "
+        LOG.info("AbstractCGroupElasticMemoryController currently is supported only "
             + "on Linux.");
         return false;
       }
       if (ResourceHandlerModule.getCGroupsHandler() == null ||
           ResourceHandlerModule.getMemoryResourceHandler() == null) {
-        LOG.info("CGroupElasticMemoryController requires enabling " +
+        LOG.info("AbstractCGroupElasticMemoryController requires enabling " +
             "memory CGroups with" +
             YarnConfiguration.NM_MEMORY_RESOURCE_ENABLED);
         return false;
@@ -249,7 +245,9 @@ public class CGroupElasticMemoryController extends Thread {
 
       // Start a listener process
       ProcessBuilder oomListener = new ProcessBuilder();
-      oomListener.command(oomListenerPath, yarnCGroupPath);
+      oomListener.command(oomListenerPath,
+          ResourceHandlerModule.isCGroupsV2Enabled() ? "2" : "1",
+          yarnCGroupPath);
       synchronized (this) {
         if (!stopped) {
           process = oomListener.start();
@@ -364,11 +362,7 @@ public class CGroupElasticMemoryController extends Thread {
       // Throw an error, if we are still in OOM after 5 seconds
       while(end - start < timeoutMS) {
         end = clock.getTime();
-        String underOOM = cgroups.getCGroupParam(
-            CGroupsHandler.CGroupController.MEMORY,
-            "",
-            CGROUP_PARAM_MEMORY_OOM_CONTROL);
-        if (underOOM.contains(CGroupsHandler.UNDER_OOM)) {
+        if (isUnderOOM()) {
           if (end - lastLog > 1000) {
             LOG.warn(String.format(
                 "OOM not resolved in %d ms", end - start));
@@ -395,68 +389,6 @@ public class CGroupElasticMemoryController extends Thread {
     return false;
   }
 
-  /**
-   * Update root memory cgroup. This contains all containers.
-   * The physical limit has to be set first then the virtual limit.
-   */
-  private void setCGroupParameters() throws ResourceHandlerException {
-    // Disable the OOM killer
-    cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-        CGROUP_PARAM_MEMORY_OOM_CONTROL, "1");
-    if (controlPhysicalMemory && !controlVirtualMemory) {
-      try {
-        // Ignore virtual memory limits, since we do not know what it is set to
-        cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-            CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
-      } catch (ResourceHandlerException ex) {
-        LOG.debug("Swap monitoring is turned off in the kernel");
-      }
-      // Set physical memory limits
-      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, Long.toString(limit));
-    } else if (controlVirtualMemory && !controlPhysicalMemory) {
-      // Ignore virtual memory limits, since we do not know what it is set to
-      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
-      // Set physical limits to no more than virtual limits
-      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, Long.toString(limit));
-      // Set virtual memory limits
-      // Important: it has to be set after physical limit is set
-      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, Long.toString(limit));
-    } else {
-      throw new ResourceHandlerException(
-          String.format("Unsupported scenario physical:%b virtual:%b",
-              controlPhysicalMemory, controlVirtualMemory));
-    }
-  }
-
-  /**
-   * Reset root memory cgroup to OS defaults. This controls all containers.
-   */
-  private void resetCGroupParameters() {
-    try {
-      try {
-        // Disable memory limits
-        cgroups.updateCGroupParam(
-            CGroupsHandler.CGroupController.MEMORY, "",
-            CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
-      } catch (ResourceHandlerException ex) {
-        LOG.debug("Swap monitoring is turned off in the kernel");
-      }
-      cgroups.updateCGroupParam(
-          CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
-      // Enable the OOM killer
-      cgroups.updateCGroupParam(
-          CGroupsHandler.CGroupController.MEMORY, "",
-          CGROUP_PARAM_MEMORY_OOM_CONTROL, "0");
-    } catch (ResourceHandlerException ex) {
-      LOG.warn("Error in cleanup", ex);
-    }
-  }
-
   private static String getOOMListenerExecutablePath(Configuration conf) {
     String yarnHomeEnvVar =
         System.getenv(ApplicationConstants.Environment.HADOOP_YARN_HOME.key());
@@ -472,4 +404,17 @@ public class CGroupElasticMemoryController extends Thread {
     LOG.debug(String.format("oom-listener path: %s %s", path, defaultPath));
     return path;
   }
+
+  /**
+   * Update root memory cgroup. This contains all containers.
+   * The physical limit has to be set first then the virtual limit.
+   */
+  abstract void setCGroupParameters() throws ResourceHandlerException;
+
+  /**
+   * Reset root memory cgroup to OS defaults. This controls all containers.
+   */
+  abstract void resetCGroupParameters();
+
+  abstract boolean isUnderOOM() throws Exception;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupElasticMemoryControllerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupElasticMemoryControllerImpl.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.nodemanager.Context;
+
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_OOM_CONTROL;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_NO_LIMIT;
+
+public class CGroupElasticMemoryControllerImpl extends  AbstractCGroupElasticMemoryController{
+
+  public CGroupElasticMemoryControllerImpl(Configuration conf, Context context,
+      CGroupsHandler cgroups, boolean controlPhysicalMemory,
+      boolean controlVirtualMemory, long limit)
+      throws YarnException {
+    this(conf, context, cgroups, controlPhysicalMemory, controlVirtualMemory,
+        limit, null);
+  }
+
+  public CGroupElasticMemoryControllerImpl(Configuration conf, Context context,
+      CGroupsHandler cgroups, boolean controlPhysicalMemory,
+      boolean controlVirtualMemory, long limit, Runnable oomHandlerOverride)
+      throws YarnException {
+    super(conf, context, cgroups, controlPhysicalMemory, controlVirtualMemory,
+        limit, oomHandlerOverride);
+  }
+
+  @Override
+  void setCGroupParameters() throws ResourceHandlerException {
+    // Disable the OOM killer
+    cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+        CGROUP_PARAM_MEMORY_OOM_CONTROL, "1");
+    if (controlPhysicalMemory && !controlVirtualMemory) {
+      try {
+        // Ignore virtual memory limits, since we do not know what it is set to
+        cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+            CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
+      } catch (ResourceHandlerException ex) {
+        LOG.debug("Swap monitoring is turned off in the kernel");
+      }
+      // Set physical memory limits
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, Long.toString(limit));
+    } else if (controlVirtualMemory && !controlPhysicalMemory) {
+      // Ignore virtual memory limits, since we do not know what it is set to
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
+      // Set physical limits to no more than virtual limits
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, Long.toString(limit));
+      // Set virtual memory limits
+      // Important: it has to be set after physical limit is set
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, Long.toString(limit));
+    } else {
+      throw new ResourceHandlerException(
+          String.format("Unsupported scenario physical:%b virtual:%b",
+              controlPhysicalMemory, controlVirtualMemory));
+    }
+  }
+
+  @Override
+  void resetCGroupParameters() {
+    try {
+      try {
+        // Disable memory limits
+        cgroups.updateCGroupParam(
+            CGroupsHandler.CGroupController.MEMORY, "",
+            CGROUP_PARAM_MEMORY_SWAP_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
+      } catch (ResourceHandlerException ex) {
+        LOG.debug("Swap monitoring is turned off in the kernel");
+      }
+      cgroups.updateCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_HARD_LIMIT_BYTES, CGROUP_NO_LIMIT);
+      // Enable the OOM killer
+      cgroups.updateCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL, "0");
+    } catch (ResourceHandlerException ex) {
+      LOG.warn("Error in cleanup", ex);
+    }
+  }
+
+  @Override
+  boolean isUnderOOM() throws Exception {
+    String underOOM = cgroups.getCGroupParam(
+        CGroupsHandler.CGroupController.MEMORY,
+        "",
+        CGROUP_PARAM_MEMORY_OOM_CONTROL);
+    return underOOM.contains(CGroupsHandler.UNDER_OOM);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupV2ElasticMemoryControllerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupV2ElasticMemoryControllerImpl.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.server.nodemanager.Context;
+
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_MEMORY_CURRENT;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_MEMORY_MAX;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_MEMORY_HIGH;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_SWAP_MEMORY_MAX;
+
+public class CGroupV2ElasticMemoryControllerImpl extends AbstractCGroupElasticMemoryController{
+  public CGroupV2ElasticMemoryControllerImpl(Configuration conf,
+      Context context, CGroupsHandler cgroups, boolean controlPhysicalMemory,
+      boolean controlVirtualMemory, long limit)
+      throws YarnException {
+    super(conf, context, cgroups, controlPhysicalMemory, controlVirtualMemory,
+        limit);
+  }
+
+  @Override
+  void setCGroupParameters() throws ResourceHandlerException {
+    if (controlPhysicalMemory && !controlVirtualMemory) {
+      try {
+        cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+            CGROUP_SWAP_MEMORY_MAX, "max");
+      } catch (ResourceHandlerException ex) {
+        LOG.debug("Swap monitoring is turned off in the kernel");
+      }
+      // Set physical memory limits
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_MAX, Long.toString(limit) + 5 * 1024 * 1024 * 1024);
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_HIGH, Long.toString(limit));
+    } else if (controlVirtualMemory && !controlPhysicalMemory) {
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_HIGH, Long.toString(limit));
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_SWAP_MEMORY_MAX, Long.toString(limit));
+    }
+  }
+
+  @Override
+  void resetCGroupParameters() {
+    try {
+      try {
+        cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+            CGROUP_SWAP_MEMORY_MAX, "max");
+      } catch (ResourceHandlerException ex) {
+        LOG.debug("Swap monitoring is turned off in the kernel");
+      }
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_MAX, "max");
+      cgroups.updateCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_HIGH, "max");
+    } catch (ResourceHandlerException ex) {
+      LOG.warn("Error in cleanup", ex);
+    }
+  }
+
+  @Override
+  boolean isUnderOOM() throws Exception {
+    long used =  Long.parseLong(cgroups.getCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+        CGROUP_MEMORY_CURRENT));
+    long limit = Long.parseLong(cgroups.getCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+        CGROUP_MEMORY_HIGH));
+    return used >= limit;
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsHandler.java
@@ -124,7 +124,11 @@ public interface CGroupsHandler {
   String CGROUP_SUBTREE_CONTROL_FILE = "cgroup.subtree_control";
   String CGROUP_CPU_MAX = "max";
   String CGROUP_MEMORY_MAX = "max";
+  String CGROUP_MEMORY_HIGH = "high";
   String CGROUP_MEMORY_LOW = "low";
+  String CGROUP_MEMORY_CURRENT = "current";
+  String CGROUP_SWAP_MEMORY_MAX = "swap.max";
+  String CGROUP_SWAP_MEMORY_CURRENT = "swap.current";
 
   // present in v1 and v2
   String CGROUP_PROCS_FILE = "cgroup.procs";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/DefaultOOMHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/DefaultOOMHandler.java
@@ -34,10 +34,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_MEMORY_CURRENT;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_MEMORY_HIGH;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PROCS_FILE;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_OOM_CONTROL;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_PARAM_MEMORY_USAGE_BYTES;
+import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler.CGROUP_SWAP_MEMORY_CURRENT;
+
+
 
 /**
  * A very basic OOM handler implementation.
@@ -51,6 +56,7 @@ public class DefaultOOMHandler implements Runnable {
   private final Context context;
   private final String memoryStatFile;
   private final CGroupsHandler cgroups;
+  private final boolean cgroupsV2Enabled;
 
   /**
    * Create an OOM handler.
@@ -61,9 +67,16 @@ public class DefaultOOMHandler implements Runnable {
    */
   public DefaultOOMHandler(Context context, boolean enforceVirtualMemory) {
     this.context = context;
-    this.memoryStatFile = enforceVirtualMemory ?
-        CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES :
-        CGROUP_PARAM_MEMORY_USAGE_BYTES;
+    this.cgroupsV2Enabled = ResourceHandlerModule.isCGroupsV2Enabled();
+    if (cgroupsV2Enabled) {
+      this.memoryStatFile = enforceVirtualMemory ?
+          CGROUP_SWAP_MEMORY_CURRENT :
+          CGROUP_MEMORY_CURRENT;
+    } else {
+      this.memoryStatFile = enforceVirtualMemory ?
+          CGROUP_PARAM_MEMORY_MEMSW_USAGE_BYTES :
+          CGROUP_PARAM_MEMORY_USAGE_BYTES;
+    }
     this.cgroups = getCGroupsHandler();
   }
 
@@ -185,11 +198,7 @@ public class DefaultOOMHandler implements Runnable {
       // We kill containers until the kernel reports the OOM situation resolved
       // Note: If the kernel has a delay this may kill more than necessary
       while (true) {
-        String status = cgroups.getCGroupParam(
-            CGroupsHandler.CGroupController.MEMORY,
-            "",
-            CGROUP_PARAM_MEMORY_OOM_CONTROL);
-        if (!status.contains(CGroupsHandler.UNDER_OOM)) {
+        if (!isUnderOOM()) {
           break;
         }
 
@@ -254,6 +263,22 @@ public class DefaultOOMHandler implements Runnable {
       }
     }
     return containerKilled;
+  }
+
+  private boolean isUnderOOM() throws ResourceHandlerException {
+    if (cgroupsV2Enabled) {
+      long used =  Long.parseLong(cgroups.getCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_CURRENT));
+      long limit = Long.parseLong(cgroups.getCGroupParam(CGroupsHandler.CGroupController.MEMORY, "",
+          CGROUP_MEMORY_HIGH));
+      return used >= limit;
+    } else {
+      String status = cgroups.getCGroupParam(
+          CGroupsHandler.CGroupController.MEMORY,
+          "",
+          CGROUP_PARAM_MEMORY_OOM_CONTROL);
+      return status.contains(CGroupsHandler.UNDER_OOM);
+    }
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -118,6 +118,10 @@ public class ResourceHandlerModule {
     return (cGroupV2Handler != null && cGroupV2Handler.getControllerPath(controller) != null);
   }
 
+  public static boolean isCGroupsV2Enabled() {
+    return cgroupsV2Enabled;
+  }
+
   /**
    * Returns a (possibly null) reference to a cGroupsHandler. This handler is
    * non-null only if one or more of the known cgroups-based resource
@@ -125,7 +129,7 @@ public class ResourceHandlerModule {
    */
 
   public static CGroupsHandler getCGroupsHandler() {
-    return cGroupV1Handler;
+    return cgroupsV2Enabled ? cGroupV2Handler : cGroupV1Handler;
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/monitor/ContainersMonitorImpl.java
@@ -22,7 +22,9 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupElasticMemoryController;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.AbstractCGroupElasticMemoryController;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupElasticMemoryControllerImpl;
+import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupV2ElasticMemoryControllerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerModule;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
 import org.slf4j.Logger;
@@ -76,7 +78,7 @@ public class ContainersMonitorImpl extends AbstractService implements
   private LogMonitorThread logMonitorThread;
   private long logDirSizeLimit;
   private long logTotalSizeLimit;
-  private CGroupElasticMemoryController oomListenerThread;
+  private AbstractCGroupElasticMemoryController oomListenerThread;
   private boolean containerMetricsEnabled;
   private long containerMetricsPeriodMs;
   private long containerMetricsUnregisterDelayMs;
@@ -212,23 +214,15 @@ public class ContainersMonitorImpl extends AbstractService implements
     LOG.info("Strict memory control enabled: {}", strictMemoryEnforcement);
 
     if (elasticMemoryEnforcement) {
-      if (!CGroupElasticMemoryController.isAvailable()) {
+      if (!AbstractCGroupElasticMemoryController.isAvailable()) {
         // Test for availability outside the constructor
         // to be able to write non-Linux unit tests for
-        // CGroupElasticMemoryController
+        // AbstractCGroupElasticMemoryController
         throw new YarnException(
             "CGroup Elastic Memory controller enabled but " +
             "it is not available. Exiting.");
       } else {
-        this.oomListenerThread = new CGroupElasticMemoryController(
-            conf,
-            context,
-            ResourceHandlerModule.getCGroupsHandler(),
-            pmemCheckEnabled,
-            vmemCheckEnabled,
-            pmemCheckEnabled ?
-                maxPmemAllottedForContainers : maxVmemAllottedForContainers
-        );
+        this.oomListenerThread = getCGroupElasticMemoryController();
       }
     }
 
@@ -270,6 +264,24 @@ public class ContainersMonitorImpl extends AbstractService implements
       }
     }
     super.serviceInit(this.conf);
+  }
+
+  private AbstractCGroupElasticMemoryController getCGroupElasticMemoryController()
+      throws YarnException {
+    AbstractCGroupElasticMemoryController controller;
+    if (ResourceHandlerModule
+        .isCGroupsV2Enabled()) {
+      controller = new CGroupV2ElasticMemoryControllerImpl(conf, context,
+          ResourceHandlerModule.getCGroupsHandler(), pmemCheckEnabled,
+          vmemCheckEnabled, pmemCheckEnabled ? maxPmemAllottedForContainers :
+          maxVmemAllottedForContainers);
+    } else {
+      controller = new CGroupElasticMemoryControllerImpl(conf, context,
+          ResourceHandlerModule.getCGroupsHandler(), pmemCheckEnabled,
+          vmemCheckEnabled, pmemCheckEnabled ? maxPmemAllottedForContainers :
+          maxVmemAllottedForContainers);
+    }
+    return controller;
   }
 
   private boolean isContainerMonitorEnabled() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener.c
@@ -168,4 +168,88 @@ int oom_listener(_oom_listener_descriptors *descriptors, const char *cgroup, int
   return EXIT_SUCCESS;
 }
 
+int oom_listenerV2(_oom_listenerV2_descriptors *descriptors, const char *cgroup, int fd) {
+    const char *pattern =
+            cgroup[MAX(strlen(cgroup), 1) - 1] == '/'
+            ? "%s%s" :"%s/%s";
+
+    if (snprintf(descriptors->oom_pressure_path,
+                 sizeof(descriptors->oom_pressure_path),
+                 pattern,
+                 cgroup,
+                 "memory.pressure") < 0) {
+        print_error(descriptors->command, "path too long %s\n", cgroup);
+        return EXIT_FAILURE;
+    }
+
+    if ((descriptors->event_fd = open(
+            descriptors->oom_pressure_path,
+            O_RDWR | O_NONBLOCK)) == -1) {
+        print_error(descriptors->command, "Could not open %s. errno:%d %s\n",
+                    descriptors->oom_pressure_path,
+                    errno, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+
+    if ((descriptors->oom_command_len =
+            (size_t) snprintf(descriptors->oom_command,
+        sizeof(descriptors->oom_command),
+        "%s",
+        "some 1000000 3000000")) < 0) {
+        print_error(descriptors->command, "Could print %s\n",
+                    "some 1000000 3000000");
+    }
+
+    if (write(descriptors->event_fd,
+              descriptors->oom_command,
+              descriptors->oom_command_len) == -1) {
+        print_error(descriptors->command, "Could not write to %s errno:%d\n",
+                    descriptors->oom_pressure_path, errno);
+        return EXIT_FAILURE;
+    }
+
+    for (;;) {
+        uint64_t u;
+        ssize_t ret = 0;
+        struct stat stat_buffer = {0};
+        struct pollfd poll_fd = {
+                .fd = descriptors->event_fd,
+                .events = POLLPRI
+        };
+
+        ret = poll(&poll_fd, 1, descriptors->watch_timeout);
+        if (ret < 0) {
+            /* Error calling poll */
+            print_error(descriptors->command,
+                  "Could not poll eventfd %d errno:%d %s\n", ret,
+                  errno, strerror(errno));
+            return EXIT_FAILURE;
+        }
+
+        if (ret > 0) {
+            if (poll_fd.revents & POLLERR) {
+                print_error(descriptors->command, "Got POLLERR, event source is gone\n");
+                return EXIT_FAILURE;
+            }
+
+            if (poll_fd.revents & POLLPRI) {
+                    if ((ret = write(fd, &u, sizeof(u))) != sizeof(u)) {
+                    print_error(descriptors->command,
+                                "Could not write to pipe %d errno:%d %s\n", ret,
+                                errno, strerror(errno));
+                    return EXIT_FAILURE;
+                }
+            }
+        } else if (ret == 0) {
+            /* Timeout has elapsed*/
+            /* Quit, if the cgroup is deleted */
+            if (stat(cgroup, &stat_buffer) != 0) {
+                break;
+            }
+        }
+    }
+    return EXIT_SUCCESS;
+}
+
 #endif

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener.h
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener.h
@@ -91,6 +91,15 @@ inline void cleanup(_oom_listener_descriptors *descriptors) {
   descriptors->watch_timeout = 1000;
 }
 
+typedef struct _oom_listenerV2_descriptors {
+    const char *command;
+    int event_fd;
+    char oom_pressure_path[PATH_MAX];
+    char oom_command[25];
+    size_t oom_command_len;
+    int watch_timeout;
+} _oom_listenerV2_descriptors;
+
 /*
  * Enable an OOM listener on the memory cgroup cgroup
  * descriptors: Structure that holds state for testing purposes
@@ -98,5 +107,7 @@ inline void cleanup(_oom_listener_descriptors *descriptors) {
  * fd: File to forward events to. Normally this is stdout
  */
 int oom_listener(_oom_listener_descriptors *descriptors, const char *cgroup, int fd);
+
+int oom_listenerV2(_oom_listenerV2_descriptors *descriptors, const char *cgroup, int fd);
 
 #endif

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener_main.c
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/impl/oom_listener_main.c
@@ -30,11 +30,14 @@ extern inline void cleanup(_oom_listener_descriptors *descriptors);
 void print_usage(void) {
   fprintf(stderr, "oom-listener");
   fprintf(stderr, "Listen to OOM events in a cgroup");
-  fprintf(stderr, "usage to listen: oom-listener <cgroup directory>\n");
+  fprintf(stderr, "usage to listen: oom-listener <cgroup version> <cgroup directory>\n");
   fprintf(stderr, "usage to test: oom-listener oom [<pgid>]\n");
-  fprintf(stderr, "example listening: oom-listener /sys/fs/cgroup/memory/hadoop-yarn | xxd -c 8\n");
+  fprintf(stderr, "example listening: oom-listener 1 /sys/fs/cgroup/memory/hadoop-yarn | xxd -c 8\n");
+  fprintf(stderr, "                   oom-listener 2 /sys/fs/cgroup/hadoop-yarn | xxd -c 8\n");
   fprintf(stderr, "example oom to test: bash -c 'echo $$ >/sys/fs/cgroup/memory/hadoop-yarn/tasks;oom-listener oom'\n");
+  fprintf(stderr, "                     bash -c 'echo $$ >/sys/fs/cgroup/hadoop-yarn/cgroup.procs;oom-listener oom'\n");
   fprintf(stderr, "example container overload: sudo -u <user> bash -c 'echo $$ && oom-listener oom 0' >/sys/fs/cgroup/memory/hadoop-yarn/<container>/tasks\n");
+  fprintf(stderr, "                            sudo -u <user> bash -c 'echo $$ && oom-listener oom 0' >/sys/fs/cgroup/hadoop-yarn/<container>/cgroup.procs\n");
   exit(EXIT_FAILURE);
 }
 
@@ -71,24 +74,35 @@ int main(int argc, char *argv[]) {
       strcmp(argv[1], "oom") == 0)
     test_oom_infinite(argc < 3 ? NULL : argv[2]);
 
-  if (argc != 2)
+  if (argc != 3)
     print_usage();
 
-  _oom_listener_descriptors descriptors = {
-      .command = argv[0],
-      .event_fd = -1,
-      .event_control_fd = -1,
-      .oom_control_fd = -1,
-      .event_control_path = {0},
-      .oom_control_path = {0},
-      .oom_command = {0},
-      .oom_command_len = 0,
-      .watch_timeout = 1000
-  };
-
-  int ret = oom_listener(&descriptors, argv[1], STDOUT_FILENO);
-
-  cleanup(&descriptors);
+  int ret = 0;
+  if (strcmp(argv[1], "1") == 0) {
+      _oom_listener_descriptors descriptors = {
+              .command = argv[0],
+              .event_fd = -1,
+              .event_control_fd = -1,
+              .oom_control_fd = -1,
+              .event_control_path = {0},
+              .oom_control_path = {0},
+              .oom_command = {0},
+              .oom_command_len = 0,
+              .watch_timeout = 1000
+      };
+      ret = oom_listener(&descriptors, argv[2], STDOUT_FILENO);
+      cleanup(&descriptors);
+  } else if (strcmp(argv[1], "2") == 0) {
+      _oom_listenerV2_descriptors descriptors = {
+              .command = argv[0],
+              .event_fd = -1,
+              .oom_pressure_path = {0},
+              .oom_command = {0},
+              .oom_command_len = 0,
+              .watch_timeout = 1000
+      };
+      ret = oom_listenerV2(&descriptors, argv[2], STDOUT_FILENO);
+  }
 
   return ret;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/test/oom_listener_test_main.cc
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/oom-listener/test/oom_listener_test_main.cc
@@ -36,12 +36,18 @@ extern "C" {
 #define CGROUP_EVENT_CONTROL "cgroup.event_control"
 #define CGROUP_LIMIT (5 * 1024 * 1024)
 
+#define CGROUPV2_ROOT "/sys/fs/cgroup/"
+#define CGROUPV2_MEMORY_PRESSURE "memory.pressure"
+#define CGROUPV2_MEMORY_HIGH "memory.high"
+#define CGROUPV2_PROCS "cgroup.procs"
+
 // We try multiple cgroup directories
 // We try first the official path to test
 // in production
 // If we are running as a user we fall back
 // to mock cgroup
 static const char *cgroup_candidates[] = { CGROUP_ROOT, TEST_ROOT };
+static const char *cgroupv2_candidates[] = {CGROUPV2_ROOT, TEST_ROOT};
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
@@ -49,7 +55,7 @@ int main(int argc, char **argv) {
 }
 
 class OOMListenerTest : public ::testing::Test {
-private:
+protected:
   char cgroup[PATH_MAX];
   const char* cgroup_root;
 public:
@@ -280,6 +286,149 @@ TEST_F(OOMListenerTest, test_oom) {
         << "Listener process exited with invalid status";
     }
   }
+}
+
+class OOMListenerTestForCGroupV2 : public OOMListenerTest {
+public:
+    OOMListenerTestForCGroupV2() : OOMListenerTest() {}
+    void SetUp() {
+        struct stat cgroup_memory = {};
+        for (unsigned int i = 0; i < GTEST_ARRAY_SIZE_(cgroupv2_candidates); ++i) {
+            cgroup_root = cgroupv2_candidates[i];
+
+            // Try to create the root.
+            // We might not have permission and
+            // it may already exist
+            mkdir(cgroup_root, 0700);
+
+            if (0 != stat(cgroup_root, &cgroup_memory)) {
+                printf("%s missing. Skipping test\n", cgroup_root);
+                continue;
+            }
+
+            timespec timespec1 = {};
+            if (0 != clock_gettime(CLOCK_MONOTONIC, &timespec1)) {
+                ASSERT_TRUE(false) << " clock_gettime failed\n";
+            }
+
+            if (snprintf(cgroup, sizeof(cgroup), "%s%lx/",
+                         cgroup_root, timespec1.tv_nsec) <= 0) {
+                cgroup[0] = '\0';
+                printf("%s snprintf failed\n", cgroup_root);
+                continue;
+            }
+
+            // Create a cgroup named the current timestamp
+            // to make it quasi unique
+            if (0 != mkdir(cgroup, 0700)) {
+                printf("%s not writable.\n", cgroup);
+                continue;
+            }
+            break;
+        }
+        printf("cgroup: %s \n", cgroup);
+        ASSERT_EQ(0, stat(cgroup, &cgroup_memory))
+                << "Cannot use or simulate cgroup " << cgroup;
+    }
+};
+
+TEST_F(OOMListenerTestForCGroupV2, test_oom2) {
+std::cout << "OOMListenerTestForCGroupV2" << std::endl;
+    //Set a low enough limit for memory.high
+    std::ofstream limit;
+    std::string memory_high_file =
+            std::string(GetCGroup()).append(CGROUPV2_MEMORY_HIGH);
+    limit.open(memory_high_file.c_str(), limit.out);
+    limit << CGROUP_LIMIT << std::endl;
+    limit.close();
+
+    std::string tasks_file =
+            std::string(GetCGroup()).append(CGROUPV2_PROCS);
+
+    pid_t mem_hog_pid = fork();
+    if (!mem_hog_pid) {
+        pid_t cgroupPid;
+        do {
+            std::ifstream tasks;
+            tasks.open(tasks_file.c_str(), tasks.in);
+            tasks >> cgroupPid;
+            tasks.close();
+        } while (cgroupPid != getpid());
+
+        const int bufferSize = 1024 * 1024;
+        std::cout << "Consuming too much memory" << std::endl;
+        for (;;) {
+            auto buffer = (char *) malloc(bufferSize);
+            if (buffer != NULL) {
+                for (int i = 0; i < bufferSize; ++i) {
+                    buffer[i] = (char) std::rand();
+                }
+            }
+        }
+    } else {
+        // Parent test
+        ASSERT_GE(mem_hog_pid, 1) << "Fork failed " << errno;
+
+        // Put child into cgroup
+        std::ofstream tasks;
+        tasks.open(tasks_file.c_str(), tasks.out);
+        tasks << mem_hog_pid << std::endl;
+        tasks.close();
+
+        // Create pipe to get forwarded eventfd
+        int test_pipe[2];
+        ASSERT_EQ(0, pipe(test_pipe));
+
+        // Launch OOM listener
+        // There is no race condition with the process
+        // running out of memory. If oom is 1 at startup
+        // oom_listener will send an initial notification
+        pid_t listener = fork();
+        if (listener == 0) {
+            _oom_listenerV2_descriptors descriptors = {
+            .command = "test",
+            .event_fd = -1,
+            .oom_pressure_path = {0},
+            .oom_command = {0},
+            .oom_command_len = 0,
+            .watch_timeout = 1000
+            };
+            int ret = oom_listenerV2(&descriptors, GetCGroup(), test_pipe[1]);
+            close(test_pipe[0]);
+            close(test_pipe[1]);
+            exit(ret);
+        } else {
+            uint64_t event_id = 1;
+            ASSERT_EQ(sizeof(event_id),
+                    read(test_pipe[0],
+                    &event_id,
+                    sizeof(event_id)))
+                    << "The event has not arrived";
+            close(test_pipe[0]);
+            close(test_pipe[1]);
+
+            // Simulate OOM killer
+            ASSERT_EQ(0, kill(mem_hog_pid, SIGKILL));
+
+            // Verify that process was killed
+            int* mem_hog_status = {};
+            pid_t exited0 = wait(mem_hog_status);
+            ASSERT_EQ(mem_hog_pid, exited0)
+                << "Wrong process exited";
+            ASSERT_EQ(NULL, mem_hog_status)
+                << "Test process killed with invalid status";
+
+            ASSERT_EQ(0, rmdir(GetCGroup()))
+                    << "Could not delete cgroup " << GetCGroup();
+
+            int* oom_listener_status = {};
+            pid_t exited1 = wait(oom_listener_status);
+            ASSERT_EQ(listener, exited1)
+                << "Wrong process exited";
+            ASSERT_EQ(NULL, oom_listener_status)
+                << "Listener process exited with invalid status";
+        }
+    }
 }
 
 #else

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupElasticMemoryController.java
@@ -56,7 +56,7 @@ public class TestCGroupElasticMemoryController {
   @Test(expected = YarnException.class)
   public void testConstructorOff()
       throws YarnException {
-    new CGroupElasticMemoryController(
+    new CGroupElasticMemoryControllerImpl(
         conf,
         null,
         null,
@@ -77,7 +77,7 @@ public class TestCGroupElasticMemoryController {
         DummyRunnableWithContext.class, Runnable.class);
     CGroupsHandler handler = mock(CGroupsHandler.class);
     when(handler.getPathForCGroup(any(), any())).thenReturn("");
-    new CGroupElasticMemoryController(
+    new CGroupElasticMemoryControllerImpl(
         conf,
         null,
         handler,
@@ -109,8 +109,8 @@ public class TestCGroupElasticMemoryController {
       Runnable handler = mock(Runnable.class);
       doNothing().when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
+      AbstractCGroupElasticMemoryController controller =
+          new CGroupElasticMemoryControllerImpl(
               conf,
               null,
               cgroups,
@@ -150,8 +150,8 @@ public class TestCGroupElasticMemoryController {
       Runnable handler = mock(Runnable.class);
       doNothing().when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
+      AbstractCGroupElasticMemoryController controller =
+          new CGroupElasticMemoryControllerImpl(
               conf,
               null,
               cgroups,
@@ -191,8 +191,8 @@ public class TestCGroupElasticMemoryController {
 
       doNothing().when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
+      AbstractCGroupElasticMemoryController controller =
+          new CGroupElasticMemoryControllerImpl(
               conf,
               null,
               cgroups,
@@ -232,8 +232,8 @@ public class TestCGroupElasticMemoryController {
 
       doThrow(new YarnRuntimeException("Expected")).when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
+      AbstractCGroupElasticMemoryController controller =
+          new CGroupElasticMemoryControllerImpl(
               conf,
               null,
               cgroups,
@@ -272,8 +272,8 @@ public class TestCGroupElasticMemoryController {
       Runnable handler = mock(Runnable.class);
       doNothing().when(handler).run();
 
-      CGroupElasticMemoryController controller =
-          new CGroupElasticMemoryController(
+      AbstractCGroupElasticMemoryController controller =
+          new CGroupElasticMemoryControllerImpl(
               conf,
               null,
               cgroups,
@@ -309,7 +309,7 @@ public class TestCGroupElasticMemoryController {
   public void testDefaultConstructor() throws YarnException{
     CGroupsHandler handler = mock(CGroupsHandler.class);
     when(handler.getPathForCGroup(any(), any())).thenReturn("");
-    new CGroupElasticMemoryController(
+    new CGroupElasticMemoryControllerImpl(
         conf, null, handler, true, false, 10);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Currently, CGroupElasticMemoryController's implementation is based on CGroup V1. The PR si to Update CGroupElasticMemoryController for cgroup v2 support. 

The CGroupElasticMemoryController's implementation is following:
1. Disable OOM Killer by writing 1 to memory.oom_control file
2. Update memory limit, memory.memsw.limit_in_bytes for virtual memory control, and memory.limit_in_bytes for physical memory control
3. Launch subprocess OOM-Listener to listen OOM event through cgroup.event_control
4. When OOM happens, OOM-Listener notify NM
5. NM call DefaultOOMHandler to resolve OOM

While in CGroup V2, there is no way to disable OOM Killer. It means that once memory usage exceed the threshold containers will be killed randomly by system and NM can not do anything.
But CGroup V2 provide throttle mechanism. The memory.high is the memory usage throttle limit. If a cgroup's memory use goes over the high boundary specified here, the cgroup's processes are throttled and put under heavy reclaim pressure (refer https://facebookmicrosites.github.io/cgroup2/docs/memory-controller.html#:~:text=memory.max-,memory.,put%20under%20heavy%20reclaim%20pressure.). 
And CGroup V2 provide PSI (Pressure Stall Information), we can get notification by writing information to memory.pressure(refer https://docs.kernel.org/accounting/psi.html).

So the implementation based CGroup V2 can be as follows:
1. Update memory limit, memory.swap.max for virtual memory control and memory.high & memory.max for physical memory control (memory.max shoulb be a little more than memory.high, maybe 5GB)
2. Launch subprocess OOM-Listener to monitor memory pressure by writing some like "some 150000 100000" to memory.pressure file.
3. Once the memory usage goes over memory.high, the processes are throttled which mean that some tasks will be stall.
4. OOM-Listener is woken up and notify the NM
5. NM call DefaultOOMHandler to resolve OOM



### How was this patch tested?
Unit test and manually test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

