### PR TITLE
HDFS-15474: Enable WebHdfsFileSystem to parse InvalidToken responce from HttpFS

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -520,7 +520,7 @@ public class WebHdfsFileSystem extends FileSystem
       final Map<?, ?> m;
       try {
         m = jsonParse(conn, true);
-      } catch(Exception e) {
+      } catch (Exception e) {
         throw new IOException("Unexpected HTTP response: code=" + code + " != "
             + op.getExpectedHttpResponseCode() + ", " + op.toQueryString()
             + ", message=" + conn.getResponseMessage(), e);
@@ -536,22 +536,28 @@ public class WebHdfsFileSystem extends FileSystem
 
       IOException re = JsonUtilClient.toRemoteException(m);
 
-      //check if exception is due to communication with a Standby name node
-      if (re.getMessage() != null && re.getMessage().endsWith(
-          StandbyException.class.getSimpleName())) {
+      if (re.getMessage() == null) {
+        throw unwrapException ? toIOException(re) : re;
+      }
+
+      // check if exception is due to communication with a Standby name node
+      if (re.getMessage().endsWith(StandbyException.class.getSimpleName())) {
         LOG.trace("Detected StandbyException", re);
         throw new IOException(re);
       }
       // extract UGI-related exceptions and unwrap InvalidToken
       // the NN mangles these exceptions but the DN does not and may need
       // to re-fetch a token if either report the token is expired
-      if (re.getMessage() != null && re.getMessage().startsWith(
-          SecurityUtil.FAILED_TO_GET_UGI_MSG_HEADER)) {
-        String[] parts = re.getMessage().split(":\\s+", 3);
-        re = new RemoteException(parts[1], parts[2]);
-        re = ((RemoteException)re).unwrapRemoteException(InvalidToken.class);
+      if (re.getMessage().startsWith(SecurityUtil.FAILED_TO_GET_UGI_MSG_HEADER) ||
+          // For HttpFS responses, there is no header string
+          re.getMessage().startsWith(InvalidToken.class.getName() + ":")) {
+        final String invalidTokenMsg = re.getMessage()
+                .substring(re.getMessage().indexOf(InvalidToken.class.getName()));
+        String[] parts = invalidTokenMsg.split(":\\s+", 2);
+        re = new RemoteException(parts[0], parts[1]);
+        re = ((RemoteException) re).unwrapRemoteException(InvalidToken.class);
       }
-      throw unwrapException? toIOException(re): re;
+      throw unwrapException ? toIOException(re) : re;
     }
     return null;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSResponse.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSResponse.java
@@ -54,276 +54,300 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class TestWebHDFSResponse {
 
-    private ClientAndServer mockWebHDFS;
+  private ClientAndServer mockWebHDFS;
 
-    private final static String WEBHDFS_HOST = "localhost";
-    private final static int WEBHDFS_PORT = 8552;
-    private final static URI WEBHDFS_URI = URI.create("webhdfs://" + WEBHDFS_HOST + ":" + WEBHDFS_PORT);
-    private final static Header CONTENT_TYPE_APPLICATION_JSON = new Header("Content-Type", "application/json");
-    private final static String TEST_WEBHDFS_PATH = "/test1/test2";
-    final HttpRequest FILE_SYSTEM_REQUEST = request()
-            .withMethod("GET")
-            .withPath(WebHdfsFileSystem.PATH_PREFIX + TEST_WEBHDFS_PATH);
+  private final static String WEBHDFS_HOST = "localhost";
+  private final static int WEBHDFS_PORT = 8552;
+  private final static URI WEBHDFS_URI =
+      URI.create("webhdfs://" + WEBHDFS_HOST + ":" + WEBHDFS_PORT);
+  private final static Header CONTENT_TYPE_APPLICATION_JSON =
+      new Header("Content-Type", "application/json");
+  private final static String TEST_WEBHDFS_PATH = "/test1/test2";
+  private final static String INVALID_TOKEN_MESSAGE =
+      SecretManager.InvalidToken.class.getName() + ": " +
+          "token (token for test_user: HDFS_DELEGATION_TOKEN owner=test_user, " +
+          "renewer=test_user, realUser=test_user, issueDate=0, maxDate=99999, " +
+          "sequenceNumber=9999, masterKeyId=999) can't be found in cache";
+  private final static HttpRequest FILE_SYSTEM_REQUEST = request()
+      .withMethod("GET")
+      .withPath(WebHdfsFileSystem.PATH_PREFIX + TEST_WEBHDFS_PATH);
 
-    @Before
-    public void startMockWebHDFSServer() {
-        System.setProperty("hadoop.home.dir", System.getProperty("user.dir"));
-        mockWebHDFS = startClientAndServer(WEBHDFS_PORT);
+  @Before
+  public void startMockWebHDFSServer() {
+    System.setProperty("hadoop.home.dir", System.getProperty("user.dir"));
+    mockWebHDFS = startClientAndServer(WEBHDFS_PORT);
+  }
+
+  @Test
+  public void testSuccess() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"FileStatuses\": {\n" +
+          "    \"FileStatus\": [{\n" +
+          "      \"accessTime\": 1320171722771,\n" +
+          "      \"blockSize\": 33554432,\n" +
+          "      \"group\": \"supergroup\",\n" +
+          "      \"length\": 24930,\n" +
+          "      \"modificationTime\": 1320171722771,\n" +
+          "      \"owner\": \"webuser\",\n" +
+          "      \"pathSuffix\": \"a.patch\",\n" +
+          "      \"permission\": \"644\",\n" +
+          "      \"replication\": 1,\n" +
+          "      \"type\": \"FILE\"\n" +
+          "    }]\n" +
+          "  }\n" +
+          "}\n";
+
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_OK)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
+
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+        fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+      }
     }
+  }
 
-    @Test
-    public void testSuccess() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_OK)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"FileStatuses\": {\n" +
-                                    "    \"FileStatus\": [{\n" +
-                                    "      \"accessTime\": 1320171722771,\n" +
-                                    "      \"blockSize\": 33554432,\n" +
-                                    "      \"group\": \"supergroup\",\n" +
-                                    "      \"length\": 24930,\n" +
-                                    "      \"modificationTime\": 1320171722771,\n" +
-                                    "      \"owner\": \"webuser\",\n" +
-                                    "      \"pathSuffix\": \"a.patch\",\n" +
-                                    "      \"permission\": \"644\",\n" +
-                                    "      \"replication\": 1,\n" +
-                                    "      \"type\": \"FILE\"\n" +
-                                    "    }]\n" +
-                                    "  }\n" +
-                                    "}\n"));
+  @Test(expected = AccessControlException.class)
+  public void testUnAuthorized() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_UNAUTHORIZED));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+        fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+      }
     }
+  }
 
-    @Test(expected = AccessControlException.class)
-    public void testUnAuthorized() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_UNAUTHORIZED));
+  @Test
+  public void testUnexpectedResponse() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+              .withBody("Unexpected error occurred"));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+
+        final Exception e = assertThrows(IOException.class,
+            () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+        assertEquals(JsonParseException.class, e.getCause().getClass());
+      }
     }
+  }
 
-    @Test
-    public void testUnexpectedResponse() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-                            .withBody("Unexpected error occurred"));
+  @Test
+  public void testEmptyResponse() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
 
-                final Exception e = assertThrows(IOException.class,
-                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+        final Exception e = assertThrows(IOException.class,
+            () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
 
-                assertEquals(JsonParseException.class, e.getCause().getClass());
-            }
-        }
+        assertNull(e.getCause());
+      }
     }
+  }
 
-    @Test
-    public void testEmptyResponse() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+  @Test
+  public void testNonRemoteExceptions() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final int expectedStatus = HttpStatus.SC_BAD_REQUEST;
+      final String responseBody = "{\n" +
+          "  \"UnexpectedServerException\": {\n" +
+          "    \"javaClassName\": \"" + UnexpectedServerException.class.getName() + "\",\n" +
+          "    \"exception\": \"" + UnexpectedServerException.class.getSimpleName() + "\",\n" +
+          "    \"message\": \"Unexpected exception thrown\"\n" +
+          "  }\n" +
+          "}";
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(expectedStatus)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-                final Exception e = assertThrows(IOException.class,
-                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
 
-                assertNull(e.getCause());
-            }
-        }
+        final Exception e = assertThrows(IOException.class,
+            () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+        assertThat(e.getMessage(),
+            startsWith(WEBHDFS_HOST + ":" + WEBHDFS_PORT +
+                ": Server returned HTTP response code: " + expectedStatus));
+      }
     }
+  }
 
-    @Test
-    public void testNonRemoteExceptions() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            final int expectedStatus = HttpStatus.SC_BAD_REQUEST;
+  @Test
+  public void testExceptionMessageIsNull() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"RemoteException\": {\n" +
+          "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
+          "    \"exception\": \"" + Exception.class.getSimpleName() + "\"\n" +
+          "  }\n" +
+          "}";
 
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(expectedStatus)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"UnexpectedServerException\": {\n" +
-                                    "    \"javaClassName\": \"" + UnexpectedServerException.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + UnexpectedServerException.class.getSimpleName() + "\",\n" +
-                                    "    \"message\": \"Unexpected exception thrown\"\n" +
-                                    "  }\n" +
-                                    "}"));
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
 
-                final Exception e = assertThrows(IOException.class,
-                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+        final Exception e = assertThrows(IOException.class,
+            () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
 
-                assertThat(e.getMessage(), startsWith(WEBHDFS_HOST + ":" + WEBHDFS_PORT + ": Server returned HTTP response code: " + expectedStatus));
-            }
-        }
+        assertNull(e.getMessage());
+      }
     }
+  }
 
-    @Test
-    public void testExceptionMessageIsNull() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"RemoteException\": {\n" +
-                                    "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + Exception.class.getSimpleName() + "\"\n" +
-                                    "  }\n" +
-                                    "}"));
+  @Test
+  public void testStandbyException() throws IOException {
+    final String reMessage = "Server returned: " + StandbyException.class.getSimpleName();
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"RemoteException\": {\n" +
+          "    \"javaClassName\": \"" + StandbyException.class.getName() + "\",\n" +
+          "    \"exception\": \"" + StandbyException.class.getSimpleName() + "\",\n" +
+          "    \"message\": \"" + reMessage + "\"\n" +
+          "  }\n" +
+          "}";
 
-                final Exception e = assertThrows(IOException.class,
-                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_FORBIDDEN)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-                assertNull(e.getMessage());
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+
+        final Exception e = assertThrows(IOException.class,
+            () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+        assertEquals(WEBHDFS_HOST + ":" + WEBHDFS_PORT + ": " + RemoteException.class.getName() +
+                "(" + StandbyException.class.getName() + "): " + reMessage,
+            e.getMessage());
+      }
     }
+  }
 
-    @Test
-    public void testStandbyException() throws IOException {
-        final String reMessage = "Server returned: " + StandbyException.class.getSimpleName();
+  @Test(expected = SecretManager.InvalidToken.class)
+  public void testInvalidToken() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"RemoteException\": {\n" +
+          "    \"javaClassName\": \"" + SecretManager.InvalidToken.class.getName() + "\",\n" +
+          "    \"exception\": \"" + SecretManager.InvalidToken.class.getSimpleName() + "\",\n" +
+          "    \"message\": \"" + SecurityUtil.FAILED_TO_GET_UGI_MSG_HEADER + " " +
+          INVALID_TOKEN_MESSAGE + "\"\n" +
+          "  }\n" +
+          "}";
 
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"RemoteException\": {\n" +
-                                    "    \"javaClassName\": \"" + StandbyException.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + StandbyException.class.getSimpleName() + "\",\n" +
-                                    "    \"message\": \"" + reMessage + "\"\n" +
-                                    "  }\n" +
-                                    "}"));
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_FORBIDDEN)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-
-                final Exception e = assertThrows(IOException.class,
-                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
-
-                assertEquals(WEBHDFS_HOST + ":" + WEBHDFS_PORT + ": " + RemoteException.class.getName() +
-                                "(" + StandbyException.class.getName() + "): " + reMessage,
-                        e.getMessage());
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+        fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+      }
     }
+  }
 
-    @Test(expected = SecretManager.InvalidToken.class)
-    public void testInvalidToken() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            final String reMessage = SecurityUtil.FAILED_TO_GET_UGI_MSG_HEADER + " " +
-                    SecretManager.InvalidToken.class.getName() + ": " +
-                    "token (token for test_user: HDFS_DELEGATION_TOKEN owner=test_user, renewer=test_user, " +
-                    "realUser=test_user, issueDate=0, maxDate=99999, sequenceNumber=9999, masterKeyId=999) can't be found in cache";
+  @Test(expected = SecretManager.InvalidToken.class)
+  public void testInvalidTokenForHttpFS() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"RemoteException\": {\n" +
+          "    \"javaClassName\": \"" + AuthenticationException.class.getName() + "\",\n" +
+          "    \"exception\": \"" + AuthenticationException.class.getSimpleName() + "\",\n" +
+          "    \"message\": \"" + INVALID_TOKEN_MESSAGE + "\"\n" +
+          "  }\n" +
+          "}";
 
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"RemoteException\": {\n" +
-                                    "    \"javaClassName\": \"" + SecretManager.InvalidToken.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + SecretManager.InvalidToken.class.getSimpleName() + "\",\n" +
-                                    "    \"message\": \"" + reMessage + "\"\n" +
-                                    "  }\n" +
-                                    "}"));
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_FORBIDDEN)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+        fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+      }
     }
+  }
 
-    @Test(expected = SecretManager.InvalidToken.class)
-    public void testInvalidTokenForHttpFS() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            final String reMessage = SecretManager.InvalidToken.class.getName() + ": " +
-                    "token (token for test_user: HDFS_DELEGATION_TOKEN owner=test_user, renewer=test_user, " +
-                    "realUser=test_user, issueDate=0, maxDate=99999, sequenceNumber=9999, masterKeyId=999) can't be found in cache";
+  @Test(expected = RemoteException.class)
+  public void testOtherRemoteException() throws IOException {
+    try (MockServerClient mockWebHDFSServerClient =
+             new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+      final String responseBody = "{\n" +
+          "  \"RemoteException\": {\n" +
+          "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
+          "    \"exception\": \"" + Exception.class.getSimpleName() + "\",\n" +
+          "    \"message\": \"Other RemoteException\"\n" +
+          "  }\n" +
+          "}";
 
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"RemoteException\": {\n" +
-                                    "    \"javaClassName\": \"" + AuthenticationException.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + AuthenticationException.class.getSimpleName() + "\",\n" +
-                                    "    \"message\": \"" + reMessage + "\"\n" +
-                                    "  }\n" +
-                                    "}"));
+      mockWebHDFSServerClient
+          .when(FILE_SYSTEM_REQUEST, exactly(1))
+          .respond(response()
+              .withStatusCode(HttpStatus.SC_FORBIDDEN)
+              .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+              .withBody(responseBody));
 
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
-            }
-        }
+      try (FileSystem fs = new WebHdfsFileSystem()) {
+        fs.initialize(WEBHDFS_URI, new Configuration());
+        fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+      }
     }
+  }
 
-    @Test(expected = RemoteException.class)
-    public void testOtherRemoteException() throws IOException {
-        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
-            mockWebHDFSServerClient
-                    .when(FILE_SYSTEM_REQUEST, exactly(1))
-                    .respond(response()
-                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
-                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
-                            .withBody("{\n" +
-                                    "  \"RemoteException\": {\n" +
-                                    "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
-                                    "    \"exception\": \"" + Exception.class.getSimpleName() + "\",\n" +
-                                    "    \"message\": \"Other RemoteException\"\n" +
-                                    "  }\n" +
-                                    "}"));
-
-            try (FileSystem fs = new WebHdfsFileSystem()) {
-                fs.initialize(WEBHDFS_URI, new Configuration());
-                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
-            }
-        }
-    }
-
-    @After
-    public void stopMockWebHDFSServer() {
-        mockWebHDFS.stop();
-    }
+  @After
+  public void stopMockWebHDFSServer() {
+    mockWebHDFS.stop();
+  }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSResponse.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/web/TestWebHDFSResponse.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.hadoop.hdfs.web;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ipc.StandbyException;
+import org.apache.hadoop.ipc.UnexpectedServerException;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.token.SecretManager;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+
+public class TestWebHDFSResponse {
+
+    private ClientAndServer mockWebHDFS;
+
+    private final static String WEBHDFS_HOST = "localhost";
+    private final static int WEBHDFS_PORT = 8552;
+    private final static URI WEBHDFS_URI = URI.create("webhdfs://" + WEBHDFS_HOST + ":" + WEBHDFS_PORT);
+    private final static Header CONTENT_TYPE_APPLICATION_JSON = new Header("Content-Type", "application/json");
+    private final static String TEST_WEBHDFS_PATH = "/test1/test2";
+    final HttpRequest FILE_SYSTEM_REQUEST = request()
+            .withMethod("GET")
+            .withPath(WebHdfsFileSystem.PATH_PREFIX + TEST_WEBHDFS_PATH);
+
+    @Before
+    public void startMockWebHDFSServer() {
+        System.setProperty("hadoop.home.dir", System.getProperty("user.dir"));
+        mockWebHDFS = startClientAndServer(WEBHDFS_PORT);
+    }
+
+    @Test
+    public void testSuccess() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_OK)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"FileStatuses\": {\n" +
+                                    "    \"FileStatus\": [{\n" +
+                                    "      \"accessTime\": 1320171722771,\n" +
+                                    "      \"blockSize\": 33554432,\n" +
+                                    "      \"group\": \"supergroup\",\n" +
+                                    "      \"length\": 24930,\n" +
+                                    "      \"modificationTime\": 1320171722771,\n" +
+                                    "      \"owner\": \"webuser\",\n" +
+                                    "      \"pathSuffix\": \"a.patch\",\n" +
+                                    "      \"permission\": \"644\",\n" +
+                                    "      \"replication\": 1,\n" +
+                                    "      \"type\": \"FILE\"\n" +
+                                    "    }]\n" +
+                                    "  }\n" +
+                                    "}\n"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+            }
+        }
+    }
+
+    @Test(expected = AccessControlException.class)
+    public void testUnAuthorized() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_UNAUTHORIZED));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+            }
+        }
+    }
+
+    @Test
+    public void testUnexpectedResponse() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                            .withBody("Unexpected error occurred"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+
+                final Exception e = assertThrows(IOException.class,
+                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+                assertEquals(JsonParseException.class, e.getCause().getClass());
+            }
+        }
+    }
+
+    @Test
+    public void testEmptyResponse() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+
+                final Exception e = assertThrows(IOException.class,
+                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+                assertNull(e.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void testNonRemoteExceptions() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            final int expectedStatus = HttpStatus.SC_BAD_REQUEST;
+
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(expectedStatus)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"UnexpectedServerException\": {\n" +
+                                    "    \"javaClassName\": \"" + UnexpectedServerException.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + UnexpectedServerException.class.getSimpleName() + "\",\n" +
+                                    "    \"message\": \"Unexpected exception thrown\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+
+                final Exception e = assertThrows(IOException.class,
+                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+                assertThat(e.getMessage(), startsWith(WEBHDFS_HOST + ":" + WEBHDFS_PORT + ": Server returned HTTP response code: " + expectedStatus));
+            }
+        }
+    }
+
+    @Test
+    public void testExceptionMessageIsNull() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"RemoteException\": {\n" +
+                                    "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + Exception.class.getSimpleName() + "\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+
+                final Exception e = assertThrows(IOException.class,
+                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+                assertNull(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testStandbyException() throws IOException {
+        final String reMessage = "Server returned: " + StandbyException.class.getSimpleName();
+
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"RemoteException\": {\n" +
+                                    "    \"javaClassName\": \"" + StandbyException.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + StandbyException.class.getSimpleName() + "\",\n" +
+                                    "    \"message\": \"" + reMessage + "\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+
+                final Exception e = assertThrows(IOException.class,
+                        () -> fs.listStatus(new Path(TEST_WEBHDFS_PATH)));
+
+                assertEquals(WEBHDFS_HOST + ":" + WEBHDFS_PORT + ": " + RemoteException.class.getName() +
+                                "(" + StandbyException.class.getName() + "): " + reMessage,
+                        e.getMessage());
+            }
+        }
+    }
+
+    @Test(expected = SecretManager.InvalidToken.class)
+    public void testInvalidToken() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            final String reMessage = SecurityUtil.FAILED_TO_GET_UGI_MSG_HEADER + " " +
+                    SecretManager.InvalidToken.class.getName() + ": " +
+                    "token (token for test_user: HDFS_DELEGATION_TOKEN owner=test_user, renewer=test_user, " +
+                    "realUser=test_user, issueDate=0, maxDate=99999, sequenceNumber=9999, masterKeyId=999) can't be found in cache";
+
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"RemoteException\": {\n" +
+                                    "    \"javaClassName\": \"" + SecretManager.InvalidToken.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + SecretManager.InvalidToken.class.getSimpleName() + "\",\n" +
+                                    "    \"message\": \"" + reMessage + "\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+            }
+        }
+    }
+
+    @Test(expected = SecretManager.InvalidToken.class)
+    public void testInvalidTokenForHttpFS() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            final String reMessage = SecretManager.InvalidToken.class.getName() + ": " +
+                    "token (token for test_user: HDFS_DELEGATION_TOKEN owner=test_user, renewer=test_user, " +
+                    "realUser=test_user, issueDate=0, maxDate=99999, sequenceNumber=9999, masterKeyId=999) can't be found in cache";
+
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"RemoteException\": {\n" +
+                                    "    \"javaClassName\": \"" + AuthenticationException.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + AuthenticationException.class.getSimpleName() + "\",\n" +
+                                    "    \"message\": \"" + reMessage + "\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+            }
+        }
+    }
+
+    @Test(expected = RemoteException.class)
+    public void testOtherRemoteException() throws IOException {
+        try (final MockServerClient mockWebHDFSServerClient = new MockServerClient(WEBHDFS_HOST, WEBHDFS_PORT)) {
+            mockWebHDFSServerClient
+                    .when(FILE_SYSTEM_REQUEST, exactly(1))
+                    .respond(response()
+                            .withStatusCode(HttpStatus.SC_FORBIDDEN)
+                            .withHeaders(CONTENT_TYPE_APPLICATION_JSON)
+                            .withBody("{\n" +
+                                    "  \"RemoteException\": {\n" +
+                                    "    \"javaClassName\": \"" + Exception.class.getName() + "\",\n" +
+                                    "    \"exception\": \"" + Exception.class.getSimpleName() + "\",\n" +
+                                    "    \"message\": \"Other RemoteException\"\n" +
+                                    "  }\n" +
+                                    "}"));
+
+            try (FileSystem fs = new WebHdfsFileSystem()) {
+                fs.initialize(WEBHDFS_URI, new Configuration());
+                fs.listStatus(new Path(TEST_WEBHDFS_PATH));
+            }
+        }
+    }
+
+    @After
+    public void stopMockWebHDFSServer() {
+        mockWebHDFS.stop();
+    }
+
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: https://issues.apache.org/jira/browse/HDFS-15474

### How was this patch tested?

Confirm the HttpFS response message in my environment and add unit tests

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?