### PR TITLE
HADOOP-19487. Upgrade libopenssl to 3.1.1 for rsync on Windows

### DIFF
--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -81,11 +81,11 @@ RUN powershell Invoke-WebRequest -Uri https://github.com/facebook/zstd/releases/
 RUN powershell Expand-Archive -Path $Env:TEMP\zstd-v1.5.4-win64.zip -DestinationPath "C:\ZStd"
 RUN setx PATH "%PATH%;C:\ZStd"
 
-# Install libopenssl 3.1.0 needed for rsync 3.2.7.
-RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.1.0-2-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.1.0-2-x86_64.pkg.tar.zst
-RUN powershell zstd -d $Env:TEMP\libopenssl-3.1.0-2-x86_64.pkg.tar.zst -o $Env:TEMP\libopenssl-3.1.0-2-x86_64.pkg.tar
+# Install libopenssl 3.1.1 needed for rsync 3.2.7.
+RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.1.1-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.1.1-1-x86_64.pkg.tar.zst
+RUN powershell zstd -d $Env:TEMP\libopenssl-3.1.1-1-x86_64.pkg.tar.zst -o $Env:TEMP\libopenssl-3.1.1-1-x86_64.pkg.tar
 RUN powershell mkdir "C:\LibOpenSSL"
-RUN powershell tar -xvf $Env:TEMP\libopenssl-3.1.0-2-x86_64.pkg.tar -C "C:\LibOpenSSL"
+RUN powershell tar -xvf $Env:TEMP\libopenssl-3.1.1-1-x86_64.pkg.tar -C "C:\LibOpenSSL"
 
 # Install libxxhash 0.8.1 needed for rsync 3.2.7.
 RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libxxhash-0.8.1-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libxxhash-0.8.1-1-x86_64.pkg.tar.zst


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* We're currently using libopenssl 3.1.0 which
  is needed for rsync 3.2.7 on Windows for the
  Yetus build validation.
* However, libopenssl 3.1.0 is no longer
  available for download on the msys2 site. Thus,
  building the Docker image for Windows is failing -
```
PS D:\projects\github\apache\hadoop> Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.1.0-2-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.1.0-2-x86_64.pkg.tar.zst
Invoke-WebRequest:
404 Not Found

404 Not Found
nginx/1.26.3
```
* This PR upgrades libopenssl to the next
  available version - 3.1.1 to mitigate this
  issue.

### How was this patch tested?

* Jenkins CI validation. Logs - [archive.zip](https://github.com/user-attachments/files/19160541/archive.zip)

![image](https://github.com/user-attachments/assets/94514646-e285-4512-ba63-baab3cf31d38)

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

