### PR TITLE
YARN-11790: TestAmFilter#testProxyUpdate fails in some networks

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/amfilter/TestAmFilter.java
@@ -202,7 +202,7 @@ public class TestAmFilter {
 
     // change proxy configurations
     params = new HashMap<>();
-    params.put(AmIpFilter.PROXY_HOSTS, "unknownhost");
+    params.put(AmIpFilter.PROXY_HOSTS, "unknownhostaf79d34c");
     params.put(AmIpFilter.PROXY_URI_BASES, proxyUri);
     conf = new DummyFilterConfig(params);
     filter.init(conf);


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11790: TestAmFilter#testProxyUpdate fails in some networks.

While working on [SPARK-51408](https://issues.apache.org/jira/browse/SPARK-51408), I discovered an issue that can cause their `AmIpFilterSuite#testProxyUpdate` to fail in certain unusual network setups. This test is a fork of a YARN test from Hadoop. As part of the solution, I included some additional randomization on a fake host name intended to simulate an unresolvable host. I'd like to bring the same change back into the original YARN test to make sure this doesn't become a problem in Hadoop test runs and we keep the code in sync.

### How was this patch tested?

```
mvn -o \
    -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy \
    test \
    -Dtest=TestAmFilter
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

