### PR TITLE
YARN-11776. Handle NPE in the RMDelegationTokenIdentifier if localServiceAddress is null.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/client/RMDelegationTokenIdentifier.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.security.client;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.InetAddress;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
@@ -139,9 +140,10 @@ public class RMDelegationTokenIdentifier extends YARNDelegationTokenIdentifier {
       String[] services = token.getService().toString().split(",");
       for (String service : services) {
         InetSocketAddress addr = NetUtils.createSocketAddr(service);
-        if (localSecretManager != null) {
+        if (localSecretManager != null && localServiceAddress != null) {
           // return null if it's our token
-          if (localServiceAddress.getAddress().isAnyLocalAddress()) {
+          InetAddress localServiceAddr = localServiceAddress.getAddress();
+          if (localServiceAddr != null && localServiceAddr.isAnyLocalAddress()) {
             if (NetUtils.isLocalAddress(addr.getAddress()) &&
                 addr.getPort() == localServiceAddress.getPort()) {
               return null;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11776. Handle NPE in the RMDelegationTokenIdentifier if localServiceAddress is null.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

