### PR TITLE
HADOOP-19476. Create python3 symlink needed for mvnsite

### DIFF
--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -147,6 +147,8 @@ RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"
+RUN powershell dir 'C:\Python'
+RUN setx PATH "%PATH%;C:\Python"
 
 # We get strange Javadoc errors without this.
 RUN setx classpath ""

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -147,8 +147,11 @@ RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"
-RUN powershell Copy-Item -Path "C:\Python\python.exe" -Destination "C:\Python\python3"
 RUN setx PATH "%PATH%;C:\Python"
+
+# The mvnsite module runs a bash script and somewhere down in the invocation, it resorts to call
+# /usr/bin/env python3. Thus, we need to create the following symbolic link to satisfy this need.
+RUN powershell New-Item -ItemType SymbolicLink -Path "C:\Python\python3" -Target "C:\Python\python.exe"
 
 # We get strange Javadoc errors without this.
 RUN setx classpath ""

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -147,7 +147,7 @@ RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"
-RUN powershell dir 'C:\Python'
+RUN powershell Copy-Item -Path "C:\Python\python.exe" -Destination "C:\Python\python3"
 RUN setx PATH "%PATH%;C:\Python"
 
 # We get strange Javadoc errors without this.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* The mvnsite compilation step needs python3.
  Although we're installing python3 in the build
  environment, the python3 executable is missing.
* Thus, we need to create a symbolic link python3
  pointing to python.exe needed for mvnsite.

Failure logs - [archive.zip](https://github.com/user-attachments/files/19041819/archive.zip)

```
[INFO] ------------------< org.apache.hadoop:hadoop-common >-------------------
[INFO] Building Apache Hadoop Common 3.5.0-SNAPSHOT                    [11/115]
[INFO]   from hadoop-common-project\hadoop-common\pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ hadoop-common ---
[INFO] Deleting C:\hadoop\hadoop-common-project\hadoop-common\target
[INFO] Deleting C:\hadoop\hadoop-common-project\hadoop-common\src\site\markdown (includes = [UnixShellAPI.md], excludes = [])
[INFO] Deleting C:\hadoop\hadoop-common-project\hadoop-common\src\site\resources (includes = [configuration.xsl, core-default.xml], excludes = [])
[INFO] 
[INFO] --- exec-maven-plugin:1.3.1:exec (shelldocs) @ hadoop-common ---
/usr/bin/env: 'python3': No such file or directory
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Hadoop Main 3.5.0-SNAPSHOT:
[INFO] 
[INFO] Apache Hadoop Main ................................. SUCCESS [21:20 min]
...
[INFO] Apache Hadoop Common ............................... FAILURE [  6.722 s]
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21:54 min
[INFO] Finished at: 2025-02-28T07:36:22Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.3.1:exec (shelldocs) on project hadoop-common: Command execution failed. Process exited with an error: 127 (Exit value: 127) -> [Help 1]
[ERROR] 
```

### How was this patch tested?

Jenkins CI validation - https://[ci-hadoop.apache.org/view/Hadoop/job/hadoop-qbt-trunk-java8-win10-x86_64/822/artifact/out/report.html](https://ci-hadoop.apache.org/view/Hadoop/job/hadoop-qbt-trunk-java8-win10-x86_64/822/artifact/out/report.html)

![image](https://github.com/user-attachments/assets/d9623731-c77a-4a33-b818-ffac3eaae8c8)

Yetus logs - [archive.zip](https://github.com/user-attachments/files/19041829/archive.zip)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

