### PR TITLE
YARN-11258. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-common.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZKFederationStateStoreOpDurations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZKFederationStateStoreOpDurations.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.yarn.server.federation.store.impl;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsSource;
@@ -235,5 +236,10 @@ public final class ZKFederationStateStoreOpDurations implements MetricsSource {
 
   public void getTokenByRouterStoreTokenDuration(long startTime, long endTime) {
     getTokenByRouterStoreToken.add(endTime - startTime);
+  }
+
+  @VisibleForTesting
+  protected ZKFederationStateStoreOpDurations resetOpDurations() {
+    return new ZKFederationStateStoreOpDurations();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -2095,4 +2095,9 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     }
     return applicationHomeSubClusters;
   }
+
+  @VisibleForTesting
+  public void resetOpDurations() {
+    opDurations = opDurations.resetOpDurations();
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestRPC.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestRPC.java
@@ -83,8 +83,12 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.ReportNewCollectorInfoR
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReportNewCollectorInfoResponse;
 import org.apache.hadoop.yarn.server.api.records.AppCollectorData;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestRPC {
 
@@ -136,9 +140,9 @@ public class TestRPC {
     try {
       proxy.getNewApplication(Records
           .newRecord(GetNewApplicationRequest.class));
-      Assert.fail("Excepted RPC call to fail with unknown method.");
+      fail("Excepted RPC call to fail with unknown method.");
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().matches(
+      assertTrue(e.getMessage().matches(
           "Unknown method getNewApplication called on.*"
               + "org.apache.hadoop.yarn.proto.ApplicationClientProtocol"
               + "\\$ApplicationClientProtocolService\\$BlockingInterface "
@@ -171,9 +175,9 @@ public class TestRPC {
     try {
       unknownProxy.getNewApplication(Records
           .newRecord(GetNewApplicationRequest.class));
-      Assert.fail("Excepted RPC call to fail with unknown method.");
+      fail("Excepted RPC call to fail with unknown method.");
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().matches(
+      assertTrue(e.getMessage().matches(
           "Unknown method getNewApplication called on.*"
               + "org.apache.hadoop.yarn.proto.ApplicationClientProtocol"
               + "\\$ApplicationClientProtocolService\\$BlockingInterface "
@@ -195,7 +199,7 @@ public class TestRPC {
               DEFAULT_APP_ID, DEFAULT_COLLECTOR_ADDR, null);
       proxy.reportNewCollectorInfo(request);
     } catch (YarnException e) {
-      Assert.fail("RPC call failured is not expected here.");
+      fail("RPC call failured is not expected here.");
     }
 
     try {
@@ -204,7 +208,7 @@ public class TestRPC {
               DEFAULT_APP_ID, DEFAULT_COLLECTOR_ADDR, DEFAULT_COLLECTOR_TOKEN);
       proxy.reportNewCollectorInfo(request);
     } catch (YarnException e) {
-      Assert.fail("RPC call failured is not expected here.");
+      fail("RPC call failured is not expected here.");
     }
 
     // Verify empty request get YarnException back (by design in
@@ -212,9 +216,9 @@ public class TestRPC {
     try {
       proxy.reportNewCollectorInfo(Records
           .newRecord(ReportNewCollectorInfoRequest.class));
-      Assert.fail("Excepted RPC call to fail with YarnException.");
+      fail("Excepted RPC call to fail with YarnException.");
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().contains(ILLEGAL_NUMBER_MESSAGE));
+      assertTrue(e.getMessage().contains(ILLEGAL_NUMBER_MESSAGE));
     }
 
     // Verify request with a valid app ID
@@ -224,12 +228,12 @@ public class TestRPC {
               ApplicationId.newInstance(0, 1));
       GetTimelineCollectorContextResponse response =
           proxy.getTimelineCollectorContext(request);
-      Assert.assertEquals("test_user_id", response.getUserId());
-      Assert.assertEquals("test_flow_name", response.getFlowName());
-      Assert.assertEquals("test_flow_version", response.getFlowVersion());
-      Assert.assertEquals(12345678L, response.getFlowRunId());
+      assertEquals("test_user_id", response.getUserId());
+      assertEquals("test_flow_name", response.getFlowName());
+      assertEquals("test_flow_version", response.getFlowVersion());
+      assertEquals(12345678L, response.getFlowRunId());
     } catch (YarnException | IOException e) {
-      Assert.fail("RPC call failured is not expected here.");
+      fail("RPC call failured is not expected here.");
     }
 
     // Verify request with an invalid app ID
@@ -238,10 +242,10 @@ public class TestRPC {
           GetTimelineCollectorContextRequest.newInstance(
               ApplicationId.newInstance(0, 2));
       proxy.getTimelineCollectorContext(request);
-      Assert.fail("RPC call failured is expected here.");
+      fail("RPC call failured is expected here.");
     } catch (YarnException | IOException e) {
-      Assert.assertTrue(e instanceof  YarnException);
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e instanceof  YarnException);
+      assertTrue(e.getMessage().contains(
           "The application is not found."));
     }
     server.stop();
@@ -309,17 +313,17 @@ public class TestRPC {
       proxy.stopContainers(stopRequest);
     } catch (YarnException e) {
       exception = true;
-      Assert.assertTrue(e.getMessage().contains(EXCEPTION_MSG));
-      Assert.assertTrue(e.getMessage().contains(EXCEPTION_CAUSE));
+      assertTrue(e.getMessage().contains(EXCEPTION_MSG));
+      assertTrue(e.getMessage().contains(EXCEPTION_CAUSE));
       System.out.println("Test Exception is " + e.getMessage());
     } catch (Exception ex) {
       ex.printStackTrace();
     } finally {
       server.stop();
     }
-    Assert.assertTrue(exception);
-    Assert.assertNotNull(statuses.get(0));
-    Assert.assertEquals(ContainerState.RUNNING, statuses.get(0).getState());
+    assertTrue(exception);
+    assertNotNull(statuses.get(0));
+    assertEquals(ContainerState.RUNNING, statuses.get(0).getState());
   }
 
   public class DummyContainerManager implements ContainerManagementProtocol {
@@ -468,11 +472,11 @@ public class TestRPC {
       if (appCollectors.size() == 1) {
         // check default appID and collectorAddr
         AppCollectorData appCollector = appCollectors.get(0);
-        Assert.assertEquals(appCollector.getApplicationId(),
+        assertEquals(appCollector.getApplicationId(),
             DEFAULT_APP_ID);
-        Assert.assertEquals(appCollector.getCollectorAddr(),
+        assertEquals(appCollector.getCollectorAddr(),
             DEFAULT_COLLECTOR_ADDR);
-        Assert.assertTrue(appCollector.getCollectorToken() == null ||
+        assertTrue(appCollector.getCollectorToken() == null ||
             appCollector.getCollectorToken().equals(DEFAULT_COLLECTOR_TOKEN));
       } else {
         throw new YarnException(ILLEGAL_NUMBER_MESSAGE);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestResourceTrackerPBClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestResourceTrackerPBClientImpl.java
@@ -35,11 +35,13 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerRequ
 import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UnRegisterNodeManagerRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UnRegisterNodeManagerResponse;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test ResourceTrackerPBClientImpl. this class should have methods
@@ -52,7 +54,7 @@ public class TestResourceTrackerPBClientImpl {
   private final static org.apache.hadoop.yarn.factories.RecordFactory recordFactory = RecordFactoryProvider
       .getRecordFactory(null);
 
-  @BeforeClass
+  @BeforeAll
   public static void start() {
     InetSocketAddress address = new InetSocketAddress(0);
     Configuration configuration = new Configuration();
@@ -67,7 +69,7 @@ public class TestResourceTrackerPBClientImpl {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void stop() {
     if (server != null) {
       server.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYSCRPCFactories.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYSCRPCFactories.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.yarn;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import org.junit.Assert;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.net.NetUtils;
@@ -37,7 +35,9 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerRequ
 import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UnRegisterNodeManagerRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UnRegisterNodeManagerResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestYSCRPCFactories {
   
@@ -64,7 +64,7 @@ public class TestYSCRPCFactories {
       server.start();
     } catch (YarnRuntimeException e) {
       e.printStackTrace();
-      Assert.fail("Failed to create server");
+      fail("Failed to create server");
     } finally {
       server.stop();
     }
@@ -90,12 +90,12 @@ public class TestYSCRPCFactories {
         client = (ResourceTracker) RpcClientFactoryPBImpl.get().getClient(ResourceTracker.class, 1, NetUtils.getConnectAddress(server), conf);
       } catch (YarnRuntimeException e) {
         e.printStackTrace();
-        Assert.fail("Failed to create client");
+        fail("Failed to create client");
       }
       
     } catch (YarnRuntimeException e) {
       e.printStackTrace();
-      Assert.fail("Failed to create server");
+      fail("Failed to create server");
     } finally {
       server.stop();
     }     

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYSCRecordFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYSCRecordFactory.java
@@ -18,14 +18,15 @@
 
 package org.apache.hadoop.yarn;
 
-import org.junit.Assert;
-
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NodeHeartbeatRequestPBImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestYSCRecordFactory {
   
@@ -34,10 +35,10 @@ public class TestYSCRecordFactory {
     RecordFactory pbRecordFactory = RecordFactoryPBImpl.get();
     try {
       NodeHeartbeatRequest request = pbRecordFactory.newRecordInstance(NodeHeartbeatRequest.class);
-      Assert.assertEquals(NodeHeartbeatRequestPBImpl.class, request.getClass());
+      assertEquals(NodeHeartbeatRequestPBImpl.class, request.getClass());
     } catch (YarnRuntimeException e) {
       e.printStackTrace();
-      Assert.fail("Failed to crete record");
+      fail("Failed to crete record");
     }
     
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYarnServerApiClasses.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/TestYarnServerApiClasses.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.yarn;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -63,8 +65,7 @@ import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.api.records.impl.pb.MasterKeyPBImpl;
 import org.apache.hadoop.yarn.server.api.records.impl.pb.NodeStatusPBImpl;
 import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple test classes from org.apache.hadoop.yarn.server.api
@@ -127,14 +128,14 @@ public class TestYarnServerApiClasses {
     assertEquals("localhost", copy.getNodeStatus().getNodeId().getHost());
     assertEquals(collectors, copy.getRegisteringCollectors());
     // check labels are coming with valid values
-    Assert.assertTrue(original.getNodeLabels()
+    assertTrue(original.getNodeLabels()
         .containsAll(copy.getNodeLabels()));
     // check for empty labels
     original.setNodeLabels(new HashSet<NodeLabel> ());
     copy = new NodeHeartbeatRequestPBImpl(
         original.getProto());
-    Assert.assertNotNull(copy.getNodeLabels());
-    Assert.assertEquals(0, copy.getNodeLabels().size());
+    assertNotNull(copy.getNodeLabels());
+    assertEquals(0, copy.getNodeLabels().size());
   }
 
   @Test
@@ -155,7 +156,7 @@ public class TestYarnServerApiClasses {
     NodeHeartbeatRequestPBImpl original = new NodeHeartbeatRequestPBImpl();
     NodeHeartbeatRequestPBImpl copy =
         new NodeHeartbeatRequestPBImpl(original.getProto());
-    Assert.assertNull(copy.getNodeLabels());
+    assertNull(copy.getNodeLabels());
   }
 
   /**
@@ -218,7 +219,7 @@ public class TestYarnServerApiClasses {
         YarnServerBuilderUtils
             .convertFromProtoFormat(copy.getSystemCredentialsForApps())
             .get(getApplicationId(1));
-    Assert.assertNotNull(buffer);
+    assertNotNull(buffer);
     buffer.rewind();
     buf.reset(buffer);
     credentials1Out.readTokenStorageStream(buf);
@@ -370,7 +371,7 @@ public class TestYarnServerApiClasses {
             ((RegisterNodeManagerRequestPBImpl) request).getProto());
 
     // check labels are coming with no values
-    Assert.assertNull(request1.getNodeLabels());
+    assertNull(request1.getNodeLabels());
   }
 
   @Test
@@ -387,14 +388,14 @@ public class TestYarnServerApiClasses {
             ((RegisterNodeManagerRequestPBImpl) request).getProto());
 
     // check labels are coming with valid values
-    Assert.assertEquals(true, nodeLabels.containsAll(copy.getNodeLabels()));
+    assertEquals(true, nodeLabels.containsAll(copy.getNodeLabels()));
 
     // check for empty labels
     request.setNodeLabels(new HashSet<NodeLabel> ());
     copy = new RegisterNodeManagerRequestPBImpl(
         ((RegisterNodeManagerRequestPBImpl) request).getProto());
-    Assert.assertNotNull(copy.getNodeLabels());
-    Assert.assertEquals(0, copy.getNodeLabels().size());
+    assertNotNull(copy.getNodeLabels());
+    assertEquals(0, copy.getNodeLabels().size());
   }
 
   @Test
@@ -405,7 +406,7 @@ public class TestYarnServerApiClasses {
 
     UnRegisterNodeManagerRequestPBImpl copy = new UnRegisterNodeManagerRequestPBImpl(
         request.getProto());
-    Assert.assertEquals(nodeId, copy.getNodeId());
+    assertEquals(nodeId, copy.getNodeId());
   }
 
   private HashSet<NodeLabel> getValidNodeLabels() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/lib/TestZKClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/lib/TestZKClient.java
@@ -27,16 +27,18 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 
 import org.apache.hadoop.net.ServerSocketUtil;
-import org.junit.Assert;
 
 import org.apache.hadoop.yarn.lib.ZKClient;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestZKClient  {
 
@@ -136,12 +138,12 @@ public class TestZKClient  {
     // don't delete tmpFile - this ensures we don't attempt to create
     // a tmpDir with a duplicate name
     File tmpDir = new File(tmpFile + ".dir");
-    Assert.assertFalse(tmpDir.exists()); 
-    Assert.assertTrue(tmpDir.mkdirs());
+    assertFalse(tmpDir.exists());
+    assertTrue(tmpDir.mkdirs());
     return tmpDir;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, InterruptedException {
     System.setProperty("zookeeper.preAllocSize", "100");
     System.setProperty("zookeeper.4lw.commands.whitelist", "*");
@@ -157,13 +159,12 @@ public class TestZKClient  {
       factory.configure(new InetSocketAddress(PORT), maxCnxns);
     }
     factory.startup(zks);
-    Assert.assertTrue("waiting for server up",
-        waitForServerUp("127.0.0.1:" + PORT,
-            CONNECTION_TIMEOUT));
+    assertTrue(waitForServerUp("127.0.0.1:" + PORT,
+        CONNECTION_TIMEOUT), "waiting for server up");
     
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws IOException, InterruptedException {
     if (zks != null) {
       ZKDatabase zkDb = zks.getZKDatabase();
@@ -174,9 +175,8 @@ public class TestZKClient  {
       }
       final int PORT = Integer.parseInt(hostPort.split(":")[1]);
 
-      Assert.assertTrue("waiting for server down",
-          waitForServerDown("127.0.0.1:" + PORT,
-              CONNECTION_TIMEOUT));
+      assertTrue(waitForServerDown("127.0.0.1:" + PORT,
+          CONNECTION_TIMEOUT), "waiting for server down");
     }
 
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/MockResourceManagerFacade.java
@@ -170,7 +170,6 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRespo
 import org.apache.hadoop.yarn.server.api.protocolrecords.GetSubClustersRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.GetSubClustersResponse;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodesToAttributesMappingRequest;
@@ -188,6 +187,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.DeleteFederationApplica
 import org.apache.hadoop.yarn.server.api.protocolrecords.DeleteFederationQueuePoliciesRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.DeleteFederationQueuePoliciesResponse;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Mock Resource Manager facade implementation that exposes all the methods
@@ -347,8 +348,8 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
 
     synchronized (applicationContainerIdMap) {
       // Remove the containers that were being tracked for this application
-      Assert.assertTrue("The application id is NOT registered: " + attemptId,
-          applicationContainerIdMap.containsKey(appId));
+      assertTrue(applicationContainerIdMap.containsKey(appId),
+          "The application id is NOT registered: " + attemptId);
       applicationContainerIdMap.remove(appId);
     }
 
@@ -417,10 +418,8 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
           synchronized (applicationContainerIdMap) {
             // Keep track of the containers returned to this application. We
             // will need it in future
-            Assert.assertTrue(
-                "The application id is Not registered before allocate(): "
-                    + appId,
-                applicationContainerIdMap.containsKey(appId));
+            assertTrue(applicationContainerIdMap.containsKey(appId),
+                "The application id is Not registered before allocate(): " + appId);
             List<ContainerId> ids = applicationContainerIdMap.get(appId);
             ids.add(containerId);
           }
@@ -433,9 +432,8 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
         && request.getReleaseList().size() > 0) {
       LOG.info("Releasing containers: " + request.getReleaseList().size());
       synchronized (applicationContainerIdMap) {
-        Assert.assertTrue(
-            "The application id is not registered before allocate(): " + appId,
-            applicationContainerIdMap.containsKey(appId));
+        assertTrue(applicationContainerIdMap.containsKey(appId),
+            "The application id is not registered before allocate(): " + appId);
         List<ContainerId> ids = applicationContainerIdMap.get(appId);
 
         for (ContainerId id : request.getReleaseList()) {
@@ -447,9 +445,8 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
             }
           }
 
-          Assert.assertTrue("ContainerId " + id
-              + " being released is not valid for application: " + attemptId,
-              found);
+          assertTrue(found, "ContainerId " + id
+              + " being released is not valid for application: " + attemptId);
 
           ids.remove(id);
           completedList.add(
@@ -672,8 +669,8 @@ public class MockResourceManagerFacade implements ApplicationClientProtocol,
     synchronized (applicationContainerIdMap) {
       // Return the list of running containers that were being tracked for this
       // application
-      Assert.assertTrue("The application id is NOT registered: " + appId,
-          applicationContainerIdMap.containsKey(appId));
+      assertTrue(applicationContainerIdMap.containsKey(appId),
+          "The application id is NOT registered: " + appId);
       List<ContainerId> ids = applicationContainerIdMap.get(appId);
       for (ContainerId c : ids) {
         containers.add(ContainerReport.newInstance(c, null, null, null, 0, 0,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/TestAMRMClientRelayer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/TestAMRMClientRelayer.java
@@ -46,10 +46,12 @@ import org.apache.hadoop.yarn.exceptions.InvalidApplicationMasterRequestExceptio
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.scheduler.ResourceRequestSet;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for AMRMClientRelayer.
@@ -150,7 +152,7 @@ public class TestAMRMClientRelayer {
   private List<String> blacklistAdditions = new ArrayList<>();
   private List<String> blacklistRemoval = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException, IOException {
     this.conf = new Configuration();
 
@@ -162,21 +164,21 @@ public class TestAMRMClientRelayer {
     clearAllocateRequestLists();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     this.relayer.shutdown();
   }
 
   private void assertAsksAndReleases(int expectedAsk, int expectedRelease) {
-    Assert.assertEquals(expectedAsk, this.mockAMS.lastAsk.size());
-    Assert.assertEquals(expectedRelease, this.mockAMS.lastRelease.size());
+    assertEquals(expectedAsk, this.mockAMS.lastAsk.size());
+    assertEquals(expectedRelease, this.mockAMS.lastRelease.size());
   }
 
   private void assertBlacklistAdditionsAndRemovals(int expectedAdditions,
       int expectedRemovals) {
-    Assert.assertEquals(expectedAdditions,
+    assertEquals(expectedAdditions,
         this.mockAMS.lastBlacklistAdditions.size());
-    Assert.assertEquals(expectedRemovals,
+    assertEquals(expectedRemovals,
         this.mockAMS.lastBlacklistRemovals.size());
   }
 
@@ -229,10 +231,10 @@ public class TestAMRMClientRelayer {
     this.relayer.allocate(getAllocateRequest());
 
     assertAsksAndReleases(3, 0);
-    Assert.assertEquals(1, this.relayer.getRemotePendingAsks().size());
+    assertEquals(1, this.relayer.getRemotePendingAsks().size());
     ResourceRequestSet set =
         this.relayer.getRemotePendingAsks().values().iterator().next();
-    Assert.assertEquals(3, set.getAsks().size());
+    assertEquals(3, set.getAsks().size());
     clearAllocateRequestLists();
 
     // Cancel one ask
@@ -243,9 +245,9 @@ public class TestAMRMClientRelayer {
     this.relayer.allocate(getAllocateRequest());
 
     assertAsksAndReleases(2, 0);
-    Assert.assertEquals(1, relayer.getRemotePendingAsks().size());
+    assertEquals(1, relayer.getRemotePendingAsks().size());
     set = this.relayer.getRemotePendingAsks().values().iterator().next();
-    Assert.assertEquals(2, set.getAsks().size());
+    assertEquals(2, set.getAsks().size());
     clearAllocateRequestLists();
 
     // Cancel the other ask, the pending askSet should be removed
@@ -254,7 +256,7 @@ public class TestAMRMClientRelayer {
     this.relayer.allocate(AllocateRequest.newInstance(0, 0, asks, null, null));
 
     assertAsksAndReleases(1, 0);
-    Assert.assertEquals(0, this.relayer.getRemotePendingAsks().size());
+    assertEquals(0, this.relayer.getRemotePendingAsks().size());
   }
 
   /**
@@ -310,26 +312,26 @@ public class TestAMRMClientRelayer {
     this.responseId = 10;
 
     AllocateResponse response = this.relayer.allocate(getAllocateRequest());
-    Assert.assertEquals(this.responseId + 1, response.getResponseId());
+    assertEquals(this.responseId + 1, response.getResponseId());
 
     int expected = 5;
     this.mockAMS.setResponseIdReset(expected);
 
     try {
       this.relayer.allocate(getAllocateRequest());
-      Assert.fail("Expecting exception from RM");
+      fail("Expecting exception from RM");
     } catch (InvalidApplicationMasterRequestException e) {
       // Expected exception
     }
 
     // Verify that the responseId is overridden
     response = this.relayer.allocate(getAllocateRequest());
-    Assert.assertEquals(expected + 1, response.getResponseId());
+    assertEquals(expected + 1, response.getResponseId());
 
     // Verify it is no longer overriden
     this.responseId = response.getResponseId();
     response = this.relayer.allocate(getAllocateRequest());
-    Assert.assertEquals(this.responseId + 1, response.getResponseId());
+    assertEquals(this.responseId + 1, response.getResponseId());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/TestServerRMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/TestServerRMProxy.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.yarn.server.api;
 
 import org.apache.hadoop.yarn.conf.HAUtil;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test ServerRMProxy.
@@ -35,7 +36,7 @@ public class TestServerRMProxy {
     try {
       ServerRMProxy.createRMProxy(conf, DistributedSchedulingAMProtocol.class);
     } catch (Exception e) {
-      Assert.fail("DistributedSchedulingAMProtocol fail in non HA");
+      fail("DistributedSchedulingAMProtocol fail in non HA");
     }
 
     // HA is enabled
@@ -46,7 +47,7 @@ public class TestServerRMProxy {
     try {
       ServerRMProxy.createRMProxy(conf, DistributedSchedulingAMProtocol.class);
     } catch (Exception e) {
-      Assert.fail("DistributedSchedulingAMProtocol fail in HA");
+      fail("DistributedSchedulingAMProtocol fail in HA");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestProtocolRecords.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestProtocolRecords.java
@@ -57,8 +57,11 @@ import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.api.records.OpportunisticContainersStatus;
 import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestProtocolRecords {
 
@@ -69,14 +72,14 @@ public class TestProtocolRecords {
     final Resource r = Resource.newInstance(mem, vcores);
     // should be a lightweight SimpleResource which is a private inner class
     // so just verify it's not the heavyweight pb impl.
-    Assert.assertFalse(r instanceof ResourcePBImpl);
-    Assert.assertEquals(mem, r.getMemorySize());
-    Assert.assertEquals(vcores, r.getVirtualCores());
+    assertFalse(r instanceof ResourcePBImpl);
+    assertEquals(mem, r.getMemorySize());
+    assertEquals(vcores, r.getVirtualCores());
 
     ResourceProto proto = ProtoUtils.convertToProtoFormat(r);
-    Assert.assertEquals(mem, proto.getMemory());
-    Assert.assertEquals(vcores, proto.getVirtualCores());
-    Assert.assertEquals(r, ProtoUtils.convertFromProtoFormat(proto));
+    assertEquals(mem, proto.getMemory());
+    assertEquals(vcores, proto.getVirtualCores());
+    assertEquals(r, ProtoUtils.convertFromProtoFormat(proto));
   }
 
   @Test
@@ -93,15 +96,15 @@ public class TestProtocolRecords {
     NMContainerStatus reportProto =
         new NMContainerStatusPBImpl(
           ((NMContainerStatusPBImpl) report).getProto());
-    Assert.assertEquals("diagnostics", reportProto.getDiagnostics());
-    Assert.assertEquals(resource, reportProto.getAllocatedResource());
-    Assert.assertEquals(ContainerExitStatus.ABORTED,
+    assertEquals("diagnostics", reportProto.getDiagnostics());
+    assertEquals(resource, reportProto.getAllocatedResource());
+    assertEquals(ContainerExitStatus.ABORTED,
       reportProto.getContainerExitStatus());
-    Assert.assertEquals(ContainerState.COMPLETE,
+    assertEquals(ContainerState.COMPLETE,
       reportProto.getContainerState());
-    Assert.assertEquals(containerId, reportProto.getContainerId());
-    Assert.assertEquals(Priority.newInstance(10), reportProto.getPriority());
-    Assert.assertEquals(1234, reportProto.getCreationTime());
+    assertEquals(containerId, reportProto.getContainerId());
+    assertEquals(Priority.newInstance(10), reportProto.getPriority());
+    assertEquals(1234, reportProto.getCreationTime());
   }
 
   @Test
@@ -123,16 +126,16 @@ public class TestProtocolRecords {
     RegisterNodeManagerRequest requestProto =
         new RegisterNodeManagerRequestPBImpl(
           ((RegisterNodeManagerRequestPBImpl) request).getProto());
-    Assert.assertEquals(containerReport, requestProto
+    assertEquals(containerReport, requestProto
       .getNMContainerStatuses().get(0));
-    Assert.assertEquals(8080, requestProto.getHttpPort());
-    Assert.assertEquals("NM-version-id", requestProto.getNMVersion());
-    Assert.assertEquals(NodeId.newInstance("1.1.1.1", 1000),
+    assertEquals(8080, requestProto.getHttpPort());
+    assertEquals("NM-version-id", requestProto.getNMVersion());
+    assertEquals(NodeId.newInstance("1.1.1.1", 1000),
       requestProto.getNodeId());
-    Assert.assertEquals(Resource.newInstance(1024, 1),
+    assertEquals(Resource.newInstance(1024, 1),
       requestProto.getResource());
-    Assert.assertEquals(1, requestProto.getRunningApplications().size());
-    Assert.assertEquals(appId, requestProto.getRunningApplications().get(0)); 
+    assertEquals(1, requestProto.getRunningApplications().size());
+    assertEquals(appId, requestProto.getRunningApplications().get(0));
   }
 
   @Test
@@ -163,7 +166,7 @@ public class TestProtocolRecords {
     NodeHeartbeatResponse proto =
         new NodeHeartbeatResponsePBImpl(
           ((NodeHeartbeatResponsePBImpl) record).getProto());
-    Assert.assertEquals(appCredentials, YarnServerBuilderUtils
+    assertEquals(appCredentials, YarnServerBuilderUtils
         .convertFromProtoFormat(proto.getSystemCredentialsForApps()));
   }
 
@@ -191,13 +194,13 @@ public class TestProtocolRecords {
         NodeHeartbeatRequestPBImpl(
         ((NodeHeartbeatRequestPBImpl) record).getProto());
 
-    Assert.assertEquals(123,
+    assertEquals(123,
         pb.getNodeStatus()
             .getOpportunisticContainersStatus().getEstimatedQueueWaitTime());
-    Assert.assertEquals(321,
+    assertEquals(321,
         pb.getNodeStatus().getOpportunisticContainersStatus()
             .getWaitQueueLength());
-    Assert.assertEquals(2, pb.getNodeAttributes().size());
+    assertEquals(2, pb.getNodeAttributes().size());
   }
 
   @Test
@@ -208,10 +211,10 @@ public class TestProtocolRecords {
     status.setHost("locahost123");
     ContainerStatusPBImpl pb =
         new ContainerStatusPBImpl(((ContainerStatusPBImpl) status).getProto());
-    Assert.assertEquals(ips, pb.getIPs());
-    Assert.assertEquals("locahost123", pb.getHost());
-    Assert.assertEquals(ExecutionType.GUARANTEED, pb.getExecutionType());
+    assertEquals(ips, pb.getIPs());
+    assertEquals("locahost123", pb.getHost());
+    assertEquals(ExecutionType.GUARANTEED, pb.getExecutionType());
     status.setIPs(null);
-    Assert.assertNull(status.getIPs());
+    assertNull(status.getIPs());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestRegisterNodeManagerRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestRegisterNodeManagerRequest.java
@@ -28,8 +28,9 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerRequestPBImpl;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRegisterNodeManagerRequest {
   @Test
@@ -52,15 +53,15 @@ public class TestRegisterNodeManagerRequest {
             ((RegisterNodeManagerRequestPBImpl) request).getProto());
 
     // check values
-    Assert.assertEquals(request1.getNMContainerStatuses().size(), request
+    assertEquals(request1.getNMContainerStatuses().size(), request
         .getNMContainerStatuses().size());
-    Assert.assertEquals(request1.getNMContainerStatuses().get(0).getContainerId(),
+    assertEquals(request1.getNMContainerStatuses().get(0).getContainerId(),
         request.getNMContainerStatuses().get(0).getContainerId());
-    Assert.assertEquals(request1.getRunningApplications().size(), request
+    assertEquals(request1.getRunningApplications().size(), request
         .getRunningApplications().size());
-    Assert.assertEquals(request1.getRunningApplications().get(0), request
+    assertEquals(request1.getRunningApplications().get(0), request
         .getRunningApplications().get(0));
-    Assert.assertEquals(request1.getRunningApplications().get(1), request
+    assertEquals(request1.getRunningApplications().get(1), request
         .getRunningApplications().get(1));
   }
   
@@ -76,7 +77,7 @@ public class TestRegisterNodeManagerRequest {
             ((RegisterNodeManagerRequestPBImpl) request).getProto());
 
     // check values
-    Assert.assertEquals(0, request1.getNMContainerStatuses().size());
-    Assert.assertEquals(0, request1.getRunningApplications().size());
+    assertEquals(0, request1.getNMContainerStatuses().size());
+    assertEquals(0, request1.getRunningApplications().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestRegisterNodeManagerResponse.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/api/protocolrecords/TestRegisterNodeManagerResponse.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.yarn.server.api.protocolrecords;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,7 +31,7 @@ import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerResponsePBImpl;
 import org.apache.hadoop.yarn.server.api.records.MasterKey;
 import org.apache.hadoop.yarn.server.api.records.NodeAction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.yarn.proto.YarnServerCommonServiceProtos.RegisterNodeManagerResponseProto;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/failover/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/failover/TestFederationRMFailoverProxyProvider.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.yarn.client.DefaultNoHARMFailoverProxyProvider;
 import org.apache.hadoop.yarn.client.RMFailoverProxyProvider;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * We will test the failover of Federation.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.nio.ByteBuffer;
@@ -48,7 +49,7 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterRegisterRequest;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class for policies tests, tests for common reinitialization cases.
@@ -81,49 +82,57 @@ public abstract class BaseFederationPoliciesTest {
     getPolicy().reinitialize(fpc);
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void testReinitilializeBad1() throws YarnException {
-    getPolicy().reinitialize(null);
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      getPolicy().reinitialize(null);
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void testReinitilializeBad2() throws YarnException {
-    FederationPolicyInitializationContext fpc =
-        new FederationPolicyInitializationContext();
-    getPolicy().reinitialize(fpc);
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      FederationPolicyInitializationContext fpc =
+          new FederationPolicyInitializationContext();
+      getPolicy().reinitialize(fpc);
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void testReinitilializeBad3() throws YarnException {
-    FederationPolicyInitializationContext fpc =
-        new FederationPolicyInitializationContext();
-    ByteBuffer buf = mock(ByteBuffer.class);
-    fpc.setSubClusterPolicyConfiguration(SubClusterPolicyConfiguration
-        .newInstance("queue1", "WrongPolicyName", buf));
-    fpc.setFederationSubclusterResolver(
-        FederationPoliciesTestUtil.initResolver());
-    Configuration conf = new Configuration();
-    fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade(conf));
-    getPolicy().reinitialize(fpc);
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      FederationPolicyInitializationContext fpc =
+          new FederationPolicyInitializationContext();
+      ByteBuffer buf = mock(ByteBuffer.class);
+      fpc.setSubClusterPolicyConfiguration(SubClusterPolicyConfiguration
+          .newInstance("queue1", "WrongPolicyName", buf));
+      fpc.setFederationSubclusterResolver(
+          FederationPoliciesTestUtil.initResolver());
+      Configuration conf = new Configuration();
+      fpc.setFederationStateStoreFacade(FederationPoliciesTestUtil.initFacade(conf));
+      getPolicy().reinitialize(fpc);
+    });
   }
 
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testNoSubclusters() throws YarnException {
-    // empty the activeSubclusters map
-    FederationPoliciesTestUtil.initializePolicyContext(getPolicy(),
-        getPolicyInfo(), new HashMap<>());
+    assertThrows(FederationPolicyException.class, () -> {
+      // empty the activeSubclusters map
+      FederationPoliciesTestUtil.initializePolicyContext(getPolicy(),
+          getPolicyInfo(), new HashMap<>());
 
-    ConfigurableFederationPolicy localPolicy = getPolicy();
-    if (localPolicy instanceof FederationRouterPolicy) {
-      ((FederationRouterPolicy) localPolicy)
-          .getHomeSubcluster(getApplicationSubmissionContext(), null);
-    } else {
-      String[] hosts = new String[] {"host1", "host2"};
-      List<ResourceRequest> resourceRequests = FederationPoliciesTestUtil
-          .createResourceRequests(hosts, 2 * 1024, 2, 1, 3, null, false);
-      ((FederationAMRMProxyPolicy) localPolicy).splitResourceRequests(
-          resourceRequests, new HashSet<SubClusterId>());
-    }
+      ConfigurableFederationPolicy localPolicy = getPolicy();
+      if (localPolicy instanceof FederationRouterPolicy) {
+        ((FederationRouterPolicy) localPolicy)
+        .getHomeSubcluster(getApplicationSubmissionContext(), null);
+      } else {
+        String[] hosts = new String[] {"host1", "host2"};
+        List<ResourceRequest> resourceRequests = FederationPoliciesTestUtil
+            .createResourceRequests(hosts, 2 * 1024, 2, 1, 3, null, false);
+        ((FederationAMRMProxyPolicy) localPolicy).splitResourceRequests(
+            resourceRequests, new HashSet<SubClusterId>());
+      }
+    });
   }
 
   public ConfigurableFederationPolicy getPolicy() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyInitializationContextValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyInitializationContextValidator.java
@@ -31,8 +31,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test class for {@link FederationPolicyInitializationContextValidator}.
@@ -45,7 +47,7 @@ public class TestFederationPolicyInitializationContextValidator {
   private SubClusterId goodHome;
   private FederationPolicyInitializationContext context;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration conf = new Configuration();
     goodFacade = FederationPoliciesTestUtil.initFacade(conf);
@@ -62,42 +64,54 @@ public class TestFederationPolicyInitializationContextValidator {
         MockPolicyManager.class.getCanonicalName());
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void nullContext() throws Exception {
-    FederationPolicyInitializationContextValidator.validate(null,
-        MockPolicyManager.class.getCanonicalName());
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      FederationPolicyInitializationContextValidator.validate(null,
+          MockPolicyManager.class.getCanonicalName());
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void nullType() throws Exception {
-    FederationPolicyInitializationContextValidator.validate(context, null);
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      FederationPolicyInitializationContextValidator.validate(context, null);
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void wrongType() throws Exception {
-    FederationPolicyInitializationContextValidator.validate(context,
-        "WrongType");
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      FederationPolicyInitializationContextValidator.validate(context,
+          "WrongType");
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void nullConf() throws Exception {
-    context.setSubClusterPolicyConfiguration(null);
-    FederationPolicyInitializationContextValidator.validate(context,
-        MockPolicyManager.class.getCanonicalName());
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      context.setSubClusterPolicyConfiguration(null);
+      FederationPolicyInitializationContextValidator.validate(context,
+          MockPolicyManager.class.getCanonicalName());
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void nullResolver() throws Exception {
-    context.setFederationSubclusterResolver(null);
-    FederationPolicyInitializationContextValidator.validate(context,
-        MockPolicyManager.class.getCanonicalName());
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      context.setFederationSubclusterResolver(null);
+      FederationPolicyInitializationContextValidator.validate(context,
+          MockPolicyManager.class.getCanonicalName());
+    });
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void nullFacade() throws Exception {
-    context.setFederationStateStoreFacade(null);
-    FederationPolicyInitializationContextValidator.validate(context,
-        MockPolicyManager.class.getCanonicalName());
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      context.setFederationStateStoreFacade(null);
+      FederationPolicyInitializationContextValidator.validate(context,
+          MockPolicyManager.class.getCanonicalName());
+    });
   }
 
   private class MockPolicyManager implements FederationPolicyManager {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestFederationPolicyUtils.java
@@ -19,8 +19,9 @@ package org.apache.hadoop.yarn.server.federation.policies;
 
 import java.util.ArrayList;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit test for {@link FederationPolicyUtils}.
@@ -49,10 +50,9 @@ public class TestFederationPolicyUtils {
     for (i = 0; i < weights.length; i++) {
       double actualWeight = (float) result[i] / n;
       System.out.println(i + " " + actualWeight);
-      Assert.assertTrue(
+      assertTrue(Math.abs(actualWeight - expectedWeights[i]) < 0.01,
           "Index " + i + " Actual weight: " + actualWeight
-              + " expected weight: " + expectedWeights[i],
-          Math.abs(actualWeight - expectedWeights[i]) < 0.01);
+          + " expected weight: " + expectedWeights[i]);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
@@ -43,9 +43,11 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyCo
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Simple test of {@link RouterPolicyFacade}.
@@ -58,7 +60,7 @@ public class TestRouterPolicyFacade {
   private String queue1 = "queue1";
   private String defQueueKey = YarnConfiguration.DEFAULT_FEDERATION_POLICY_KEY;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
 
     // setting up a store and its facade (with caching off)
@@ -95,8 +97,8 @@ public class TestRouterPolicyFacade {
     // first call runs using standard UniformRandomRouterPolicy
     SubClusterId chosen =
         routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(subClusterIds.contains(chosen));
-    Assert.assertTrue(routerFacade.globalPolicyMap
+    assertTrue(subClusterIds.contains(chosen));
+    assertTrue(routerFacade.globalPolicyMap
         .get(queue1) instanceof UniformRandomRouterPolicy);
 
     // then the operator changes how queue1 is routed setting it to
@@ -107,8 +109,8 @@ public class TestRouterPolicyFacade {
 
     // second call is routed by new policy PriorityRouterPolicy
     chosen = routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(chosen.equals(subClusterIds.get(0)));
-    Assert.assertTrue(routerFacade.globalPolicyMap
+    assertTrue(chosen.equals(subClusterIds.get(0)));
+    assertTrue(routerFacade.globalPolicyMap
         .get(queue1) instanceof PriorityRouterPolicy);
   }
 
@@ -120,25 +122,25 @@ public class TestRouterPolicyFacade {
     when(applicationSubmissionContext.getQueue()).thenReturn(queue1);
 
     // the facade only contains the fallback behavior
-    Assert.assertTrue(routerFacade.globalPolicyMap.containsKey(defQueueKey)
+    assertTrue(routerFacade.globalPolicyMap.containsKey(defQueueKey)
         && routerFacade.globalPolicyMap.size() == 1);
 
     // when invoked it returns the expected SubClusterId.
     SubClusterId chosen =
         routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(subClusterIds.contains(chosen));
+    assertTrue(subClusterIds.contains(chosen));
 
     // now the caching of policies must have added an entry for this queue
-    Assert.assertTrue(routerFacade.globalPolicyMap.size() == 2);
+    assertTrue(routerFacade.globalPolicyMap.size() == 2);
 
     // after the facade is used the policyMap contains the expected policy type.
-    Assert.assertTrue(routerFacade.globalPolicyMap
+    assertTrue(routerFacade.globalPolicyMap
         .get(queue1) instanceof UniformRandomRouterPolicy);
 
     // the facade is again empty after reset
     routerFacade.reset();
     // the facade only contains the fallback behavior
-    Assert.assertTrue(routerFacade.globalPolicyMap.containsKey(defQueueKey)
+    assertTrue(routerFacade.globalPolicyMap.containsKey(defQueueKey)
         && routerFacade.globalPolicyMap.size() == 1);
 
   }
@@ -160,20 +162,20 @@ public class TestRouterPolicyFacade {
     when(applicationSubmissionContext.getQueue()).thenReturn(uninitQueue);
     SubClusterId chosen =
         routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(subClusterIds.contains(chosen));
-    Assert.assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
+    assertTrue(subClusterIds.contains(chosen));
+    assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
 
     // empty string
     when(applicationSubmissionContext.getQueue()).thenReturn("");
     chosen = routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(subClusterIds.contains(chosen));
-    Assert.assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
+    assertTrue(subClusterIds.contains(chosen));
+    assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
 
     // null queue also falls back to default
     when(applicationSubmissionContext.getQueue()).thenReturn(null);
     chosen = routerFacade.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertTrue(subClusterIds.contains(chosen));
-    Assert.assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
+    assertTrue(subClusterIds.contains(chosen));
+    assertFalse(routerFacade.globalPolicyMap.containsKey(uninitQueue));
 
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestBroadcastAMRMProxyFederationPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestBroadcastAMRMProxyFederationPolicy.java
@@ -33,9 +33,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Simple test class for the {@link BroadcastAMRMProxyPolicy}.
@@ -43,7 +44,7 @@ import org.junit.Test;
 public class TestBroadcastAMRMProxyFederationPolicy
     extends BaseFederationPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new BroadcastAMRMProxyPolicy());
     // needed for base test to work
@@ -72,17 +73,17 @@ public class TestBroadcastAMRMProxyFederationPolicy
     Map<SubClusterId, List<ResourceRequest>> response =
         ((FederationAMRMProxyPolicy) getPolicy()).splitResourceRequests(
             resourceRequests, new HashSet<SubClusterId>());
-    Assert.assertTrue(response.size() == 2);
+    assertTrue(response.size() == 2);
     for (Map.Entry<SubClusterId, List<ResourceRequest>> entry : response
         .entrySet()) {
-      Assert.assertTrue(getActiveSubclusters().get(entry.getKey()) != null);
+      assertTrue(getActiveSubclusters().get(entry.getKey()) != null);
       for (ResourceRequest r : entry.getValue()) {
-        Assert.assertTrue(resourceRequests.contains(r));
+        assertTrue(resourceRequests.contains(r));
       }
     }
     for (SubClusterId subClusterId : getActiveSubclusters().keySet()) {
       for (ResourceRequest r : response.get(subClusterId)) {
-        Assert.assertTrue(resourceRequests.contains(r));
+        assertTrue(resourceRequests.contains(r));
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.yarn.server.federation.policies.amrmproxy;
 
 import static org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil.createResourceRequests;
 import static org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil.initializePolicyContext;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashSet;
@@ -39,8 +39,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple test class for the {@link HomeAMRMProxyPolicy}.
@@ -53,7 +53,7 @@ public class TestHomeAMRMProxyPolicy extends BaseFederationPoliciesTest {
   private static final SubClusterId HOME_SC_ID =
       SubClusterId.newInstance(HOME_SC_NAME);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new HomeAMRMProxyPolicy());
     // needed for base test to work

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestRejectAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestRejectAMRMProxyPolicy.java
@@ -33,8 +33,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Simple test class for the {@link RejectAMRMProxyPolicy}.
@@ -42,7 +44,7 @@ import org.junit.Test;
 public class TestRejectAMRMProxyPolicy
     extends BaseFederationPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new RejectAMRMProxyPolicy());
     // needed for base test to work
@@ -61,16 +63,18 @@ public class TestRejectAMRMProxyPolicy
 
   }
 
-  @Test (expected = FederationPolicyException.class)
+  @Test
   public void testSplitAllocateRequest() throws Exception {
-    // verify the request is broadcasted to all subclusters
-    String[] hosts = new String[] {"host1", "host2" };
-    List<ResourceRequest> resourceRequests = FederationPoliciesTestUtil
-        .createResourceRequests(hosts, 2 * 1024, 2, 1, 3, null, false);
+    assertThrows(FederationPolicyException.class, () -> {
+      // verify the request is broadcasted to all subclusters
+      String[] hosts = new String[] {"host1", "host2" };
+      List<ResourceRequest> resourceRequests = FederationPoliciesTestUtil
+          .createResourceRequests(hosts, 2 * 1024, 2, 1, 3, null, false);
 
-    Map<SubClusterId, List<ResourceRequest>> response =
-        ((FederationAMRMProxyPolicy) getPolicy()).splitResourceRequests(
-            resourceRequests, new HashSet<SubClusterId>());
+      Map<SubClusterId, List<ResourceRequest>> response =
+          ((FederationAMRMProxyPolicy) getPolicy()).splitResourceRequests(
+          resourceRequests, new HashSet<SubClusterId>());
+    });
   }
 
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/BasePolicyManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/BasePolicyManagerTest.java
@@ -27,7 +27,9 @@ import org.apache.hadoop.yarn.server.federation.policies.router.FederationRouter
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class provides common test methods for testing {@code
@@ -50,22 +52,28 @@ public abstract class BasePolicyManagerTest {
         expectedAMRMProxyPolicy, expectedRouterPolicy);
   }
 
-  @Test(expected = FederationPolicyInitializationException.class)
+  @Test
   public void testSerializeAndInstantiateBad1() throws Exception {
-    serializeAndDeserializePolicyManager(wfp, String.class,
-        expectedAMRMProxyPolicy, expectedRouterPolicy);
+    assertThrows(FederationPolicyInitializationException.class, () -> {
+      serializeAndDeserializePolicyManager(wfp, String.class,
+          expectedAMRMProxyPolicy, expectedRouterPolicy);
+    });
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSerializeAndInstantiateBad2() throws Exception {
-    serializeAndDeserializePolicyManager(wfp, expectedPolicyManager,
-        String.class, expectedRouterPolicy);
+    assertThrows(AssertionError.class, () -> {
+      serializeAndDeserializePolicyManager(wfp, expectedPolicyManager,
+          String.class, expectedRouterPolicy);
+    });
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSerializeAndInstantiateBad3() throws Exception {
-    serializeAndDeserializePolicyManager(wfp, expectedPolicyManager,
-        expectedAMRMProxyPolicy, String.class);
+    assertThrows(AssertionError.class, () -> {
+      serializeAndDeserializePolicyManager(wfp, expectedPolicyManager,
+          expectedAMRMProxyPolicy, String.class);
+    });
   }
 
   protected static void serializeAndDeserializePolicyManager(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestHashBasedBroadcastPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestHashBasedBroadcastPolicyManager.java
@@ -19,14 +19,14 @@ package org.apache.hadoop.yarn.server.federation.policies.manager;
 
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.BroadcastAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.router.HashBasedRouterPolicy;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Simple test of {@link HashBroadcastPolicyManager}.
  */
 public class TestHashBasedBroadcastPolicyManager extends BasePolicyManagerTest {
 
-  @Before
+  @BeforeEach
   public void setup() {
     // config policy
     wfp = new HashBroadcastPolicyManager();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestHomePolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestHomePolicyManager.java
@@ -19,14 +19,14 @@ package org.apache.hadoop.yarn.server.federation.policies.manager;
 
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.HomeAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.router.UniformRandomRouterPolicy;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Simple test of {@link HomePolicyManager}.
  */
 public class TestHomePolicyManager extends BasePolicyManagerTest {
 
-  @Before
+  @BeforeEach
   public void setup() {
 
     wfp = new HomePolicyManager();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestPriorityBroadcastPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestPriorityBroadcastPolicyManager.java
@@ -25,9 +25,10 @@ import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.router.PriorityRouterPolicy;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Simple test of {@link PriorityBroadcastPolicyManager}.
@@ -36,7 +37,7 @@ public class TestPriorityBroadcastPolicyManager extends BasePolicyManagerTest {
 
   private WeightedPolicyInfo policyInfo;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // configure a policy
 
@@ -65,7 +66,7 @@ public class TestPriorityBroadcastPolicyManager extends BasePolicyManagerTest {
         expectedAMRMProxyPolicy, expectedRouterPolicy);
 
     // check the policyInfo propagates through ser/der correctly
-    Assert.assertEquals(
+    assertEquals(
         ((PriorityBroadcastPolicyManager) wfp).getWeightedPolicyInfo(),
         policyInfo);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestRejectAllPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestRejectAllPolicyManager.java
@@ -19,14 +19,14 @@ package org.apache.hadoop.yarn.server.federation.policies.manager;
 
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.RejectAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.router.RejectRouterPolicy;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Simple test of {@link RejectAllPolicyManager}.
  */
 public class TestRejectAllPolicyManager extends BasePolicyManagerTest {
 
-  @Before
+  @BeforeEach
   public void setup() {
     // config policy
     wfp = new RejectAllPolicyManager();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestUniformBroadcastPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestUniformBroadcastPolicyManager.java
@@ -19,14 +19,14 @@ package org.apache.hadoop.yarn.server.federation.policies.manager;
 
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.BroadcastAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.router.UniformRandomRouterPolicy;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Simple test of {@link UniformBroadcastPolicyManager}.
  */
 public class TestUniformBroadcastPolicyManager extends BasePolicyManagerTest {
 
-  @Before
+  @BeforeEach
   public void setup() {
     //config policy
     wfp = new UniformBroadcastPolicyManager();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestWeightedHomePolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestWeightedHomePolicyManager.java
@@ -21,17 +21,18 @@ import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.router.WeightedRandomRouterPolicy;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TestWeightedHomePolicyManager extends BasePolicyManagerTest {
   private WeightedPolicyInfo policyInfo;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // configure a policy
     WeightedHomePolicyManager whpm = new WeightedHomePolicyManager();
@@ -57,7 +58,7 @@ public class TestWeightedHomePolicyManager extends BasePolicyManagerTest {
     serializeAndDeserializePolicyManager(wfp, expectedPolicyManager,
         expectedAMRMProxyPolicy, expectedRouterPolicy);
     // check the policyInfo propagates through ser/der correctly
-    Assert.assertEquals(((WeightedHomePolicyManager) wfp)
+    assertEquals(((WeightedHomePolicyManager) wfp)
         .getWeightedPolicyInfo(), policyInfo);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestWeightedLocalityPolicyManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/manager/TestWeightedLocalityPolicyManager.java
@@ -22,12 +22,13 @@ import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.router.LocalityRouterPolicy;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Simple test of {@link WeightedLocalityPolicyManager}.
@@ -37,7 +38,7 @@ public class TestWeightedLocalityPolicyManager extends
 
   private WeightedPolicyInfo policyInfo;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // configure a policy
 
@@ -73,7 +74,7 @@ public class TestWeightedLocalityPolicyManager extends
                                          expectedRouterPolicy);
 
     //check the policyInfo propagates through ser/der correctly
-    Assert.assertEquals(((WeightedLocalityPolicyManager) wfp)
-                            .getWeightedPolicyInfo(), policyInfo);
+    assertEquals(((WeightedLocalityPolicyManager) wfp)
+        .getWeightedPolicyInfo(), policyInfo);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/BaseRouterPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/BaseRouterPoliciesTest.java
@@ -43,9 +43,13 @@ import org.apache.hadoop.yarn.server.federation.store.records.ReservationHomeSub
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 /**
@@ -62,12 +66,14 @@ public abstract class BaseRouterPoliciesTest
             false, false, 0, Resources.none(), null, false, null, null);
     SubClusterId chosen =
         localPolicy.getHomeSubcluster(applicationSubmissionContext, null);
-    Assert.assertNotNull(chosen);
+    assertNotNull(chosen);
   }
 
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testNullAppContext() throws YarnException {
-    ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(null, null);
+    assertThrows(FederationPolicyException.class, () -> {
+      ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(null, null);
+    });
   }
 
   @Test
@@ -96,8 +102,8 @@ public abstract class BaseRouterPoliciesTest
           applicationSubmissionContext, blacklistSubclusters);
 
       // check that the selected sub-cluster is only one not blacklisted
-      Assert.assertNotNull(chosen);
-      Assert.assertEquals(removed, chosen);
+      assertNotNull(chosen);
+      assertEquals(removed, chosen);
     }
   }
 
@@ -120,9 +126,9 @@ public abstract class BaseRouterPoliciesTest
       try {
         localPolicy.getHomeSubcluster(applicationSubmissionContext,
             blacklistSubclusters);
-        Assert.fail();
+        fail();
       } catch (YarnException e) {
-        Assert.assertTrue(e.getMessage()
+        assertTrue(e.getMessage()
             .equals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE));
       }
     }
@@ -191,7 +197,7 @@ public abstract class BaseRouterPoliciesTest
         applicationSubmissionContext, Collections.emptyList());
 
     // application follows reservation
-    Assert.assertEquals(chosen, chosen2);
+    assertEquals(chosen, chosen2);
   }
 
   @Test
@@ -232,7 +238,7 @@ public abstract class BaseRouterPoliciesTest
     SubClusterId chosen3 = routerPolicy.getHomeSubcluster(
         applicationSubmissionContext, new ArrayList<>());
 
-    Assert.assertEquals(chosen2, chosen3);
+    assertEquals(chosen2, chosen3);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestHashBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestHashBasedRouterPolicy.java
@@ -27,9 +27,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Simple test class for the {@link HashBasedRouterPolicy}. Tests that one of
@@ -39,7 +40,7 @@ public class TestHashBasedRouterPolicy extends BaseRouterPoliciesTest {
 
   private int numSubclusters = 10;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 
     // set policy in base class
@@ -74,7 +75,7 @@ public class TestHashBasedRouterPolicy extends BaseRouterPoliciesTest {
 
     // hash spread the jobs equally among the subclusters
     for (AtomicLong a : counter.values()) {
-      Assert.assertEquals(a.get(), jobPerSub);
+      assertEquals(a.get(), jobPerSub);
     }
 
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
@@ -39,10 +39,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.ReservationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 /**
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
  */
 public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new LoadBasedRouterPolicy());
     setPolicyInfo(new WeightedPolicyInfo());
@@ -115,7 +115,7 @@ public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
 
     // check the "planted" best cluster is chosen
-    Assert.assertEquals("sc05", chosen.getId());
+    assertEquals("sc05", chosen.getId());
   }
 
   @Test
@@ -196,6 +196,6 @@ public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
     SubClusterId chosen3 = routerPolicy.getHomeSubcluster(
         applicationSubmissionContext, new ArrayList<>());
 
-    Assert.assertEquals(chosen2, chosen3);
+    assertEquals(chosen2, chosen3);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
@@ -37,9 +37,13 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyConfiguration;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test class to validate the correctness of LocalityRouterPolicy.
@@ -66,7 +70,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * SubCluster2-RACK3-HOST3<=>subcluster2
    */
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new LocalityRouterPolicy());
     setPolicyInfo(new WeightedPolicyInfo());
@@ -117,12 +121,12 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
     if (getActiveSubclusters().containsKey(
         getFederationPolicyContext().getFederationSubclusterResolver()
             .getSubClusterForNode("node1").getId())) {
-      Assert.assertEquals(
+      assertEquals(
           getFederationPolicyContext().getFederationSubclusterResolver()
               .getSubClusterForNode("node1"), chosen);
     }
     // Regardless, we should choose an active SubCluster
-    Assert.assertTrue(getActiveSubclusters().containsKey(chosen));
+    assertTrue(getActiveSubclusters().containsKey(chosen));
   }
 
   /**
@@ -145,9 +149,9 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
     asc.setAMContainerResourceRequests(requests);
     try {
       ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(asc, null);
-      Assert.fail();
+      fail();
     } catch (FederationPolicyException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid number of resource requests: "));
     }
   }
@@ -177,7 +181,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
     try {
       ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(asc, null);
     } catch (FederationPolicyException e) {
-      Assert.fail();
+      fail();
     }
   }
 
@@ -220,9 +224,9 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
       SubClusterId targetId =
           ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(asc, null);
       // The selected subcluster HAS no to be the same as the one blacklisted.
-      Assert.assertNotEquals(targetId.getId(), subClusterToBlacklist);
+      assertNotEquals(targetId.getId(), subClusterToBlacklist);
     } catch (FederationPolicyException e) {
-      Assert.fail();
+      fail();
     }
 
     // Set again the previous value for the other tests
@@ -268,9 +272,9 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
       SubClusterId targetId =
           ((FederationRouterPolicy) getPolicy()).getHomeSubcluster(asc, null);
       // The selected subcluster HAS no to be the same as the one blacklisted.
-      Assert.assertNotEquals(targetId.getId(), subClusterToBlacklist);
+      assertNotEquals(targetId.getId(), subClusterToBlacklist);
     } catch (FederationPolicyException e) {
-      Assert.fail();
+      fail();
     }
 
     // Set again the previous value for the other tests

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Simple test class for the {@link PriorityRouterPolicy}. Tests that the
@@ -40,7 +41,7 @@ import org.junit.Test;
  */
 public class TestPriorityRouterPolicy extends BaseRouterPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new PriorityRouterPolicy());
     setPolicyInfo(new WeightedPolicyInfo());
@@ -80,7 +81,7 @@ public class TestPriorityRouterPolicy extends BaseRouterPoliciesTest {
   public void testPickLowestWeight() throws YarnException {
     SubClusterId chosen = ((FederationRouterPolicy) getPolicy())
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
-    Assert.assertEquals("sc5", chosen.getId());
+    assertEquals("sc5", chosen.getId());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestRejectRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestRejectRouterPolicy.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Simple test class for the {@link RejectRouterPolicy}. Tests that one of the
@@ -30,7 +32,7 @@ import org.junit.Test;
  */
 public class TestRejectRouterPolicy extends BaseRouterPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new RejectRouterPolicy());
 
@@ -42,37 +44,47 @@ public class TestRejectRouterPolicy extends BaseRouterPoliciesTest {
 
   }
 
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testNoClusterIsChosen() throws YarnException {
-    ((FederationRouterPolicy) getPolicy())
-        .getHomeSubcluster(getApplicationSubmissionContext(), null);
+    assertThrows(FederationPolicyException.class, () -> {
+      ((FederationRouterPolicy) getPolicy())
+          .getHomeSubcluster(getApplicationSubmissionContext(), null);
+    });
   }
 
   @Override
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testNullQueueRouting() throws YarnException {
-    FederationRouterPolicy localPolicy = (FederationRouterPolicy) getPolicy();
-    ApplicationSubmissionContext applicationSubmissionContext =
-        ApplicationSubmissionContext.newInstance(null, null, null, null, null,
-            false, false, 0, Resources.none(), null, false, null, null);
-    localPolicy.getHomeSubcluster(applicationSubmissionContext, null);
+    assertThrows(FederationPolicyException.class, () -> {
+      FederationRouterPolicy localPolicy = (FederationRouterPolicy) getPolicy();
+      ApplicationSubmissionContext applicationSubmissionContext =
+          ApplicationSubmissionContext.newInstance(null, null, null, null, null,
+          false, false, 0, Resources.none(), null, false, null, null);
+      localPolicy.getHomeSubcluster(applicationSubmissionContext, null);
+    });
   }
 
   @Override
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testFollowReservation() throws YarnException {
-    super.testFollowReservation();
+    assertThrows(FederationPolicyException.class, () -> {
+      super.testFollowReservation();
+    });
   }
 
   @Override
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testUpdateReservation() throws YarnException {
-    super.testUpdateReservation();
+    assertThrows(FederationPolicyException.class, () -> {
+      super.testUpdateReservation();
+    });
   }
 
   @Override
-  @Test(expected = FederationPolicyException.class)
+  @Test
   public void testDeleteReservation() throws Exception {
-    super.testDeleteReservation();
+    assertThrows(FederationPolicyException.class, () -> {
+      super.testDeleteReservation();
+    });
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestUniformRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestUniformRandomRouterPolicy.java
@@ -26,9 +26,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Simple test class for the {@link UniformRandomRouterPolicy}. Tests that one
@@ -36,7 +37,7 @@ import org.junit.Test;
  */
 public class TestUniformRandomRouterPolicy extends BaseRouterPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new UniformRandomRouterPolicy());
     // needed for base test to work
@@ -57,7 +58,7 @@ public class TestUniformRandomRouterPolicy extends BaseRouterPoliciesTest {
   public void testOneSubclusterIsChosen() throws YarnException {
     SubClusterId chosen = ((FederationRouterPolicy) getPolicy())
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
-    Assert.assertTrue(getActiveSubclusters().keySet().contains(chosen));
+    assertTrue(getActiveSubclusters().keySet().contains(chosen));
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
@@ -33,9 +33,10 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Simple test class for the {@link WeightedRandomRouterPolicy}. Generate large
@@ -44,7 +45,7 @@ import org.junit.Test;
  */
 public class TestWeightedRandomRouterPolicy extends BaseRouterPoliciesTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setPolicy(new WeightedRandomRouterPolicy());
     setPolicyInfo(new WeightedPolicyInfo());
@@ -128,17 +129,13 @@ public class TestWeightedRandomRouterPolicy extends BaseRouterPoliciesTest {
       // make sure that the weights is respected among active subclusters
       // and no jobs are routed to inactive subclusters.
       if (getActiveSubclusters().containsKey(counterEntry.getKey())) {
-        Assert.assertTrue(
+        assertTrue(Math.abs(actualWeight - expectedWeight) < 0.01,
             "Id " + counterEntry.getKey() + " Actual weight: " + actualWeight
-                + " expected weight: " + expectedWeight,
-            Math.abs(actualWeight - expectedWeight) < 0.01);
+            + " expected weight: " + expectedWeight);
       } else {
-        Assert
-            .assertTrue(
-                "Id " + counterEntry.getKey() + " Actual weight: "
-                    + actualWeight + " expected weight: " + expectedWeight,
-                actualWeight == 0);
-
+        assertTrue(actualWeight == 0,
+            "Id " + counterEntry.getKey() + " Actual weight: "
+            + actualWeight + " expected weight: " + expectedWeight);
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/resolver/TestDefaultSubClusterResolver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/resolver/TestDefaultSubClusterResolver.java
@@ -26,8 +26,11 @@ import java.util.Set;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test {@link SubClusterResolver} against correct and malformed Federation
@@ -87,20 +90,20 @@ public class TestDefaultSubClusterResolver {
     setUpGoodFile();
 
     // All lowercase, no whitespace in machine list file
-    Assert.assertEquals(SubClusterId.newInstance("subcluster1"),
+    assertEquals(SubClusterId.newInstance("subcluster1"),
         resolver.getSubClusterForNode("node1"));
     // Leading and trailing whitespace in machine list file
-    Assert.assertEquals(SubClusterId.newInstance("subcluster2"),
+    assertEquals(SubClusterId.newInstance("subcluster2"),
         resolver.getSubClusterForNode("node2"));
     // Node name capitalization in machine list file
-    Assert.assertEquals(SubClusterId.newInstance("subcluster3"),
+    assertEquals(SubClusterId.newInstance("subcluster3"),
         resolver.getSubClusterForNode("node3"));
 
     try {
       resolver.getSubClusterForNode("nodeDoesNotExist");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Cannot find subClusterId for node"));
     }
   }
@@ -111,28 +114,28 @@ public class TestDefaultSubClusterResolver {
 
     try {
       resolver.getSubClusterForNode("node1");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Cannot find subClusterId for node"));
     }
 
     try {
       resolver.getSubClusterForNode("node2");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Cannot find subClusterId for node"));
     }
 
-    Assert.assertEquals(SubClusterId.newInstance("subcluster3"),
+    assertEquals(SubClusterId.newInstance("subcluster3"),
         resolver.getSubClusterForNode("node3"));
 
     try {
       resolver.getSubClusterForNode("nodeDoesNotExist");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Cannot find subClusterId for node"));
     }
   }
@@ -143,9 +146,9 @@ public class TestDefaultSubClusterResolver {
 
     try {
       resolver.getSubClusterForNode("node1");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Cannot find subClusterId for node"));
     }
   }
@@ -162,16 +165,16 @@ public class TestDefaultSubClusterResolver {
     rack2Expected.add(SubClusterId.newInstance("subcluster3"));
 
     // Two subclusters have nodes in rack1
-    Assert.assertEquals(rack1Expected, resolver.getSubClustersForRack("rack1"));
+    assertEquals(rack1Expected, resolver.getSubClustersForRack("rack1"));
 
     // Two nodes are in rack2, but both belong to subcluster3
-    Assert.assertEquals(rack2Expected, resolver.getSubClustersForRack("rack2"));
+    assertEquals(rack2Expected, resolver.getSubClustersForRack("rack2"));
 
     try {
       resolver.getSubClustersForRack("rackDoesNotExist");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Cannot resolve rack"));
+      assertTrue(e.getMessage().startsWith("Cannot resolve rack"));
     }
   }
 
@@ -181,9 +184,9 @@ public class TestDefaultSubClusterResolver {
 
     try {
       resolver.getSubClustersForRack("rack1");
-      Assert.fail();
+      fail();
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Cannot resolve rack"));
+      assertTrue(e.getMessage().startsWith("Cannot resolve rack"));
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
@@ -89,13 +89,16 @@ import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenReque
 import org.apache.hadoop.yarn.server.federation.store.records.RouterRMTokenResponse;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.util.MonotonicClock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class for FederationMembershipStateStore implementations.
@@ -117,13 +120,13 @@ public abstract class FederationStateStoreBaseTest {
 
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException, YarnException {
     stateStore = createStateStore();
     stateStore.init(conf);
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     testDeleteStateStore();
     testDeletePolicyStore();
@@ -147,13 +150,13 @@ public abstract class FederationStateStoreBaseTest {
     long currentTimeStamp =
         Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTimeInMillis();
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(subClusterInfo, querySubClusterInfo(subClusterId));
+    assertNotNull(result);
+    assertEquals(subClusterInfo, querySubClusterInfo(subClusterId));
 
     // The saved heartbeat is between the old one and the current timestamp
-    Assert.assertTrue(querySubClusterInfo(subClusterId)
+    assertTrue(querySubClusterInfo(subClusterId)
         .getLastHeartBeat() <= currentTimeStamp);
-    Assert.assertTrue(querySubClusterInfo(subClusterId)
+    assertTrue(querySubClusterInfo(subClusterId)
         .getLastHeartBeat() >= previousTimeStamp);
   }
 
@@ -167,7 +170,7 @@ public abstract class FederationStateStoreBaseTest {
 
     stateStore.deregisterSubCluster(deregisterRequest);
 
-    Assert.assertEquals(SubClusterState.SC_UNREGISTERED,
+    assertEquals(SubClusterState.SC_UNREGISTERED,
         querySubClusterInfo(subClusterId).getState());
   }
 
@@ -191,7 +194,7 @@ public abstract class FederationStateStoreBaseTest {
 
     GetSubClusterInfoRequest request =
         GetSubClusterInfoRequest.newInstance(subClusterId);
-    Assert.assertEquals(subClusterInfo,
+    assertEquals(subClusterInfo,
         stateStore.getSubCluster(request).getSubClusterInfo());
   }
 
@@ -202,7 +205,7 @@ public abstract class FederationStateStoreBaseTest {
         GetSubClusterInfoRequest.newInstance(subClusterId);
 
     GetSubClusterInfoResponse response = stateStore.getSubCluster(request);
-    Assert.assertNull(response);
+    assertNull(response);
   }
 
   @Test
@@ -232,17 +235,17 @@ public abstract class FederationStateStoreBaseTest {
             .getSubClusters();
 
     // SC1 is the only active
-    Assert.assertEquals(1, subClustersActive.size());
+    assertEquals(1, subClustersActive.size());
     SubClusterInfo sc1 = subClustersActive.get(0);
-    Assert.assertEquals(subClusterId1, sc1.getSubClusterId());
+    assertEquals(subClusterId1, sc1.getSubClusterId());
 
     // SC1 and SC2 are the SubCluster present into the StateStore
 
-    Assert.assertEquals(2, subClustersAll.size());
-    Assert.assertTrue(subClustersAll.contains(sc1));
+    assertEquals(2, subClustersAll.size());
+    assertTrue(subClustersAll.contains(sc1));
     subClustersAll.remove(sc1);
     SubClusterInfo sc2 = subClustersAll.get(0);
-    Assert.assertEquals(subClusterId2, sc2.getSubClusterId());
+    assertEquals(subClusterId2, sc2.getSubClusterId());
   }
 
   @Test
@@ -260,13 +263,13 @@ public abstract class FederationStateStoreBaseTest {
     long currentTimeStamp =
         Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTimeInMillis();
 
-    Assert.assertEquals(SubClusterState.SC_RUNNING,
+    assertEquals(SubClusterState.SC_RUNNING,
         querySubClusterInfo(subClusterId).getState());
 
     // The saved heartbeat is between the old one and the current timestamp
-    Assert.assertTrue(querySubClusterInfo(subClusterId)
+    assertTrue(querySubClusterInfo(subClusterId)
         .getLastHeartBeat() <= currentTimeStamp);
-    Assert.assertTrue(querySubClusterInfo(subClusterId)
+    assertTrue(querySubClusterInfo(subClusterId)
         .getLastHeartBeat() >= previousHeartBeat);
   }
 
@@ -295,8 +298,8 @@ public abstract class FederationStateStoreBaseTest {
     AddApplicationHomeSubClusterResponse response =
         stateStore.addApplicationHomeSubCluster(request);
 
-    Assert.assertEquals(subClusterId, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId, queryApplicationHomeSC(appId));
+    assertEquals(subClusterId, response.getHomeSubCluster());
+    assertEquals(subClusterId, queryApplicationHomeSC(appId));
 
   }
 
@@ -315,8 +318,8 @@ public abstract class FederationStateStoreBaseTest {
         stateStore.addApplicationHomeSubCluster(
             AddApplicationHomeSubClusterRequest.newInstance(ahsc2));
 
-    Assert.assertEquals(subClusterId1, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId1, queryApplicationHomeSC(appId));
+    assertEquals(subClusterId1, response.getHomeSubCluster());
+    assertEquals(subClusterId1, queryApplicationHomeSC(appId));
 
   }
 
@@ -334,8 +337,8 @@ public abstract class FederationStateStoreBaseTest {
         stateStore.addApplicationHomeSubCluster(
             AddApplicationHomeSubClusterRequest.newInstance(ahsc2));
 
-    Assert.assertEquals(subClusterId1, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId1, queryApplicationHomeSC(appId));
+    assertEquals(subClusterId1, response.getHomeSubCluster());
+    assertEquals(subClusterId1, queryApplicationHomeSC(appId));
 
   }
 
@@ -351,12 +354,12 @@ public abstract class FederationStateStoreBaseTest {
     DeleteApplicationHomeSubClusterResponse response =
         stateStore.deleteApplicationHomeSubCluster(delRequest);
 
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     try {
       queryApplicationHomeSC(appId);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Application " + appId + " does not exist"));
     }
 
@@ -370,9 +373,9 @@ public abstract class FederationStateStoreBaseTest {
 
     try {
       stateStore.deleteApplicationHomeSubCluster(delRequest);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Application " + appId.toString() + " does not exist"));
     }
   }
@@ -389,9 +392,9 @@ public abstract class FederationStateStoreBaseTest {
     GetApplicationHomeSubClusterResponse result =
         stateStore.getApplicationHomeSubCluster(getRequest);
 
-    Assert.assertEquals(appId,
+    assertEquals(appId,
         result.getApplicationHomeSubCluster().getApplicationId());
-    Assert.assertEquals(subClusterId,
+    assertEquals(subClusterId,
         result.getApplicationHomeSubCluster().getHomeSubCluster());
   }
 
@@ -403,9 +406,9 @@ public abstract class FederationStateStoreBaseTest {
 
     try {
       stateStore.getApplicationHomeSubCluster(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Application " + appId.toString() + " does not exist"));
     }
   }
@@ -431,9 +434,9 @@ public abstract class FederationStateStoreBaseTest {
     GetApplicationsHomeSubClusterResponse result =
         stateStore.getApplicationsHomeSubCluster(getRequest);
 
-    Assert.assertEquals(2, result.getAppsHomeSubClusters().size());
-    Assert.assertTrue(result.getAppsHomeSubClusters().contains(ahsc1));
-    Assert.assertTrue(result.getAppsHomeSubClusters().contains(ahsc2));
+    assertEquals(2, result.getAppsHomeSubClusters().size());
+    assertTrue(result.getAppsHomeSubClusters().contains(ahsc1));
+    assertTrue(result.getAppsHomeSubClusters().contains(ahsc2));
   }
 
   @Test
@@ -472,15 +475,15 @@ public abstract class FederationStateStoreBaseTest {
 
     GetApplicationsHomeSubClusterResponse result =
         stateStore.getApplicationsHomeSubCluster(getRequest);
-    Assert.assertNotNull(result);
+    assertNotNull(result);
 
     List<ApplicationHomeSubCluster> items = result.getAppsHomeSubClusters();
-    Assert.assertNotNull(items);
-    Assert.assertEquals(10, items.size());
+    assertNotNull(items);
+    assertEquals(10, items.size());
 
     for (ApplicationHomeSubCluster item : items) {
       appHomeSubClusters.contains(item);
-      Assert.assertTrue(appHomeSubClusters.contains(item));
+      assertTrue(appHomeSubClusters.contains(item));
     }
   }
 
@@ -500,24 +503,24 @@ public abstract class FederationStateStoreBaseTest {
     getRequest.setSubClusterId(SubClusterId.newInstance("SC1"));
     GetApplicationsHomeSubClusterResponse result =
         stateStore.getApplicationsHomeSubCluster(getRequest);
-    Assert.assertNotNull(result);
+    assertNotNull(result);
 
     // Write 50 records, but get 10 records because the maximum number is limited to 10
     List<ApplicationHomeSubCluster> items = result.getAppsHomeSubClusters();
-    Assert.assertNotNull(items);
-    Assert.assertEquals(10, items.size());
+    assertNotNull(items);
+    assertEquals(10, items.size());
 
     GetApplicationsHomeSubClusterRequest getRequest1 =
         GetApplicationsHomeSubClusterRequest.newInstance();
     getRequest1.setSubClusterId(SubClusterId.newInstance("SC2"));
     GetApplicationsHomeSubClusterResponse result1 =
         stateStore.getApplicationsHomeSubCluster(getRequest1);
-    Assert.assertNotNull(result1);
+    assertNotNull(result1);
 
     // SC2 data does not exist, so the number of returned records is 0
     List<ApplicationHomeSubCluster> items1 = result1.getAppsHomeSubClusters();
-    Assert.assertNotNull(items1);
-    Assert.assertEquals(0, items1.size());
+    assertNotNull(items1);
+    assertEquals(0, items1.size());
   }
 
   @Test
@@ -536,8 +539,8 @@ public abstract class FederationStateStoreBaseTest {
     UpdateApplicationHomeSubClusterResponse response =
         stateStore.updateApplicationHomeSubCluster(updateRequest);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(subClusterId2, queryApplicationHomeSC(appId));
+    assertNotNull(response);
+    assertEquals(subClusterId2, queryApplicationHomeSC(appId));
   }
 
   @Test
@@ -552,9 +555,9 @@ public abstract class FederationStateStoreBaseTest {
 
     try {
       stateStore.updateApplicationHomeSubCluster((updateRequest));
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Application " + appId.toString() + " does not exist"));
     }
   }
@@ -570,8 +573,8 @@ public abstract class FederationStateStoreBaseTest {
     SetSubClusterPolicyConfigurationResponse result =
         stateStore.setPolicyConfiguration(request);
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(createSCPolicyConf("Queue", "PolicyType"),
+    assertNotNull(result);
+    assertEquals(createSCPolicyConf("Queue", "PolicyType"),
         queryPolicy("Queue"));
 
   }
@@ -586,8 +589,8 @@ public abstract class FederationStateStoreBaseTest {
     SetSubClusterPolicyConfigurationResponse result =
         stateStore.setPolicyConfiguration(request2);
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(createSCPolicyConf("Queue", "PolicyType2"),
+    assertNotNull(result);
+    assertEquals(createSCPolicyConf("Queue", "PolicyType2"),
         queryPolicy("Queue"));
   }
 
@@ -600,8 +603,8 @@ public abstract class FederationStateStoreBaseTest {
     GetSubClusterPolicyConfigurationResponse result =
         stateStore.getPolicyConfiguration(getRequest);
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(createSCPolicyConf("Queue", "PolicyType"),
+    assertNotNull(result);
+    assertEquals(createSCPolicyConf("Queue", "PolicyType"),
         result.getPolicyConfiguration());
 
   }
@@ -614,7 +617,7 @@ public abstract class FederationStateStoreBaseTest {
 
     GetSubClusterPolicyConfigurationResponse response =
         stateStore.getPolicyConfiguration(request);
-    Assert.assertNull(response);
+    assertNull(response);
   }
 
   @Test
@@ -626,14 +629,14 @@ public abstract class FederationStateStoreBaseTest {
         stateStore.getPoliciesConfigurations(
             GetSubClusterPoliciesConfigurationsRequest.newInstance());
 
-    Assert.assertNotNull(response);
-    Assert.assertNotNull(response.getPoliciesConfigs());
+    assertNotNull(response);
+    assertNotNull(response.getPoliciesConfigs());
 
-    Assert.assertEquals(2, response.getPoliciesConfigs().size());
+    assertEquals(2, response.getPoliciesConfigs().size());
 
-    Assert.assertTrue(response.getPoliciesConfigs()
+    assertTrue(response.getPoliciesConfigs()
         .contains(createSCPolicyConf("Queue1", "PolicyType1")));
-    Assert.assertTrue(response.getPoliciesConfigs()
+    assertTrue(response.getPoliciesConfigs()
         .contains(createSCPolicyConf("Queue2", "PolicyType2")));
   }
 
@@ -757,8 +760,8 @@ public abstract class FederationStateStoreBaseTest {
     AddReservationHomeSubClusterResponse response =
         stateStore.addReservationHomeSubCluster(request);
 
-    Assert.assertEquals(subClusterId, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId, queryReservationHomeSC(reservationId));
+    assertEquals(subClusterId, response.getHomeSubCluster());
+    assertEquals(subClusterId, queryReservationHomeSC(reservationId));
   }
 
   private void addReservationHomeSC(ReservationId reservationId, SubClusterId subClusterId)
@@ -786,9 +789,9 @@ public abstract class FederationStateStoreBaseTest {
     AddReservationHomeSubClusterResponse response =
         stateStore.addReservationHomeSubCluster(request2);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(subClusterId1, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId1, queryReservationHomeSC(reservationId));
+    assertNotNull(response);
+    assertEquals(subClusterId1, response.getHomeSubCluster());
+    assertEquals(subClusterId1, queryReservationHomeSC(reservationId));
   }
 
   @Test
@@ -806,9 +809,9 @@ public abstract class FederationStateStoreBaseTest {
     AddReservationHomeSubClusterResponse response =
         stateStore.addReservationHomeSubCluster(request2);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(subClusterId1, response.getHomeSubCluster());
-    Assert.assertEquals(subClusterId1, queryReservationHomeSC(reservationId));
+    assertNotNull(response);
+    assertEquals(subClusterId1, response.getHomeSubCluster());
+    assertEquals(subClusterId1, queryReservationHomeSC(reservationId));
   }
 
   @Test
@@ -823,7 +826,7 @@ public abstract class FederationStateStoreBaseTest {
     DeleteReservationHomeSubClusterResponse delReservationResponse =
         stateStore.deleteReservationHomeSubCluster(delReservationRequest);
 
-    Assert.assertNotNull(delReservationResponse);
+    assertNotNull(delReservationResponse);
 
     LambdaTestUtils.intercept(YarnException.class,
         "Reservation " + reservationId + " does not exist",
@@ -860,8 +863,8 @@ public abstract class FederationStateStoreBaseTest {
     UpdateReservationHomeSubClusterResponse updateReservationResponse =
         stateStore.updateReservationHomeSubCluster(updateReservationRequest);
 
-    Assert.assertNotNull(updateReservationResponse);
-    Assert.assertEquals(subClusterId2, queryReservationHomeSC(reservationId));
+    assertNotNull(updateReservationResponse);
+    assertEquals(subClusterId2, queryReservationHomeSC(reservationId));
   }
 
   @Test
@@ -894,12 +897,12 @@ public abstract class FederationStateStoreBaseTest {
         RouterMasterKeyRequest.newInstance(routerMasterKey);
     RouterMasterKeyResponse response = stateStore.storeNewMasterKey(routerMasterKeyRequest);
 
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     RouterMasterKey routerMasterKeyResp = response.getRouterMasterKey();
-    Assert.assertNotNull(routerMasterKeyResp);
-    Assert.assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
-    Assert.assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
-    Assert.assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
+    assertNotNull(routerMasterKeyResp);
+    assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
+    assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
+    assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
 
     checkRouterMasterKey(key, routerMasterKey);
   }
@@ -916,18 +919,18 @@ public abstract class FederationStateStoreBaseTest {
     RouterMasterKeyRequest routerMasterKeyRequest =
         RouterMasterKeyRequest.newInstance(routerMasterKey);
     RouterMasterKeyResponse response = stateStore.storeNewMasterKey(routerMasterKeyRequest);
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     RouterMasterKeyResponse routerMasterKeyResponse =
         stateStore.getMasterKeyByDelegationKey(routerMasterKeyRequest);
 
-    Assert.assertNotNull(routerMasterKeyResponse);
+    assertNotNull(routerMasterKeyResponse);
 
     RouterMasterKey routerMasterKeyResp = routerMasterKeyResponse.getRouterMasterKey();
-    Assert.assertNotNull(routerMasterKeyResp);
-    Assert.assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
-    Assert.assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
-    Assert.assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
+    assertNotNull(routerMasterKeyResp);
+    assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
+    assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
+    assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
   }
 
   @Test
@@ -942,16 +945,16 @@ public abstract class FederationStateStoreBaseTest {
     RouterMasterKeyRequest routerMasterKeyRequest =
         RouterMasterKeyRequest.newInstance(routerMasterKey);
     RouterMasterKeyResponse response = stateStore.storeNewMasterKey(routerMasterKeyRequest);
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     RouterMasterKeyResponse masterKeyResponse =
         stateStore.removeStoredMasterKey(routerMasterKeyRequest);
-    Assert.assertNotNull(masterKeyResponse);
+    assertNotNull(masterKeyResponse);
 
     RouterMasterKey routerMasterKeyResp = masterKeyResponse.getRouterMasterKey();
-    Assert.assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
-    Assert.assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
-    Assert.assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
+    assertEquals(routerMasterKey.getKeyId(), routerMasterKeyResp.getKeyId());
+    assertEquals(routerMasterKey.getKeyBytes(), routerMasterKeyResp.getKeyBytes());
+    assertEquals(routerMasterKey.getExpiryDate(), routerMasterKeyResp.getExpiryDate());
   }
 
   @Test
@@ -971,12 +974,12 @@ public abstract class FederationStateStoreBaseTest {
 
     // Verify the returned result to ensure that the returned Response is not empty
     // and the returned result is consistent with the input parameters.
-    Assert.assertNotNull(routerRMTokenResponse);
+    assertNotNull(routerRMTokenResponse);
     RouterStoreToken storeTokenResp = routerRMTokenResponse.getRouterStoreToken();
-    Assert.assertNotNull(storeTokenResp);
-    Assert.assertEquals(storeToken.getRenewDate(), storeTokenResp.getRenewDate());
-    Assert.assertEquals(storeToken.getTokenIdentifier(), storeTokenResp.getTokenIdentifier());
-    Assert.assertEquals(storeToken.getTokenInfo(), storeTokenResp.getTokenInfo());
+    assertNotNull(storeTokenResp);
+    assertEquals(storeToken.getRenewDate(), storeTokenResp.getRenewDate());
+    assertEquals(storeToken.getTokenIdentifier(), storeTokenResp.getTokenIdentifier());
+    assertEquals(storeToken.getTokenInfo(), storeTokenResp.getTokenInfo());
 
     checkRouterStoreToken(identifier, storeTokenResp);
   }
@@ -995,7 +998,7 @@ public abstract class FederationStateStoreBaseTest {
     RouterStoreToken storeToken = RouterStoreToken.newInstance(identifier, renewDate, tokenInfo);
     RouterRMTokenRequest request = RouterRMTokenRequest.newInstance(storeToken);
     RouterRMTokenResponse routerRMTokenResponse = stateStore.storeNewToken(request);
-    Assert.assertNotNull(routerRMTokenResponse);
+    assertNotNull(routerRMTokenResponse);
 
     // prepare updateToken parameters
     Long renewDate2 = Time.now();
@@ -1006,12 +1009,12 @@ public abstract class FederationStateStoreBaseTest {
     RouterRMTokenRequest updateTokenRequest = RouterRMTokenRequest.newInstance(updateToken);
     RouterRMTokenResponse updateTokenResponse = stateStore.updateStoredToken(updateTokenRequest);
 
-    Assert.assertNotNull(updateTokenResponse);
+    assertNotNull(updateTokenResponse);
     RouterStoreToken updateTokenResp = updateTokenResponse.getRouterStoreToken();
-    Assert.assertNotNull(updateTokenResp);
-    Assert.assertEquals(updateToken.getRenewDate(), updateTokenResp.getRenewDate());
-    Assert.assertEquals(updateToken.getTokenIdentifier(), updateTokenResp.getTokenIdentifier());
-    Assert.assertEquals(updateToken.getTokenInfo(), updateTokenResp.getTokenInfo());
+    assertNotNull(updateTokenResp);
+    assertEquals(updateToken.getRenewDate(), updateTokenResp.getRenewDate());
+    assertEquals(updateToken.getTokenIdentifier(), updateTokenResp.getTokenIdentifier());
+    assertEquals(updateToken.getTokenInfo(), updateTokenResp.getTokenInfo());
 
     checkRouterStoreToken(identifier, updateTokenResp);
   }
@@ -1030,15 +1033,15 @@ public abstract class FederationStateStoreBaseTest {
     RouterStoreToken storeToken = RouterStoreToken.newInstance(identifier, renewDate, tokenInfo);
     RouterRMTokenRequest request = RouterRMTokenRequest.newInstance(storeToken);
     RouterRMTokenResponse routerRMTokenResponse = stateStore.storeNewToken(request);
-    Assert.assertNotNull(routerRMTokenResponse);
+    assertNotNull(routerRMTokenResponse);
 
     // remove rm-token
     RouterRMTokenResponse removeTokenResponse = stateStore.removeStoredToken(request);
-    Assert.assertNotNull(removeTokenResponse);
+    assertNotNull(removeTokenResponse);
     RouterStoreToken removeTokenResp = removeTokenResponse.getRouterStoreToken();
-    Assert.assertNotNull(removeTokenResp);
-    Assert.assertEquals(removeTokenResp.getRenewDate(), storeToken.getRenewDate());
-    Assert.assertEquals(removeTokenResp.getTokenIdentifier(), storeToken.getTokenIdentifier());
+    assertNotNull(removeTokenResp);
+    assertEquals(removeTokenResp.getRenewDate(), storeToken.getRenewDate());
+    assertEquals(removeTokenResp.getTokenIdentifier(), storeToken.getTokenIdentifier());
   }
 
   @Test
@@ -1055,15 +1058,15 @@ public abstract class FederationStateStoreBaseTest {
     RouterStoreToken storeToken = RouterStoreToken.newInstance(identifier, renewDate, tokenInfo);
     RouterRMTokenRequest request = RouterRMTokenRequest.newInstance(storeToken);
     RouterRMTokenResponse routerRMTokenResponse = stateStore.storeNewToken(request);
-    Assert.assertNotNull(routerRMTokenResponse);
+    assertNotNull(routerRMTokenResponse);
 
     // getTokenByRouterStoreToken
     RouterRMTokenResponse getRouterRMTokenResp = stateStore.getTokenByRouterStoreToken(request);
-    Assert.assertNotNull(getRouterRMTokenResp);
+    assertNotNull(getRouterRMTokenResp);
     RouterStoreToken getStoreTokenResp = getRouterRMTokenResp.getRouterStoreToken();
-    Assert.assertNotNull(getStoreTokenResp);
-    Assert.assertEquals(getStoreTokenResp.getRenewDate(), storeToken.getRenewDate());
-    Assert.assertEquals(storeToken.getTokenInfo(), getStoreTokenResp.getTokenInfo());
+    assertNotNull(getStoreTokenResp);
+    assertEquals(getStoreTokenResp.getRenewDate(), storeToken.getRenewDate());
+    assertEquals(storeToken.getTokenInfo(), getStoreTokenResp.getTokenInfo());
 
     checkRouterStoreToken(identifier, getStoreTokenResp);
   }
@@ -1162,10 +1165,10 @@ public abstract class FederationStateStoreBaseTest {
         stateStore.getPoliciesConfigurations(policyRequest);
 
     // Step2. Confirm that the initialized queue policy meets expectations.
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     List<SubClusterPolicyConfiguration> policiesConfigs = response.getPoliciesConfigs();
     for (SubClusterPolicyConfiguration policyConfig : policiesConfigs) {
-      Assert.assertTrue(queues.contains(policyConfig.getQueue()));
+      assertTrue(queues.contains(policyConfig.getQueue()));
     }
 
     // Step3. Delete the policy of queue (Queue1, Queue2).
@@ -1182,10 +1185,10 @@ public abstract class FederationStateStoreBaseTest {
         GetSubClusterPoliciesConfigurationsRequest.newInstance();
     GetSubClusterPoliciesConfigurationsResponse response2 =
         stateStore.getPoliciesConfigurations(policyRequest2);
-    Assert.assertNotNull(response2);
+    assertNotNull(response2);
     List<SubClusterPolicyConfiguration> policiesConfigs2 = response2.getPoliciesConfigs();
     for (SubClusterPolicyConfiguration policyConfig : policiesConfigs2) {
-      Assert.assertFalse(deleteQueues.contains(policyConfig.getQueue()));
+      assertFalse(deleteQueues.contains(policyConfig.getQueue()));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestMemoryFederationStateStore.java
@@ -33,9 +33,9 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for MemoryFederationStateStore.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestSQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestSQLFederationStateStore.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.yarn.server.federation.store.sql.FederationQueryRunner;
 import org.apache.hadoop.yarn.server.federation.store.sql.RouterMasterKeyHandler;
 import org.apache.hadoop.yarn.server.federation.store.sql.RouterStoreTokenHandler;
 import org.apache.hadoop.yarn.server.federation.store.utils.FederationStateStoreUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,8 +72,8 @@ import static org.apache.hadoop.yarn.server.federation.store.impl.HSQLDBFederati
 import static org.apache.hadoop.yarn.server.federation.store.impl.HSQLDBFederationStateStore.SP_UPDATERESERVATIONHOMESUBCLUSTER2;
 import static org.apache.hadoop.yarn.server.federation.store.impl.HSQLDBFederationStateStore.SP_DROP_DELETERESERVATIONHOMESUBCLUSTER;
 import static org.apache.hadoop.yarn.server.federation.store.impl.HSQLDBFederationStateStore.SP_DELETERESERVATIONHOMESUBCLUSTER2;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static java.sql.Types.VARCHAR;
 import static java.sql.Types.BIGINT;
 import static org.mockito.Mockito.mock;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/TestZookeeperFederationStateStore.java
@@ -41,16 +41,16 @@ import org.apache.hadoop.yarn.server.federation.store.records.RouterMasterKeyReq
 import org.apache.hadoop.yarn.server.federation.store.records.RouterMasterKeyResponse;
 import org.apache.hadoop.yarn.server.federation.store.records.RouterStoreToken;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.util.curator.ZKCuratorManager.getNodePath;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests for ZookeeperFederationStateStore.
@@ -80,7 +80,7 @@ public class TestZookeeperFederationStateStore extends FederationStateStoreBaseT
   private static TestingServer curatorTestingServer;
   private static CuratorFramework curatorFramework;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException, YarnException {
     try {
       curatorTestingServer = new TestingServer();
@@ -104,7 +104,7 @@ public class TestZookeeperFederationStateStore extends FederationStateStoreBaseT
     super.before();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     super.after();
     curatorFramework.close();
@@ -123,6 +123,7 @@ public class TestZookeeperFederationStateStore extends FederationStateStoreBaseT
   @Test
   public void testMetricsInited() throws Exception {
     ZookeeperFederationStateStore zkStateStore = (ZookeeperFederationStateStore) createStateStore();
+    zkStateStore.resetOpDurations();
     ZKFederationStateStoreOpDurations zkStateStoreOpDurations = zkStateStore.getOpDurations();
     MetricsCollectorImpl collector = new MetricsCollectorImpl();
 
@@ -150,7 +151,7 @@ public class TestZookeeperFederationStateStore extends FederationStateStoreBaseT
     zkStateStoreOpDurations.addUpdateReservationHomeSubClusterDuration(start, end);
 
     zkStateStoreOpDurations.getMetrics(collector, true);
-    assertEquals("Incorrect number of perf metrics", 1, collector.getRecords().size());
+    assertEquals(1, collector.getRecords().size(), "Incorrect number of perf metrics");
 
     MetricsRecord record = collector.getRecords().get(0);
     MetricsRecords.assertTag(record, ZKFederationStateStoreOpDurations.RECORD_INFO.name(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/metrics/TestFederationStateStoreClientMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/metrics/TestFederationStateStoreClientMetrics.java
@@ -17,10 +17,11 @@
 
 package org.apache.hadoop.yarn.server.federation.store.metrics;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unittests for {@link FederationStateStoreClientMetrics}.
@@ -39,9 +40,9 @@ public class TestFederationStateStoreClientMetrics {
   public void testAggregateMetricInit() {
     LOG.info("Test: aggregate metrics are initialized correctly");
 
-    Assert.assertEquals(0,
+    assertEquals(0,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(0,
+    assertEquals(0,
         FederationStateStoreClientMetrics.getNumFailedCalls());
 
     LOG.info("Test: aggregate metrics are updated correctly");
@@ -58,26 +59,26 @@ public class TestFederationStateStoreClientMetrics {
 
     goodStateStore.registerSubCluster(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(100,
+    assertEquals(100,
         FederationStateStoreClientMetrics.getLatencySucceededCalls(), 0);
-    Assert.assertEquals(apiGoodBefore + 1,
+    assertEquals(apiGoodBefore + 1,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(100, FederationStateStoreClientMetrics
+    assertEquals(100, FederationStateStoreClientMetrics
         .getLatencySucceessfulCallsForMethod("registerSubCluster"), 0);
 
     LOG.info("Test: Running stats correctly calculated for 2 metrics");
 
     goodStateStore.registerSubCluster(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(150,
+    assertEquals(150,
         FederationStateStoreClientMetrics.getLatencySucceededCalls(), 0);
-    Assert.assertEquals(apiGoodBefore + 2,
+    assertEquals(apiGoodBefore + 2,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(150, FederationStateStoreClientMetrics
+    assertEquals(150, FederationStateStoreClientMetrics
         .getLatencySucceessfulCallsForMethod("registerSubCluster"), 0);
 
   }
@@ -92,9 +93,9 @@ public class TestFederationStateStoreClientMetrics {
     badStateStore.registerSubCluster();
 
     LOG.info("Test: Aggregate and method failed calls updated correctly");
-    Assert.assertEquals(totalBadbefore + 1,
+    assertEquals(totalBadbefore + 1,
         FederationStateStoreClientMetrics.getNumFailedCalls());
-    Assert.assertEquals(apiBadBefore + 1, FederationStateStoreClientMetrics
+    assertEquals(apiBadBefore + 1, FederationStateStoreClientMetrics
         .getNumFailedCallsForMethod("registerSubCluster"));
 
   }
@@ -115,14 +116,14 @@ public class TestFederationStateStoreClientMetrics {
     FederationStateStoreClientMetrics.succeededStateStoreCall(100);
 
     LOG.info("Test: Aggregate and method calls did not update");
-    Assert.assertEquals(totalBadbefore,
+    assertEquals(totalBadbefore,
         FederationStateStoreClientMetrics.getNumFailedCalls());
-    Assert.assertEquals(apiBadBefore, FederationStateStoreClientMetrics
+    assertEquals(apiBadBefore, FederationStateStoreClientMetrics
         .getNumFailedCallsForMethod("registerSubCluster"));
 
-    Assert.assertEquals(totalGoodBefore,
+    assertEquals(totalGoodBefore,
         FederationStateStoreClientMetrics.getNumSucceededCalls());
-    Assert.assertEquals(apiGoodBefore, FederationStateStoreClientMetrics
+    assertEquals(apiGoodBefore, FederationStateStoreClientMetrics
         .getNumSucceessfulCallsForMethod("registerSubCluster"));
 
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/records/TestFederationProtocolRecords.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/records/TestFederationProtocolRecords.java
@@ -104,13 +104,13 @@ import org.apache.hadoop.yarn.security.client.YARNDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.federation.store.records.impl.pb.ApplicationHomeSubClusterPBImpl;
 import org.apache.hadoop.yarn.server.federation.store.records.impl.pb.GetReservationHomeSubClusterRequestPBImpl;
 import org.apache.hadoop.yarn.server.records.Version;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -118,7 +118,7 @@ import static org.mockito.Mockito.mock;
  */
 public class TestFederationProtocolRecords extends BasePBImplRecordsTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     generateByNewInstance(ApplicationId.class);
     generateByNewInstance(Version.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationSQLAccuracyTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/FederationSQLAccuracyTest.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 
@@ -39,7 +39,7 @@ public abstract class FederationSQLAccuracyTest {
 
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException, YarnException {
     stateStore = createStateStore();
     conf = new YarnConfiguration();
@@ -50,7 +50,7 @@ public abstract class FederationSQLAccuracyTest {
     stateStore.init(conf);
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     stateStore.close();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationMySQLScriptAccuracy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationMySQLScriptAccuracy.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.yarn.server.federation.store.sql;
 
 import org.apache.hadoop.yarn.server.federation.store.impl.MySQLFederationStateStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationSQLServerScriptAccuracy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/sql/TestFederationSQLServerScriptAccuracy.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.yarn.server.federation.store.sql;
 
 import org.apache.hadoop.yarn.server.federation.store.impl.SQLServerFederationStateStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/utils/TestFederationStateStoreInputValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/utils/TestFederationStateStoreInputValidator.java
@@ -37,11 +37,13 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyCo
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterRegisterRequest;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.UpdateApplicationHomeSubClusterRequest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for FederationApplicationInputValidator,
@@ -90,7 +92,7 @@ public class TestFederationStateStoreInputValidator {
   private static String typeEmpty;
   private static String typeNull;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     subClusterId = SubClusterId.newInstance("abc");
     amRMServiceAddress = "localhost:8032";
@@ -147,7 +149,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -156,10 +158,10 @@ public class TestFederationStateStoreInputValidator {
       SubClusterRegisterRequest request = null;
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubClusterRegister Request."));
     }
 
@@ -171,10 +173,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Information."));
     }
 
@@ -189,10 +191,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -207,10 +209,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
 
@@ -225,10 +227,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster State information."));
     }
 
@@ -244,7 +246,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with Empty Capability
@@ -259,7 +261,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 
@@ -277,10 +279,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid timestamp information."));
     }
 
@@ -295,10 +297,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid timestamp information."));
     }
   }
@@ -316,10 +318,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -333,10 +335,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -351,10 +353,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -369,10 +371,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -387,10 +389,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -405,10 +407,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -422,10 +424,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
 
@@ -439,10 +441,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SubCluster Endpoint information."));
     }
   }
@@ -461,10 +463,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Address is not in host:port format for clientRMService
@@ -478,10 +480,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Address is not in host:port format for rmAdminService
@@ -495,10 +497,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Address is not in host:port format for rmWebService
@@ -511,10 +513,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Port is not an integer for amRMService
@@ -527,10 +529,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Port is not an integer for clientRMService
@@ -544,10 +546,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Port is not an integer for rmAdminService
@@ -561,10 +563,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
     // Port is not an integer for rmWebService
@@ -577,10 +579,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterRegisterRequest.newInstance(subClusterInfo);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().contains("valid host:port authority:"));
+      assertTrue(e.getMessage().contains("valid host:port authority:"));
     }
 
   }
@@ -596,7 +598,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -605,10 +607,10 @@ public class TestFederationStateStoreInputValidator {
       SubClusterDeregisterRequest request = null;
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubClusterDeregister Request."));
     }
 
@@ -619,10 +621,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterDeregisterRequest.newInstance(subClusterIdNull, stateLost);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -633,10 +635,10 @@ public class TestFederationStateStoreInputValidator {
           .newInstance(subClusterIdInvalid, stateLost);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
 
@@ -647,10 +649,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterDeregisterRequest.newInstance(subClusterId, stateNull);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster State information."));
     }
 
@@ -661,10 +663,10 @@ public class TestFederationStateStoreInputValidator {
           SubClusterDeregisterRequest.newInstance(subClusterId, stateNew);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(e.getMessage().startsWith("Invalid non-final state: "));
+      assertTrue(e.getMessage().startsWith("Invalid non-final state: "));
     }
   }
 
@@ -679,7 +681,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -688,10 +690,10 @@ public class TestFederationStateStoreInputValidator {
       SubClusterHeartbeatRequest request = null;
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubClusterHeartbeat Request."));
     }
 
@@ -702,10 +704,10 @@ public class TestFederationStateStoreInputValidator {
           .newInstance(subClusterIdNull, lastHeartBeat, stateLost, capability);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -717,10 +719,10 @@ public class TestFederationStateStoreInputValidator {
               lastHeartBeat, stateLost, capability);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
 
@@ -731,10 +733,10 @@ public class TestFederationStateStoreInputValidator {
           .newInstance(subClusterId, lastHeartBeat, stateNull, capability);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster State information."));
     }
 
@@ -746,10 +748,10 @@ public class TestFederationStateStoreInputValidator {
               lastHeartBeatNegative, stateLost, capability);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid timestamp information."));
     }
 
@@ -760,10 +762,10 @@ public class TestFederationStateStoreInputValidator {
           .newInstance(subClusterId, lastHeartBeat, stateLost, capabilityNull);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid capability information."));
     }
 
@@ -774,10 +776,10 @@ public class TestFederationStateStoreInputValidator {
           .newInstance(subClusterId, lastHeartBeat, stateLost, capabilityEmpty);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid capability information."));
     }
   }
@@ -793,7 +795,7 @@ public class TestFederationStateStoreInputValidator {
       FederationMembershipStateStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -802,10 +804,10 @@ public class TestFederationStateStoreInputValidator {
       GetSubClusterInfoRequest request = null;
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing GetSubClusterInfo Request."));
     }
 
@@ -816,10 +818,10 @@ public class TestFederationStateStoreInputValidator {
           GetSubClusterInfoRequest.newInstance(subClusterIdNull);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -830,10 +832,10 @@ public class TestFederationStateStoreInputValidator {
           GetSubClusterInfoRequest.newInstance(subClusterIdInvalid);
       FederationMembershipStateStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
   }
@@ -852,7 +854,7 @@ public class TestFederationStateStoreInputValidator {
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -861,9 +863,9 @@ public class TestFederationStateStoreInputValidator {
       AddApplicationHomeSubClusterRequest request = null;
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing AddApplicationHomeSubCluster Request."));
     }
 
@@ -876,9 +878,9 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing ApplicationHomeSubCluster Info."));
     }
 
@@ -892,10 +894,10 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -909,10 +911,10 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
 
@@ -926,9 +928,9 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Application Id."));
+      assertTrue(e.getMessage().startsWith("Missing Application Id."));
     }
   }
 
@@ -946,7 +948,7 @@ public class TestFederationStateStoreInputValidator {
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -955,9 +957,9 @@ public class TestFederationStateStoreInputValidator {
       UpdateApplicationHomeSubClusterRequest request = null;
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing UpdateApplicationHomeSubCluster Request."));
     }
 
@@ -970,9 +972,9 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing ApplicationHomeSubCluster Info."));
     }
 
@@ -986,10 +988,10 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubCluster Id information."));
     }
 
@@ -1003,10 +1005,10 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
       LOG.info(e.getMessage());
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Invalid SubCluster Id information."));
     }
 
@@ -1020,9 +1022,9 @@ public class TestFederationStateStoreInputValidator {
               .newInstance(applicationHomeSubCluster);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Application Id."));
+      assertTrue(e.getMessage().startsWith("Missing Application Id."));
     }
   }
 
@@ -1037,7 +1039,7 @@ public class TestFederationStateStoreInputValidator {
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -1046,9 +1048,9 @@ public class TestFederationStateStoreInputValidator {
       GetApplicationHomeSubClusterRequest request = null;
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing GetApplicationHomeSubCluster Request."));
     }
 
@@ -1059,9 +1061,9 @@ public class TestFederationStateStoreInputValidator {
           GetApplicationHomeSubClusterRequest.newInstance(appIdNull);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Application Id."));
+      assertTrue(e.getMessage().startsWith("Missing Application Id."));
     }
 
   }
@@ -1077,7 +1079,7 @@ public class TestFederationStateStoreInputValidator {
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -1086,9 +1088,9 @@ public class TestFederationStateStoreInputValidator {
       DeleteApplicationHomeSubClusterRequest request = null;
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing DeleteApplicationHomeSubCluster Request."));
     }
 
@@ -1099,9 +1101,9 @@ public class TestFederationStateStoreInputValidator {
           DeleteApplicationHomeSubClusterRequest.newInstance(appIdNull);
       FederationApplicationHomeSubClusterStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Application Id."));
+      assertTrue(e.getMessage().startsWith("Missing Application Id."));
     }
 
   }
@@ -1117,7 +1119,7 @@ public class TestFederationStateStoreInputValidator {
       FederationPolicyStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -1126,9 +1128,9 @@ public class TestFederationStateStoreInputValidator {
       GetSubClusterPolicyConfigurationRequest request = null;
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing GetSubClusterPolicyConfiguration Request."));
     }
 
@@ -1139,9 +1141,9 @@ public class TestFederationStateStoreInputValidator {
           GetSubClusterPolicyConfigurationRequest.newInstance(queueNull);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Queue."));
+      assertTrue(e.getMessage().startsWith("Missing Queue."));
     }
 
     // Execution with empty queue id
@@ -1151,9 +1153,9 @@ public class TestFederationStateStoreInputValidator {
           GetSubClusterPolicyConfigurationRequest.newInstance(queueEmpty);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Queue."));
+      assertTrue(e.getMessage().startsWith("Missing Queue."));
     }
 
   }
@@ -1171,7 +1173,7 @@ public class TestFederationStateStoreInputValidator {
       FederationPolicyStoreInputValidator
           .validate(request);
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     // Execution with null request
@@ -1180,9 +1182,9 @@ public class TestFederationStateStoreInputValidator {
       SetSubClusterPolicyConfigurationRequest request = null;
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .startsWith("Missing SetSubClusterPolicyConfiguration Request."));
     }
 
@@ -1194,9 +1196,9 @@ public class TestFederationStateStoreInputValidator {
           SetSubClusterPolicyConfigurationRequest.newInstance(policy);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().startsWith("Missing SubClusterPolicyConfiguration."));
     }
 
@@ -1209,9 +1211,9 @@ public class TestFederationStateStoreInputValidator {
           SetSubClusterPolicyConfigurationRequest.newInstance(policy);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Queue."));
+      assertTrue(e.getMessage().startsWith("Missing Queue."));
     }
 
     // Execution with empty queue id
@@ -1223,9 +1225,9 @@ public class TestFederationStateStoreInputValidator {
           SetSubClusterPolicyConfigurationRequest.newInstance(policy);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Queue."));
+      assertTrue(e.getMessage().startsWith("Missing Queue."));
     }
 
     // Execution with null policy type
@@ -1237,9 +1239,9 @@ public class TestFederationStateStoreInputValidator {
           SetSubClusterPolicyConfigurationRequest.newInstance(policy);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Policy Type."));
+      assertTrue(e.getMessage().startsWith("Missing Policy Type."));
     }
 
     // Execution with empty policy type
@@ -1251,9 +1253,9 @@ public class TestFederationStateStoreInputValidator {
           SetSubClusterPolicyConfigurationRequest.newInstance(policy);
       FederationPolicyStoreInputValidator
           .validate(request);
-      Assert.fail();
+      fail();
     } catch (FederationStateStoreInvalidInputException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Missing Policy Type."));
+      assertTrue(e.getMessage().startsWith("Missing Policy Type."));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationRegistryClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationRegistryClient.java
@@ -26,10 +26,11 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit test for FederationRegistryClient.
@@ -40,7 +41,7 @@ public class TestFederationRegistryClient {
   private RegistryOperations registry;
   private FederationRegistryClient registryClient;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     this.conf = new YarnConfiguration();
 
@@ -52,13 +53,13 @@ public class TestFederationRegistryClient {
     this.registryClient =
         new FederationRegistryClient(this.conf, this.registry, this.user);
     this.registryClient.cleanAllApplications();
-    Assert.assertEquals(0, this.registryClient.getAllApplications().size());
+    assertEquals(0, this.registryClient.getAllApplications().size());
   }
 
-  @After
+  @AfterEach
   public void breakDown() {
     registryClient.cleanAllApplications();
-    Assert.assertEquals(0, registryClient.getAllApplications().size());
+    assertEquals(0, registryClient.getAllApplications().size());
     registry.stop();
   }
 
@@ -76,14 +77,14 @@ public class TestFederationRegistryClient {
     this.registryClient.writeAMRMTokenForUAM(appId, scId1,
         new Token<AMRMTokenIdentifier>());
 
-    Assert.assertEquals(1, this.registryClient.getAllApplications().size());
-    Assert.assertEquals(2,
+    assertEquals(1, this.registryClient.getAllApplications().size());
+    assertEquals(2,
         this.registryClient.loadStateFromRegistry(appId).size());
 
     this.registryClient.removeAppFromRegistry(appId);
 
-    Assert.assertEquals(0, this.registryClient.getAllApplications().size());
-    Assert.assertEquals(0,
+    assertEquals(0, this.registryClient.getAllApplications().size());
+    assertEquals(0,
         this.registryClient.loadStateFromRegistry(appId).size());
   }
 
@@ -95,7 +96,7 @@ public class TestFederationRegistryClient {
 
     this.registryClient.writeAMRMTokenForUAM(appId1, scId0, new Token<>());
     this.registryClient.writeAMRMTokenForUAM(appId2, scId0, new Token<>());
-    Assert.assertEquals(2, this.registryClient.getAllApplications().size());
+    assertEquals(2, this.registryClient.getAllApplications().size());
 
     // Create a new client instance
     this.registryClient =
@@ -104,14 +105,14 @@ public class TestFederationRegistryClient {
     this.registryClient.loadStateFromRegistry(appId2);
     // Should remove app2
     this.registryClient.removeAppFromRegistry(appId2, false);
-    Assert.assertEquals(1, this.registryClient.getAllApplications().size());
+    assertEquals(1, this.registryClient.getAllApplications().size());
 
     // Should not remove app1 since memory state don't have it
     this.registryClient.removeAppFromRegistry(appId1, false);
-    Assert.assertEquals(1, this.registryClient.getAllApplications().size());
+    assertEquals(1, this.registryClient.getAllApplications().size());
 
     // Should remove app1
     this.registryClient.removeAppFromRegistry(appId1, true);
-    Assert.assertEquals(0, this.registryClient.getAllApplications().size());
+    assertEquals(0, this.registryClient.getAllApplications().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacadeRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/TestFederationStateStoreFacadeRetry.java
@@ -27,11 +27,12 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.store.exception.FederationStateStoreException;
 import org.apache.hadoop.yarn.server.federation.store.exception.FederationStateStoreInvalidInputException;
 import org.apache.hadoop.yarn.server.federation.store.exception.FederationStateStoreRetriableException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.zaxxer.hikari.pool.HikariPool.PoolInitializationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class to validate FederationStateStoreFacade retry policy.
@@ -41,7 +42,7 @@ public class TestFederationStateStoreFacadeRetry {
   private int maxRetries = 4;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
     conf.setInt(YarnConfiguration.CLIENT_FAILOVER_RETRIES, maxRetries);
@@ -58,12 +59,12 @@ public class TestFederationStateStoreFacadeRetry {
         new FederationStateStoreRetriableException(""), 0, 0, false);
     // We compare only the action, since delay and the reason are random values
     // during this test
-    Assert.assertEquals(RetryAction.RETRY.action, action.action);
+    assertEquals(RetryAction.RETRY.action, action.action);
 
     // After maxRetries we stop to retry
     action = policy.shouldRetry(new FederationStateStoreRetriableException(""),
         maxRetries, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 
   /*
@@ -73,7 +74,7 @@ public class TestFederationStateStoreFacadeRetry {
   public void testFacadeYarnException() throws Exception {
     RetryPolicy policy = FederationStateStoreFacade.createRetryPolicy(conf);
     RetryAction action = policy.shouldRetry(new YarnException(), 0, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 
   /*
@@ -85,7 +86,7 @@ public class TestFederationStateStoreFacadeRetry {
     RetryPolicy policy = FederationStateStoreFacade.createRetryPolicy(conf);
     RetryAction action = policy
         .shouldRetry(new FederationStateStoreException("Error"), 0, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 
   /*
@@ -97,7 +98,7 @@ public class TestFederationStateStoreFacadeRetry {
     RetryPolicy policy = FederationStateStoreFacade.createRetryPolicy(conf);
     RetryAction action = policy.shouldRetry(
         new FederationStateStoreInvalidInputException(""), 0, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 
   /*
@@ -110,12 +111,12 @@ public class TestFederationStateStoreFacadeRetry {
         policy.shouldRetry(new CacheLoaderException(""), 0, 0, false);
     // We compare only the action, since delay and the reason are random values
     // during this test
-    Assert.assertEquals(RetryAction.RETRY.action, action.action);
+    assertEquals(RetryAction.RETRY.action, action.action);
 
     // After maxRetries we stop to retry
     action =
         policy.shouldRetry(new CacheLoaderException(""), maxRetries, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 
   /*
@@ -129,12 +130,12 @@ public class TestFederationStateStoreFacadeRetry {
         new PoolInitializationException(new YarnException()), 0, 0, false);
     // We compare only the action, delay and the reason are random value
     // during this test
-    Assert.assertEquals(RetryAction.RETRY.action, action.action);
+    assertEquals(RetryAction.RETRY.action, action.action);
 
     // After maxRetries we stop to retry
     action =
         policy.shouldRetry(new PoolInitializationException(new YarnException()),
             maxRetries, 0, false);
-    Assert.assertEquals(RetryAction.FAIL.action, action.action);
+    assertEquals(RetryAction.FAIL.action, action.action);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/metrics/TestAMRMClientRelayerMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/metrics/TestAMRMClientRelayerMetrics.java
@@ -46,13 +46,15 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.AMRMClientRelayer;
 import org.apache.hadoop.yarn.server.metrics.AMRMClientRelayerMetrics.RequestType;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for AMRMClientRelayer.
@@ -133,7 +135,7 @@ public class TestAMRMClientRelayerMetrics {
   private List<String> blacklistAdditions = new ArrayList<>();
   private List<String> blacklistRemoval = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException, IOException {
     this.conf = new Configuration();
 
@@ -236,39 +238,39 @@ public class TestAMRMClientRelayerMetrics {
         ExecutionType.GUARANTEED, 2));
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Ask from the uam
     this.uamRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Update the any to ask for an extra container
     this.asks.get(2).setNumContainers(3);
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(3, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(3, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Update the any to ask to pretend a container was allocated
     this.asks.get(2).setNumContainers(2);
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
   }
 
@@ -281,7 +283,7 @@ public class TestAMRMClientRelayerMetrics {
 
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(3, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(3, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Promote).value());
 
     // Demote 2 containers, one of which is pending promote
@@ -291,7 +293,7 @@ public class TestAMRMClientRelayerMetrics {
 
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Promote).value());
 
     // Let the RM respond with two successful promotions, one of which
@@ -309,7 +311,7 @@ public class TestAMRMClientRelayerMetrics {
 
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(1, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(1, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Promote).value());
 
     // Remove the promoted container and clean up response
@@ -327,7 +329,7 @@ public class TestAMRMClientRelayerMetrics {
 
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Promote).value());
   }
 
@@ -354,10 +356,10 @@ public class TestAMRMClientRelayerMetrics {
     // After finish, the metrics should reset to zero
     this.homeRelayer.shutdown();
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Promote).value());
   }
 
@@ -381,28 +383,28 @@ public class TestAMRMClientRelayerMetrics {
     mockAMS.failover = true;
     this.homeRelayer.allocate(getAllocateRequest());
     // The failover metric should be incremented
-    Assert.assertEquals(++previousFailover,
+    assertEquals(++previousFailover,
         AMRMClientRelayerMetrics.getInstance()
         .getRMMasterSlaveSwitchMetric(homeID).value());
 
     // The success metric should be incremented once
-    Assert.assertEquals(++previousSuccess,
+    assertEquals(++previousSuccess,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatSuccessMetric(homeID).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Ask from the uam
     this.uamRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Update the any to ask for an extra container
@@ -410,19 +412,19 @@ public class TestAMRMClientRelayerMetrics {
     mockAMS.failover = true;
     this.homeRelayer.allocate(getAllocateRequest());
     // The failover metric should be incremented
-    Assert.assertEquals(++previousFailover,
+    assertEquals(++previousFailover,
         AMRMClientRelayerMetrics.getInstance()
             .getRMMasterSlaveSwitchMetric(homeID).value());
 
     // The success metric should be incremented once
-    Assert.assertEquals(++previousSuccess,
+    assertEquals(++previousSuccess,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatSuccessMetric(homeID).value());
 
-    Assert.assertEquals(3, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(3, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     // Update the any to ask to pretend a container was allocated
@@ -430,19 +432,19 @@ public class TestAMRMClientRelayerMetrics {
     mockAMS.failover = true;
     this.homeRelayer.allocate(getAllocateRequest());
     // The failover metric should be incremented
-    Assert.assertEquals(++previousFailover,
+    assertEquals(++previousFailover,
         AMRMClientRelayerMetrics.getInstance()
             .getRMMasterSlaveSwitchMetric(homeID).value());
 
     // The success metric should be incremented once
-    Assert.assertEquals(++previousSuccess,
+    assertEquals(++previousSuccess,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatSuccessMetric(homeID).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(2, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(2, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
 
     long previousFailure = AMRMClientRelayerMetrics.getInstance()
@@ -451,21 +453,21 @@ public class TestAMRMClientRelayerMetrics {
     mockAMS.exception = true;
     try{
       this.homeRelayer.allocate(getAllocateRequest());
-      Assert.fail();
+      fail();
     } catch (YarnException e){
     }
     // The failover metric should not be incremented
-    Assert.assertEquals(previousFailover,
+    assertEquals(previousFailover,
         AMRMClientRelayerMetrics.getInstance()
             .getRMMasterSlaveSwitchMetric(homeID).value());
 
     // The success metric should not be incremented
-    Assert.assertEquals(previousSuccess,
+    assertEquals(previousSuccess,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatSuccessMetric(homeID).value());
 
     // The failure metric should be incremented
-    Assert.assertEquals(++previousFailure,
+    assertEquals(++previousFailure,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatFailureMetric(homeID).value());
 
@@ -473,21 +475,21 @@ public class TestAMRMClientRelayerMetrics {
     mockAMS.exception = true;
     try{
       this.homeRelayer.allocate(getAllocateRequest());
-      Assert.fail();
+      fail();
     } catch (YarnException e){
     }
     // The failover metric should be incremented
-    Assert.assertEquals(++previousFailover,
+    assertEquals(++previousFailover,
         AMRMClientRelayerMetrics.getInstance()
             .getRMMasterSlaveSwitchMetric(homeID).value());
 
     // The success metric should not be incremented
-    Assert.assertEquals(previousSuccess,
+    assertEquals(previousSuccess,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatSuccessMetric(homeID).value());
 
     // The failure metric should be incremented
-    Assert.assertEquals(++previousFailure,
+    assertEquals(++previousFailure,
         AMRMClientRelayerMetrics.getInstance()
             .getHeartbeatFailureMetric(homeID).value());
   }
@@ -500,10 +502,10 @@ public class TestAMRMClientRelayerMetrics {
         ExecutionType.GUARANTEED, 0));
     this.homeRelayer.allocate(getAllocateRequest());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(homeID, RequestType.Guaranteed).value());
 
-    Assert.assertEquals(0, AMRMClientRelayerMetrics.getInstance()
+    assertEquals(0, AMRMClientRelayerMetrics.getInstance()
         .getPendingMetric(uamID, RequestType.Guaranteed).value());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestDistributedOpportunisticContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestDistributedOpportunisticContainerAllocator.java
@@ -35,9 +35,8 @@ import org.apache.hadoop.yarn.server.api.records.MasterKey;
 import org.apache.hadoop.yarn.server.metrics.OpportunisticSchedulerMetrics;
 import org.apache.hadoop.yarn.server.security.BaseContainerTokenSecretManager;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +48,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -73,7 +75,7 @@ public class TestDistributedOpportunisticContainerAllocator {
   private static final ExecutionTypeRequest OPPORTUNISTIC_REQ =
       ExecutionTypeRequest.newInstance(ExecutionType.OPPORTUNISTIC, true);
 
-  @Before
+  @BeforeEach
   public void setup() {
     SecurityUtil.setTokenServiceUseIp(false);
     final MasterKey mKey = new MasterKey() {
@@ -126,8 +128,8 @@ public class TestDistributedOpportunisticContainerAllocator {
                 NodeId.newInstance("h1", 1234), "h1:1234", "/r1")));
     List<Container> containers = allocator.allocateContainers(
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
-    Assert.assertEquals(1, containers.size());
-    Assert.assertEquals(0, oppCntxt.getOutstandingOpReqs().size());
+    assertEquals(1, containers.size());
+    assertEquals(0, oppCntxt.getOutstandingOpReqs().size());
   }
 
   @Test
@@ -149,8 +151,8 @@ public class TestDistributedOpportunisticContainerAllocator {
                 NodeId.newInstance("h2", 1234), "h2:1234", "/r2")));
     List<Container> containers = allocator.allocateContainers(
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
-    Assert.assertEquals(0, containers.size());
-    Assert.assertEquals(1, oppCntxt.getOutstandingOpReqs().size());
+    assertEquals(0, containers.size());
+    assertEquals(1, oppCntxt.getOutstandingOpReqs().size());
   }
 
   @Test
@@ -197,10 +199,10 @@ public class TestDistributedOpportunisticContainerAllocator {
     for (Container c : containers) {
       allocatedHosts.add(c.getNodeHttpAddress());
     }
-    Assert.assertTrue(allocatedHosts.contains("h1:1234"));
-    Assert.assertTrue(allocatedHosts.contains("h2:1234"));
-    Assert.assertTrue(allocatedHosts.contains("h3:1234"));
-    Assert.assertEquals(3, containers.size());
+    assertTrue(allocatedHosts.contains("h1:1234"));
+    assertTrue(allocatedHosts.contains("h2:1234"));
+    assertTrue(allocatedHosts.contains("h3:1234"));
+    assertEquals(3, containers.size());
   }
 
   @Test
@@ -268,11 +270,11 @@ public class TestDistributedOpportunisticContainerAllocator {
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
     LOG.info("Containers: {}", containers);
     // all 3 containers should be allocated.
-    Assert.assertEquals(3, containers.size());
+    assertEquals(3, containers.size());
     // container with allocation id 2 and 3 should be allocated on node h1
     for (Container c : containers) {
       if (c.getAllocationRequestId() == 2 || c.getAllocationRequestId() == 3) {
-        Assert.assertEquals("h1:1234", c.getNodeHttpAddress());
+        assertEquals("h1:1234", c.getNodeHttpAddress());
       }
     }
   }
@@ -324,10 +326,10 @@ public class TestDistributedOpportunisticContainerAllocator {
     for (Container c : containers) {
       allocatedHosts.add(c.getNodeHttpAddress());
     }
-    Assert.assertEquals(2, containers.size());
-    Assert.assertTrue(allocatedHosts.contains("h1:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h2:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h3:1234"));
+    assertEquals(2, containers.size());
+    assertTrue(allocatedHosts.contains("h1:1234"));
+    assertFalse(allocatedHosts.contains("h2:1234"));
+    assertFalse(allocatedHosts.contains("h3:1234"));
   }
 
   @Test
@@ -361,10 +363,10 @@ public class TestDistributedOpportunisticContainerAllocator {
     for (Container c : containers) {
       allocatedHosts.add(c.getNodeHttpAddress());
     }
-    Assert.assertTrue(allocatedHosts.contains("h2:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h3:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h4:1234"));
-    Assert.assertEquals(1, containers.size());
+    assertTrue(allocatedHosts.contains("h2:1234"));
+    assertFalse(allocatedHosts.contains("h3:1234"));
+    assertFalse(allocatedHosts.contains("h4:1234"));
+    assertEquals(1, containers.size());
   }
 
   @Test
@@ -431,11 +433,11 @@ public class TestDistributedOpportunisticContainerAllocator {
       allocatedHosts.add(c.getNodeHttpAddress());
     }
     LOG.info("Containers: {}", containers);
-    Assert.assertTrue(allocatedHosts.contains("h2:1234"));
-    Assert.assertTrue(allocatedHosts.contains("h5:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h3:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h4:1234"));
-    Assert.assertEquals(2, containers.size());
+    assertTrue(allocatedHosts.contains("h2:1234"));
+    assertTrue(allocatedHosts.contains("h5:1234"));
+    assertFalse(allocatedHosts.contains("h3:1234"));
+    assertFalse(allocatedHosts.contains("h4:1234"));
+    assertEquals(2, containers.size());
   }
 
   @Test
@@ -472,11 +474,11 @@ public class TestDistributedOpportunisticContainerAllocator {
       allocatedHosts.add(c.getNodeHttpAddress());
     }
     LOG.info("Containers: {}", containers);
-    Assert.assertTrue(allocatedHosts.contains("h2:1234"));
-    Assert.assertTrue(allocatedHosts.contains("h5:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h3:1234"));
-    Assert.assertFalse(allocatedHosts.contains("h4:1234"));
-    Assert.assertEquals(2, containers.size());
+    assertTrue(allocatedHosts.contains("h2:1234"));
+    assertTrue(allocatedHosts.contains("h5:1234"));
+    assertFalse(allocatedHosts.contains("h3:1234"));
+    assertFalse(allocatedHosts.contains("h4:1234"));
+    assertEquals(2, containers.size());
   }
 
   @Test
@@ -509,7 +511,7 @@ public class TestDistributedOpportunisticContainerAllocator {
     List<Container> containers = allocator.allocateContainers(
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
     LOG.info("Containers: {}", containers);
-    Assert.assertEquals(2, containers.size());
+    assertEquals(2, containers.size());
   }
 
   @Test
@@ -545,7 +547,7 @@ public class TestDistributedOpportunisticContainerAllocator {
       containers.addAll(allocator.allocateContainers(
           blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser"));
     }
-    Assert.assertEquals(1000, containers.size());
+    assertEquals(1000, containers.size());
   }
 
   @Test
@@ -594,7 +596,7 @@ public class TestDistributedOpportunisticContainerAllocator {
       containers.addAll(allocator.allocateContainers(
           blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser"));
     }
-    Assert.assertEquals(100, containers.size());
+    assertEquals(100, containers.size());
   }
 
   @Test
@@ -617,8 +619,8 @@ public class TestDistributedOpportunisticContainerAllocator {
     /* Since there is no node satisfying node label constraints, requests
        won't get fulfilled.
     */
-    Assert.assertEquals(0, containers.size());
-    Assert.assertEquals(1, oppCntxt.getOutstandingOpReqs().size());
+    assertEquals(0, containers.size());
+    assertEquals(1, oppCntxt.getOutstandingOpReqs().size());
 
     oppCntxt.updateNodeList(
         Arrays.asList(
@@ -628,8 +630,8 @@ public class TestDistributedOpportunisticContainerAllocator {
 
     containers = allocator.allocateContainers(
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
-    Assert.assertEquals(1, containers.size());
-    Assert.assertEquals(0, oppCntxt.getOutstandingOpReqs().size());
+    assertEquals(1, containers.size());
+    assertEquals(0, oppCntxt.getOutstandingOpReqs().size());
   }
 
   /**
@@ -669,12 +671,12 @@ public class TestDistributedOpportunisticContainerAllocator {
     LOG.info("Containers: {}", containers);
     // Although capacity is present, but only 2 containers should be allocated
     // as max allocation per AM heartbeat is set to 2.
-    Assert.assertEquals(2, containers.size());
+    assertEquals(2, containers.size());
     containers = allocator.allocateContainers(
         blacklistRequest, new ArrayList<>(), appAttId, oppCntxt, 1L, "user1");
     LOG.info("Containers: {}", containers);
     // Remaining 1 container should be allocated.
-    Assert.assertEquals(1, containers.size());
+    assertEquals(1, containers.size());
   }
 
   /**
@@ -718,17 +720,17 @@ public class TestDistributedOpportunisticContainerAllocator {
     LOG.info("Containers: {}", containers);
     // Although capacity is present, but only 2 containers should be allocated
     // as max allocation per AM heartbeat is set to 2.
-    Assert.assertEquals(2, containers.size());
+    assertEquals(2, containers.size());
     containers = allocator.allocateContainers(
         blacklistRequest, new ArrayList<>(), appAttId, oppCntxt, 1L, "user1");
     LOG.info("Containers: {}", containers);
     // 2 more containers should be allocated from pending allocation requests.
-    Assert.assertEquals(2, containers.size());
+    assertEquals(2, containers.size());
     containers = allocator.allocateContainers(
         blacklistRequest, new ArrayList<>(), appAttId, oppCntxt, 1L, "user1");
     LOG.info("Containers: {}", containers);
     // Remaining 1 container should be allocated.
-    Assert.assertEquals(1, containers.size());
+    assertEquals(1, containers.size());
   }
 
   /**
@@ -766,7 +768,7 @@ public class TestDistributedOpportunisticContainerAllocator {
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "user1");
 
     // all containers should be allocated in single heartbeat.
-    Assert.assertEquals(20, containers.size());
+    assertEquals(20, containers.size());
   }
 
   /**
@@ -805,7 +807,7 @@ public class TestDistributedOpportunisticContainerAllocator {
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "user1");
 
     // all containers should be allocated in single heartbeat.
-    Assert.assertEquals(20, containers.size());
+    assertEquals(20, containers.size());
   }
 
   /**
@@ -845,7 +847,7 @@ public class TestDistributedOpportunisticContainerAllocator {
     List<Container> containers = allocator.allocateContainers(
         blacklistRequest, reqs, appAttId, oppCntxt, 1L, "luser");
     LOG.info("Containers: {}", containers);
-    Assert.assertEquals(2, containers.size());
+    assertEquals(2, containers.size());
     // for each allocated container, latency should be added.
     verify(metrics, times(2)).addAllocateOLatencyEntry(anyLong());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterInitializer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/timeline/security/TestTimelineAuthenticationFilterInitializer.java
@@ -18,14 +18,14 @@
 
 package org.apache.hadoop.yarn.server.timeline.security;
 
-import org.junit.Assert;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.http.FilterContainer;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.TIMELINE_HTTP_AUTH_PREFIX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests {@link TimelineAuthenticationFilterInitializer}.
@@ -67,12 +67,9 @@ public class TestTimelineAuthenticationFilterInitializer {
       TimelineAuthenticationFilterInitializer initializer =
           new TimelineAuthenticationFilterInitializer();
       initializer.initFilter(container, conf);
-      Assert.assertEquals(
-          "*", initializer.filterConfig.get("proxyuser.foo.hosts"));
-      Assert.assertEquals(
-          "*", initializer.filterConfig.get("proxyuser.foo.users"));
-      Assert.assertEquals(
-          "*", initializer.filterConfig.get("proxyuser.foo.groups"));
+      assertEquals("*", initializer.filterConfig.get("proxyuser.foo.hosts"));
+      assertEquals("*", initializer.filterConfig.get("proxyuser.foo.users"));
+      assertEquals("*", initializer.filterConfig.get("proxyuser.foo.groups"));
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/utils/TestLeveldbIterator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/utils/TestLeveldbIterator.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.yarn.server.utils;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -31,7 +31,7 @@ import java.lang.reflect.Proxy;
 
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.DBIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLeveldbIterator {
   private static class CallInfo {
@@ -79,16 +79,16 @@ public class TestLeveldbIterator {
     LeveldbIterator iter = new LeveldbIterator(dbiter);
     for (CallInfo ci : RTEXC_METHODS) {
       Method method = iter.getClass().getMethod(ci.methodName, ci.argTypes);
-      assertNotNull("unable to locate method " + ci.methodName, method);
+      assertNotNull(method, "unable to locate method " + ci.methodName);
       try {
         method.invoke(iter, ci.args);
         fail("operation should have thrown");
       } catch (InvocationTargetException ite) {
         Throwable exc = ite.getTargetException();
-        assertTrue("Method " + ci.methodName + " threw non-DBException: "
-            + exc, exc instanceof DBException);
-        assertFalse("Method " + ci.methodName + " double-wrapped DBException",
-            exc.getCause() instanceof DBException);
+        assertTrue(exc instanceof DBException,
+            "Method " + ci.methodName + " threw non-DBException: " + exc);
+        assertFalse(exc.getCause() instanceof DBException,
+            "Method " + ci.methodName + " double-wrapped DBException");
       }
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/ContainerBlockTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/ContainerBlockTest.java
@@ -31,8 +31,7 @@ import org.apache.hadoop.yarn.resourcetypes.ResourceTypesTestHelper;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
 import org.apache.hadoop.yarn.webapp.View;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_RM_SCHEDULER_MAXIMUM_ALLOCATION_MB;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.DEFAULT_RM_SCHEDULER_MAXIMUM_ALLOCATION_VCORES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -87,7 +87,7 @@ public class ContainerBlockTest {
     ContainerInfo containerInfo = new ContainerInfo(containerReport);
     String resources = block.getResources(containerInfo);
 
-    Assert.assertEquals("8192 Memory, 4 VCores, 5 yarn.io/gpu", resources);
+    assertEquals("8192 Memory, 4 VCores, 5 yarn.io/gpu", resources);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestAppsBlock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestAppsBlock.java
@@ -29,7 +29,9 @@ import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.view.BlockForTest;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlock;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlockForTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestAppsBlock {
 
@@ -37,29 +39,31 @@ public class TestAppsBlock {
    * Test invalid application state.Exception should be thrown if application
    * state is not valid.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidAppState() {
-    AppsBlock appBlock = new AppsBlock(null, null) {
-      // override this so that apps block can fetch app state.
-      @Override
-      public Map<String, String> moreParams() {
-        Map<String, String> map = new HashMap<>();
-        map.put(YarnWebParams.APP_STATE, "ACCEPTEDPING");
-        return map;
-      }
+    assertThrows(IllegalArgumentException.class, () -> {
+      AppsBlock appBlock = new AppsBlock(null, null) {
+        // override this so that apps block can fetch app state.
+        @Override
+        public Map<String, String> moreParams() {
+          Map<String, String> map = new HashMap<>();
+          map.put(YarnWebParams.APP_STATE, "ACCEPTEDPING");
+          return map;
+        }
 
-      @Override
-      protected void renderData(Block html) {
-      }
-    };
+        @Override
+        protected void renderData(Block html) {
+        }
+      };
 
-    // set up the test block to render AppsBlock
-    OutputStream outputStream = new ByteArrayOutputStream();
-    HtmlBlock.Block block = createBlockToCreateTo(outputStream);
+      // set up the test block to render AppsBlock
+      OutputStream outputStream = new ByteArrayOutputStream();
+      HtmlBlock.Block block = createBlockToCreateTo(outputStream);
 
-    // If application state is invalid it should throw exception
-    // instead of catching it.
-    appBlock.render(block);
+      // If application state is invalid it should throw exception
+      // instead of catching it.
+      appBlock.render(block);
+    });
   }
 
   private static HtmlBlock.Block createBlockToCreateTo(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestLogServlet.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestLogServlet.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.server.webapp;
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestLogWebService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/webapp/TestLogWebService.java
@@ -24,9 +24,8 @@ import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEntityType;
 import org.apache.hadoop.yarn.server.metrics.ApplicationMetricsConstants;
 import org.apache.hadoop.yarn.server.metrics.ContainerMetricsConstants;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,6 +33,8 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * test class for log web service.
@@ -48,7 +49,7 @@ public class TestLogWebService {
   private Map<String, TimelineEntity> entities;
   private String nodeHttpAddress = "localhost:0";
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     appId = ApplicationId.fromString("application_1518143905142_509690");
     cId =
@@ -66,8 +67,8 @@ public class TestLogWebService {
   public void testGetApp() {
     BasicAppInfo app =
         logWebService.getApp(request, appId.toString(), null);
-    Assert.assertEquals("RUNNING", app.getAppState().toString());
-    Assert.assertEquals(user, app.getUser());
+    assertEquals("RUNNING", app.getAppState().toString());
+    assertEquals(user, app.getUser());
   }
 
   @Test
@@ -75,7 +76,7 @@ public class TestLogWebService {
     String address = logWebService
         .getNodeHttpAddress(request, appId.toString(), null, cId.toString(),
             null);
-    Assert.assertEquals(this.nodeHttpAddress, address);
+    assertEquals(this.nodeHttpAddress, address);
   }
 
   class LogWebServiceTest extends LogWebService {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11258. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-common.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

