### PR TITLE
YARN-11779. Reset mockito version to 2.18.0 in hadoop-yarn-ui

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
@@ -274,8 +274,8 @@
               <!-- TODO: Remove this dependency after upgrading wro4j-maven-plugin to 1.8.1 or later. -->
               <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>4.11.0</version>
+                <artifactId>mockito-core</artifactId>
+                <version>2.18.0</version>
               </dependency>
             </dependencies>
             <executions>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* There was a change to upgrade Mockito to 4.11.0 in #6968.
* This broke the build on Windows in the hadoop-yarn-ui module - https://github.com/apache/hadoop/pull/6968#issuecomment-2688763321.
* Thus, we need to revert back to the previous stable version (2.18.0) of mockito for hadoop-yarn-ui.

### How was this patch tested?

Verified by building locally on Windows 11.

![image](https://github.com/user-attachments/assets/f4ebc3a6-66c4-427c-98bc-9817fc202976)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

