### PR TITLE
HADOOP-19399. S3A:  support CRT client.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -204,6 +204,7 @@
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.29.52</aws-java-sdk-v2.version>
+    <aws-crt-client.version>0.33.3</aws-crt-client.version>
     <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
     <amazon-s3-analyticsaccelerator-s3.version>1.0.0</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
@@ -1107,6 +1108,11 @@
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk.crt</groupId>
+        <artifactId>aws-crt</artifactId>
+        <version>${aws-crt-client.version}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.encryption.s3</groupId>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -123,6 +123,8 @@
                 <fs.s3a.scale.test.timeout>${fs.s3a.scale.test.timeout}</fs.s3a.scale.test.timeout>
                 <!-- Stream Type -->
                 <fs.s3a.input.stream.type>${stream}</fs.s3a.input.stream.type>
+                <!-- S3 CRT Client -->
+                <fs.s3a.crt.enabled>${fs.s3a.crt.enabled}</fs.s3a.crt.enabled>
               </systemPropertyVariables>
             </configuration>
           </plugin>
@@ -324,6 +326,19 @@
       </properties>
     </profile>
 
+    <!-- Use the S3 CRT client -->
+    <profile>
+      <id>crt</id>
+      <activation>
+        <property>
+          <name>crt</name>
+        </property>
+      </activation>
+      <properties>
+        <fs.s3a.crt.enabled>true</fs.s3a.crt.enabled>
+      </properties>
+    </profile>
+
   </profiles>
 
   <build>
@@ -477,6 +492,11 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bundle</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1886,8 +1886,4 @@ public final class Constants {
    */
   public static final boolean DEFAULT_CRT_ENABLED = false;
 
-  /**
-   * Requester pays header value. Value {@value}.
-   */
-  public static final String REQUESTER_PAYS_HEADER_VALUE = "requester";
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -1860,7 +1860,6 @@ public final class Constants {
    */
   public static final String S3A_IO_RATE_LIMIT = "fs.s3a.io.rate.limit";
 
-
   /**
    * Prefix to configure Analytics Accelerator Library.
    * Value: {@value}.
@@ -1875,4 +1874,20 @@ public final class Constants {
    *      AWS S3 PutObject API Documentation</a>
    */
   public static final String IF_NONE_MATCH_STAR = "*";
+
+  /**
+   * Flag to enable the CRT client. Value {@value}.
+   */
+  public static final String CRT_CLIENT_ENABLED = "fs.s3a.crt.enabled";
+
+  /**
+   * Default value for {@link #DEFAULT_CRT_ENABLED}.
+   * Value: {@value}.
+   */
+  public static final boolean DEFAULT_CRT_ENABLED = false;
+
+  /**
+   * Requester pays header value. Value {@value}.
+   */
+  public static final String REQUESTER_PAYS_HEADER_VALUE = "requester";
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -63,10 +63,10 @@ import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_CLASS_NAME;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED_DEFAULT;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
-import static org.apache.hadoop.fs.s3a.Constants.REQUESTER_PAYS_HEADER_VALUE;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.REQUESTER_PAYS_HEADER_VALUE;
 
 
 /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -20,16 +20,12 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.s3a.impl.AWSClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -39,13 +35,14 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.metrics.LoggingMetricPublisher;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.s3accessgrants.plugin.S3AccessGrantsPlugin;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
@@ -54,27 +51,22 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.s3a.impl.AWSRegionEndpointInformation;
+import org.apache.hadoop.fs.s3a.impl.AWSRegionEndpointResolver;
 import org.apache.hadoop.fs.s3a.statistics.impl.AwsStatisticsCollector;
 import org.apache.hadoop.fs.store.LogExactlyOnce;
 
-import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_ACCESS_GRANTS_FALLBACK_TO_IAM_ENABLED;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT;
-import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_DEFAULT_REGION;
-import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_CLASS_NAME;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.HTTP_SIGNER_ENABLED_DEFAULT;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
-import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.Constants.AWS_SERVICE_IDENTIFIER_S3;
+import static org.apache.hadoop.fs.s3a.Constants.REQUESTER_PAYS_HEADER_VALUE;
 import static org.apache.hadoop.fs.s3a.auth.SignerFactory.createHttpSigner;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.AUTH_SCHEME_AWS_SIGV_4;
-import static org.apache.hadoop.util.Preconditions.checkArgument;
 
 
 /**
@@ -87,13 +79,6 @@ import static org.apache.hadoop.util.Preconditions.checkArgument;
 public class DefaultS3ClientFactory extends Configured
     implements S3ClientFactory {
 
-  private static final String REQUESTER_PAYS_HEADER_VALUE = "requester";
-
-  private static final String S3_SERVICE_NAME = "s3";
-
-  private static final Pattern VPC_ENDPOINT_PATTERN =
-          Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.vpce\\.amazonaws\\.(?:com|com\\.cn)$");
-
   /**
    * Subclasses refer to this.
    */
@@ -101,17 +86,9 @@ public class DefaultS3ClientFactory extends Configured
       LoggerFactory.getLogger(DefaultS3ClientFactory.class);
 
   /**
-   * A one-off warning of default region chains in use.
+   * A one-off log stating whether S3 CRT client is enabled.
    */
-  private static final LogExactlyOnce WARN_OF_DEFAULT_REGION_CHAIN =
-      new LogExactlyOnce(LOG);
-
-  /**
-   * Warning message printed when the SDK Region chain is in use.
-   */
-  private static final String SDK_REGION_CHAIN_IN_USE =
-      "S3A filesystem client is using"
-          + " the SDK region resolution chain.";
+  private static final LogExactlyOnce LOG_S3_CRT_ENABLED = new LogExactlyOnce(LOG);
 
 
   /** Exactly once log to inform about ignoring the AWS-SDK Warnings for CSE. */
@@ -146,7 +123,17 @@ public class DefaultS3ClientFactory extends Configured
   }
 
   @Override
-  public S3AsyncClient createS3AsyncClient(
+  public S3AsyncClient createS3AsyncClient(final URI uri,
+      final S3ClientCreationParameters parameters) throws IOException {
+    if (parameters.isCrtEnabled()) {
+      LOG_S3_CRT_ENABLED.debug("The S3 CRT client is enabled");
+      return createS3CrtAsyncClient(uri, parameters);
+    } else {
+      return createJavaAsyncClient(uri, parameters);
+    }
+  }
+
+  public S3AsyncClient createJavaAsyncClient(
       final URI uri,
       final S3ClientCreationParameters parameters) throws IOException {
 
@@ -166,14 +153,41 @@ public class DefaultS3ClientFactory extends Configured
             configureClientBuilder(S3AsyncClient.builder(), parameters, conf, bucket)
                 .httpClientBuilder(httpClientBuilder);
 
-    // multipart upload pending with HADOOP-19326.
-    if (!parameters.isClientSideEncryptionEnabled() &&
-        !parameters.isAnalyticsAcceleratorEnabled()) {
-      s3AsyncClientBuilder.multipartConfiguration(multipartConfiguration)
+    s3AsyncClientBuilder.multipartConfiguration(multipartConfiguration)
               .multipartEnabled(parameters.isMultipartCopy());
-    }
 
     return s3AsyncClientBuilder.build();
+  }
+
+  private S3AsyncClient createS3CrtAsyncClient(URI uri, S3ClientCreationParameters parameters)
+      throws IOException {
+    Configuration conf = getConf();
+    String bucket = uri.getHost();
+
+    S3CrtAsyncClientBuilder s3CrtAsyncClientBuilder = S3CrtAsyncClient.builder();
+
+    AWSRegionEndpointInformation regionEndpointInformation =
+        AWSRegionEndpointResolver.getEndpointRegionResolution(parameters, conf);
+
+    if (regionEndpointInformation.getRegion() != null) {
+      s3CrtAsyncClientBuilder.region(regionEndpointInformation.getRegion());
+    }
+
+    if (regionEndpointInformation.getEndpoint() != null) {
+      s3CrtAsyncClientBuilder.endpointOverride(regionEndpointInformation.getEndpoint());
+    }
+
+    s3CrtAsyncClientBuilder
+        .crossRegionAccessEnabled(regionEndpointInformation.isCrossRegionAccessEnabled());
+
+    AWSClientConfig.configureConnectionSettings(s3CrtAsyncClientBuilder, conf, bucket);
+
+    s3CrtAsyncClientBuilder
+        .credentialsProvider(parameters.getCredentialSet())
+        .forcePathStyle(parameters.isPathStyleAccess())
+        .checksumValidationEnabled(parameters.isChecksumValidationEnabled());
+
+    return s3CrtAsyncClientBuilder.build();
   }
 
   @Override
@@ -200,7 +214,19 @@ public class DefaultS3ClientFactory extends Configured
       BuilderT builder, S3ClientCreationParameters parameters, Configuration conf, String bucket)
       throws IOException {
 
-    configureEndpointAndRegion(builder, parameters, conf);
+    AWSRegionEndpointInformation regionEndpointInformation =
+        AWSRegionEndpointResolver.getEndpointRegionResolution(parameters, conf);
+
+    if(regionEndpointInformation.getRegion() != null) {
+      builder.region(regionEndpointInformation.getRegion());
+    }
+
+    if (regionEndpointInformation.getEndpoint() != null) {
+      builder.endpointOverride(regionEndpointInformation.getEndpoint());
+    }
+
+    builder.crossRegionAccessEnabled(regionEndpointInformation.isCrossRegionAccessEnabled());
+    builder.fipsEnabled(regionEndpointInformation.isFipsEnabled());
 
     maybeApplyS3AccessGrantsConfigurations(builder, conf);
 
@@ -277,178 +303,6 @@ public class DefaultS3ClientFactory extends Configured
     clientOverrideConfigBuilder.retryPolicy(retryPolicyBuilder.build());
 
     return clientOverrideConfigBuilder;
-  }
-
-  /**
-   * This method configures the endpoint and region for a S3 client.
-   * The order of configuration is:
-   *
-   * <ol>
-   * <li>If region is configured via fs.s3a.endpoint.region, use it.</li>
-   * <li>If endpoint is configured via via fs.s3a.endpoint, set it.
-   *     If no region is configured, try to parse region from endpoint. </li>
-   * <li> If no region is configured, and it could not be parsed from the endpoint,
-   *     set the default region as US_EAST_2</li>
-   * <li> If configured region is empty, fallback to SDK resolution chain. </li>
-   * <li> S3 cross region is enabled by default irrespective of region or endpoint
-   *      is set or not.</li>
-   * </ol>
-   *
-   * @param builder S3 client builder.
-   * @param parameters parameter object
-   * @param conf  conf configuration object
-   * @param <BuilderT> S3 client builder type
-   * @param <ClientT> S3 client type
-   * @throws IllegalArgumentException if endpoint is set when FIPS is enabled.
-   */
-  private <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> void configureEndpointAndRegion(
-      BuilderT builder, S3ClientCreationParameters parameters, Configuration conf) {
-    final String endpointStr = parameters.getEndpoint();
-    final URI endpoint = getS3Endpoint(endpointStr, conf);
-
-    final String configuredRegion = parameters.getRegion();
-    Region region = null;
-    String origin = "";
-
-    // If the region was configured, set it.
-    if (configuredRegion != null && !configuredRegion.isEmpty()) {
-      origin = AWS_REGION;
-      region = Region.of(configuredRegion);
-    }
-
-    // FIPs? Log it, then reject any attempt to set an endpoint
-    final boolean fipsEnabled = parameters.isFipsEnabled();
-    if (fipsEnabled) {
-      LOG.debug("Enabling FIPS mode");
-    }
-    // always setting it guarantees the value is non-null,
-    // which tests expect.
-    builder.fipsEnabled(fipsEnabled);
-
-    if (endpoint != null) {
-      boolean endpointEndsWithCentral =
-          endpointStr.endsWith(CENTRAL_ENDPOINT);
-      checkArgument(!fipsEnabled || endpointEndsWithCentral, "%s : %s",
-          ERROR_ENDPOINT_WITH_FIPS,
-          endpoint);
-
-      // No region was configured,
-      // determine the region from the endpoint.
-      if (region == null) {
-        region = getS3RegionFromEndpoint(endpointStr,
-            endpointEndsWithCentral);
-        if (region != null) {
-          origin = "endpoint";
-        }
-      }
-
-      // No need to override endpoint with "s3.amazonaws.com".
-      // Let the client take care of endpoint resolution. Overriding
-      // the endpoint with "s3.amazonaws.com" causes 400 Bad Request
-      // errors for non-existent buckets and objects.
-      // ref: https://github.com/aws/aws-sdk-java-v2/issues/4846
-      if (!endpointEndsWithCentral) {
-        builder.endpointOverride(endpoint);
-        LOG.debug("Setting endpoint to {}", endpoint);
-      } else {
-        origin = "central endpoint with cross region access";
-        LOG.debug("Enabling cross region access for endpoint {}",
-            endpointStr);
-      }
-    }
-
-    if (region != null) {
-      builder.region(region);
-    } else if (configuredRegion == null) {
-      // no region is configured, and none could be determined from the endpoint.
-      // Use US_EAST_2 as default.
-      region = Region.of(AWS_S3_DEFAULT_REGION);
-      builder.region(region);
-      origin = "cross region access fallback";
-    } else if (configuredRegion.isEmpty()) {
-      // region configuration was set to empty string.
-      // allow this if people really want it; it is OK to rely on this
-      // when deployed in EC2.
-      WARN_OF_DEFAULT_REGION_CHAIN.warn(SDK_REGION_CHAIN_IN_USE);
-      LOG.debug(SDK_REGION_CHAIN_IN_USE);
-      origin = "SDK region chain";
-    }
-    boolean isCrossRegionAccessEnabled = conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
-        AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT);
-    // s3 cross region access
-    if (isCrossRegionAccessEnabled) {
-      builder.crossRegionAccessEnabled(true);
-    }
-    LOG.debug("Setting region to {} from {} with cross region access {}",
-        region, origin, isCrossRegionAccessEnabled);
-  }
-
-  /**
-   * Given a endpoint string, create the endpoint URI.
-   *
-   * @param endpoint possibly null endpoint.
-   * @param conf config to build the URI from.
-   * @return an endpoint uri
-   */
-  protected static URI getS3Endpoint(String endpoint, final Configuration conf) {
-
-    boolean secureConnections = conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS);
-
-    String protocol = secureConnections ? "https" : "http";
-
-    if (endpoint == null || endpoint.isEmpty()) {
-      // don't set an endpoint if none is configured, instead let the SDK figure it out.
-      return null;
-    }
-
-    if (!endpoint.contains("://")) {
-      endpoint = String.format("%s://%s", protocol, endpoint);
-    }
-
-    try {
-      return new URI(endpoint);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
-  }
-
-  /**
-   * Parses the endpoint to get the region.
-   * If endpoint is the central one, use US_EAST_2.
-   *
-   * @param endpoint the configure endpoint.
-   * @param endpointEndsWithCentral true if the endpoint is configured as central.
-   * @return the S3 region, null if unable to resolve from endpoint.
-   */
-  @VisibleForTesting
-  static Region getS3RegionFromEndpoint(final String endpoint,
-      final boolean endpointEndsWithCentral) {
-
-    if (!endpointEndsWithCentral) {
-      // S3 VPC endpoint parsing
-      Matcher matcher = VPC_ENDPOINT_PATTERN.matcher(endpoint);
-      if (matcher.find()) {
-        LOG.debug("Mapping to VPCE");
-        LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
-        return Region.of(matcher.group(1));
-      }
-
-      LOG.debug("Endpoint {} is not the default; parsing", endpoint);
-      return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME).orElse(null);
-    }
-
-    // Select default region here to enable cross-region access.
-    // If both "fs.s3a.endpoint" and "fs.s3a.endpoint.region" are empty,
-    // Spark sets "fs.s3a.endpoint" to "s3.amazonaws.com".
-    // This applies to Spark versions with the changes of SPARK-35878.
-    // ref:
-    // https://github.com/apache/spark/blob/v3.5.0/core/
-    // src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala#L528
-    // If we do not allow cross region access, Spark would not be able to
-    // access any bucket that is not present in the given region.
-    // Hence, we should use default region us-east-2 to allow cross-region
-    // access.
-    return Region.of(AWS_S3_DEFAULT_REGION);
   }
 
   private static <BuilderT extends S3BaseClientBuilder<BuilderT, ClientT>, ClientT> void

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -154,6 +154,7 @@ import org.apache.hadoop.fs.s3a.impl.streams.ObjectInputStreamCallbacks;
 import org.apache.hadoop.fs.s3a.impl.streams.StreamFactoryRequirements;
 import org.apache.hadoop.fs.s3a.impl.streams.StreamIntegration;
 import org.apache.hadoop.fs.s3a.impl.write.WriteObjectFlags;
+import org.apache.hadoop.fs.s3a.impl.AWSClientConfig;
 import org.apache.hadoop.fs.s3a.tools.MarkerToolOperations;
 import org.apache.hadoop.fs.s3a.tools.MarkerToolOperationsImpl;
 import org.apache.hadoop.fs.statistics.DurationTracker;
@@ -481,6 +482,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
   private boolean fipsEnabled;
 
   /**
+   * Is CRT enabled?
+   */
+  private boolean isCRTEnabled;
+
+  /**
    * A cache of files that should be deleted when the FileSystem is closed
    * or the JVM is exited.
    */
@@ -646,6 +652,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
       // If encryption method is set to CSE-KMS or CSE-CUSTOM then CSE is enabled.
       isCSEEnabled = CSEUtils.isCSEEnabled(getS3EncryptionAlgorithm().getMethod());
+
+      isCRTEnabled = conf.getBoolean(CRT_CLIENT_ENABLED, DEFAULT_CRT_ENABLED);
 
       isAnalyticsAcceleratorEnabled = StreamIntegration.determineInputStreamType(conf)
           .equals(InputStreamType.Analytics);
@@ -969,7 +977,6 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * runs.
    * <p>
    * It requires the S3Store to have been instantiated.
-   * @param conf configuration.
    */
   private void initThreadPools() {
     Configuration conf = getConf();
@@ -1181,7 +1188,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withClientSideEncryptionEnabled(isCSEEnabled)
         .withClientSideEncryptionMaterials(cseMaterials)
         .withAnalyticsAcceleratorEnabled(isAnalyticsAcceleratorEnabled)
-        .withKMSRegion(conf.get(S3_ENCRYPTION_CSE_KMS_REGION));
+        .withKMSRegion(conf.get(S3_ENCRYPTION_CSE_KMS_REGION))
+        .withCrtEnabled(isCRTEnabled);
 
     // this is where clients and the transfer manager are created on demand.
     return createClientManager(clientFactory, unencryptedClientFactory, parameters,
@@ -1342,6 +1350,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withMultipartUploadEnabled(isMultipartUploadEnabled)
         .withPartUploadTimeout(partUploadTimeout)
         .withChecksumAlgorithm(ChecksumSupport.getChecksumAlgorithm(getConf()))
+        .withCRTEnabled(isCRTEnabled)
+        .withRequesterPays(getConf().getBoolean(ALLOW_REQUESTER_PAYS, DEFAULT_ALLOW_REQUESTER_PAYS))
+        .withUserAgent(AWSClientConfig.getUserAgent(getConf()))
         .build();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -5475,6 +5475,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     case AWS_S3_ACCESS_GRANTS_ENABLED:
       return s3AccessGrantsEnabled;
 
+    case CRT_CLIENT_ENABLED:
+      return isCRTEnabled;
+
     default:
       // is it a performance flag?
       if (performanceFlags.hasCapability(capability)) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -208,6 +208,11 @@ public interface S3ClientFactory {
     private boolean isAnalyticsAcceleratorEnabled;
 
     /**
+     * Is CRT enabled?
+     */
+    private boolean crtEnabled;
+
+    /**
      * List of execution interceptors to include in the chain
      * of interceptors in the SDK.
      * @return the interceptors list
@@ -600,6 +605,24 @@ public interface S3ClientFactory {
      */
     public S3ClientCreationParameters withFipsEnabled(final boolean value) {
       fipsEnabled = value;
+      return this;
+    }
+
+    /**
+     * Get the crt enabled flag.
+     * @return is crt enabled
+     */
+    public boolean isCrtEnabled() {
+      return crtEnabled;
+    }
+
+    /**
+     * Set builder value.
+     * @param value new value
+     * @return the builder
+     */
+    public S3ClientCreationParameters withCrtEnabled(final boolean value) {
+      crtEnabled = value;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -35,6 +35,10 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+import software.amazon.awssdk.services.s3.crt.S3CrtProxyConfiguration;
+import software.amazon.awssdk.services.s3.crt.S3CrtRetryConfiguration;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -163,6 +167,36 @@ public final class AWSClientConfig {
   }
 
   /**
+   * Configure connection settings for the CRT client.
+   *
+   * @param s3CrtAsyncClientBuilder CRT client builder
+   * @param conf configuration
+   * @param bucket bucket to use to look up per-bucket proxy secrets
+   * @return S3CrtAsyncClientBuilder
+   * @throws IOException on any problem
+   */
+  public static S3CrtAsyncClientBuilder configureConnectionSettings(
+      S3CrtAsyncClientBuilder s3CrtAsyncClientBuilder, Configuration conf, String bucket)
+      throws IOException {
+    final ConnectionSettings conn = createConnectionSettings(conf);
+
+    S3CrtHttpConfiguration.Builder s3CrtHttpConfiguration =
+        S3CrtHttpConfiguration.builder().connectionTimeout(conn.getEstablishTimeout());
+
+    S3CrtRetryConfiguration.Builder s3CrtRetryConfiguration = S3CrtRetryConfiguration.builder();
+    s3CrtRetryConfiguration.numRetries(
+        S3AUtils.intOption(conf, MAX_ERROR_RETRIES, DEFAULT_MAX_ERROR_RETRIES, 0));
+
+    return s3CrtAsyncClientBuilder.httpConfiguration(
+        s3CrtHttpConfiguration
+             .proxyConfiguration(mapCRTProxyConfiguration(createAsyncProxyConfiguration(conf, bucket)))
+            .connectionTimeout(conn.getEstablishTimeout())
+            .build())
+        .maxConcurrency(conn.getMaxConnections())
+        .retryConfiguration(s3CrtRetryConfiguration.build());
+  }
+
+  /**
    * Create and configure the async http client with timeouts for:
    * connection acquisition, max idle, timeout, TTL, socket and keepalive.
    * This is netty based and does not allow for the SSL channel mode to be set.
@@ -210,6 +244,27 @@ public final class AWSClientConfig {
         DEFAULT_MAX_ERROR_RETRIES, 0));
 
     return retryPolicyBuilder;
+  }
+
+
+  private static S3CrtProxyConfiguration mapCRTProxyConfiguration(
+          software.amazon.awssdk.http.nio.netty.ProxyConfiguration proxyConfiguration) {
+
+    // If no proxy configurations are set, then proxy configuration can be null.
+    if (proxyConfiguration == null) {
+      return null;
+    }
+
+    S3CrtProxyConfiguration.Builder builder = S3CrtProxyConfiguration.builder();
+
+    builder.host(proxyConfiguration.host());
+    builder.port(proxyConfiguration.port());
+    builder.scheme(proxyConfiguration.scheme());
+
+    builder.username(proxyConfiguration.username());
+    builder.password(proxyConfiguration.password());
+
+    return builder.build();
   }
 
   /**
@@ -371,14 +426,23 @@ public final class AWSClientConfig {
    * @param clientConfig AWS SDK configuration to update
    */
   private static void initUserAgent(Configuration conf,
-      ClientOverrideConfiguration.Builder clientConfig) {
+     ClientOverrideConfiguration.Builder clientConfig) {
+     clientConfig.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, getUserAgent(conf));
+  }
+
+  /**
+   * Builds user agent string
+   * @param conf Hadoop configuration
+   * @return String
+   */
+  public static String getUserAgent(Configuration conf) {
     String userAgent = "Hadoop " + VersionInfo.getVersion();
     String userAgentPrefix = conf.getTrimmed(USER_AGENT_PREFIX, "");
     if (!userAgentPrefix.isEmpty()) {
       userAgent = userAgentPrefix + ", " + userAgent;
     }
     LOG.debug("Using User-Agent: {}", userAgent);
-    clientConfig.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, userAgent);
+    return userAgent;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSClientConfig.java
@@ -431,7 +431,7 @@ public final class AWSClientConfig {
   }
 
   /**
-   * Builds user agent string
+   * Builds user agent string.
    * @param conf Hadoop configuration
    * @return String
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSHeaders.java
@@ -40,6 +40,7 @@ public interface AWSHeaders {
   String LAST_MODIFIED = "Last-Modified";
   String IF_NONE_MATCH = "If-None-Match";
   String IF_MATCH = "If-Match";
+  String USER_AGENT = "User-Agent";
 
   /*
    * Amazon HTTP Headers used by S3A.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointInformation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointInformation.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.net.URI;
+
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Container class to store endpoint and region information which is used to configure SDK
+ * clients.
+ */
+public class AWSRegionEndpointInformation {
+
+  private final URI endpoint;
+  private final Region region;
+  private final boolean fipsEnabled;
+  private final boolean crossRegionAccessEnabled;
+
+
+  AWSRegionEndpointInformation(Builder builder) {
+    this.endpoint = builder.endpoint;
+    this.region = builder.region;
+    this.fipsEnabled = builder.fipsEnabled;
+    this.crossRegionAccessEnabled = builder.crossRegionAccessEnabled;
+  }
+
+  public URI getEndpoint() {
+    return endpoint;
+  }
+
+  public Region getRegion() {
+    return region;
+  }
+
+  public boolean isFipsEnabled() {
+    return fipsEnabled;
+  }
+
+  public boolean isCrossRegionAccessEnabled() {
+    return crossRegionAccessEnabled;
+  }
+
+  public static class Builder {
+
+    private URI endpoint;
+    private Region region;
+    private boolean fipsEnabled;
+    private boolean crossRegionAccessEnabled;
+
+
+    public AWSRegionEndpointInformation build() {
+      return new AWSRegionEndpointInformation(this);
+    }
+
+    public Builder withRegion(final Region value) {
+      this.region = value;
+      return this;
+    }
+
+    public Builder withEndpoint(final URI value) {
+      this.endpoint = value;
+      return this;
+    }
+
+    public Builder fipsEnabled(final boolean value) {
+      this.fipsEnabled = value;
+      return this;
+    }
+
+    public Builder crossRegionAccessEnabled(final boolean value) {
+      this.crossRegionAccessEnabled = value;
+      return this;
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointResolver.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointResolver.java
@@ -150,7 +150,6 @@ public class AWSRegionEndpointResolver {
       // region configuration was set to empty string.
       // allow this if people really want it; it is OK to rely on this
       // when deployed in EC2.
-      WARN_OF_DEFAULT_REGION_CHAIN.debug(SDK_REGION_CHAIN_IN_USE);
       LOG.debug(SDK_REGION_CHAIN_IN_USE);
       origin = "SDK region chain";
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointResolver.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AWSRegionEndpointResolver.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
+import software.amazon.awssdk.regions.Region;
+
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.S3ClientFactory;
+import org.apache.hadoop.fs.store.LogExactlyOnce;
+
+import static org.apache.hadoop.fs.s3a.Constants.AWS_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT;
+import static org.apache.hadoop.fs.s3a.Constants.AWS_S3_DEFAULT_REGION;
+import static org.apache.hadoop.fs.s3a.Constants.CENTRAL_ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.FIPS_ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
+import static org.apache.hadoop.util.Preconditions.checkArgument;
+
+/**
+ * This class uses Hadoop configurations to resolve endpoint and region information which
+ * is then set in the SDK clients.
+ */
+public class AWSRegionEndpointResolver {
+
+  private static final String S3_SERVICE_NAME = "s3";
+
+  private static final Pattern VPC_ENDPOINT_PATTERN =
+      Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.vpce\\.amazonaws\\.(?:com|com\\.cn)$");
+
+  protected static final Logger LOG =
+      LoggerFactory.getLogger(AWSRegionEndpointResolver.class);
+
+  /**
+   * A one-off warning of default region chains in use.
+   */
+  private static final LogExactlyOnce WARN_OF_DEFAULT_REGION_CHAIN =
+      new LogExactlyOnce(LOG);
+
+  /**
+   * Warning message printed when the SDK Region chain is in use.
+   */
+  private static final String SDK_REGION_CHAIN_IN_USE =
+      "S3A filesystem client is using"
+          + " the SDK region resolution chain.";
+
+  /**
+   * Error message when an endpoint is set with FIPS enabled: {@value}.
+   */
+  @VisibleForTesting
+  public static final String ERROR_ENDPOINT_WITH_FIPS =
+      "Non central endpoint cannot be set when " + FIPS_ENDPOINT + " is true";
+
+  private AWSRegionEndpointResolver() {}
+
+  public static AWSRegionEndpointInformation getEndpointRegionResolution(
+          S3ClientFactory.S3ClientCreationParameters parameters, Configuration conf) {
+    final String endpointStr = parameters.getEndpoint();
+    final URI endpoint = getS3Endpoint(endpointStr, conf);
+
+    AWSRegionEndpointInformation.Builder builder = new AWSRegionEndpointInformation.Builder();
+
+    final String configuredRegion = parameters.getRegion();
+    Region region = null;
+    String origin = "";
+
+    // If the region was configured, set it.
+    if (configuredRegion != null && !configuredRegion.isEmpty()) {
+      origin = AWS_REGION;
+      region = Region.of(configuredRegion);
+    }
+
+    // FIPs? Log it, then reject any attempt to set an endpoint
+    final boolean fipsEnabled = parameters.isFipsEnabled();
+    if (fipsEnabled) {
+      LOG.debug("Enabling FIPS mode");
+    }
+    // always setting it guarantees the value is non-null,
+    // which tests expect.
+    builder.fipsEnabled(fipsEnabled);
+
+    if (endpoint != null) {
+      boolean endpointEndsWithCentral =
+          endpointStr.endsWith(CENTRAL_ENDPOINT);
+      checkArgument(!fipsEnabled || endpointEndsWithCentral, "%s : %s",
+          ERROR_ENDPOINT_WITH_FIPS,
+          endpoint);
+
+      // No region was configured,
+      // determine the region from the endpoint.
+      if (region == null) {
+        region = getS3RegionFromEndpoint(endpointStr,
+            endpointEndsWithCentral);
+        if (region != null) {
+          origin = "endpoint";
+        }
+      }
+
+      // No need to override endpoint with "s3.amazonaws.com".
+      // Let the client take care of endpoint resolution. Overriding
+      // the endpoint with "s3.amazonaws.com" causes 400 Bad Request
+      // errors for non-existent buckets and objects.
+      // ref: https://github.com/aws/aws-sdk-java-v2/issues/4846
+      if (!endpointEndsWithCentral) {
+        builder.withEndpoint(endpoint);
+        LOG.debug("Setting endpoint to {}", endpoint);
+      } else {
+        origin = "central endpoint with cross region access";
+        LOG.debug("Enabling cross region access for endpoint {}",
+            endpointStr);
+      }
+    }
+
+    if (region != null) {
+      builder.withRegion(region);
+    } else if (configuredRegion == null) {
+      // no region is configured, and none could be determined from the endpoint.
+      // Use US_EAST_2 as default.
+      region = Region.of(AWS_S3_DEFAULT_REGION);
+      builder.withRegion(region);
+      origin = "cross region access fallback";
+    } else if (configuredRegion.isEmpty()) {
+      // region configuration was set to empty string.
+      // allow this if people really want it; it is OK to rely on this
+      // when deployed in EC2.
+      WARN_OF_DEFAULT_REGION_CHAIN.debug(SDK_REGION_CHAIN_IN_USE);
+      LOG.debug(SDK_REGION_CHAIN_IN_USE);
+      origin = "SDK region chain";
+    }
+    boolean isCrossRegionAccessEnabled = conf.getBoolean(AWS_S3_CROSS_REGION_ACCESS_ENABLED,
+        AWS_S3_CROSS_REGION_ACCESS_ENABLED_DEFAULT);
+    // s3 cross region access
+    if (isCrossRegionAccessEnabled) {
+      builder.crossRegionAccessEnabled(true);
+    }
+    LOG.debug("Setting region to {} from {} with cross region access {}",
+        region, origin, isCrossRegionAccessEnabled);
+
+    return builder.build();
+  }
+
+  /**
+   * Builds a URI from the configured S3 endpoint.
+   * Will throw an IllegalArgumentException for malformed endpoint strings, for example:
+   * https ://s3.us-east-1.amazonaws.com
+   *
+   * @param endpoint configured S3 endpoint
+   * @param conf configuration
+   * @return S3 endpoint URI.
+   */
+  protected static URI getS3Endpoint(String endpoint, final Configuration conf) {
+
+    boolean secureConnections = conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS);
+
+    String protocol = secureConnections ? "https" : "http";
+
+    if (endpoint == null || endpoint.isEmpty()) {
+      // don't set an endpoint if none is configured, instead let the SDK figure it out.
+      return null;
+    }
+
+    if (!endpoint.contains("://")) {
+      endpoint = String.format("%s://%s", protocol, endpoint);
+    }
+
+    try {
+      return new URI(endpoint);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * Parses the endpoint to get the region.
+   * If endpoint is the central one, use US_EAST_2.
+   *
+   * @param endpoint the configure endpoint.
+   * @param endpointEndsWithCentral true if the endpoint is configured as central.
+   * @return the S3 region, null if unable to resolve from endpoint.
+   */
+  @VisibleForTesting
+  public static Region getS3RegionFromEndpoint(final String endpoint,
+      final boolean endpointEndsWithCentral) {
+
+    if (!endpointEndsWithCentral) {
+      // S3 VPC endpoint parsing
+      Matcher matcher = VPC_ENDPOINT_PATTERN.matcher(endpoint);
+      if (matcher.find()) {
+        LOG.debug("Mapping to VPCE");
+        LOG.debug("Endpoint {} is vpc endpoint; parsing region as {}", endpoint, matcher.group(1));
+        return Region.of(matcher.group(1));
+      }
+
+      LOG.debug("Endpoint {} is not the default; parsing", endpoint);
+      return AwsHostNameUtils.parseSigningRegion(endpoint, S3_SERVICE_NAME).orElse(null);
+    }
+
+    // Select default region here to enable cross-region access.
+    // If both "fs.s3a.endpoint" and "fs.s3a.endpoint.region" are empty,
+    // Spark sets "fs.s3a.endpoint" to "s3.amazonaws.com".
+    // This applies to Spark versions with the changes of SPARK-35878.
+    // ref:
+    // https://github.com/apache/spark/blob/v3.5.0/core/
+    // src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala#L528
+    // If we do not allow cross region access, Spark would not be able to
+    // access any bucket that is not present in the given region.
+    // Hence, we should use default region us-east-2 to allow cross-region
+    // access.
+    return Region.of(AWS_S3_DEFAULT_REGION);
+  }
+
+
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/ClientManagerImpl.java
@@ -142,11 +142,11 @@ public class ClientManagerImpl
    * @return a callable which will create the client.
    */
   private CallableRaisingIOE<S3AsyncClient> createAsyncClient() {
-    return trackDurationOfOperation(
-        durationTrackerFactory,
+    return trackDurationOfOperation(durationTrackerFactory,
         STORE_CLIENT_CREATION.getSymbol(),
         () -> clientFactory.createS3AsyncClient(getUri(), clientCreationParameters));
   }
+
 
   /**
    * Create the function to create the unencrypted S3 client.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/EncryptionS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/EncryptionS3ClientFactory.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.functional.LazyAtomicReference;
 
+import static org.apache.hadoop.fs.s3a.impl.AWSRegionEndpointResolver.getS3Endpoint;
 import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.unavailable;
 
 /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/InternalConstants.java
@@ -55,6 +55,7 @@ import static org.apache.hadoop.fs.s3a.Constants.STORE_CAPABILITY_DIRECTORY_MARK
 import static org.apache.hadoop.fs.s3a.Constants.STORE_CAPABILITY_DIRECTORY_MARKER_POLICY_DELETE;
 import static org.apache.hadoop.fs.s3a.Constants.STORE_CAPABILITY_DIRECTORY_MARKER_POLICY_KEEP;
 import static org.apache.hadoop.fs.s3a.Constants.STORE_CAPABILITY_MULTIPART_UPLOAD_ENABLED;
+import static org.apache.hadoop.fs.s3a.Constants.CRT_CLIENT_ENABLED;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.STORE_CAPABILITY_MAGIC_COMMITTER;
 
 /**
@@ -286,7 +287,7 @@ public final class InternalConstants {
           DIRECTORY_LISTING_INCONSISTENT,
           FIPS_ENDPOINT,
           AWS_S3_ACCESS_GRANTS_ENABLED,
-
+          CRT_CLIENT_ENABLED,
           // s3 specific
           STORE_CAPABILITY_AWS_V2,
           STORE_CAPABILITY_DIRECTORY_MARKER_POLICY_KEEP,
@@ -313,4 +314,8 @@ public final class InternalConstants {
   public static final String UPLOAD_PROGRESS_LOG_NAME =
       "org.apache.hadoop.fs.s3a.S3AFileSystem.Progress";
 
+  /**
+   * Requester pays header value. Value {@value}.
+   */
+  public static final String REQUESTER_PAYS_HEADER_VALUE = "requester";
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -66,7 +66,6 @@ import org.apache.hadoop.fs.s3a.impl.write.WriteObjectFlags;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.apache.hadoop.fs.s3a.Constants.REQUESTER_PAYS_HEADER_VALUE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_PART_UPLOAD_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.IF_NONE_MATCH_STAR;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_C;
@@ -77,6 +76,7 @@ import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.IF_NONE_MATCH;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.USER_AGENT;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.DEFAULT_UPLOAD_PART_COUNT_LIMIT;
+import static org.apache.hadoop.fs.s3a.impl.InternalConstants.REQUESTER_PAYS_HEADER_VALUE;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
 import static org.apache.hadoop.util.Preconditions.checkNotNull;
 import static software.amazon.awssdk.services.s3.model.StorageClass.UNKNOWN_TO_SDK_VERSION;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
@@ -64,6 +66,7 @@ import org.apache.hadoop.fs.s3a.impl.write.WriteObjectFlags;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.hadoop.fs.s3a.Constants.REQUESTER_PAYS_HEADER_VALUE;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_PART_UPLOAD_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.Constants.IF_NONE_MATCH_STAR;
 import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_C;
@@ -71,6 +74,8 @@ import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.UNKNOWN_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.impl.AWSClientConfig.setRequestTimeout;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.IF_MATCH;
 import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.IF_NONE_MATCH;
+import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.REQUESTER_PAYS_HEADER;
+import static org.apache.hadoop.fs.s3a.impl.AWSHeaders.USER_AGENT;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.DEFAULT_UPLOAD_PART_COUNT_LIMIT;
 import static org.apache.hadoop.util.Preconditions.checkArgument;
 import static org.apache.hadoop.util.Preconditions.checkNotNull;
@@ -151,6 +156,21 @@ public class RequestFactoryImpl implements RequestFactory {
   private final ChecksumAlgorithm checksumAlgorithm;
 
   /**
+   * Is the S3 CRT client enabled?
+   */
+  private final Boolean isCRTEnabled;
+
+  /**
+   * Is requester pays?
+   */
+  private final Boolean isRequesterPays;
+
+  /**
+   * User agent to use on requests.
+   */
+  private final String userAgent;
+
+  /**
    * Constructor.
    * @param builder builder with all the configuration.
    */
@@ -166,6 +186,9 @@ public class RequestFactoryImpl implements RequestFactory {
     this.isMultipartUploadEnabled = builder.isMultipartUploadEnabled;
     this.partUploadTimeout = builder.partUploadTimeout;
     this.checksumAlgorithm = builder.checksumAlgorithm;
+    this.isCRTEnabled = builder.isCRTEnabled;
+    this.isRequesterPays = builder.isRequesterPays;
+    this.userAgent = builder.userAgent;
   }
 
   /**
@@ -275,6 +298,10 @@ public class RequestFactoryImpl implements RequestFactory {
       copyObjectRequestBuilder.storageClass(srcom.storageClass());
     }
 
+    if (isCRTEnabled) {
+      addRequestLevelHeaders(copyObjectRequestBuilder);
+    }
+
     copyObjectRequestBuilder.destinationBucket(getBucket())
         .destinationKey(dstKey).sourceBucket(getBucket()).sourceKey(srcKey);
 
@@ -372,10 +399,13 @@ public class RequestFactoryImpl implements RequestFactory {
       putObjectRequestBuilder.storageClass(storageClass);
     }
 
-    // Set the timeout for object uploads but not directory markers.
-    if (!isDirectoryMarker) {
+    // Set the timeout for object uploads but not directory markers, or if using the CRT client.
+    // CRT client is used for the upload when doing a copyFromLocal() operation only,
+    // as that uses the transfer manager.
+    if (!isDirectoryMarker && !isCRTEnabled) {
       setRequestTimeout(putObjectRequestBuilder, partUploadTimeout);
     }
+
 
     if (options != null) {
       if (options.isNoObjectOverwrite()) {
@@ -387,6 +417,10 @@ public class RequestFactoryImpl implements RequestFactory {
         LOG.debug("setting If-Match");
         putObjectRequestBuilder.overrideConfiguration(
                 override -> override.putHeader(IF_MATCH, options.getEtagOverwrite()));
+      }
+
+    if (isCRTEnabled) {
+      addRequestLevelHeaders(putObjectRequestBuilder);
       }
     }
 
@@ -741,6 +775,18 @@ public class RequestFactoryImpl implements RequestFactory {
     encryptionSecrets = secrets;
   }
 
+  private void addRequestLevelHeaders(AwsRequest.Builder requestBuilder) {
+    AwsRequestOverrideConfiguration.Builder builder = AwsRequestOverrideConfiguration.builder();
+
+    if (isRequesterPays) {
+      builder.putHeader(REQUESTER_PAYS_HEADER, REQUESTER_PAYS_HEADER_VALUE);
+    }
+
+    builder.putHeader(USER_AGENT, userAgent);
+
+    requestBuilder.overrideConfiguration(builder.build());
+  }
+
   /**
    * Create a builder.
    * @return new builder.
@@ -791,6 +837,21 @@ public class RequestFactoryImpl implements RequestFactory {
      * Is Multipart Enabled on the path.
      */
     private boolean isMultipartUploadEnabled = true;
+
+    /**
+     * Is the S3 CRT client enabled?
+     */
+    private boolean isCRTEnabled;
+
+    /**
+     * Is requester pays?
+     */
+    private boolean isRequesterPays;
+
+    /**
+     * User agent to use on requests.
+     */
+    private String userAgent;
 
     /**
      * Timeout for uploading objects/parts.
@@ -921,6 +982,38 @@ public class RequestFactoryImpl implements RequestFactory {
      */
     public RequestFactoryBuilder withChecksumAlgorithm(final ChecksumAlgorithm value) {
       checksumAlgorithm = value;
+      return this;
+    }
+
+    /**
+     * Should the CRT client be used as the S3 Async client?
+     * @param value new value
+     * @return the builder
+     */
+    public RequestFactoryBuilder withCRTEnabled(final boolean value) {
+      isCRTEnabled = value;
+      return this;
+    }
+
+    /**
+     * Is requester pays enabled?
+     * Required for the CRT client, where this header must be set on the request level.
+     * @param value new value
+     * @return the builder
+     */
+    public RequestFactoryBuilder withRequesterPays(final boolean value) {
+      isRequesterPays = value;
+      return this;
+    }
+
+    /**
+     * User agent to use on requests.
+     * Required for the CRT client, where this header must be set on the request level.
+     * @param value new value
+     * @return the builder
+     */
+    public RequestFactoryBuilder withUserAgent(final String value) {
+      userAgent = value;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -991,8 +991,7 @@ public class S3AStoreImpl
   private class FactoryCallbacks implements StreamFactoryCallbacks {
 
     @Override
-    public S3AsyncClient getOrCreateAsyncClient(final boolean requireCRT) throws IOException {
-      // Needs support of the CRT before the requireCRT can be used
+    public S3AsyncClient getOrCreateAsyncClient() throws IOException {
       LOG.debug("Stream factory requested async client");
       return clientManager().getOrCreateAsyncClient();
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
@@ -43,7 +43,6 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
 
   private S3SeekableInputStreamConfiguration seekableInputStreamConfiguration;
   private LazyAutoCloseableReference<S3SeekableInputStreamFactory>  s3SeekableInputStreamFactory;
-  private boolean requireCrt;
 
   public AnalyticsStreamFactory() {
     super("AnalyticsStreamFactory");
@@ -56,7 +55,6 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
                 ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX);
     this.seekableInputStreamConfiguration =
                 S3SeekableInputStreamConfiguration.fromConfiguration(configuration);
-    this.requireCrt = false;
   }
 
   @Override
@@ -110,7 +108,7 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
 
   private CallableRaisingIOE<S3SeekableInputStreamFactory> createS3SeekableInputStreamFactory() {
     return () -> new S3SeekableInputStreamFactory(
-            new S3SdkObjectClient(callbacks().getOrCreateAsyncClient(requireCrt)),
+            new S3SdkObjectClient(callbacks().getOrCreateAsyncClient()),
             seekableInputStreamConfiguration);
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectInputStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectInputStreamFactory.java
@@ -81,11 +81,10 @@ public interface ObjectInputStreamFactory
 
     /**
      * Get the Async S3Client, raising a failure to create as an IOException.
-     * @param requireCRT is the CRT required.
      * @return the Async S3 client
      * @throws IOException failure to create the client.
      */
-    S3AsyncClient getOrCreateAsyncClient(boolean requireCRT) throws IOException;
+    S3AsyncClient getOrCreateAsyncClient() throws IOException;
 
     void incrementFactoryStatistic(Statistic statistic);
   }

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/crt_client.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/crt_client.md
@@ -22,8 +22,8 @@ transfer throughput from S3 due to its enhanced connection pool management. More
 can be found
 [here](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
 
-When making multiple parallel GET requests, using the CRT ensures load is evenly distributed across S3. This can be
-useful for all three input streams available with versions > 3.4.2, as:
+When making multiple parallel GET requests, using the CRT ensures load is evenly distributed across S3 front-end. 
+This can be useful for all three input streams available with versions >= 3.4.2, as:
 * The Analytics accelerator will make parallel GETs for columns it predicts will be required on a Parquet file open.
 * The Prefetch input stream can make up to 8 parallel 8MB GETs by default.
 * The Classic input stream will make async parallel GETs for column reads when using VectoredIO.
@@ -40,7 +40,7 @@ asynchronous client. The move to an async client is tracked in
 ## Enabling the CRT Client
 The CRT client can be enabled as follows:
 
-```
+```xml
     <property>
         <name>fs.s3a.crt.enabled</name>
         <value>true</value>

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/crt_client.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/crt_client.md
@@ -1,0 +1,66 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Using the S3 CRT client
+
+This document explains usage of the CRT client.
+
+The [AWS CRT-based S3 client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html)
+is built on top of the AWS Common Runtime (CRT), is an alternative S3 asynchronous client. It can provide higher
+transfer throughput from S3 due to its enhanced connection pool management. More information
+can be found
+[here](https://aws.amazon.com/blogs/developer/introducing-crt-based-s3-client-and-the-s3-transfer-manager-in-the-aws-sdk-for-java-2-x/).
+
+When making multiple parallel GET requests, using the CRT ensures load is evenly distributed across S3. This can be
+useful for all three input streams available with versions > 3.4.2, as:
+* The Analytics accelerator will make parallel GETs for columns it predicts will be required on a Parquet file open.
+* The Prefetch input stream can make up to 8 parallel 8MB GETs by default.
+* The Classic input stream will make async parallel GETs for column reads when using VectoredIO.
+
+Since the CRT client is an async client, when enabled in S3A, it will currently be used wherever
+* When reading data using the Analytics stream.
+* When copying files between buckets using the Transfer manager, for example, on a rename.
+* When copying from the local file system to S3.
+
+This is because all other operations in S3A currently use the S3 Sync client, and so cannot be replaced by an
+asynchronous client. The move to an async client is tracked in
+[HADOOP-18877](https://issues.apache.org/jira/browse/HADOOP-18877).
+
+## Enabling the CRT Client
+The CRT client can be enabled as follows:
+
+```
+    <property>
+        <name>fs.s3a.crt.enabled</name>
+        <value>true</value>
+    </property>
+```
+
+## Limitations
+
+Using the CRT client currently comes with the following limitations:
+
+* The CRT client has limited options for configurations, this means only certain connection level configurations are
+applied:
+  * `fs.s3a.connection.maximum`
+  * `fs.s3a.connection.establish.timeout`
+* No request level timeouts.
+* No support for configuring custom signers, signers registered via `fs.s3a.custom.signers`, will not be set.
+* No support for execution interceptors, so auditing is not supported.
+* Multipart uploads cannot be disabled, so copy requests which use the transfer manager will be split into 8MB. The
+transfer manager is used when:
+  * the file size to copy is >= value of `fs.s3a.multipart.threshold`. Default value of this configuration is 128MB.
+  * multipart copying is not explicitly disabled using `fs.s3a.multipart.uploads.enabled`
+* The CRT client is written in C, and used with the SDK via Java bindings. This means on failures, the entire stack
+trace is not surfaced up and can make debugging issues challenging. 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -50,6 +50,7 @@ full details.
 * [Auditing Architecture](./auditing_architecture.html).
 * [Testing](./testing.html)
 * [S3Guard](./s3guard.html)
+* [Using the S3 CRT Client](./crt_client.html).
 
 ## <a name="overview"></a> Overview
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/performance.md
@@ -263,6 +263,16 @@ however the overall process is much less expensive than either sequentially
 reading through a file with the `random` policy, or reading columnar data
 with the `sequential` policy.
 
+## <a name="analytics-stream"></a> Improving read performance through Analytics Accelerator Library for S3
+
+Support for the Analytics Accelerator Library was added in Hadoop version 3.4.2. This library provides file format 
+aware input stream implementations, with current support for Parquet. For parquet file formats, it implements 
+optimisations uch as pre-fetching metadata located in the footer of the object and predictive column pre-fetching. 
+For more details, see the analytics accelerator library
+[documentation](https://github.com/awslabs/analytics-accelerator-s3/tree/main/input-stream).
+
+This input stream can also be used with the S3 CRT client, see the [crt client documentation](./crt_client.html) for
+more details.
 
 ## <a name="commit"></a> Committing Work in MapReduce and Spark
 

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/reading.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/reading.md
@@ -79,7 +79,8 @@ Weaknesses
 
 An input stream aware-of and adapted-to the columnar storage
 formats used in production, currently with specific support for
-Apache Parquet.
+Apache Parquet. More details about this stream can be found in the analytics accelerator library 
+[documentation](https://github.com/awslabs/analytics-accelerator-s3/tree/main/input-stream).
 
 ```xml
 <property>
@@ -87,6 +88,9 @@ Apache Parquet.
   <value>analytics</value>
 </property>
 ```
+
+This stream can also be used with the CRT client, see the [crt client documentation](./crt_client.html) for 
+more details.
 
 Strengths
 * Significant speedup measured when reading Parquet files through Spark.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -22,6 +22,8 @@ package org.apache.hadoop.fs.s3a;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +38,8 @@ import org.apache.hadoop.fs.s3a.impl.streams.InputStreamType;
 import org.apache.hadoop.fs.s3a.impl.streams.ObjectInputStream;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 
@@ -43,6 +47,7 @@ import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_RE
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_PARQUET;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
 import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
+import static org.apache.hadoop.fs.s3a.Constants.CRT_CLIENT_ENABLED;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
@@ -61,11 +66,29 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * parquet files.
  *
  */
+@RunWith(Parameterized.class)
 public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBase {
 
   private static final String PHYSICAL_IO_PREFIX = "physicalio";
 
+  /**
+   * Parameterization.
+   */
+  @Parameterized.Parameters(name = "crtEnabled={0}")
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+        {true},
+        {false},
+    });
+  }
+
+  private final boolean isCRTEnabled;
+
   private Path externalTestFile;
+
+  public ITestS3AAnalyticsAcceleratorStreamReading(final boolean isCRTEnabled) {
+    this.isCRTEnabled =  isCRTEnabled;
+  }
 
   @Before
   public void setUp() throws Exception {
@@ -77,6 +100,10 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
   @Override
   public Configuration createConfiguration() {
     Configuration configuration = super.createConfiguration();
+
+    removeBaseAndBucketOverrides(configuration, CRT_CLIENT_ENABLED);
+    configuration.setBoolean(CRT_CLIENT_ENABLED, isCRTEnabled);
+
     enableAnalyticsAccelerator(configuration);
     return configuration;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
@@ -22,6 +22,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
 
+import org.apache.hadoop.fs.s3a.impl.AWSRegionEndpointResolver;
+
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+
+
 public class TestS3AEndpointParsing extends AbstractS3AMockTest {
 
     private static final String VPC_ENDPOINT = "vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com";
@@ -31,13 +36,21 @@ public class TestS3AEndpointParsing extends AbstractS3AMockTest {
 
     @Test
     public void testVPCEndpoint() {
-        Region region = DefaultS3ClientFactory.getS3RegionFromEndpoint(VPC_ENDPOINT, false);
-        Assertions.assertThat(region).isEqualTo(Region.of(US_WEST_2));
+      Region region = AWSRegionEndpointResolver.getS3RegionFromEndpoint(VPC_ENDPOINT, false);
+      Assertions.assertThat(region).isEqualTo(Region.of(US_WEST_2));
     }
 
     @Test
     public void testNonVPCEndpoint() {
-        Region region = DefaultS3ClientFactory.getS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
-        Assertions.assertThat(region).isEqualTo(Region.of(EU_WEST_1));
+      Region region = AWSRegionEndpointResolver.getS3RegionFromEndpoint(NON_VPC_ENDPOINT, false);
+      Assertions.assertThat(region).isEqualTo(Region.of(EU_WEST_1));
+    }
+
+    @Test
+    public void testWithMalformedEndpoint() throws Throwable  {
+      intercept(IllegalArgumentException.class,
+              () -> AWSRegionEndpointResolver.getEndpointRegionResolution(
+                        new S3ClientFactory.S3ClientCreationParameters()
+                                .withEndpoint("https ://s3.us-east-1.amazonaws.com"), conf));
     }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/streams/TestStreamFactories.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/streams/TestStreamFactories.java
@@ -332,7 +332,7 @@ public class TestStreamFactories extends AbstractHadoopTestBase {
   private static final class Callbacks implements ObjectInputStreamFactory.StreamFactoryCallbacks {
 
     @Override
-    public S3AsyncClient getOrCreateAsyncClient(final boolean requireCRT) throws IOException {
+    public S3AsyncClient getOrCreateAsyncClient() throws IOException {
       throw new UnsupportedOperationException("not implemented");
     }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Adds support S3 CRT client. 

* Configuration mapping b/w clients is getting tricky, I moved endpoint/region resolution logic out so it can be re-used. 

* CRT does not support client level headers for user agent and requester pays, so those have to be added on a per request level. Only added for `copyObject()` and `putObject()` as those are the only two places CRT will be used in S3A.

### How was this patch tested?

Tested in `us-east-2` with `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`. All good, failures is `ITestS3AEndpointRegion` and `ITestAwsSdkWorkarounds` are related to SDK upgrade. 

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

