### PR TITLE
HDFS-17754: Add uriparser2 to notices

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -809,7 +809,7 @@ This product includes software developed by Apache
  PureJavaCrc32C from apache-hadoop-common http://hadoop.apache.org/
  (Apache 2.0 license)
 
-This library containd statically linked libstdc++. This inclusion is allowed by
+This library contains statically linked libstdc++. This inclusion is allowed by
 "GCC RUntime Library Exception"
 http://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
 
@@ -825,3 +825,10 @@ Copyright 2009-2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+This product includes code from uriparser2, a C and C++ library for URI parsing.
+
+  * LICENSE:
+    * license/LICENSE-uriparser2.txt (MIT License)
+  * HOMEPAGE:
+    * https://github.com/bnoordhuis/uriparser2

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser/UriQuery.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/third_party/uriparser2/uriparser2/uriparser/UriQuery.c
@@ -219,6 +219,7 @@ int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
 
 			/* Copy key */
 			if (firstItem == URI_TRUE) {
+				ampersandLen = 1;
 				firstItem = URI_FALSE;
 			} else {
 				write[0] = _UT('&');

--- a/licenses-binary/LICENSE-uriparser2.txt
+++ b/licenses-binary/LICENSE-uriparser2.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2010 Ben Noordhuis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
### Description of PR

Add mention of uriparser2, used by the native HDFS client, to the notices information for binary distributions.

### How was this patch tested?

Verified licensing information manually.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

