### PR TITLE
HADOOP-19477:Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,11 +28,11 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
         with:
           sparse-checkout: |
             .github
-      - uses: actions/labeler@v4.3.0
+      - uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Hadoop trunk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
         with:
           repository: apache/hadoop
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.7.0
         with:
           java-version: '8'
           distribution: 'temurin'
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -50,7 +50,7 @@ jobs:
       - name: Stage document
         run: mvn site:stage -DstagingDirectory=${GITHUB_WORKSPACE}/staging/
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./staging/hadoop-project


### PR DESCRIPTION
Updated GitHub Actions workflows to use the latest stable versions of various actions

- Updated actions/checkout to v4
- Updated other outdated GitHub Actions dependencies
- Ensured compatibility and successful workflow execution