### PR TITLE
HDFS-17741. The old blocks should be added into MarkedDeleteQueue when create a file with overwrite

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -795,6 +795,12 @@ public class BlockManager implements BlockStatsMXBean {
     checkNSRunning = false;
   }
 
+  /** get the markedDeleteBlockScrubberThread */
+  @VisibleForTesting
+  Daemon getMarkedDeleteBlockScrubberThread() {
+    return markedDeleteBlockScrubberThread;
+  }
+
   protected boolean isBlockTokenEnabled() {
     return blockTokenSecretManager != null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2864,10 +2864,10 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       // They need to be sync'ed even when an exception was thrown.
       if (!skipSync) {
         getEditLog().logSync();
-        if (toRemoveBlocks != null) {
-          blockManager.addBLocksToMarkedDeleteQueue(
-              toRemoveBlocks.getToDeleteList());
-        }
+      }
+      if (toRemoveBlocks != null) {
+        blockManager.addBLocksToMarkedDeleteQueue(
+            toRemoveBlocks.getToDeleteList());
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
@@ -1411,7 +1411,75 @@ public class TestFileCreation {
       }
     }
   }
-  
+
+  /**
+   *  The old blocks should be added into MarkedDeleteQueue after creating with overwrite
+   */
+  @Test(timeout = 120000)
+  public void testFileCreationWithOverwriteAddToMarkedDeleteQueue() throws Exception {
+    Configuration conf = new Configuration();
+    conf.setInt("dfs.blocksize", blockSize);
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf).
+        numDataNodes(3).build();
+    DistributedFileSystem dfs = cluster.getFileSystem();
+    try {
+      dfs.mkdirs(new Path("/foo/dir"));
+      String file = "/foo/dir/file";
+      Path filePath = new Path(file);
+      // Case 1: Create file with overwrite, check the blocks of old file
+      // are cleaned after creating with overwrite
+      NameNode nn = cluster.getNameNode();
+      FSNamesystem fsn = NameNodeAdapter.getNamesystem(nn);
+      BlockManager bm = fsn.getBlockManager();
+
+      FSDataOutputStream out = dfs.create(filePath);
+      byte[] oldData = AppendTestUtil.randomBytes(seed, fileSize);
+      try {
+        out.write(oldData);
+      } finally {
+        out.close();
+      }
+
+      LocatedBlocks oldBlocks = NameNodeAdapter.getBlockLocations(
+          nn, file, 0, fileSize);
+      assertBlocks(bm, oldBlocks, true);
+
+      BlockManager blockManager = cluster.getNamesystem(0).getBlockManager();
+      BlockManagerTestUtil.interruptAndJoinMarkedDeleteBlockScrubberThread(blockManager);
+
+      out = dfs.create(filePath, true);
+      byte[] newData = AppendTestUtil.randomBytes(seed, fileSize);
+      try {
+        out.write(newData);
+      } finally {
+        out.close();
+      }
+      dfs.deleteOnExit(filePath);
+
+      assertEquals(3, blockManager.getMarkedDeleteQueue().poll().size());
+
+      LocatedBlocks newBlocks = NameNodeAdapter.getBlockLocations(
+          nn, file, 0, fileSize);
+      assertBlocks(bm, newBlocks, true);
+      assertBlocks(bm, oldBlocks, true);
+      FSDataInputStream in = dfs.open(filePath);
+      byte[] result = null;
+      try {
+        result = readAll(in);
+      } finally {
+        in.close();
+      }
+      Assert.assertArrayEquals(newData, result);
+    } finally {
+      if (dfs != null) {
+        dfs.close();
+      }
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
   private void assertBlocks(BlockManager bm, LocatedBlocks lbs, 
       boolean exist) {
     for (LocatedBlock locatedBlock : lbs.getLocatedBlocks()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.Assert;
 
+import org.apache.hadoop.util.Daemon;
 import org.apache.hadoop.util.Preconditions;
 
 public class BlockManagerTestUtil {
@@ -196,6 +197,16 @@ public class BlockManagerTestUtil {
       }
       Thread.sleep(SLEEP_TIME);
     }
+  }
+
+  /**
+   * MarkedDeleteBlockScrubberThread interrupt and join.
+   */
+  public static void interruptAndJoinMarkedDeleteBlockScrubberThread(BlockManager blockManager)
+      throws InterruptedException {
+    Daemon daemon = blockManager.getMarkedDeleteBlockScrubberThread();
+    daemon.interrupt();
+    daemon.join();
   }
 
   /**


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HDFS-17741](https://issues.apache.org/jira/browse/HDFS-17741)

When create a file with overwrite, the old blocks will not delete immediately because these blocks not add into MarkedDeleteQueue.

This will have two consequences

（1）The block will delete when datanode block report comes.

  (2)  If the block is in the PendingReconstructionBlocks, it will  be timeouted after 300s.

 
### How was this patch tested?
Add a test case.

