### PR TITLE
YARN-11783. Upgrade wro4j to 1.8.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -362,6 +362,7 @@ org.objenesis:objenesis:2.6
 org.xerial.snappy:snappy-java:1.1.10.4
 org.yaml:snakeyaml:2.0
 org.wildfly.openssl:wildfly-openssl:2.1.4.Final
+ro.isdc.wro4j:wro4j-maven-plugin:1.8.0
 software.amazon.awssdk:bundle:2.25.53
 net.jodah:failsafe:2.4.4
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
@@ -269,15 +269,7 @@
           <plugin>
             <groupId>ro.isdc.wro4j</groupId>
             <artifactId>wro4j-maven-plugin</artifactId>
-            <version>1.7.9</version>
-            <dependencies>
-              <!-- TODO: Remove this dependency after upgrading wro4j-maven-plugin to 1.8.1 or later. -->
-              <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>4.11.0</version>
-              </dependency>
-            </dependencies>
+            <version>1.8.0</version>
             <executions>
               <execution>
                 <phase>prepare-package</phase>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/WEB-INF/wro.properties
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/WEB-INF/wro.properties
@@ -1,2 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
+#
+
 groups.vendor=vendor.js
 groups.yarn-ui=yarn-ui.js

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/WEB-INF/wro.properties
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/src/main/webapp/WEB-INF/wro.properties
@@ -1,0 +1,2 @@
+groups.vendor=vendor.js
+groups.yarn-ui=yarn-ui.js


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* There was a change to upgrade Mockito to 4.11.0 in #6968.
* This broke the build on Windows in the hadoop-yarn-ui module - https://github.com/apache/hadoop/pull/6968#issuecomment-2688763321.
* We need to upgrade the version wro4j to `1.8.0` to get rid of its dependency on mockito, in order to fix the build failure of `hadoop-yarn-ui` module.
* We tried reverting the wro4j version in #7440. But it looks like this isn't feasible and could impede the JDK17 upgrade of Hadoop.

### How was this patch tested?

Verified by building locally on Windows 11.

![image](https://github.com/user-attachments/assets/683e645a-6921-4411-811a-c9291486d4e1)


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

