### PR TITLE
HDFS-17745. TestRouterMountTable should reset defaultNSEnable to true after each test method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterMountTable.java
@@ -132,6 +132,7 @@ public class TestRouterMountTable {
           RemoveMountTableEntryRequest.newInstance(entry.getSourcePath());
       mountTableManager.removeMountTableEntry(req2);
     }
+    mountTable.setDefaultNSEnable(true);
   }
 
   @Test


### PR DESCRIPTION
### Description of PR
TestRouterMountTable should reset `defaultNSEnable` to true after each test method.

Because we invoke `mountTable.setDefaultNSEnable(false);` in method testListNonExistPath and testListWhenDisableDefaultMountTable,  but we don't reset to true in any place.
 
The failure of unit tests can be reproduced by adding `@FixMethodOrder(MethodSorters.NAME_ASCENDING) to this class.`

### How was this patch tested?
modify the unit test.