### PR TITLE
YARN-11268. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-documentstore.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
@@ -188,7 +188,11 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreCollectionCreator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreCollectionCreator.java
@@ -26,9 +26,8 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.Docume
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.DummyDocumentStoreWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -37,8 +36,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test case for ${@link DocumentStoreCollectionCreator}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentStoreFactory.class)
+@ExtendWith(MockitoExtension.class)
 public class TestDocumentStoreCollectionCreator {
 
   private final DocumentStoreWriter<TimelineDocument> documentStoreWriter = new

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreCollectionCreator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreCollectionCreator.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.lib.DocumentStoreFactory;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.DocumentStoreWriter;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.DummyDocumentStoreWriter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -45,7 +45,7 @@ public class TestDocumentStoreCollectionCreator {
       DummyDocumentStoreWriter<>();
   private final Configuration conf = new Configuration();
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException {
     conf.set(DocumentStoreUtils.TIMELINE_SERVICE_DOCUMENTSTORE_DATABASE_NAME,
         "TestDB");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineReaderImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineReaderImpl.java
@@ -38,31 +38,30 @@ import org.apache.hadoop.yarn.server.timelineservice.storage.TimelineReader;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.TimelineDocument;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineEntityDocument;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
  * Test case for {@link DocumentStoreTimelineReaderImpl}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentStoreFactory.class)
+@ExtendWith(MockitoExtension.class)
 public class TestDocumentStoreTimelineReaderImpl {
 
   private final DocumentStoreReader<TimelineDocument> documentStoreReader = new
@@ -84,7 +83,7 @@ public class TestDocumentStoreTimelineReaderImpl {
 
   private MockedStatic<DocumentStoreFactory> documentStoreFactoryMockedStatic;
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException {
     conf.set(DocumentStoreUtils.TIMELINE_SERVICE_DOCUMENTSTORE_DATABASE_NAME,
         "TestDB");
@@ -98,14 +97,16 @@ public class TestDocumentStoreTimelineReaderImpl {
         .thenReturn(documentStoreReader);
   }
 
-  @After
+  @AfterEach
   public void close() {
     documentStoreFactoryMockedStatic.close();
   }
 
-  @Test(expected = YarnException.class)
+  @Test
   public void testFailOnNoCosmosDBConfigs() throws Exception {
-    DocumentStoreUtils.validateCosmosDBConf(new Configuration());
+    assertThrows(YarnException.class, () -> {
+      DocumentStoreUtils.validateCosmosDBConf(new Configuration());
+    });
   }
 
   @Test
@@ -120,12 +121,12 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assert.assertEquals(0, timelineEntity .getMetrics().size());
-    Assert.assertEquals(0, timelineEntity.getEvents().size());
-    Assert.assertEquals(0, timelineEntity.getConfigs().size());
-    Assert.assertEquals(appTimelineEntity.getInfo().size(),
+    Assertions.assertEquals(0, timelineEntity .getMetrics().size());
+    Assertions.assertEquals(0, timelineEntity.getEvents().size());
+    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
+    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -139,13 +140,13 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assert.assertEquals(appTimelineEntity.getMetrics().size(),
+    Assertions.assertEquals(appTimelineEntity.getMetrics().size(),
         timelineEntity.getMetrics().size());
-    Assert.assertEquals(0, timelineEntity.getEvents().size());
-    Assert.assertEquals(0, timelineEntity.getConfigs().size());
-    Assert.assertEquals(appTimelineEntity.getInfo().size(),
+    Assertions.assertEquals(0, timelineEntity.getEvents().size());
+    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
+    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -159,15 +160,15 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assert.assertEquals(appTimelineEntity.getMetrics().size(),
+    Assertions.assertEquals(appTimelineEntity.getMetrics().size(),
         timelineEntity .getMetrics().size());
-    Assert.assertEquals(appTimelineEntity.getEvents().size(),
+    Assertions.assertEquals(appTimelineEntity.getEvents().size(),
         timelineEntity.getEvents().size());
-    Assert.assertEquals(appTimelineEntity.getConfigs().size(),
+    Assertions.assertEquals(appTimelineEntity.getConfigs().size(),
         timelineEntity.getConfigs().size());
-    Assert.assertEquals(appTimelineEntity.getInfo().size(),
+    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -181,7 +182,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     Set<TimelineEntity> actualEntities = timelineReader.getEntities(context,
         new TimelineEntityFilters.Builder().build(), dataToRetrieve);
 
-    Assert.assertEquals(entities.size(), actualEntities.size());
+    Assertions.assertEquals(entities.size(), actualEntities.size());
   }
 
   @Test
@@ -194,7 +195,7 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().entityLimit(2L).build(),
         dataToRetrieve);
 
-    Assert.assertEquals(2, actualEntities.size());
+    Assertions.assertEquals(2, actualEntities.size());
   }
 
   @Test
@@ -207,7 +208,7 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().createdTimeBegin(1533985554927L)
             .createTimeEnd(1533985554927L).build(), dataToRetrieve);
 
-    Assert.assertEquals(1, actualEntities.size());
+    Assertions.assertEquals(1, actualEntities.size());
   }
 
   @Test
@@ -227,11 +228,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().infoFilters(infoFilterList).build(),
         dataToRetrieve);
 
-    Assert.assertEquals(1, actualEntities.size());
+    Assertions.assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_APPLICATION_ATTEMPT should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_APPLICATION_ATTEMPT")) {
-        Assert.fail("Incorrect filtering based on info filters");
+        Assertions.fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -245,11 +246,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().configFilters(confFilterList)
             .build(), dataToRetrieve);
 
-    Assert.assertEquals(1, actualEntities.size());
+    Assertions.assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_APPLICATION should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_APPLICATION")) {
-        Assert.fail("Incorrect filtering based on info filters");
+        Assertions.fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -263,11 +264,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().eventFilters(eventFilters).build(),
         dataToRetrieve);
 
-    Assert.assertEquals(1, actualEntities.size());
+    Assertions.assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_CONTAINER should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_CONTAINER")) {
-        Assert.fail("Incorrect filtering based on info filters");
+        Assertions.fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -279,11 +280,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().metricFilters(metricFilterList)
             .build(), dataToRetrieve);
 
-    Assert.assertEquals(1, actualEntities.size());
+    Assertions.assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_CONTAINER should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_CONTAINER")) {
-        Assert.fail("Incorrect filtering based on info filters");
+        Assertions.fail("Incorrect filtering based on info filters");
       }
     }
   }
@@ -300,7 +301,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
+    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
         timelineEntity.getType());
 
     // reading YARN_FLOW_RUN
@@ -308,7 +309,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(TimelineEntityType.YARN_FLOW_RUN.toString(),
+    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_RUN.toString(),
         timelineEntity.getType());
 
     // reading YARN_APPLICATION
@@ -316,7 +317,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assert.assertEquals(TimelineEntityType.YARN_APPLICATION.toString(),
+    Assertions.assertEquals(TimelineEntityType.YARN_APPLICATION.toString(),
         timelineEntity.getType());
   }
 
@@ -327,9 +328,9 @@ public class TestDocumentStoreTimelineReaderImpl {
 
     context.setEntityType(TimelineEntityType.YARN_CONTAINER.toString());
     Set<String> entityTypes = timelineReader.getEntityTypes(context);
-    Assert.assertTrue(entityTypes.contains(TimelineEntityType.YARN_CONTAINER
+    Assertions.assertTrue(entityTypes.contains(TimelineEntityType.YARN_CONTAINER
         .toString()));
-    Assert.assertTrue(entityTypes.contains(TimelineEntityType
+    Assertions.assertTrue(entityTypes.contains(TimelineEntityType
         .YARN_APPLICATION_ATTEMPT.toString()));
   }
 
@@ -351,7 +352,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertEquals(0, timelineEntity.getMetrics().size());
+    Assertions.assertEquals(0, timelineEntity.getMetrics().size());
 
     timelineFilterList.addFilter(new TimelinePrefixFilter(
         TimelineCompareOp.EQUAL,
@@ -361,19 +362,19 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertTrue(timelineEntity.getMetrics().size() > 0);
+    Assertions.assertTrue(timelineEntity.getMetrics().size() > 0);
 
     //testing metrics prefix for AND condition
     timelineFilterList.setOperator(TimelineFilterList.Operator.AND);
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertEquals(0, timelineEntity.getMetrics().size());
+    Assertions.assertEquals(0, timelineEntity.getMetrics().size());
 
     dataToRetrieve.getMetricsToRetrieve().getFilterList().remove(0);
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertTrue(timelineEntity.getMetrics().size() > 0);
+    Assertions.assertTrue(timelineEntity.getMetrics().size() > 0);
   }
 
   @Test
@@ -394,7 +395,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertEquals(0, timelineEntity.getConfigs().size());
+    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
 
     timelineFilterList.addFilter(new TimelinePrefixFilter(
         TimelineCompareOp.EQUAL, "YARN_AM_NODE_LABEL_EXPRESSION"));
@@ -403,18 +404,18 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertTrue(timelineEntity.getConfigs().size() > 0);
+    Assertions.assertTrue(timelineEntity.getConfigs().size() > 0);
 
     //testing metrics prefix for AND condition
     timelineFilterList.setOperator(TimelineFilterList.Operator.AND);
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertEquals(0, timelineEntity.getConfigs().size());
+    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
 
     dataToRetrieve.getConfsToRetrieve().getFilterList().remove(0);
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assert.assertTrue(timelineEntity.getConfigs().size() > 0);
+    Assertions.assertTrue(timelineEntity.getConfigs().size() > 0);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineReaderImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineReaderImpl.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineEntityDocument;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,7 +53,10 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -121,12 +123,12 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assertions.assertEquals(0, timelineEntity .getMetrics().size());
-    Assertions.assertEquals(0, timelineEntity.getEvents().size());
-    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
-    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
+    assertEquals(0, timelineEntity .getMetrics().size());
+    assertEquals(0, timelineEntity.getEvents().size());
+    assertEquals(0, timelineEntity.getConfigs().size());
+    assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -140,13 +142,13 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assertions.assertEquals(appTimelineEntity.getMetrics().size(),
+    assertEquals(appTimelineEntity.getMetrics().size(),
         timelineEntity.getMetrics().size());
-    Assertions.assertEquals(0, timelineEntity.getEvents().size());
-    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
-    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
+    assertEquals(0, timelineEntity.getEvents().size());
+    assertEquals(0, timelineEntity.getConfigs().size());
+    assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -160,15 +162,15 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
+    assertEquals(appTimelineEntity.getCreatedTime(), timelineEntity
         .getCreatedTime().longValue());
-    Assertions.assertEquals(appTimelineEntity.getMetrics().size(),
+    assertEquals(appTimelineEntity.getMetrics().size(),
         timelineEntity .getMetrics().size());
-    Assertions.assertEquals(appTimelineEntity.getEvents().size(),
+    assertEquals(appTimelineEntity.getEvents().size(),
         timelineEntity.getEvents().size());
-    Assertions.assertEquals(appTimelineEntity.getConfigs().size(),
+    assertEquals(appTimelineEntity.getConfigs().size(),
         timelineEntity.getConfigs().size());
-    Assertions.assertEquals(appTimelineEntity.getInfo().size(),
+    assertEquals(appTimelineEntity.getInfo().size(),
         timelineEntity.getInfo().size());
   }
 
@@ -182,7 +184,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     Set<TimelineEntity> actualEntities = timelineReader.getEntities(context,
         new TimelineEntityFilters.Builder().build(), dataToRetrieve);
 
-    Assertions.assertEquals(entities.size(), actualEntities.size());
+    assertEquals(entities.size(), actualEntities.size());
   }
 
   @Test
@@ -195,7 +197,7 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().entityLimit(2L).build(),
         dataToRetrieve);
 
-    Assertions.assertEquals(2, actualEntities.size());
+    assertEquals(2, actualEntities.size());
   }
 
   @Test
@@ -208,7 +210,7 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().createdTimeBegin(1533985554927L)
             .createTimeEnd(1533985554927L).build(), dataToRetrieve);
 
-    Assertions.assertEquals(1, actualEntities.size());
+    assertEquals(1, actualEntities.size());
   }
 
   @Test
@@ -228,11 +230,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().infoFilters(infoFilterList).build(),
         dataToRetrieve);
 
-    Assertions.assertEquals(1, actualEntities.size());
+    assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_APPLICATION_ATTEMPT should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_APPLICATION_ATTEMPT")) {
-        Assertions.fail("Incorrect filtering based on info filters");
+        fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -246,11 +248,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().configFilters(confFilterList)
             .build(), dataToRetrieve);
 
-    Assertions.assertEquals(1, actualEntities.size());
+    assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_APPLICATION should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_APPLICATION")) {
-        Assertions.fail("Incorrect filtering based on info filters");
+        fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -264,11 +266,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().eventFilters(eventFilters).build(),
         dataToRetrieve);
 
-    Assertions.assertEquals(1, actualEntities.size());
+    assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_CONTAINER should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_CONTAINER")) {
-        Assertions.fail("Incorrect filtering based on info filters");
+        fail("Incorrect filtering based on info filters");
       }
     }
 
@@ -280,11 +282,11 @@ public class TestDocumentStoreTimelineReaderImpl {
         new TimelineEntityFilters.Builder().metricFilters(metricFilterList)
             .build(), dataToRetrieve);
 
-    Assertions.assertEquals(1, actualEntities.size());
+    assertEquals(1, actualEntities.size());
     // Only one entity with type YARN_CONTAINER should be returned.
     for (TimelineEntity entity : actualEntities) {
       if (!entity.getType().equals("YARN_CONTAINER")) {
-        Assertions.fail("Incorrect filtering based on info filters");
+        fail("Incorrect filtering based on info filters");
       }
     }
   }
@@ -301,7 +303,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
+    assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
         timelineEntity.getType());
 
     // reading YARN_FLOW_RUN
@@ -309,7 +311,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_RUN.toString(),
+    assertEquals(TimelineEntityType.YARN_FLOW_RUN.toString(),
         timelineEntity.getType());
 
     // reading YARN_APPLICATION
@@ -317,7 +319,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
 
-    Assertions.assertEquals(TimelineEntityType.YARN_APPLICATION.toString(),
+    assertEquals(TimelineEntityType.YARN_APPLICATION.toString(),
         timelineEntity.getType());
   }
 
@@ -328,9 +330,9 @@ public class TestDocumentStoreTimelineReaderImpl {
 
     context.setEntityType(TimelineEntityType.YARN_CONTAINER.toString());
     Set<String> entityTypes = timelineReader.getEntityTypes(context);
-    Assertions.assertTrue(entityTypes.contains(TimelineEntityType.YARN_CONTAINER
+    assertTrue(entityTypes.contains(TimelineEntityType.YARN_CONTAINER
         .toString()));
-    Assertions.assertTrue(entityTypes.contains(TimelineEntityType
+    assertTrue(entityTypes.contains(TimelineEntityType
         .YARN_APPLICATION_ATTEMPT.toString()));
   }
 
@@ -352,7 +354,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertEquals(0, timelineEntity.getMetrics().size());
+    assertEquals(0, timelineEntity.getMetrics().size());
 
     timelineFilterList.addFilter(new TimelinePrefixFilter(
         TimelineCompareOp.EQUAL,
@@ -362,19 +364,19 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertTrue(timelineEntity.getMetrics().size() > 0);
+    assertTrue(timelineEntity.getMetrics().size() > 0);
 
     //testing metrics prefix for AND condition
     timelineFilterList.setOperator(TimelineFilterList.Operator.AND);
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertEquals(0, timelineEntity.getMetrics().size());
+    assertEquals(0, timelineEntity.getMetrics().size());
 
     dataToRetrieve.getMetricsToRetrieve().getFilterList().remove(0);
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertTrue(timelineEntity.getMetrics().size() > 0);
+    assertTrue(timelineEntity.getMetrics().size() > 0);
   }
 
   @Test
@@ -395,7 +397,7 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     TimelineEntity timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
+    assertEquals(0, timelineEntity.getConfigs().size());
 
     timelineFilterList.addFilter(new TimelinePrefixFilter(
         TimelineCompareOp.EQUAL, "YARN_AM_NODE_LABEL_EXPRESSION"));
@@ -404,18 +406,18 @@ public class TestDocumentStoreTimelineReaderImpl {
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertTrue(timelineEntity.getConfigs().size() > 0);
+    assertTrue(timelineEntity.getConfigs().size() > 0);
 
     //testing metrics prefix for AND condition
     timelineFilterList.setOperator(TimelineFilterList.Operator.AND);
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertEquals(0, timelineEntity.getConfigs().size());
+    assertEquals(0, timelineEntity.getConfigs().size());
 
     dataToRetrieve.getConfsToRetrieve().getFilterList().remove(0);
     context.setEntityType(TimelineEntityType.YARN_APPLICATION.toString());
     timelineEntity = timelineReader.getEntity(context,
         dataToRetrieve);
-    Assertions.assertTrue(timelineEntity.getConfigs().size() > 0);
+    assertTrue(timelineEntity.getConfigs().size() > 0);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineWriterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineWriterImpl.java
@@ -28,24 +28,25 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.DocumentStoreWriter;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.writer.DummyDocumentStoreWriter;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
 
 /**
  * Test case for {@link DocumentStoreTimelineWriterImpl}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentStoreFactory.class)
+@ExtendWith(MockitoExtension.class)
 public class TestDocumentStoreTimelineWriterImpl {
 
   private final DocumentStoreWriter<TimelineDocument> documentStoreWriter = new
@@ -53,7 +54,7 @@ public class TestDocumentStoreTimelineWriterImpl {
   private final Configuration conf = new Configuration();
   private MockedStatic<DocumentStoreFactory> mockedFactory;
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException {
     conf.set(DocumentStoreUtils.TIMELINE_SERVICE_DOCUMENTSTORE_DATABASE_NAME,
         "TestDB");
@@ -67,16 +68,18 @@ public class TestDocumentStoreTimelineWriterImpl {
             .thenReturn(documentStoreWriter);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (mockedFactory != null) {
       mockedFactory.close();
     }
   }
 
-  @Test(expected = YarnException.class)
+  @Test
   public void testFailOnNoCosmosDBConfigs() throws Exception {
-    DocumentStoreUtils.validateCosmosDBConf(new Configuration());
+    assertThrows(YarnException.class, ()->{
+      DocumentStoreUtils.validateCosmosDBConf(new Configuration());
+    });
   }
 
   @Test
@@ -91,7 +94,9 @@ public class TestDocumentStoreTimelineWriterImpl {
     entities.addEntity(DocumentStoreTestUtils.bakeTimelineEntityDoc()
         .fetchTimelineEntity());
 
-    PowerMockito.verifyStatic(DocumentStoreFactory.class);
+    mockedFactory.verify(()->
+        DocumentStoreFactory.createDocumentStoreWriter(ArgumentMatchers.any(Configuration.class)),
+        times(4));
 
     TimelineCollectorContext context = new TimelineCollectorContext();
     context.setFlowName("TestFlow");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineWriterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/TestDocumentStoreTimelineWriterImpl.java
@@ -38,7 +38,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.powermock.api.mockito.PowerMockito;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/collection/TestDocumentOperations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/collection/TestDocumentOperations.java
@@ -26,10 +26,12 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineMetricSubDoc;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.flowactivity.FlowActivityDocument;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.flowrun.FlowRunDocument;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Timeline Entity Document merge and aggregation test.
@@ -47,26 +49,26 @@ public class TestDocumentOperations {
     TimelineEntityDocument expectedEntityDoc =
         DocumentStoreTestUtils.bakeTimelineEntityDoc();
 
-    Assertions.assertEquals(1, actualEntityDoc.getInfo().size());
-    Assertions.assertEquals(0, actualEntityDoc.getMetrics().size());
-    Assertions.assertEquals(0, actualEntityDoc.getEvents().size());
-    Assertions.assertEquals(0, actualEntityDoc.getConfigs().size());
-    Assertions.assertEquals(0, actualEntityDoc.getIsRelatedToEntities().size());
-    Assertions.assertEquals(0, actualEntityDoc.getRelatesToEntities().size());
+    assertEquals(1, actualEntityDoc.getInfo().size());
+    assertEquals(0, actualEntityDoc.getMetrics().size());
+    assertEquals(0, actualEntityDoc.getEvents().size());
+    assertEquals(0, actualEntityDoc.getConfigs().size());
+    assertEquals(0, actualEntityDoc.getIsRelatedToEntities().size());
+    assertEquals(0, actualEntityDoc.getRelatesToEntities().size());
 
     actualEntityDoc.merge(expectedEntityDoc);
 
-    Assertions.assertEquals(expectedEntityDoc.getInfo().size(),
+    assertEquals(expectedEntityDoc.getInfo().size(),
         actualEntityDoc.getInfo().size());
-    Assertions.assertEquals(expectedEntityDoc.getMetrics().size(),
+    assertEquals(expectedEntityDoc.getMetrics().size(),
         actualEntityDoc.getMetrics().size());
-    Assertions.assertEquals(expectedEntityDoc.getEvents().size(),
+    assertEquals(expectedEntityDoc.getEvents().size(),
         actualEntityDoc.getEvents().size());
-    Assertions.assertEquals(expectedEntityDoc.getConfigs().size(),
+    assertEquals(expectedEntityDoc.getConfigs().size(),
         actualEntityDoc.getConfigs().size());
-    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getRelatesToEntities().size());
   }
 
@@ -76,27 +78,27 @@ public class TestDocumentOperations {
     FlowActivityDocument expectedFlowActivityDoc =
         DocumentStoreTestUtils.bakeFlowActivityDoc();
 
-    Assertions.assertEquals(0, actualFlowActivityDoc.getDayTimestamp());
-    Assertions.assertEquals(0, actualFlowActivityDoc.getFlowActivities().size());
-    Assertions.assertNull(actualFlowActivityDoc.getFlowName());
-    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
+    assertEquals(0, actualFlowActivityDoc.getDayTimestamp());
+    assertEquals(0, actualFlowActivityDoc.getFlowActivities().size());
+    assertNull(actualFlowActivityDoc.getFlowName());
+    assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
         actualFlowActivityDoc.getType());
-    Assertions.assertNull(actualFlowActivityDoc.getUser());
-    Assertions.assertNull(actualFlowActivityDoc.getId());
+    assertNull(actualFlowActivityDoc.getUser());
+    assertNull(actualFlowActivityDoc.getId());
 
     actualFlowActivityDoc.merge(expectedFlowActivityDoc);
 
-    Assertions.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
+    assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
         actualFlowActivityDoc.getDayTimestamp());
-    Assertions.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
+    assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
         actualFlowActivityDoc.getFlowActivities().size());
-    Assertions.assertEquals(expectedFlowActivityDoc.getFlowName(),
+    assertEquals(expectedFlowActivityDoc.getFlowName(),
         actualFlowActivityDoc.getFlowName());
-    Assertions.assertEquals(expectedFlowActivityDoc.getType(),
+    assertEquals(expectedFlowActivityDoc.getType(),
         actualFlowActivityDoc.getType());
-    Assertions.assertEquals(expectedFlowActivityDoc.getUser(),
+    assertEquals(expectedFlowActivityDoc.getUser(),
         actualFlowActivityDoc.getUser());
-    Assertions.assertEquals(expectedFlowActivityDoc.getId(),
+    assertEquals(expectedFlowActivityDoc.getId(),
         actualFlowActivityDoc.getId());
 
     expectedFlowActivityDoc.addFlowActivity(FLOW_NAME,
@@ -104,17 +106,17 @@ public class TestDocumentOperations {
 
     actualFlowActivityDoc.merge(expectedFlowActivityDoc);
 
-    Assertions.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
+    assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
         actualFlowActivityDoc.getDayTimestamp());
-    Assertions.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
+    assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
         actualFlowActivityDoc.getFlowActivities().size());
-    Assertions.assertEquals(expectedFlowActivityDoc.getFlowName(),
+    assertEquals(expectedFlowActivityDoc.getFlowName(),
         actualFlowActivityDoc.getFlowName());
-    Assertions.assertEquals(expectedFlowActivityDoc.getType(),
+    assertEquals(expectedFlowActivityDoc.getType(),
         actualFlowActivityDoc.getType());
-    Assertions.assertEquals(expectedFlowActivityDoc.getUser(),
+    assertEquals(expectedFlowActivityDoc.getUser(),
         actualFlowActivityDoc.getUser());
-    Assertions.assertEquals(expectedFlowActivityDoc.getId(),
+    assertEquals(expectedFlowActivityDoc.getId(),
         actualFlowActivityDoc.getId());
   }
 
@@ -135,43 +137,43 @@ public class TestDocumentOperations {
         timelineMetric);
     expectedFlowRunDoc.getMetrics().put(MEMORY_ID, metricSubDoc);
 
-    Assertions.assertNull(actualFlowRunDoc.getClusterId());
-    Assertions.assertNull(actualFlowRunDoc.getFlowName());
-    Assertions.assertNull(actualFlowRunDoc.getFlowRunId());
-    Assertions.assertNull(actualFlowRunDoc.getFlowVersion());
-    Assertions.assertNull(actualFlowRunDoc.getId());
-    Assertions.assertNull(actualFlowRunDoc.getUsername());
-    Assertions.assertEquals(actualFlowRunDoc.getType(), TimelineEntityType.
+    assertNull(actualFlowRunDoc.getClusterId());
+    assertNull(actualFlowRunDoc.getFlowName());
+    assertNull(actualFlowRunDoc.getFlowRunId());
+    assertNull(actualFlowRunDoc.getFlowVersion());
+    assertNull(actualFlowRunDoc.getId());
+    assertNull(actualFlowRunDoc.getUsername());
+    assertEquals(actualFlowRunDoc.getType(), TimelineEntityType.
         YARN_FLOW_RUN.toString());
-    Assertions.assertEquals(0, actualFlowRunDoc.getMinStartTime());
-    Assertions.assertEquals(0, actualFlowRunDoc.getMaxEndTime());
-    Assertions.assertEquals(0, actualFlowRunDoc.getMetrics().size());
+    assertEquals(0, actualFlowRunDoc.getMinStartTime());
+    assertEquals(0, actualFlowRunDoc.getMaxEndTime());
+    assertEquals(0, actualFlowRunDoc.getMetrics().size());
 
     actualFlowRunDoc.merge(expectedFlowRunDoc);
 
-    Assertions.assertEquals(expectedFlowRunDoc.getClusterId(),
+    assertEquals(expectedFlowRunDoc.getClusterId(),
         actualFlowRunDoc.getClusterId());
-    Assertions.assertEquals(expectedFlowRunDoc.getFlowName(),
+    assertEquals(expectedFlowRunDoc.getFlowName(),
         actualFlowRunDoc.getFlowName());
-    Assertions.assertEquals(expectedFlowRunDoc.getFlowRunId(),
+    assertEquals(expectedFlowRunDoc.getFlowRunId(),
         actualFlowRunDoc.getFlowRunId());
-    Assertions.assertEquals(expectedFlowRunDoc.getFlowVersion(),
+    assertEquals(expectedFlowRunDoc.getFlowVersion(),
         actualFlowRunDoc.getFlowVersion());
-    Assertions.assertEquals(expectedFlowRunDoc.getId(), actualFlowRunDoc.getId());
-    Assertions.assertEquals(expectedFlowRunDoc.getUsername(),
+    assertEquals(expectedFlowRunDoc.getId(), actualFlowRunDoc.getId());
+    assertEquals(expectedFlowRunDoc.getUsername(),
         actualFlowRunDoc.getUsername());
-    Assertions.assertEquals(expectedFlowRunDoc.getType(),
+    assertEquals(expectedFlowRunDoc.getType(),
         actualFlowRunDoc.getType());
-    Assertions.assertEquals(expectedFlowRunDoc.getMinStartTime(),
+    assertEquals(expectedFlowRunDoc.getMinStartTime(),
         actualFlowRunDoc.getMinStartTime());
-    Assertions.assertEquals(expectedFlowRunDoc.getMaxEndTime(),
+    assertEquals(expectedFlowRunDoc.getMaxEndTime(),
         actualFlowRunDoc.getMaxEndTime());
-    Assertions.assertEquals(expectedFlowRunDoc.getMetrics().size(),
+    assertEquals(expectedFlowRunDoc.getMetrics().size(),
         actualFlowRunDoc.getMetrics().size());
 
     actualFlowRunDoc.merge(expectedFlowRunDoc);
 
-    Assertions.assertEquals(value + value, actualFlowRunDoc.getMetrics()
+    assertEquals(value + value, actualFlowRunDoc.getMetrics()
         .get(MEMORY_ID).getSingleDataValue());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/collection/TestDocumentOperations.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/collection/TestDocumentOperations.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.do
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineMetricSubDoc;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.flowactivity.FlowActivityDocument;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.flowrun.FlowRunDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -47,26 +47,26 @@ public class TestDocumentOperations {
     TimelineEntityDocument expectedEntityDoc =
         DocumentStoreTestUtils.bakeTimelineEntityDoc();
 
-    Assert.assertEquals(1, actualEntityDoc.getInfo().size());
-    Assert.assertEquals(0, actualEntityDoc.getMetrics().size());
-    Assert.assertEquals(0, actualEntityDoc.getEvents().size());
-    Assert.assertEquals(0, actualEntityDoc.getConfigs().size());
-    Assert.assertEquals(0, actualEntityDoc.getIsRelatedToEntities().size());
-    Assert.assertEquals(0, actualEntityDoc.getRelatesToEntities().size());
+    Assertions.assertEquals(1, actualEntityDoc.getInfo().size());
+    Assertions.assertEquals(0, actualEntityDoc.getMetrics().size());
+    Assertions.assertEquals(0, actualEntityDoc.getEvents().size());
+    Assertions.assertEquals(0, actualEntityDoc.getConfigs().size());
+    Assertions.assertEquals(0, actualEntityDoc.getIsRelatedToEntities().size());
+    Assertions.assertEquals(0, actualEntityDoc.getRelatesToEntities().size());
 
     actualEntityDoc.merge(expectedEntityDoc);
 
-    Assert.assertEquals(expectedEntityDoc.getInfo().size(),
+    Assertions.assertEquals(expectedEntityDoc.getInfo().size(),
         actualEntityDoc.getInfo().size());
-    Assert.assertEquals(expectedEntityDoc.getMetrics().size(),
+    Assertions.assertEquals(expectedEntityDoc.getMetrics().size(),
         actualEntityDoc.getMetrics().size());
-    Assert.assertEquals(expectedEntityDoc.getEvents().size(),
+    Assertions.assertEquals(expectedEntityDoc.getEvents().size(),
         actualEntityDoc.getEvents().size());
-    Assert.assertEquals(expectedEntityDoc.getConfigs().size(),
+    Assertions.assertEquals(expectedEntityDoc.getConfigs().size(),
         actualEntityDoc.getConfigs().size());
-    Assert.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assert.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getRelatesToEntities().size());
   }
 
@@ -76,27 +76,27 @@ public class TestDocumentOperations {
     FlowActivityDocument expectedFlowActivityDoc =
         DocumentStoreTestUtils.bakeFlowActivityDoc();
 
-    Assert.assertEquals(0, actualFlowActivityDoc.getDayTimestamp());
-    Assert.assertEquals(0, actualFlowActivityDoc.getFlowActivities().size());
-    Assert.assertNull(actualFlowActivityDoc.getFlowName());
-    Assert.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
+    Assertions.assertEquals(0, actualFlowActivityDoc.getDayTimestamp());
+    Assertions.assertEquals(0, actualFlowActivityDoc.getFlowActivities().size());
+    Assertions.assertNull(actualFlowActivityDoc.getFlowName());
+    Assertions.assertEquals(TimelineEntityType.YARN_FLOW_ACTIVITY.toString(),
         actualFlowActivityDoc.getType());
-    Assert.assertNull(actualFlowActivityDoc.getUser());
-    Assert.assertNull(actualFlowActivityDoc.getId());
+    Assertions.assertNull(actualFlowActivityDoc.getUser());
+    Assertions.assertNull(actualFlowActivityDoc.getId());
 
     actualFlowActivityDoc.merge(expectedFlowActivityDoc);
 
-    Assert.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
         actualFlowActivityDoc.getDayTimestamp());
-    Assert.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
         actualFlowActivityDoc.getFlowActivities().size());
-    Assert.assertEquals(expectedFlowActivityDoc.getFlowName(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getFlowName(),
         actualFlowActivityDoc.getFlowName());
-    Assert.assertEquals(expectedFlowActivityDoc.getType(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getType(),
         actualFlowActivityDoc.getType());
-    Assert.assertEquals(expectedFlowActivityDoc.getUser(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getUser(),
         actualFlowActivityDoc.getUser());
-    Assert.assertEquals(expectedFlowActivityDoc.getId(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getId(),
         actualFlowActivityDoc.getId());
 
     expectedFlowActivityDoc.addFlowActivity(FLOW_NAME,
@@ -104,17 +104,17 @@ public class TestDocumentOperations {
 
     actualFlowActivityDoc.merge(expectedFlowActivityDoc);
 
-    Assert.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getDayTimestamp(),
         actualFlowActivityDoc.getDayTimestamp());
-    Assert.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getFlowActivities().size(),
         actualFlowActivityDoc.getFlowActivities().size());
-    Assert.assertEquals(expectedFlowActivityDoc.getFlowName(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getFlowName(),
         actualFlowActivityDoc.getFlowName());
-    Assert.assertEquals(expectedFlowActivityDoc.getType(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getType(),
         actualFlowActivityDoc.getType());
-    Assert.assertEquals(expectedFlowActivityDoc.getUser(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getUser(),
         actualFlowActivityDoc.getUser());
-    Assert.assertEquals(expectedFlowActivityDoc.getId(),
+    Assertions.assertEquals(expectedFlowActivityDoc.getId(),
         actualFlowActivityDoc.getId());
   }
 
@@ -135,43 +135,43 @@ public class TestDocumentOperations {
         timelineMetric);
     expectedFlowRunDoc.getMetrics().put(MEMORY_ID, metricSubDoc);
 
-    Assert.assertNull(actualFlowRunDoc.getClusterId());
-    Assert.assertNull(actualFlowRunDoc.getFlowName());
-    Assert.assertNull(actualFlowRunDoc.getFlowRunId());
-    Assert.assertNull(actualFlowRunDoc.getFlowVersion());
-    Assert.assertNull(actualFlowRunDoc.getId());
-    Assert.assertNull(actualFlowRunDoc.getUsername());
-    Assert.assertEquals(actualFlowRunDoc.getType(), TimelineEntityType.
+    Assertions.assertNull(actualFlowRunDoc.getClusterId());
+    Assertions.assertNull(actualFlowRunDoc.getFlowName());
+    Assertions.assertNull(actualFlowRunDoc.getFlowRunId());
+    Assertions.assertNull(actualFlowRunDoc.getFlowVersion());
+    Assertions.assertNull(actualFlowRunDoc.getId());
+    Assertions.assertNull(actualFlowRunDoc.getUsername());
+    Assertions.assertEquals(actualFlowRunDoc.getType(), TimelineEntityType.
         YARN_FLOW_RUN.toString());
-    Assert.assertEquals(0, actualFlowRunDoc.getMinStartTime());
-    Assert.assertEquals(0, actualFlowRunDoc.getMaxEndTime());
-    Assert.assertEquals(0, actualFlowRunDoc.getMetrics().size());
+    Assertions.assertEquals(0, actualFlowRunDoc.getMinStartTime());
+    Assertions.assertEquals(0, actualFlowRunDoc.getMaxEndTime());
+    Assertions.assertEquals(0, actualFlowRunDoc.getMetrics().size());
 
     actualFlowRunDoc.merge(expectedFlowRunDoc);
 
-    Assert.assertEquals(expectedFlowRunDoc.getClusterId(),
+    Assertions.assertEquals(expectedFlowRunDoc.getClusterId(),
         actualFlowRunDoc.getClusterId());
-    Assert.assertEquals(expectedFlowRunDoc.getFlowName(),
+    Assertions.assertEquals(expectedFlowRunDoc.getFlowName(),
         actualFlowRunDoc.getFlowName());
-    Assert.assertEquals(expectedFlowRunDoc.getFlowRunId(),
+    Assertions.assertEquals(expectedFlowRunDoc.getFlowRunId(),
         actualFlowRunDoc.getFlowRunId());
-    Assert.assertEquals(expectedFlowRunDoc.getFlowVersion(),
+    Assertions.assertEquals(expectedFlowRunDoc.getFlowVersion(),
         actualFlowRunDoc.getFlowVersion());
-    Assert.assertEquals(expectedFlowRunDoc.getId(), actualFlowRunDoc.getId());
-    Assert.assertEquals(expectedFlowRunDoc.getUsername(),
+    Assertions.assertEquals(expectedFlowRunDoc.getId(), actualFlowRunDoc.getId());
+    Assertions.assertEquals(expectedFlowRunDoc.getUsername(),
         actualFlowRunDoc.getUsername());
-    Assert.assertEquals(expectedFlowRunDoc.getType(),
+    Assertions.assertEquals(expectedFlowRunDoc.getType(),
         actualFlowRunDoc.getType());
-    Assert.assertEquals(expectedFlowRunDoc.getMinStartTime(),
+    Assertions.assertEquals(expectedFlowRunDoc.getMinStartTime(),
         actualFlowRunDoc.getMinStartTime());
-    Assert.assertEquals(expectedFlowRunDoc.getMaxEndTime(),
+    Assertions.assertEquals(expectedFlowRunDoc.getMaxEndTime(),
         actualFlowRunDoc.getMaxEndTime());
-    Assert.assertEquals(expectedFlowRunDoc.getMetrics().size(),
+    Assertions.assertEquals(expectedFlowRunDoc.getMetrics().size(),
         actualFlowRunDoc.getMetrics().size());
 
     actualFlowRunDoc.merge(expectedFlowRunDoc);
 
-    Assert.assertEquals(value + value, actualFlowRunDoc.getMetrics()
+    Assertions.assertEquals(value + value, actualFlowRunDoc.getMetrics()
         .get(MEMORY_ID).getSingleDataValue());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/TestCosmosDBDocumentStoreReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/TestCosmosDBDocumentStoreReader.java
@@ -22,26 +22,24 @@ import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStoreUtils;
 import org.apache.hadoop.yarn.server.timelineservice.reader.TimelineReaderContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
  * Test case for {@link CosmosDBDocumentStoreReader}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentStoreUtils.class)
+@ExtendWith(MockitoExtension.class)
 public class TestCosmosDBDocumentStoreReader {
 
-  @Before
+  @BeforeEach
   public void setUp(){
     AsyncDocumentClient asyncDocumentClient =
         Mockito.mock(AsyncDocumentClient.class);
@@ -51,17 +49,21 @@ public class TestCosmosDBDocumentStoreReader {
     when(DocumentStoreUtils.createCosmosDBAsyncClient(conf)).thenReturn(asyncDocumentClient);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFailureFOnEmptyPredicates() {
-    PowerMockito.when(DocumentStoreUtils.isNullOrEmpty(
-        ArgumentMatchers.any()))
-        .thenReturn(Boolean.TRUE);
 
-    CosmosDBDocumentStoreReader cosmosDBDocumentStoreReader =
-        new CosmosDBDocumentStoreReader(null);
-    cosmosDBDocumentStoreReader.addPredicates(
-        new TimelineReaderContext(null, "", "",
-            null, "", "", null),
-        "DummyCollection", new StringBuilder());
+    assertThrows(IllegalArgumentException.class, ()->{
+      Mockito.when(DocumentStoreUtils.isNullOrEmpty(
+                      ArgumentMatchers.any()))
+              .thenReturn(Boolean.TRUE);
+
+      CosmosDBDocumentStoreReader cosmosDBDocumentStoreReader =
+              new CosmosDBDocumentStoreReader(null);
+      cosmosDBDocumentStoreReader.addPredicates(
+              new TimelineReaderContext(null, "", "",
+                      null, "", "", null),
+              "DummyCollection", new StringBuilder());
+    });
+
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/TestCosmosDBDocumentStoreReader.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/reader/cosmosdb/TestCosmosDBDocumentStoreReader.java
@@ -54,14 +54,14 @@ public class TestCosmosDBDocumentStoreReader {
 
     assertThrows(IllegalArgumentException.class, ()->{
       Mockito.when(DocumentStoreUtils.isNullOrEmpty(
-                      ArgumentMatchers.any()))
-              .thenReturn(Boolean.TRUE);
+          ArgumentMatchers.any()))
+          .thenReturn(Boolean.TRUE);
 
       CosmosDBDocumentStoreReader cosmosDBDocumentStoreReader =
-              new CosmosDBDocumentStoreReader(null);
+          new CosmosDBDocumentStoreReader(null);
       cosmosDBDocumentStoreReader.addPredicates(
-              new TimelineReaderContext(null, "", "",
-                      null, "", "", null),
+          new TimelineReaderContext(null, "", "",
+              null, "", "", null),
               "DummyCollection", new StringBuilder());
     });
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/writer/cosmosdb/TestCosmosDBDocumentStoreWriter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/writer/cosmosdb/TestCosmosDBDocumentStoreWriter.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStore
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStoreUtils;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.CollectionType;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineEntityDocument;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mockStatic;
 
@@ -65,30 +65,30 @@ public class TestCosmosDBDocumentStoreWriter {
     TimelineEntityDocument expectedEntityDoc =
         DocumentStoreTestUtils.bakeTimelineEntityDoc();
 
-    Assertions.assertEquals(1, actualEntityDoc.getInfo().size());
-    Assertions.assertEquals(0, actualEntityDoc.getMetrics().size());
-    Assertions.assertEquals(0, actualEntityDoc.getEvents().size());
-    Assertions.assertEquals(0, actualEntityDoc.getConfigs().size());
-    Assertions.assertEquals(0,
+    assertEquals(1, actualEntityDoc.getInfo().size());
+    assertEquals(0, actualEntityDoc.getMetrics().size());
+    assertEquals(0, actualEntityDoc.getEvents().size());
+    assertEquals(0, actualEntityDoc.getConfigs().size());
+    assertEquals(0,
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assertions.assertEquals(0, actualEntityDoc.
+    assertEquals(0, actualEntityDoc.
         getRelatesToEntities().size());
 
     actualEntityDoc = (TimelineEntityDocument) documentStoreWriter
         .applyUpdatesOnPrevDoc(CollectionType.ENTITY,
             actualEntityDoc, null);
 
-    Assertions.assertEquals(expectedEntityDoc.getInfo().size(),
+    assertEquals(expectedEntityDoc.getInfo().size(),
         actualEntityDoc.getInfo().size());
-    Assertions.assertEquals(expectedEntityDoc.getMetrics().size(),
+    assertEquals(expectedEntityDoc.getMetrics().size(),
         actualEntityDoc.getMetrics().size());
-    Assertions.assertEquals(expectedEntityDoc.getEvents().size(),
+    assertEquals(expectedEntityDoc.getEvents().size(),
         actualEntityDoc.getEvents().size());
-    Assertions.assertEquals(expectedEntityDoc.getConfigs().size(),
+    assertEquals(expectedEntityDoc.getConfigs().size(),
         actualEntityDoc.getConfigs().size());
-    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getRelatesToEntities().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/writer/cosmosdb/TestCosmosDBDocumentStoreWriter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/src/test/java/org/apache/hadoop/yarn/server/timelineservice/documentstore/writer/cosmosdb/TestCosmosDBDocumentStoreWriter.java
@@ -24,13 +24,12 @@ import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStore
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.DocumentStoreUtils;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.CollectionType;
 import org.apache.hadoop.yarn.server.timelineservice.documentstore.collection.document.entity.TimelineEntityDocument;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 
@@ -40,11 +39,10 @@ import static org.mockito.Mockito.mockStatic;
 /**
  * Test case for {@link CosmosDBDocumentStoreWriter}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DocumentStoreUtils.class)
+@ExtendWith(MockitoExtension.class)
 public class TestCosmosDBDocumentStoreWriter {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     AsyncDocumentClient asyncDocumentClient =
         Mockito.mock(AsyncDocumentClient.class);
@@ -67,30 +65,30 @@ public class TestCosmosDBDocumentStoreWriter {
     TimelineEntityDocument expectedEntityDoc =
         DocumentStoreTestUtils.bakeTimelineEntityDoc();
 
-    Assert.assertEquals(1, actualEntityDoc.getInfo().size());
-    Assert.assertEquals(0, actualEntityDoc.getMetrics().size());
-    Assert.assertEquals(0, actualEntityDoc.getEvents().size());
-    Assert.assertEquals(0, actualEntityDoc.getConfigs().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(1, actualEntityDoc.getInfo().size());
+    Assertions.assertEquals(0, actualEntityDoc.getMetrics().size());
+    Assertions.assertEquals(0, actualEntityDoc.getEvents().size());
+    Assertions.assertEquals(0, actualEntityDoc.getConfigs().size());
+    Assertions.assertEquals(0,
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assert.assertEquals(0, actualEntityDoc.
+    Assertions.assertEquals(0, actualEntityDoc.
         getRelatesToEntities().size());
 
     actualEntityDoc = (TimelineEntityDocument) documentStoreWriter
         .applyUpdatesOnPrevDoc(CollectionType.ENTITY,
             actualEntityDoc, null);
 
-    Assert.assertEquals(expectedEntityDoc.getInfo().size(),
+    Assertions.assertEquals(expectedEntityDoc.getInfo().size(),
         actualEntityDoc.getInfo().size());
-    Assert.assertEquals(expectedEntityDoc.getMetrics().size(),
+    Assertions.assertEquals(expectedEntityDoc.getMetrics().size(),
         actualEntityDoc.getMetrics().size());
-    Assert.assertEquals(expectedEntityDoc.getEvents().size(),
+    Assertions.assertEquals(expectedEntityDoc.getEvents().size(),
         actualEntityDoc.getEvents().size());
-    Assert.assertEquals(expectedEntityDoc.getConfigs().size(),
+    Assertions.assertEquals(expectedEntityDoc.getConfigs().size(),
         actualEntityDoc.getConfigs().size());
-    Assert.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getIsRelatedToEntities().size());
-    Assert.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
+    Assertions.assertEquals(expectedEntityDoc.getRelatesToEntities().size(),
         actualEntityDoc.getRelatesToEntities().size());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11268. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-timelineservice-documentstore.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

