### PR TITLE
HADOOP-19475. Update Boost to 1.86.0

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -6,7 +6,7 @@ Requirements:
 * Unix System
 * JDK 1.8
 * Maven 3.3 or later
-* Boost 1.72 (if compiling native code)
+* Boost 1.86.0 (if compiling native code)
 * Protocol Buffers 3.21.12 (if compiling native code)
 * CMake 3.19 or newer (if compiling native code)
 * Zlib devel (if compiling native code)
@@ -526,7 +526,7 @@ Requirements:
 * Windows 10
 * JDK 1.8
 * Maven 3.0 or later (maven.apache.org)
-* Boost 1.72 (boost.org)
+* Boost 1.86.0 (boost.org)
 * Protocol Buffers 3.21.12 (https://github.com/protocolbuffers/protobuf/tags)
 * CMake 3.19 or newer (cmake.org)
 * Visual Studio 2019 (visualstudio.com)

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -82,8 +82,8 @@ Refer to  dev-support/docker/Dockerfile):
   $ make -j$(nproc)
   $ sudo make install
 * Boost
-  $ curl -L https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download > boost_1_72_0.tar.bz2
-  $ tar --bzip2 -xf boost_1_72_0.tar.bz2 && cd boost_1_72_0
+  $ curl -L https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download > boost_1_86_0.tar.bz2
+  $ tar --bzip2 -xf boost_1_86_0.tar.bz2 && cd boost_1_86_0
   $ ./bootstrap.sh --prefix=/usr/
   $ ./b2 --without-python
   $ sudo ./b2 --without-python install
@@ -493,9 +493,9 @@ Building on CentOS 8
   $ sudo make install
 
 * Install boost.
-  $ curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
-  $ tar xjf boost_1_72_0.tar.bz2
-  $ cd boost_1_72_0
+  $ curl -L -o boost_1_86_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download
+  $ tar xjf boost_1_86_0.tar.bz2
+  $ cd boost_1_86_0
   $ ./bootstrap.sh --prefix=/usr/local
   $ ./b2
   $ sudo ./b2 install

--- a/dev-support/docker/pkg-resolver/install-boost.sh
+++ b/dev-support/docker/pkg-resolver/install-boost.sh
@@ -27,25 +27,25 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-default_version="1.72.0"
+default_version="1.86.0"
 version_to_install=$default_version
 if [ -n "$2" ]; then
   version_to_install="$2"
 fi
 
-if [ "$version_to_install" != "1.72.0" ]; then
+if [ "$version_to_install" != "1.86.0" ]; then
   echo "WARN: Don't know how to install version $version_to_install, installing the default version $default_version instead"
   version_to_install=$default_version
 fi
 
-if [ "$version_to_install" == "1.72.0" ]; then
+if [ "$version_to_install" == "1.86.0" ]; then
   # hadolint ignore=DL3003
   mkdir -p /opt/boost-library &&
-    curl -L https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download >boost_1_72_0.tar.bz2 &&
-    mv boost_1_72_0.tar.bz2 /opt/boost-library &&
+    curl -L https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download >boost_1_86_0.tar.bz2 &&
+    mv boost_1_86_0.tar.bz2 /opt/boost-library &&
     cd /opt/boost-library &&
-    tar --bzip2 -xf boost_1_72_0.tar.bz2 &&
-    cd /opt/boost-library/boost_1_72_0 &&
+    tar --bzip2 -xf boost_1_86_0.tar.bz2 &&
+    cd /opt/boost-library/boost_1_86_0 &&
     ./bootstrap.sh --prefix=/usr/ &&
     ./b2 --without-python install &&
     cd /root &&

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -28,7 +28,7 @@ project (libhdfspp)
 
 cmake_minimum_required(VERSION 2.8)
 
-find_package (Boost 1.72.0 REQUIRED COMPONENTS date_time)
+find_package (Boost 1.86.0 REQUIRED COMPONENTS date_time)
 
 enable_testing()
 set(CMAKE_CXX_STANDARD 17)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tools/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-find_package(Boost 1.72 COMPONENTS program_options REQUIRED)
+find_package(Boost 1.86 COMPONENTS program_options REQUIRED)
 
 # Default LIBHDFSPP_DIR to the default install location.  You can override
 #    it by add -DLIBHDFSPP_DIR=... to your cmake invocation


### PR DESCRIPTION
### Description of PR

Update Boost library version to 1.86.0

### How was this patch tested?

Test suite on CI

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

