### PR TITLE
HDFS-17752. Host2DatanodeMap will not update when re-register a node with a different hostname.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -703,7 +703,10 @@ public class DatanodeManager {
     return host2DatanodeMap.getDatanodeByHost(host);
   }
 
-  /** @return the datanode descriptor for the host. */
+  /**
+   * @param hostname hostname of the datanode
+   * @return the datanode descriptor for the host.
+   */
   public DatanodeDescriptor getDatanodeByHostName(final String hostname) {
     return host2DatanodeMap.getDataNodeByHostName(hostname);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -704,6 +704,11 @@ public class DatanodeManager {
   }
 
   /** @return the datanode descriptor for the host. */
+  public DatanodeDescriptor getDatanodeByHostName(final String hostname) {
+    return host2DatanodeMap.getDataNodeByHostName(hostname);
+  }
+
+  /** @return the datanode descriptor for the host. */
   public DatanodeDescriptor getDatanodeByXferAddr(String host, int xferPort) {
     return host2DatanodeMap.getDatanodeByXferAddr(host, xferPort);
   }
@@ -1235,6 +1240,10 @@ public class DatanodeManager {
           NameNode.stateChangeLog.info("BLOCK* registerDatanode: " + nodeS
               + " is replaced by " + nodeReg + " with the same storageID "
               + nodeReg.getDatanodeUuid());
+        }
+
+        if (!updateHost2DatanodeMap) {
+          updateHost2DatanodeMap = !nodeS.getHostName().equals(nodeReg.getHostName());
         }
         
         boolean success = false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -174,6 +174,21 @@ public class TestDatanodeManager {
 
     assertNull("should be no node with old ip", dm.getDatanodeByHost(ipOld));
     assertNotNull("should be a node with new ip", dm.getDatanodeByHost(ipNew));
+
+    storageID = "someStorageID2";
+    String hostnameOld = "someHostNameOld" + storageID;
+    String hostnameNew = "someHostNameNew" + storageID;
+
+    dm.registerDatanode(new DatanodeRegistration(
+            new DatanodeID("ip", hostnameOld, storageID, 9000, 0, 0, 0),
+            null, null, "version"));
+
+    dm.registerDatanode(new DatanodeRegistration(
+            new DatanodeID("ip", hostnameNew, storageID, 9000, 0, 0, 0),
+            null, null, "version"));
+
+    assertNull("should be no node with old hostname", dm.getDatanodeByHostName(hostnameOld));
+    assertNotNull("should be a node with new hostname", dm.getDatanodeByHostName(hostnameNew));
   }
 
   /**


### PR DESCRIPTION
…with a different hostname


### Description of PR
When same Dn restart with a different hostname, host2DatanodeMap needs to be updated accordingly.

### How was this patch tested?
org.apache.hadoop.hdfs.server.blockmanagement.TestDatanodeManager#testHost2NodeMapCorrectAfterReregister

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

