### PR TITLE
HDFS-17705. Improve datasetlock related log output.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
@@ -179,7 +179,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock dirLock = getReadLock(level, resources);
       dirLock.setParentLock(volLock);
       if (openLockTrace) {
-        LOG.debug("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
+        LOG.info("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
             resources[0] + resources[1]);
       }
       return dirLock;
@@ -206,7 +206,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock dirLock = getWriteLock(level, resources);
       dirLock.setParentLock(volLock);
       if (openLockTrace) {
-        LOG.debug("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
+        LOG.info("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
             resources[0] + resources[1]);
       }
       return dirLock;
@@ -273,6 +273,9 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
           new ReentrantReadWriteLock(isFair));
       lockMap.addLock(lockName, new ReentrantReadWriteLock(isFair));
     }
+    if (openLockTrace) {
+      LOG.info("Added {} lock, lock name: {}", level.name(), lockName);
+    }
   }
 
   @Override
@@ -280,6 +283,9 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
     String lockName = generateLockName(level, resources);
     try (AutoCloseDataSetLock lock = writeLock(level, resources)) {
       lockMap.removeLock(lockName);
+    }
+    if (openLockTrace) {
+      LOG.info("Removed {} lock, lock name: {}", level.name(), lockName);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataSetLockManager.java
@@ -168,8 +168,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock volLock = getReadLock(level, resources);
       volLock.setParentLock(bpLock);
       if (openLockTrace) {
-        LOG.info("Sub lock " + resources[0] + resources[1] + " parent lock " +
-            resources[0]);
+        LOG.info("Sub lock {}, parent lock {}.", resources[0] + resources[1], resources[0]);
       }
       return volLock;
     } else {
@@ -179,7 +178,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock dirLock = getReadLock(level, resources);
       dirLock.setParentLock(volLock);
       if (openLockTrace) {
-        LOG.info("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
+        LOG.info("Sub lock {}, parent lock {}", resources[0] + resources[1] + resources[2],
             resources[0] + resources[1]);
       }
       return dirLock;
@@ -195,8 +194,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock volLock = getWriteLock(level, resources);
       volLock.setParentLock(bpLock);
       if (openLockTrace) {
-        LOG.info("Sub lock " + resources[0] + resources[1] + " parent lock " +
-            resources[0]);
+        LOG.info("Sub lock {}, parent lock {}.", resources[0] + resources[1], resources[0]);
       }
       return volLock;
     } else {
@@ -206,7 +204,7 @@ public class DataSetLockManager implements DataNodeLockManager<AutoCloseDataSetL
       AutoCloseDataSetLock dirLock = getWriteLock(level, resources);
       dirLock.setParentLock(volLock);
       if (openLockTrace) {
-        LOG.info("Sub lock " + resources[0] + resources[1] + resources[2] + " parent lock " +
+        LOG.info("Sub lock {}, parent lock {}.", resources[0] + resources[1] + resources[2],
             resources[0] + resources[1]);
       }
       return dirLock;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -440,7 +440,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       for (String dir : allSubDirNameForDataSetLock) {
         lockManager.addLock(LockLevel.DIR, bp, ref.getVolume().getStorageID(), dir);
       }
-      LOG.info("Added DIR lock for bpid:{}, volume storageid:{}.", bp, ref.getVolume().getStorageID());
+      LOG.info("Added DIR lock for bpid:{}, volume storageid:{}.", bp,
+          ref.getVolume().getStorageID());
     }
     DatanodeStorage dnStorage = storageMap.get(sd.getStorageUuid());
     if (dnStorage != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java
@@ -439,9 +439,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
       List<String> allSubDirNameForDataSetLock = datasetSubLockStrategy.getAllSubLockNames();
       for (String dir : allSubDirNameForDataSetLock) {
         lockManager.addLock(LockLevel.DIR, bp, ref.getVolume().getStorageID(), dir);
-        LOG.info("Added DIR lock for bpid:{}, volume storageid:{}, dir:{}",
-            bp, ref.getVolume().getStorageID(), dir);
       }
+      LOG.info("Added DIR lock for bpid:{}, volume storageid:{}.", bp, ref.getVolume().getStorageID());
     }
     DatanodeStorage dnStorage = storageMap.get(sd.getStorageUuid());
     if (dnStorage != null) {
@@ -3297,9 +3296,8 @@ class FsDatasetImpl implements FsDatasetSpi<FsVolumeImpl> {
         List<String> allSubDirNameForDataSetLock = datasetSubLockStrategy.getAllSubLockNames();
         for (String dir : allSubDirNameForDataSetLock) {
           lockManager.addLock(LockLevel.DIR, bpid, v, dir);
-          LOG.info("Added DIR lock for bpid:{}, volume storageid:{}, dir:{}",
-              bpid, v, dir);
         }
+        LOG.info("Added DIR lock for bpid:{}, volume storageid:{}.", bpid, v);
       }
     }
     try {


### PR DESCRIPTION
### Description of PR
Take over [HDFS-17705](https://issues.apache.org/jira/browse/HDFS-17705), thanks @huangzhaobo99 for raise this problem.
When running unit tests, there will be plenty of subdirLock logs and we may loss some important information. we should optimize it.

![image](https://github.com/user-attachments/assets/90ddda89-d796-45ed-a597-a50c67e9727e)

