### PR TITLE
HADOOP-19480. Upgrades AAL version to 1.0.0.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -206,7 +206,7 @@
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.25.53</aws-java-sdk-v2.version>
     <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
-    <amazon-s3-analyticsaccelerator-s3.version>0.0.4</amazon-s3-analyticsaccelerator-s3.version>
+    <amazon-s3-analyticsaccelerator-s3.version>1.0.0</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -487,6 +487,7 @@
     <dependency>
       <groupId>software.amazon.s3.analyticsaccelerator</groupId>
       <artifactId>analyticsaccelerator-s3</artifactId>
+      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -487,7 +487,6 @@
     <dependency>
       <groupId>software.amazon.s3.analyticsaccelerator</groupId>
       <artifactId>analyticsaccelerator-s3</artifactId>
-      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -64,8 +64,6 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBase {
 
   private static final String PHYSICAL_IO_PREFIX = "physicalio";
-  private static final String LOGICAL_IO_PREFIX = "logicalio";
-
 
   private Path externalTestFile;
 
@@ -174,35 +172,6 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
-  }
-
-  @Test
-  public void testConnectorFrameworkConfigurable() {
-    describe("Verify S3 connector framework reads configuration");
-
-    Configuration conf = new Configuration(getConfiguration());
-
-    //Disable Predictive Prefetching
-    conf.set(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-        "." + LOGICAL_IO_PREFIX + ".prefetching.mode", "all");
-
-    //Set Blobstore Capacity
-    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-        "." + PHYSICAL_IO_PREFIX + ".blobstore.capacity", 1);
-
-    ConnectorConfiguration connectorConfiguration =
-        new ConnectorConfiguration(conf, ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX);
-
-    S3SeekableInputStreamConfiguration configuration =
-        S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration);
-
-    Assertions.assertThat(configuration.getLogicalIOConfiguration().getPrefetchingMode())
-            .as("AnalyticsStream configuration is not set to expected value")
-            .isSameAs(PrefetchMode.ALL);
-
-    Assertions.assertThat(configuration.getPhysicalIOConfiguration().getBlobStoreCapacity())
-            .as("AnalyticsStream configuration is not set to expected value")
-            .isEqualTo(1);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.statistics.IOStatistics;
 
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
-import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
 
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_PARQUET;


### PR DESCRIPTION
### Description of PR

 Latest version of AAL is now available, changes since 0.0.4:

* Moves all logging to debug
* Adds in timeout and retries to requests to mitigate (very rare) hanging seen when reading from AsyncClient, related github issue: https://github.com/aws/aws-sdk-java-v2/issues/5755

### How was this patch tested?

Ran ITestS3AAnalyticsAcceleratorStreamReading, will run the test suite once it's available in Maven!

