### PR TITLE
YARN-11262. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-resourcemanager Part5.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
@@ -302,8 +302,7 @@ public class TestAMRMTokens {
 
       MasterKeyData newKey = appTokenSecretManager.getMasterKey();
       assertNotNull(newKey);
-      assertFalse(
-       oldKey.equals(newKey), "Master key should have changed!");
+      assertFalse(oldKey.equals(newKey), "Master key should have changed!");
 
       // Another allocate call with old AMRMToken. Should continue to work.
       rpc.stopProxy(rmClient, conf); // To avoid using cached client

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestAMRMTokens.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -31,6 +37,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -69,24 +77,18 @@ import org.apache.hadoop.yarn.server.security.MasterKeyData;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Timeout;
 
-@RunWith(Parameterized.class)
 public class TestAMRMTokens {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestAMRMTokens.class);
 
-  private final Configuration conf;
+  private Configuration conf;
   private static final int maxWaitAttempts = 50;
   private static final int rolling_interval_sec = 13;
   private static final long am_expire_ms = 4000;
 
-  @Parameters
   public static Collection<Object[]> configs() {
     Configuration conf = new Configuration();
     Configuration confWithSecurity = new Configuration();
@@ -95,8 +97,8 @@ public class TestAMRMTokens {
     return Arrays.asList(new Object[][] {{ conf }, { confWithSecurity } });
   }
 
-  public TestAMRMTokens(Configuration conf) {
-    this.conf = conf;
+  public void initTestAMRMTokens(Configuration pConf) {
+    this.conf = pConf;
     UserGroupInformation.setConfiguration(conf);
   }
 
@@ -107,8 +109,10 @@ public class TestAMRMTokens {
    * @throws Exception
    */
   @SuppressWarnings("unchecked")
-  @Test
-  public void testTokenExpiry() throws Exception {
+  @ParameterizedTest
+  @MethodSource("configs")
+  public void testTokenExpiry(Configuration pConf) throws Exception {
+    initTestAMRMTokens(pConf);
     conf.setLong(
         YarnConfiguration.RM_AMRM_TOKEN_MASTER_KEY_ROLLING_INTERVAL_SECS,
         YarnConfiguration.
@@ -139,7 +143,7 @@ public class TestAMRMTokens {
         LOG.info("Waiting for AM Launch to happen..");
         Thread.sleep(1000);
       }
-      Assert.assertNotNull(containerManager.containerTokens);
+      assertNotNull(containerManager.containerTokens);
 
       RMAppAttempt attempt = app.getCurrentAppAttempt();
       ApplicationAttemptId applicationAttemptId = attempt.getAppAttemptId();
@@ -192,7 +196,7 @@ public class TestAMRMTokens {
         Thread.sleep(100);
         count++;
       }
-      Assert.assertTrue(attempt.getState() == RMAppAttemptState.FINISHED);
+      assertTrue(attempt.getState() == RMAppAttemptState.FINISHED);
 
       // Now simulate trying to allocate. RPC call itself should throw auth
       // exception.
@@ -202,13 +206,13 @@ public class TestAMRMTokens {
           Records.newRecord(AllocateRequest.class);
       try {
         rmClient.allocate(allocateRequest);
-        Assert.fail("You got to be kidding me! "
+        fail("You got to be kidding me! "
             + "Using App tokens after app-finish should fail!");
       } catch (Throwable t) {
         LOG.info("Exception found is ", t);
         // The exception will still have the earlier appAttemptId as it picks it
         // up from the token.
-        Assert.assertTrue(t.getCause().getMessage().contains(
+        assertTrue(t.getCause().getMessage().contains(
           applicationAttemptId.toString()
           + " not found in AMRMTokenSecretManager."));
       }
@@ -227,9 +231,10 @@ public class TestAMRMTokens {
    * 
    * @throws Exception
    */
-  @Test
-  public void testMasterKeyRollOver() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("configs")
+  public void testMasterKeyRollOver(Configuration pConf) throws Exception {
+    initTestAMRMTokens(pConf);
     conf.setLong(
       YarnConfiguration.RM_AMRM_TOKEN_MASTER_KEY_ROLLING_INTERVAL_SECS,
       rolling_interval_sec);
@@ -247,7 +252,7 @@ public class TestAMRMTokens {
     AMRMTokenSecretManager appTokenSecretManager =
         rm.getRMContext().getAMRMTokenSecretManager();
     MasterKeyData oldKey = appTokenSecretManager.getMasterKey();
-    Assert.assertNotNull(oldKey);
+    assertNotNull(oldKey);
     try {
       MockNM nm1 = rm.registerNode("localhost:1234", 5120);
 
@@ -260,7 +265,7 @@ public class TestAMRMTokens {
         LOG.info("Waiting for AM Launch to happen..");
         Thread.sleep(1000);
       }
-      Assert.assertNotNull(containerManager.containerTokens);
+      assertNotNull(containerManager.containerTokens);
 
       RMAppAttempt attempt = app.getCurrentAppAttempt();
       ApplicationAttemptId applicationAttemptId = attempt.getAppAttemptId();
@@ -285,7 +290,7 @@ public class TestAMRMTokens {
       // One allocate call.
       AllocateRequest allocateRequest =
           Records.newRecord(AllocateRequest.class);
-      Assert.assertTrue(
+      assertTrue(
           rmClient.allocate(allocateRequest).getAMCommand() == null);
 
       // Wait for enough time and make sure the roll_over happens
@@ -296,15 +301,14 @@ public class TestAMRMTokens {
       }
 
       MasterKeyData newKey = appTokenSecretManager.getMasterKey();
-      Assert.assertNotNull(newKey);
-      Assert.assertFalse("Master key should have changed!",
-        oldKey.equals(newKey));
+      assertNotNull(newKey);
+      assertFalse(
+       oldKey.equals(newKey), "Master key should have changed!");
 
       // Another allocate call with old AMRMToken. Should continue to work.
       rpc.stopProxy(rmClient, conf); // To avoid using cached client
       rmClient = createRMClient(rm, conf, rpc, currentUser);
-      Assert
-        .assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
+      assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
 
       waitCount = 0;
       while(waitCount++ <= maxWaitAttempts) {
@@ -319,9 +323,9 @@ public class TestAMRMTokens {
         Thread.sleep(200);
       }
       // active the nextMasterKey, and replace the currentMasterKey
-      Assert.assertTrue(appTokenSecretManager.getCurrnetMasterKeyData().equals(newKey));
-      Assert.assertTrue(appTokenSecretManager.getMasterKey().equals(newKey));
-      Assert.assertTrue(appTokenSecretManager.getNextMasterKeyData() == null);
+      assertTrue(appTokenSecretManager.getCurrnetMasterKeyData().equals(newKey));
+      assertTrue(appTokenSecretManager.getMasterKey().equals(newKey));
+      assertTrue(appTokenSecretManager.getNextMasterKeyData() == null);
 
       // Create a new Token
       Token<AMRMTokenIdentifier> newToken =
@@ -332,8 +336,7 @@ public class TestAMRMTokens {
       rpc.stopProxy(rmClient, conf); // To avoid using cached client
       rmClient = createRMClient(rm, conf, rpc, currentUser);
       allocateRequest = Records.newRecord(AllocateRequest.class);
-      Assert
-        .assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
+      assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
 
       // Should not work by using the old AMRMToken.
       rpc.stopProxy(rmClient, conf); // To avoid using cached client
@@ -341,9 +344,8 @@ public class TestAMRMTokens {
         currentUser.addToken(amRMToken);
         rmClient = createRMClient(rm, conf, rpc, currentUser);
         allocateRequest = Records.newRecord(AllocateRequest.class);
-        Assert
-          .assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
-        Assert.fail("The old Token should not work");
+        assertTrue(rmClient.allocate(allocateRequest).getAMCommand() == null);
+        fail("The old Token should not work");
       } catch (Exception ex) {
         // expect exception
       }
@@ -355,8 +357,11 @@ public class TestAMRMTokens {
     }
   }
 
-  @Test (timeout = 20000)
-  public void testAMRMMasterKeysUpdate() throws Exception {
+  @ParameterizedTest
+  @MethodSource("configs")
+  @Timeout(value = 20)
+  public void testAMRMMasterKeysUpdate(Configuration pConf) throws Exception {
+    initTestAMRMTokens(pConf);
     final AtomicReference<AMRMTokenSecretManager> spySecretMgrRef =
         new AtomicReference<AMRMTokenSecretManager>();
     MockRM rm = new MockRM(conf) {
@@ -387,7 +392,7 @@ public class TestAMRMTokens {
     // Do allocate. Should not update AMRMToken
     AllocateResponse response =
         am.allocate(Records.newRecord(AllocateRequest.class));
-    Assert.assertNull(response.getAMRMToken());
+    assertNull(response.getAMRMToken());
     Token<AMRMTokenIdentifier> oldToken = rm.getRMContext().getRMApps()
         .get(app.getApplicationId())
         .getRMAppAttempt(am.getApplicationAttemptId()).getAMRMToken();
@@ -396,13 +401,13 @@ public class TestAMRMTokens {
     // Do allocate again. the AM should get the latest AMRMToken
     rm.getRMContext().getAMRMTokenSecretManager().rollMasterKey();
     response = am.allocate(Records.newRecord(AllocateRequest.class));
-    Assert.assertNotNull(response.getAMRMToken());
+    assertNotNull(response.getAMRMToken());
 
     Token<AMRMTokenIdentifier> amrmToken =
         ConverterUtils.convertFromYarn(response.getAMRMToken(), new Text(
           response.getAMRMToken().getService()));
 
-    Assert.assertEquals(amrmToken.decodeIdentifier().getKeyId(), rm
+    assertEquals(amrmToken.decodeIdentifier().getKeyId(), rm
       .getRMContext().getAMRMTokenSecretManager().getMasterKey().getMasterKey()
       .getKeyId());
 
@@ -413,19 +418,19 @@ public class TestAMRMTokens {
         am.getApplicationAttemptId().toString(), new String[0]);
     ugi.addTokenIdentifier(oldToken.decodeIdentifier());
     response = am.doAllocateAs(ugi, Records.newRecord(AllocateRequest.class));
-    Assert.assertNotNull(response.getAMRMToken());
+    assertNotNull(response.getAMRMToken());
     verify(spySecretMgr, never()).createAndGetAMRMToken(isA(ApplicationAttemptId.class));
 
     // Do allocate again with the updated token and verify we do not
     // receive a new token to use.
     response = am.allocate(Records.newRecord(AllocateRequest.class));
-    Assert.assertNull(response.getAMRMToken());
+    assertNull(response.getAMRMToken());
 
     // Activate the next master key. Since there is new master key generated
     // in AMRMTokenSecretManager. The AMRMToken will not get updated for AM
     rm.getRMContext().getAMRMTokenSecretManager().activateNextMasterKey();
     response = am.allocate(Records.newRecord(AllocateRequest.class));
-    Assert.assertNull(response.getAMRMToken());
+    assertNull(response.getAMRMToken());
     rm.stop();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
@@ -494,7 +494,7 @@ public class TestDelegationTokenRenewer {
         ";Counter = " + Renewer.counter + ";t="+  Renewer.lastRenewed);
     assertEquals(numberOfExpectedRenewals, Renewer.counter,
         "renew wasn't called as many times as expected(4):");
-    assertEquals(Renewer.lastRenewed, 
+    assertEquals(Renewer.lastRenewed,
         token1, "most recently renewed token mismatch");
     
     // Test 2. 
@@ -943,7 +943,7 @@ public class TestDelegationTokenRenewer {
 
   }
 
-  @Test                                                         
+  @Test
   @Timeout(value = 20)
   public void testConcurrentAddApplication()                                  
       throws IOException, InterruptedException, BrokenBarrierException {       

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewer.java
@@ -18,16 +18,19 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.security;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -105,12 +108,11 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.DelegationTokenRen
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -201,7 +203,7 @@ public class TestDelegationTokenRenewer {
   private MockRM rm2;
   private DelegationTokenRenewer localDtr;
  
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     conf = new Configuration();
     
@@ -215,7 +217,7 @@ public class TestDelegationTokenRenewer {
   }
   
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     counter = new AtomicInteger(0);
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -246,7 +248,7 @@ public class TestDelegationTokenRenewer {
     delegationTokenRenewer.start();
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     try {
       dispatcher.close();
@@ -438,7 +440,8 @@ public class TestDelegationTokenRenewer {
    * @throws IOException
    * @throws URISyntaxException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDTRenewal () throws Exception {
     MyFS dfs = (MyFS)FileSystem.get(conf);
     LOG.info("dfs="+(Object)dfs.hashCode() + ";conf="+conf.hashCode());
@@ -489,10 +492,10 @@ public class TestDelegationTokenRenewer {
     
     LOG.info("dfs=" + dfs.hashCode() + 
         ";Counter = " + Renewer.counter + ";t="+  Renewer.lastRenewed);
-    assertEquals("renew wasn't called as many times as expected(4):",
-        numberOfExpectedRenewals, Renewer.counter);
-    assertEquals("most recently renewed token mismatch", Renewer.lastRenewed, 
-        token1);
+    assertEquals(numberOfExpectedRenewals, Renewer.counter,
+        "renew wasn't called as many times as expected(4):");
+    assertEquals(Renewer.lastRenewed, 
+        token1, "most recently renewed token mismatch");
     
     // Test 2. 
     // add another token ( that expires in 2 secs). Then remove it, before
@@ -522,8 +525,8 @@ public class TestDelegationTokenRenewer {
     LOG.info("Counter = " + Renewer.counter + ";t="+ Renewer.lastRenewed);
     
     // counter and the token should stil be the old ones
-    assertEquals("renew wasn't called as many times as expected",
-        numberOfExpectedRenewals, Renewer.counter);
+    assertEquals(numberOfExpectedRenewals, Renewer.counter,
+        "renew wasn't called as many times as expected");
     
     // also renewing of the cancelled token should fail
     try {
@@ -534,7 +537,8 @@ public class TestDelegationTokenRenewer {
     }
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAppRejectionWithCancelledDelegationToken() throws Exception {
     MyFS dfs = (MyFS)FileSystem.get(conf);
     LOG.info("dfs="+(Object)dfs.hashCode() + ";conf="+conf.hashCode());
@@ -554,7 +558,7 @@ public class TestDelegationTokenRenewer {
       if (!eventQueue.isEmpty()) {
         Event evt = eventQueue.take();
         if (evt.getType() == RMAppEventType.APP_REJECTED) {
-          Assert.assertTrue(
+          assertTrue(
               ((RMAppEvent) evt).getApplicationId().equals(appId));
           return;
         }
@@ -567,7 +571,8 @@ public class TestDelegationTokenRenewer {
 
   // Testcase for YARN-3021, let RM skip renewing token if the renewer string
   // is empty
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAppTokenWithNonRenewer() throws Exception {
     MyFS dfs = (MyFS)FileSystem.get(conf);
     LOG.info("dfs="+(Object)dfs.hashCode() + ";conf="+conf.hashCode());
@@ -594,7 +599,8 @@ public class TestDelegationTokenRenewer {
    * @throws IOException
    * @throws URISyntaxException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDTRenewalWithNoCancel () throws Exception {
     MyFS dfs = (MyFS)FileSystem.get(conf);
     LOG.info("dfs="+(Object)dfs.hashCode() + ";conf="+conf.hashCode());
@@ -623,8 +629,8 @@ public class TestDelegationTokenRenewer {
     LOG.info("Counter = " + Renewer.counter + ";t="+ Renewer.lastRenewed);
     
     // counter and the token should still be the old ones
-    assertEquals("renew wasn't called as many times as expected",
-        numberOfExpectedRenewals, Renewer.counter);
+    assertEquals(numberOfExpectedRenewals, Renewer.counter,
+        "renew wasn't called as many times as expected");
     
     // also renewing of the canceled token should not fail, because it has not
     // been canceled
@@ -641,7 +647,8 @@ public class TestDelegationTokenRenewer {
    * @throws IOException
    * @throws URISyntaxException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDTRenewalWithNoCancelAlwaysCancel() throws Exception {
     Configuration lconf = new Configuration(conf);
     lconf.setBoolean(YarnConfiguration.RM_DELEGATION_TOKEN_ALWAYS_CANCEL,
@@ -691,8 +698,8 @@ public class TestDelegationTokenRenewer {
     LOG.info("Counter = " + Renewer.counter + ";t="+ Renewer.lastRenewed);
 
     // counter and the token should still be the old ones
-    assertEquals("renew wasn't called as many times as expected",
-        numberOfExpectedRenewals, Renewer.counter);
+    assertEquals(numberOfExpectedRenewals, Renewer.counter,
+        "renew wasn't called as many times as expected");
 
     // The token should have been cancelled at this point. Renewal will fail.
     try {
@@ -712,7 +719,8 @@ public class TestDelegationTokenRenewer {
    * @throws IOException
    * @throws URISyntaxException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDTKeepAlive1 () throws Exception {
     Configuration lconf = new Configuration(conf);
     lconf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
@@ -757,7 +765,7 @@ public class TestDelegationTokenRenewer {
     if (!eventQueue.isEmpty()){
       Event evt = eventQueue.take();
       if (evt instanceof RMAppEvent) {
-        Assert.assertEquals(((RMAppEvent)evt).getType(), RMAppEventType.START);
+        assertEquals(((RMAppEvent)evt).getType(), RMAppEventType.START);
       } else {
         fail("RMAppEvent.START was expected!!");
       }
@@ -792,7 +800,8 @@ public class TestDelegationTokenRenewer {
    * @throws IOException
    * @throws URISyntaxException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDTKeepAlive2() throws Exception {
     Configuration lconf = new Configuration(conf);
     lconf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
@@ -892,7 +901,8 @@ public class TestDelegationTokenRenewer {
     }
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testDTRonAppSubmission()
       throws IOException, InterruptedException, BrokenBarrierException {
     final Credentials credsx = new Credentials();
@@ -927,13 +937,14 @@ public class TestDelegationTokenRenewer {
           credsx, false, "user");
       fail("Catch IOException on app submission");
     } catch (IOException e){
-      Assert.assertTrue(e.getMessage().contains(tokenx.toString()));
-      Assert.assertTrue(e.getCause().toString().contains("boom"));
+      assertTrue(e.getMessage().contains(tokenx.toString()));
+      assertTrue(e.getCause().toString().contains("boom"));
     }
 
   }
 
-  @Test(timeout=20000)                                                         
+  @Test                                                         
+  @Timeout(value = 20)
   public void testConcurrentAddApplication()                                  
       throws IOException, InterruptedException, BrokenBarrierException {       
     final CyclicBarrier startBarrier = new CyclicBarrier(2);                   
@@ -1001,7 +1012,8 @@ public class TestDelegationTokenRenewer {
     submitThread.join(); 
   }
   
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testAppSubmissionWithInvalidDelegationToken() throws Exception {
     Configuration conf = new Configuration();
     conf.set(
@@ -1031,13 +1043,14 @@ public class TestDelegationTokenRenewer {
       rm.getClientRMService().submitApplication(request);
       fail("Error was excepted.");
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Bad header found in token storage"));
     }
   }
 
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testReplaceExpiringDelegationToken() throws Exception {
     conf.setBoolean(YarnConfiguration.RM_PROXY_USER_PRIVILEGES_ENABLED, true);
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -1131,13 +1144,13 @@ public class TestDelegationTokenRenewer {
         YarnServerBuilderUtils
             .convertFromProtoFormat(proto.getSystemCredentialsForApps())
             .get(app.getApplicationId());
-    Assert.assertNotNull(tokenBuffer);
+    assertNotNull(tokenBuffer);
     Credentials appCredentials = new Credentials();
     DataInputByteBuffer buf = new DataInputByteBuffer();
     tokenBuffer.rewind();
     buf.reset(tokenBuffer);
     appCredentials.readTokenStorageStream(buf);
-    Assert.assertTrue(appCredentials.getAllTokens().contains(expectedToken));
+    assertTrue(appCredentials.getAllTokens().contains(expectedToken));
   }
 
 
@@ -1240,14 +1253,14 @@ public class TestDelegationTokenRenewer {
         YarnServerBuilderUtils
             .convertFromProtoFormat(proto.getSystemCredentialsForApps())
             .get(app.getApplicationId());
-    Assert.assertNotNull(tokenBuffer);
+    assertNotNull(tokenBuffer);
     Credentials appCredentials = new Credentials();
     DataInputByteBuffer buf = new DataInputByteBuffer();
     tokenBuffer.rewind();
     buf.reset(tokenBuffer);
     appCredentials.readTokenStorageStream(buf);
-    Assert.assertTrue(firstRenewInvoked.get() && secondRenewInvoked.get());
-    Assert.assertTrue(appCredentials.getAllTokens().contains(updatedToken));
+    assertTrue(firstRenewInvoked.get() && secondRenewInvoked.get());
+    assertTrue(appCredentials.getAllTokens().contains(updatedToken));
   }
 
   // YARN will get the token for the app submitted without the delegation token.
@@ -1301,18 +1314,19 @@ public class TestDelegationTokenRenewer {
         YarnServerBuilderUtils
             .convertFromProtoFormat(proto.getSystemCredentialsForApps())
             .get(app.getApplicationId());
-    Assert.assertNotNull(tokenBuffer);
+    assertNotNull(tokenBuffer);
     Credentials appCredentials = new Credentials();
     DataInputByteBuffer buf = new DataInputByteBuffer();
     tokenBuffer.rewind();
     buf.reset(tokenBuffer);
     appCredentials.readTokenStorageStream(buf);
-    Assert.assertTrue(appCredentials.getAllTokens().contains(token2));
+    assertTrue(appCredentials.getAllTokens().contains(token2));
   }
 
   // Test submitting an application with the token obtained by a previously
   // submitted application.
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppSubmissionWithPreviousToken() throws Exception{
     rm = new TestSecurityMockRM(conf, null);
     rm.start();
@@ -1349,7 +1363,7 @@ public class TestDelegationTokenRenewer {
     DelegationTokenRenewer renewer =
         rm.getRMContext().getDelegationTokenRenewer();
     DelegationTokenToRenew dttr = renewer.getAllTokens().get(token1);
-    Assert.assertNotNull(dttr);
+    assertNotNull(dttr);
 
     // submit app2 with the same token, set cancelTokenWhenComplete to true;
     MockRMAppSubmissionData data = MockRMAppSubmissionData.Builder
@@ -1364,12 +1378,12 @@ public class TestDelegationTokenRenewer {
     MockAM am2 = MockRM.launchAndRegisterAM(app2, rm, nm1);
     rm.waitForState(app2.getApplicationId(), RMAppState.RUNNING);
     finishAMAndWaitForComplete(app2, rm, nm1, am2, dttr);
-    Assert.assertTrue(rm.getRMContext().getDelegationTokenRenewer()
+    assertTrue(rm.getRMContext().getDelegationTokenRenewer()
       .getAllTokens().containsKey(token1));
 
     finishAMAndWaitForComplete(app1, rm, nm1, am1, dttr);
     // app2 completes, app1 is still running, check the token is not cancelled
-    Assert.assertFalse(Renewer.cancelled);
+    assertFalse(Renewer.cancelled);
   }
 
   // Test FileSystem memory leak in obtainSystemTokensForUser.
@@ -1381,14 +1395,15 @@ public class TestDelegationTokenRenewer {
     delegationTokenRenewer.obtainSystemTokensForUser(user, credentials);
     delegationTokenRenewer.obtainSystemTokensForUser(user, credentials);
     delegationTokenRenewer.obtainSystemTokensForUser(user, credentials);
-    Assert.assertEquals(oldCounter, MyFS.getInstanceCounter());
+    assertEquals(oldCounter, MyFS.getInstanceCounter());
   }
   
   // Test submitting an application with the token obtained by a previously
   // submitted application that is set to be cancelled.  Token should be
   // renewed while all apps are running, and then cancelled when all apps
   // complete
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testCancelWithMultipleAppSubmissions() throws Exception{
     rm = new TestSecurityMockRM(conf, null);
     rm.start();
@@ -1410,8 +1425,8 @@ public class TestDelegationTokenRenewer {
 
     DelegationTokenRenewer renewer =
         rm.getRMContext().getDelegationTokenRenewer();
-    Assert.assertTrue(renewer.getAllTokens().isEmpty());
-    Assert.assertFalse(Renewer.cancelled);
+    assertTrue(renewer.getAllTokens().isEmpty());
+    assertFalse(Renewer.cancelled);
 
     Resource resource = Records.newRecord(Resource.class);
     resource.setMemorySize(200);
@@ -1427,8 +1442,8 @@ public class TestDelegationTokenRenewer {
     rm.waitForState(app1.getApplicationId(), RMAppState.RUNNING);
 
     DelegationTokenToRenew dttr = renewer.getAllTokens().get(token1);
-    Assert.assertNotNull(dttr);
-    Assert.assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
+    assertNotNull(dttr);
+    assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
     MockRMAppSubmissionData data1 =
         MockRMAppSubmissionData.Builder.createWithResource(resource, rm)
         .withResource(resource)
@@ -1440,18 +1455,18 @@ public class TestDelegationTokenRenewer {
     RMApp app2 = MockRMAppSubmitter.submit(rm, data1);
     MockAM am2 = MockRM.launchAndRegisterAM(app2, rm, nm1);
     rm.waitForState(app2.getApplicationId(), RMAppState.RUNNING);
-    Assert.assertTrue(renewer.getAllTokens().containsKey(token1));
-    Assert.assertTrue(dttr.referringAppIds.contains(app2.getApplicationId()));
-    Assert.assertTrue(dttr.referringAppIds.contains(app2.getApplicationId()));
-    Assert.assertFalse(Renewer.cancelled);
+    assertTrue(renewer.getAllTokens().containsKey(token1));
+    assertTrue(dttr.referringAppIds.contains(app2.getApplicationId()));
+    assertTrue(dttr.referringAppIds.contains(app2.getApplicationId()));
+    assertFalse(Renewer.cancelled);
 
     finishAMAndWaitForComplete(app2, rm, nm1, am2, dttr);
     // app2 completes, app1 is still running, check the token is not cancelled
-    Assert.assertTrue(renewer.getAllTokens().containsKey(token1));
-    Assert.assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
-    Assert.assertFalse(dttr.referringAppIds.contains(app2.getApplicationId()));
-    Assert.assertFalse(dttr.isTimerCancelled());
-    Assert.assertFalse(Renewer.cancelled);
+    assertTrue(renewer.getAllTokens().containsKey(token1));
+    assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
+    assertFalse(dttr.referringAppIds.contains(app2.getApplicationId()));
+    assertFalse(dttr.isTimerCancelled());
+    assertFalse(Renewer.cancelled);
 
     MockRMAppSubmissionData data =
         MockRMAppSubmissionData.Builder.createWithResource(resource, rm)
@@ -1464,18 +1479,18 @@ public class TestDelegationTokenRenewer {
     RMApp app3 = MockRMAppSubmitter.submit(rm, data);
     MockAM am3 = MockRM.launchAndRegisterAM(app3, rm, nm1);
     rm.waitForState(app3.getApplicationId(), RMAppState.RUNNING);
-    Assert.assertTrue(renewer.getAllTokens().containsKey(token1));
-    Assert.assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
-    Assert.assertTrue(dttr.referringAppIds.contains(app3.getApplicationId()));
-    Assert.assertFalse(dttr.isTimerCancelled());
-    Assert.assertFalse(Renewer.cancelled);
+    assertTrue(renewer.getAllTokens().containsKey(token1));
+    assertTrue(dttr.referringAppIds.contains(app1.getApplicationId()));
+    assertTrue(dttr.referringAppIds.contains(app3.getApplicationId()));
+    assertFalse(dttr.isTimerCancelled());
+    assertFalse(Renewer.cancelled);
 
     finishAMAndWaitForComplete(app1, rm, nm1, am1, dttr);
-    Assert.assertTrue(renewer.getAllTokens().containsKey(token1));
-    Assert.assertFalse(dttr.referringAppIds.contains(app1.getApplicationId()));
-    Assert.assertTrue(dttr.referringAppIds.contains(app3.getApplicationId()));
-    Assert.assertFalse(dttr.isTimerCancelled());
-    Assert.assertFalse(Renewer.cancelled);
+    assertTrue(renewer.getAllTokens().containsKey(token1));
+    assertFalse(dttr.referringAppIds.contains(app1.getApplicationId()));
+    assertTrue(dttr.referringAppIds.contains(app3.getApplicationId()));
+    assertFalse(dttr.isTimerCancelled());
+    assertFalse(Renewer.cancelled);
 
     finishAMAndWaitForComplete(app3, rm, nm1, am3, dttr);
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
@@ -1484,25 +1499,25 @@ public class TestDelegationTokenRenewer {
         return !renewer.getAllTokens().containsKey(token1);
       }
     }, 10, 5000);
-    Assert.assertFalse(renewer.getAllTokens().containsKey(token1));
-    Assert.assertTrue(dttr.referringAppIds.isEmpty());
+    assertFalse(renewer.getAllTokens().containsKey(token1));
+    assertTrue(dttr.referringAppIds.isEmpty());
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
       @Override
       public Boolean get() {
         return dttr.isTimerCancelled();
       }
     }, 10, 5000);
-    Assert.assertTrue(dttr.isTimerCancelled());
+    assertTrue(dttr.isTimerCancelled());
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
       @Override
       public Boolean get() {
         return Renewer.cancelled;
       }
     }, 10, 5000);
-    Assert.assertTrue(Renewer.cancelled);
+    assertTrue(Renewer.cancelled);
 
     // make sure the token also has been removed from appTokens
-    Assert.assertFalse(renewer.getDelegationTokens().contains(token1));
+    assertFalse(renewer.getDelegationTokens().contains(token1));
   }
 
   private void finishAMAndWaitForComplete(final RMApp app, MockRM mockrm,
@@ -1610,10 +1625,10 @@ public class TestDelegationTokenRenewer {
 
     try {
       submitApp(rm, credentials, tokenConf);
-      Assert.fail();
+      fail();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(e.getCause().getMessage()
+      assertTrue(e.getCause().getMessage()
           .contains(YarnConfiguration.RM_DELEGATION_TOKEN_MAX_CONF_SIZE));
     }
   }
@@ -1661,7 +1676,8 @@ public class TestDelegationTokenRenewer {
         BuilderUtils.newApplicationId(0, 1));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testTokenSequenceNoAfterNewTokenAndRenewal() throws Exception {
     conf.setBoolean(YarnConfiguration.RM_PROXY_USER_PRIVILEGES_ENABLED, true);
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
@@ -1708,7 +1724,7 @@ public class TestDelegationTokenRenewer {
     localDtr.addApplicationSync(appId1, credsx, false, "user1");
 
     // Ensure incrTokenSequenceNo has been called for new token request
-    Mockito.verify(mockContext, Mockito.times(1)).incrTokenSequenceNo();
+    verify(mockContext, times(1)).incrTokenSequenceNo();
 
     DelegationTokenToRenew dttr = localDtr.new DelegationTokenToRenew(appIds,
         expectedToken, conf, 1000, false, "user1");
@@ -1716,7 +1732,7 @@ public class TestDelegationTokenRenewer {
     localDtr.requestNewHdfsDelegationTokenIfNeeded(dttr);
 
     // Ensure incrTokenSequenceNo has been called for token renewal as well.
-    Mockito.verify(mockContext, Mockito.times(2)).incrTokenSequenceNo();
+    verify(mockContext, times(2)).incrTokenSequenceNo();
   }
 
   /**
@@ -1728,7 +1744,8 @@ public class TestDelegationTokenRenewer {
    *
    * @throws Exception
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testTokenThreadTimeout() throws Exception {
     Configuration yarnConf = new YarnConfiguration();
     yarnConf.set("override_token_expire_time", "30000");
@@ -1802,7 +1819,8 @@ public class TestDelegationTokenRenewer {
    *
    * @throws Exception
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testTokenThreadTimeoutWithoutDelay() throws Exception {
     Configuration yarnConf = new YarnConfiguration();
     yarnConf.setBoolean(YarnConfiguration.RM_PROXY_USER_PRIVILEGES_ENABLED,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewerLifecycle.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestDelegationTokenRenewerLifecycle.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.resourcemanager.ClientRMService;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test replicates the condition os MAPREDUCE-3431 -a failure

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestProxyCAManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestProxyCAManager.java
@@ -18,13 +18,15 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.recovery.RMStateStore;
 import org.apache.hadoop.yarn.server.webproxy.ProxyCA;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -46,20 +48,20 @@ public class TestProxyCAManager {
     when(rmContext.getStateStore()).thenReturn(rmStateStore);
     ProxyCAManager proxyCAManager = new ProxyCAManager(proxyCA, rmContext);
     proxyCAManager.init(new YarnConfiguration());
-    Assert.assertEquals(proxyCA, proxyCAManager.getProxyCA());
+    assertEquals(proxyCA, proxyCAManager.getProxyCA());
     verify(rmContext, times(0)).getStateStore();
     verify(rmStateStore, times(0)).storeProxyCACert(any(), any());
     verify(proxyCA, times(0)).init();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
 
     proxyCAManager.start();
     verify(rmContext, times(1)).getStateStore();
     verify(rmStateStore, times(1)).storeProxyCACert(proxyCA.getCaCert(),
         proxyCA.getCaKeyPair().getPrivate());
     verify(proxyCA, times(1)).init();
-    Assert.assertNotNull(proxyCA.getCaCert());
-    Assert.assertNotNull(proxyCA.getCaKeyPair());
+    assertNotNull(proxyCA.getCaCert());
+    assertNotNull(proxyCA.getCaKeyPair());
   }
 
   @Test
@@ -70,12 +72,12 @@ public class TestProxyCAManager {
     when(rmContext.getStateStore()).thenReturn(rmStateStore);
     ProxyCAManager proxyCAManager = new ProxyCAManager(proxyCA, rmContext);
     proxyCAManager.init(new YarnConfiguration());
-    Assert.assertEquals(proxyCA, proxyCAManager.getProxyCA());
+    assertEquals(proxyCA, proxyCAManager.getProxyCA());
     verify(rmContext, times(0)).getStateStore();
     verify(rmStateStore, times(0)).storeProxyCACert(any(), any());
     verify(proxyCA, times(0)).init();
-    Assert.assertNull(proxyCA.getCaCert());
-    Assert.assertNull(proxyCA.getCaKeyPair());
+    assertNull(proxyCA.getCaCert());
+    assertNull(proxyCA.getCaKeyPair());
 
     RMStateStore.RMState rmState = mock(RMStateStore.RMState.class);
     RMStateStore.ProxyCAState proxyCAState =
@@ -91,15 +93,15 @@ public class TestProxyCAManager {
     when(rmState.getProxyCAState()).thenReturn(proxyCAState);
     proxyCAManager.recover(rmState);
     verify(proxyCA, times(1)).init(certificate, privateKey);
-    Assert.assertEquals(certificate, proxyCA.getCaCert());
-    Assert.assertEquals(privateKey, proxyCA.getCaKeyPair().getPrivate());
+    assertEquals(certificate, proxyCA.getCaCert());
+    assertEquals(privateKey, proxyCA.getCaKeyPair().getPrivate());
 
     proxyCAManager.start();
     verify(rmContext, times(1)).getStateStore();
     verify(rmStateStore, times(1)).storeProxyCACert(proxyCA.getCaCert(),
         proxyCA.getCaKeyPair().getPrivate());
     verify(proxyCA, times(0)).init();
-    Assert.assertEquals(certificate, proxyCA.getCaCert());
-    Assert.assertEquals(privateKey, proxyCA.getCaKeyPair().getPrivate());
+    assertEquals(certificate, proxyCA.getCaCert());
+    assertEquals(privateKey, proxyCA.getCaKeyPair().getPrivate());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMAuthenticationFilter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMAuthenticationFilter.java
@@ -23,15 +23,17 @@ import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.yarn.server.security.http.RMAuthenticationFilter;
 import org.apache.hadoop.yarn.server.security.http
     .RMAuthenticationFilterInitializer;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test RM Auth filter.
@@ -47,8 +49,8 @@ public class TestRMAuthenticationFilter {
 
     conf.set(HttpServer2.BIND_ADDRESS, "barhost");
 
-    FilterContainer container = Mockito.mock(FilterContainer.class);
-    Mockito.doAnswer(new Answer() {
+    FilterContainer container = mock(FilterContainer.class);
+    doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
         Object[] args = invocationOnMock.getArguments();
@@ -72,7 +74,7 @@ public class TestRMAuthenticationFilter {
 
         return null;
       }
-    }).when(container).addFilter(Mockito.any(), Mockito.any(), Mockito.any());
+    }).when(container).addFilter(any(), any(), any());
 
     new RMAuthenticationFilterInitializer().initFilter(container, conf);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMDelegationTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMDelegationTokens.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,15 +52,15 @@ import org.apache.hadoop.yarn.server.resourcemanager.recovery.RMStateStore;
 import org.apache.hadoop.yarn.server.resourcemanager.recovery.RMStateStore.RMState;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestRMDelegationTokens {
 
   private YarnConfiguration testConf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
     ExitUtil.disableSystemExit();
@@ -81,12 +83,13 @@ public class TestRMDelegationTokens {
           break;
         }
       }
-      Assert.assertTrue("Master key not found: " + keyId, found);
+      assertTrue(found, "Master key not found: " + keyId);
     });
   }
 
   // Test the DT mast key in the state-store when the mast key is being rolled.
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testRMDTMasterKeyStateOnRollingMasterKey() throws Exception {
     Configuration conf = new Configuration(testConf);
     conf.set("hadoop.security.authentication", "kerberos");
@@ -146,7 +149,8 @@ public class TestRMDelegationTokens {
   }
 
   // Test all expired keys are removed from state-store.
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testRemoveExpiredMasterKeyInRMStateStore() throws Exception {
     MemoryRMStateStore memStore = new MockMemoryRMStateStore();
     memStore.init(testConf);
@@ -180,7 +184,8 @@ public class TestRMDelegationTokens {
   }
 
   // Test removing token without key from state-store.
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testUnknownKeyTokensOnRecover() throws Exception {
     final int masterID = 1234;
     final int sequenceNumber = 1000;
@@ -212,10 +217,10 @@ public class TestRMDelegationTokens {
     // Cannot recover while running: stop and clear
     dtSecretManager.stopThreads();
     dtSecretManager.reset();
-    Assert.assertEquals("Secret manager should have no tokens",
-        dtSecretManager.getAllTokens().size(), 0);
-    Assert.assertEquals("Secret manager should have no keys",
-        dtSecretManager.getAllMasterKeys().size(), 0);
+    assertEquals(dtSecretManager.getAllTokens().size(), 0,
+        "Secret manager should have no tokens");
+    assertEquals(dtSecretManager.getAllMasterKeys().size(), 0,
+        "Secret manager should have no keys");
     dtSecretManager.recover(rmState);
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
       public Boolean get() {
@@ -224,8 +229,8 @@ public class TestRMDelegationTokens {
                 containsKey(rmDT);
       }
     }, 10, 2000);
-    Assert.assertEquals("Token should have been expired but is not", 0L,
-        dtSecretManager.getRenewDate(rmDT));
+    assertEquals(0L, dtSecretManager.getRenewDate(rmDT),
+        "Token should have been expired but is not");
     // The remover thread should immediately do its work,
     // still give it some time to process
     dtSecretManager.startThreads();
@@ -296,7 +301,7 @@ public class TestRMDelegationTokens {
               break;
             }
           }
-          Assert.assertTrue(found);
+          assertTrue(found);
           return currentKey;
         }
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeCapabilityRange.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeCapabilityRange.java
@@ -32,21 +32,21 @@ public class TestVolumeCapabilityRange {
   @Test
   public void testInvalidMinCapability() throws InvalidVolumeException {
     assertThrows(InvalidVolumeException.class, () -> {
-      VolumeCapabilityRange.newBuilder()
-        .minCapacity(-1L)
-        .maxCapacity(5L)
-        .unit("Gi")
-        .build();
+        VolumeCapabilityRange.newBuilder()
+          .minCapacity(-1L)
+          .maxCapacity(5L)
+          .unit("Gi")
+          .build();
     });
   }
 
   @Test
   public void testMissingMinCapability() throws InvalidVolumeException {
     assertThrows(InvalidVolumeException.class, () -> {
-      VolumeCapabilityRange.newBuilder()
-        .maxCapacity(5L)
-        .unit("Gi")
-        .build();
+        VolumeCapabilityRange.newBuilder()
+          .maxCapacity(5L)
+          .unit("Gi")
+          .build();
     });
 
   }
@@ -54,10 +54,10 @@ public class TestVolumeCapabilityRange {
   @Test
   public void testMissingUnit() throws InvalidVolumeException {
     assertThrows(InvalidVolumeException.class, () -> {
-      VolumeCapabilityRange.newBuilder()
-        .minCapacity(0L)
-        .maxCapacity(5L)
-        .build();
+        VolumeCapabilityRange.newBuilder()
+          .minCapacity(0L)
+          .maxCapacity(5L)
+          .build();
     });
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeCapabilityRange.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeCapabilityRange.java
@@ -19,37 +19,46 @@ package org.apache.hadoop.yarn.server.resourcemanager.volume.csi;
 
 import org.apache.hadoop.yarn.server.volume.csi.exception.InvalidVolumeException;
 import org.apache.hadoop.yarn.server.volume.csi.VolumeCapabilityRange;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test cases for volume capability.
  */
 public class TestVolumeCapabilityRange {
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testInvalidMinCapability() throws InvalidVolumeException {
-    VolumeCapabilityRange.newBuilder()
+    assertThrows(InvalidVolumeException.class, () -> {
+      VolumeCapabilityRange.newBuilder()
         .minCapacity(-1L)
         .maxCapacity(5L)
         .unit("Gi")
         .build();
+    });
   }
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testMissingMinCapability() throws InvalidVolumeException {
-    VolumeCapabilityRange.newBuilder()
+    assertThrows(InvalidVolumeException.class, () -> {
+      VolumeCapabilityRange.newBuilder()
         .maxCapacity(5L)
         .unit("Gi")
         .build();
+    });
+
   }
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testMissingUnit() throws InvalidVolumeException {
-    VolumeCapabilityRange.newBuilder()
+    assertThrows(InvalidVolumeException.class, () -> {
+      VolumeCapabilityRange.newBuilder()
         .minCapacity(0L)
         .maxCapacity(5L)
         .build();
+    });
   }
 
   @Test
@@ -60,8 +69,8 @@ public class TestVolumeCapabilityRange {
         .unit("Gi")
         .build();
 
-    Assert.assertEquals(0L, vc.getMinCapacity());
-    Assert.assertEquals(5L, vc.getMaxCapacity());
-    Assert.assertEquals("Gi", vc.getUnit());
+    assertEquals(0L, vc.getMinCapacity());
+    assertEquals(5L, vc.getMaxCapacity());
+    assertEquals("Gi", vc.getUnit());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeMetaData.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeMetaData.java
@@ -25,10 +25,17 @@ import org.apache.hadoop.yarn.server.volume.csi.VolumeCapabilityRange;
 import org.apache.hadoop.yarn.server.volume.csi.VolumeMetaData;
 import org.apache.hadoop.yarn.server.volume.csi.exception.InvalidVolumeException;
 import org.apache.hadoop.yarn.server.volume.csi.VolumeId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for volume specification definition and parsing.
@@ -51,26 +58,26 @@ public class TestVolumeMetaData {
         .mountPoint("/mnt/data")
         .build();
 
-    Assert.assertEquals(new VolumeId("id-000001"), meta.getVolumeId());
-    Assert.assertEquals(1L, meta.getVolumeCapabilityRange().getMinCapacity());
-    Assert.assertEquals(5L, meta.getVolumeCapabilityRange().getMaxCapacity());
-    Assert.assertEquals("Gi", meta.getVolumeCapabilityRange().getUnit());
-    Assert.assertEquals("csi-demo-driver", meta.getDriverName());
-    Assert.assertEquals("/mnt/data", meta.getMountPoint());
-    Assert.assertNull(meta.getVolumeName());
-    Assert.assertTrue(meta.isProvisionedVolume());
+    assertEquals(new VolumeId("id-000001"), meta.getVolumeId());
+    assertEquals(1L, meta.getVolumeCapabilityRange().getMinCapacity());
+    assertEquals(5L, meta.getVolumeCapabilityRange().getMaxCapacity());
+    assertEquals("Gi", meta.getVolumeCapabilityRange().getUnit());
+    assertEquals("csi-demo-driver", meta.getDriverName());
+    assertEquals("/mnt/data", meta.getMountPoint());
+    assertNull(meta.getVolumeName());
+    assertTrue(meta.isProvisionedVolume());
 
     // Test toString
     JsonParser parser = new JsonParser();
     JsonElement element = parser.parse(meta.toString());
     JsonObject json = element.getAsJsonObject();
-    Assert.assertNotNull(json);
-    Assert.assertNull(json.get(CsiConstants.CSI_VOLUME_NAME));
-    Assert.assertEquals("id-000001",
+    assertNotNull(json);
+    assertNull(json.get(CsiConstants.CSI_VOLUME_NAME));
+    assertEquals("id-000001",
         json.get(CsiConstants.CSI_VOLUME_ID).getAsString());
-    Assert.assertEquals("csi-demo-driver",
+    assertEquals("csi-demo-driver",
         json.get(CsiConstants.CSI_DRIVER_NAME).getAsString());
-    Assert.assertEquals("/mnt/data",
+    assertEquals("/mnt/data",
         json.get(CsiConstants.CSI_VOLUME_MOUNT).getAsString());
 
   }
@@ -90,68 +97,74 @@ public class TestVolumeMetaData {
         .driverName("csi-demo-driver")
         .mountPoint("/mnt/data")
         .build();
-    Assert.assertNotNull(meta);
+    assertNotNull(meta);
 
-    Assert.assertEquals("volume-name", meta.getVolumeName());
-    Assert.assertEquals(1L, meta.getVolumeCapabilityRange().getMinCapacity());
-    Assert.assertEquals(5L, meta.getVolumeCapabilityRange().getMaxCapacity());
-    Assert.assertEquals("Gi", meta.getVolumeCapabilityRange().getUnit());
-    Assert.assertEquals("csi-demo-driver", meta.getDriverName());
-    Assert.assertEquals("/mnt/data", meta.getMountPoint());
-    Assert.assertFalse(meta.isProvisionedVolume());
+    assertEquals("volume-name", meta.getVolumeName());
+    assertEquals(1L, meta.getVolumeCapabilityRange().getMinCapacity());
+    assertEquals(5L, meta.getVolumeCapabilityRange().getMaxCapacity());
+    assertEquals("Gi", meta.getVolumeCapabilityRange().getUnit());
+    assertEquals("csi-demo-driver", meta.getDriverName());
+    assertEquals("/mnt/data", meta.getMountPoint());
+    assertFalse(meta.isProvisionedVolume());
 
     // Test toString
     JsonParser parser = new JsonParser();
     JsonElement element = parser.parse(meta.toString());
     JsonObject json = element.getAsJsonObject();
-    Assert.assertNotNull(json);
-    Assert.assertNull(json.get(CsiConstants.CSI_VOLUME_ID));
-    Assert.assertEquals("volume-name",
+    assertNotNull(json);
+    assertNull(json.get(CsiConstants.CSI_VOLUME_ID));
+    assertEquals("volume-name",
         json.get(CsiConstants.CSI_VOLUME_NAME).getAsString());
-    Assert.assertEquals("csi-demo-driver",
+    assertEquals("csi-demo-driver",
         json.get(CsiConstants.CSI_DRIVER_NAME).getAsString());
-    Assert.assertEquals("/mnt/data",
+    assertEquals("/mnt/data",
         json.get(CsiConstants.CSI_VOLUME_MOUNT).getAsString());
   }
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testMissingMountpoint() throws InvalidVolumeException {
-    VolumeCapabilityRange cap = VolumeCapabilityRange.newBuilder()
-        .minCapacity(1L)
-        .maxCapacity(5L)
-        .unit("Gi")
-        .build();
+    assertThrows(InvalidVolumeException.class, ()->{
+      VolumeCapabilityRange cap = VolumeCapabilityRange.newBuilder()
+              .minCapacity(1L)
+              .maxCapacity(5L)
+              .unit("Gi")
+              .build();
 
-    VolumeMetaData.newBuilder()
-        .volumeId(new VolumeId("id-000001"))
-        .capability(cap)
-        .driverName("csi-demo-driver")
-        .build();
+      VolumeMetaData.newBuilder()
+              .volumeId(new VolumeId("id-000001"))
+              .capability(cap)
+              .driverName("csi-demo-driver")
+              .build();
+    });
   }
 
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testMissingCsiDriverName() throws InvalidVolumeException {
-    VolumeCapabilityRange cap = VolumeCapabilityRange.newBuilder()
-        .minCapacity(1L)
-        .maxCapacity(5L)
-        .unit("Gi")
-        .build();
+    assertThrows(InvalidVolumeException.class, ()->{
+      VolumeCapabilityRange cap = VolumeCapabilityRange.newBuilder()
+              .minCapacity(1L)
+              .maxCapacity(5L)
+              .unit("Gi")
+              .build();
 
-    VolumeMetaData.newBuilder()
-        .volumeId(new VolumeId("id-000001"))
-        .capability(cap)
-        .mountPoint("/mnt/data")
-        .build();
+      VolumeMetaData.newBuilder()
+              .volumeId(new VolumeId("id-000001"))
+              .capability(cap)
+              .mountPoint("/mnt/data")
+              .build();
+    });
   }
 
-  @Test(expected = InvalidVolumeException.class)
+  @Test
   public void testMissingVolumeCapability() throws InvalidVolumeException {
-    VolumeMetaData.newBuilder()
-        .volumeId(new VolumeId("id-000001"))
-        .driverName("csi-demo-driver")
-        .mountPoint("/mnt/data")
-        .build();
+    assertThrows(InvalidVolumeException.class, ()->{
+      VolumeMetaData.newBuilder()
+              .volumeId(new VolumeId("id-000001"))
+              .driverName("csi-demo-driver")
+              .mountPoint("/mnt/data")
+              .build();
+    });
   }
 
   @Test
@@ -160,19 +173,19 @@ public class TestVolumeMetaData {
     VolumeId id11 = new VolumeId("test00001");
     VolumeId id2 = new VolumeId("test00002");
 
-    Assert.assertEquals(id1, id11);
-    Assert.assertEquals(id1.hashCode(), id11.hashCode());
-    Assert.assertNotEquals(id1, id2);
+    assertEquals(id1, id11);
+    assertEquals(id1.hashCode(), id11.hashCode());
+    assertNotEquals(id1, id2);
 
     HashMap<VolumeId, String> map = new HashMap<>();
     map.put(id1, "1");
-    Assert.assertEquals(1, map.size());
-    Assert.assertEquals("1", map.get(id11));
+    assertEquals(1, map.size());
+    assertEquals("1", map.get(id11));
     map.put(id11, "2");
-    Assert.assertEquals(1, map.size());
-    Assert.assertEquals("2", map.get(id11));
-    Assert.assertEquals("2", map.get(new VolumeId("test00001")));
+    assertEquals(1, map.size());
+    assertEquals("2", map.get(id11));
+    assertEquals("2", map.get(new VolumeId("test00001")));
 
-    Assert.assertNotEquals(id1, id2);
+    assertNotEquals(id1, id2);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeProcessor.java
@@ -53,11 +53,11 @@ import org.apache.hadoop.yarn.server.volume.csi.VolumeId;
 import org.apache.hadoop.yarn.server.volume.csi.exception.InvalidVolumeException;
 import org.apache.hadoop.yarn.server.volume.csi.exception.VolumeException;
 import org.apache.hadoop.yarn.server.volume.csi.exception.VolumeProvisioningException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -67,9 +67,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test cases for volume processor.
@@ -90,7 +91,7 @@ public class TestVolumeProcessor {
 
   private static final String VOLUME_RESOURCE_NAME = "yarn.io/csi-volume";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new YarnConfiguration();
     resourceTypesFile = new File(conf.getClassLoader()
@@ -126,7 +127,7 @@ public class TestVolumeProcessor {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (resourceTypesFile != null && resourceTypesFile.exists()) {
       resourceTypesFile.delete();
@@ -146,7 +147,8 @@ public class TestVolumeProcessor {
     }
   }
 
-  @Test (timeout = 10000L)
+  @Test
+  @Timeout(10)
   public void testVolumeProvisioning() throws Exception {
     MockRMAppSubmissionData data =
         MockRMAppSubmissionData.Builder.createWithMemory(1 * GB, rm)
@@ -179,8 +181,7 @@ public class TestVolumeProcessor {
         .build();
 
     // inject adaptor client for testing
-    CsiAdaptorProtocol mockedClient = Mockito
-        .mock(CsiAdaptorProtocol.class);
+    CsiAdaptorProtocol mockedClient = mock(CsiAdaptorProtocol.class);
     rm.getRMContext().getVolumeManager()
         .registerCsiDriverAdaptor("hostpath", mockedClient);
 
@@ -192,7 +193,7 @@ public class TestVolumeProcessor {
     am1.allocate(ar);
     VolumeStates volumeStates =
         rm.getRMContext().getVolumeManager().getVolumeStates();
-    Assert.assertNotNull(volumeStates);
+    Assertions.assertNotNull(volumeStates);
     VolumeState volumeState = VolumeState.NEW;
     while (volumeState != VolumeState.NODE_READY) {
       Volume volume = volumeStates
@@ -207,7 +208,8 @@ public class TestVolumeProcessor {
     rm.stop();
   }
 
-  @Test (timeout = 30000L)
+  @Test
+  @Timeout(30)
   public void testInvalidRequest() throws Exception {
     MockRMAppSubmissionData data =
         MockRMAppSubmissionData.Builder.createWithMemory(1 * GB, rm)
@@ -242,14 +244,15 @@ public class TestVolumeProcessor {
 
     try {
       am1.allocate(ar);
-      Assert.fail("allocate should fail because invalid request received");
+      Assertions.fail("allocate should fail because invalid request received");
     } catch (Exception e) {
-      Assert.assertTrue(e instanceof InvalidVolumeException);
+      Assertions.assertTrue(e instanceof InvalidVolumeException);
     }
     rm.stop();
   }
 
-  @Test (timeout = 30000L)
+  @Test
+  @Timeout(30)
   public void testProvisioningFailures() throws Exception {
     MockRMAppSubmissionData data =
         MockRMAppSubmissionData.Builder.createWithMemory(1 * GB, rm)
@@ -262,8 +265,7 @@ public class TestVolumeProcessor {
     RMApp app1 = MockRMAppSubmitter.submit(rm, data);
     MockAM am1 = MockRM.launchAndRegisterAM(app1, rm, mockNMS[0]);
 
-    CsiAdaptorProtocol mockedClient = Mockito
-        .mock(CsiAdaptorProtocol.class);
+    CsiAdaptorProtocol mockedClient = mock(CsiAdaptorProtocol.class);
     // inject adaptor client
     rm.getRMContext().getVolumeManager()
         .registerCsiDriverAdaptor("hostpath", mockedClient);
@@ -293,14 +295,15 @@ public class TestVolumeProcessor {
 
     try {
       am1.allocate(ar);
-      Assert.fail("allocate should fail");
+      Assertions.fail("allocate should fail");
     } catch (Exception e) {
-      Assert.assertTrue(e instanceof VolumeProvisioningException);
+      Assertions.assertTrue(e instanceof VolumeProvisioningException);
     }
     rm.stop();
   }
 
-  @Test (timeout = 10000L)
+  @Test
+  @Timeout(10)
   public void testVolumeResourceAllocate() throws Exception {
     RMApp app1 = MockRMAppSubmitter.submit(rm,
         MockRMAppSubmissionData.Builder.createWithMemory(1 * GB, rm)
@@ -328,8 +331,7 @@ public class TestVolumeProcessor {
         .build();
 
     // inject adaptor client for testing
-    CsiAdaptorProtocol mockedClient = Mockito
-        .mock(CsiAdaptorProtocol.class);
+    CsiAdaptorProtocol mockedClient = mock(CsiAdaptorProtocol.class);
     rm.getRMContext().getVolumeManager()
         .registerCsiDriverAdaptor("hostpath", mockedClient);
 
@@ -347,13 +349,13 @@ public class TestVolumeProcessor {
       Thread.sleep(500);
     }
 
-    Assert.assertEquals(1, allocated.size());
+    Assertions.assertEquals(1, allocated.size());
     Container alloc = allocated.get(0);
     assertThat(alloc.getResource().getMemorySize()).isEqualTo(1024);
     assertThat(alloc.getResource().getVirtualCores()).isEqualTo(1);
     ResourceInformation allocatedVolume =
         alloc.getResource().getResourceInformation(VOLUME_RESOURCE_NAME);
-    Assert.assertNotNull(allocatedVolume);
+    Assertions.assertNotNull(allocatedVolume);
     assertThat(allocatedVolume.getValue()).isEqualTo(1024);
     assertThat(allocatedVolume.getUnits()).isEqualTo("Mi");
     rm.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/volume/csi/TestVolumeProcessor.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.volume.csi;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
@@ -54,7 +60,6 @@ import org.apache.hadoop.yarn.server.volume.csi.exception.InvalidVolumeException
 import org.apache.hadoop.yarn.server.volume.csi.exception.VolumeException;
 import org.apache.hadoop.yarn.server.volume.csi.exception.VolumeProvisioningException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -193,7 +198,7 @@ public class TestVolumeProcessor {
     am1.allocate(ar);
     VolumeStates volumeStates =
         rm.getRMContext().getVolumeManager().getVolumeStates();
-    Assertions.assertNotNull(volumeStates);
+    assertNotNull(volumeStates);
     VolumeState volumeState = VolumeState.NEW;
     while (volumeState != VolumeState.NODE_READY) {
       Volume volume = volumeStates
@@ -244,9 +249,9 @@ public class TestVolumeProcessor {
 
     try {
       am1.allocate(ar);
-      Assertions.fail("allocate should fail because invalid request received");
+      fail("allocate should fail because invalid request received");
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof InvalidVolumeException);
+      assertTrue(e instanceof InvalidVolumeException);
     }
     rm.stop();
   }
@@ -295,9 +300,9 @@ public class TestVolumeProcessor {
 
     try {
       am1.allocate(ar);
-      Assertions.fail("allocate should fail");
+      fail("allocate should fail");
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof VolumeProvisioningException);
+      assertTrue(e instanceof VolumeProvisioningException);
     }
     rm.stop();
   }
@@ -349,13 +354,13 @@ public class TestVolumeProcessor {
       Thread.sleep(500);
     }
 
-    Assertions.assertEquals(1, allocated.size());
+    assertEquals(1, allocated.size());
     Container alloc = allocated.get(0);
     assertThat(alloc.getResource().getMemorySize()).isEqualTo(1024);
     assertThat(alloc.getResource().getVirtualCores()).isEqualTo(1);
     ResourceInformation allocatedVolume =
         alloc.getResource().getResourceInformation(VOLUME_RESOURCE_NAME);
-    Assertions.assertNotNull(allocatedVolume);
+    assertNotNull(allocatedVolume);
     assertThat(allocatedVolume.getValue()).isEqualTo(1024);
     assertThat(allocatedVolume.getUnits()).isEqualTo("Mi");
     rm.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/ActivitiesTestUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/ActivitiesTestUtils.java
@@ -47,7 +47,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Some Utils for activities tests.
@@ -148,11 +148,11 @@ public final class ActivitiesTestUtils {
   public static void verifyNumberOfNodes(JSONObject allocation, int expectValue)
       throws Exception {
     if (allocation.isNull(FN_SCHEDULER_ACT_ALLOCATIONS_ROOT)) {
-      assertEquals("State of allocation is wrong", expectValue, 0);
+      assertEquals(expectValue, 0, "State of allocation is wrong");
     } else {
-      assertEquals("State of allocation is wrong", expectValue,
-          1 + getNumberOfNodes(
-              allocation.getJSONObject(FN_SCHEDULER_ACT_ALLOCATIONS_ROOT)));
+      assertEquals(expectValue, 1 + getNumberOfNodes(
+          allocation.getJSONObject(FN_SCHEDULER_ACT_ALLOCATIONS_ROOT)),
+          "State of allocation is wrong");
     }
   }
 
@@ -176,8 +176,7 @@ public final class ActivitiesTestUtils {
 
   public static void verifyStateOfAllocations(JSONObject allocation,
       String nameToCheck, String expectState) throws Exception {
-    assertEquals("State of allocation is wrong", expectState,
-        allocation.get(nameToCheck));
+    assertEquals(expectState, allocation.get(nameToCheck), "State of allocation is wrong");
   }
 
   public static void verifyNumberOfAllocations(JSONObject json, int expectValue)
@@ -191,14 +190,14 @@ public final class ActivitiesTestUtils {
       throw new IllegalArgumentException("Can't parse allocations!");
     }
     if (activitiesJson.isNull(FN_ACT_ALLOCATIONS)) {
-      assertEquals("Number of allocations is wrong", expectValue, 0);
+      assertEquals(expectValue, 0, "Number of allocations is wrong");
     } else {
       Object object = activitiesJson.get(FN_ACT_ALLOCATIONS);
       if (object.getClass() == JSONObject.class) {
-        assertEquals("Number of allocations is wrong", expectValue, 1);
+        assertEquals(expectValue, 1, "Number of allocations is wrong");
       } else if (object.getClass() == JSONArray.class) {
-        assertEquals("Number of allocations is wrong in: " + object,
-            expectValue, ((JSONArray) object).length());
+        assertEquals(expectValue, ((JSONArray) object).length(),
+            "Number of allocations is wrong in: " + object);
       }
     }
   }
@@ -210,8 +209,8 @@ public final class ActivitiesTestUtils {
       JSONObject root = json.getJSONObject(FN_SCHEDULER_ACT_ALLOCATIONS_ROOT);
       order = root.getString(FN_SCHEDULER_ACT_NAME) + "-" + getQueueOrder(root);
     }
-    assertEquals("Order of queue is wrong", expectOrder,
-        order.substring(0, order.length() - 1));
+    assertEquals(expectOrder, order.substring(0, order.length() - 1),
+        "Order of queue is wrong");
   }
 
   public static String getQueueOrder(JSONObject node) throws Exception {
@@ -282,14 +281,14 @@ public final class ActivitiesTestUtils {
   public static void verifyNumberOfAllocationAttempts(JSONObject allocation,
       int expectValue) throws Exception {
     if (allocation.isNull(FN_APP_ACT_CHILDREN)) {
-      assertEquals("Number of allocation attempts is wrong", expectValue, 0);
+      assertEquals(expectValue, 0, "Number of allocation attempts is wrong");
     } else {
       Object object = allocation.get(FN_APP_ACT_CHILDREN);
       if (object.getClass() == JSONObject.class) {
-        assertEquals("Number of allocations attempts is wrong", expectValue, 1);
+        assertEquals(expectValue, 1, "Number of allocations attempts is wrong");
       } else if (object.getClass() == JSONArray.class) {
-        assertEquals("Number of allocations attempts is wrong", expectValue,
-            ((JSONArray) object).length());
+        assertEquals(expectValue, ((JSONArray) object).length(),
+            "Number of allocations attempts is wrong");
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestAppPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestAppPage.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.webapp.AppBlock;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.Binder;
 import com.google.inject.Injector;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestApplicationsRequestBuilder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestApplicationsRequestBuilder.java
@@ -22,13 +22,14 @@ import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.webapp.BadRequestException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.server.webapp.WebServices.parseQueries;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -70,10 +71,12 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidStateQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStateQuery("invalidState").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStateQuery("invalidState").build();
+    });
   }
 
   @Test
@@ -100,14 +103,15 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidStateQueries() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStatesQuery(Sets.newHashSet("a1", "a2", "")).build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStatesQuery(Sets.newHashSet("a1", "a2", "")).build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -197,20 +201,22 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithQueueQueryNotExistingQueue() throws IOException {
-    CapacityScheduler cs = mock(CapacityScheduler.class);
-    when(cs.getQueueInfo(eq("queue1"), anyBoolean(), anyBoolean()))
-        .thenThrow(new IOException());
-    ResourceManager rm = mock(ResourceManager.class);
-    when(rm.getResourceScheduler()).thenReturn(cs);
+    assertThrows(BadRequestException.class, () -> {
+      CapacityScheduler cs = mock(CapacityScheduler.class);
+      when(cs.getQueueInfo(eq("queue1"), anyBoolean(), anyBoolean()))
+          .thenThrow(new IOException());
+      ResourceManager rm = mock(ResourceManager.class);
+      when(rm.getResourceScheduler()).thenReturn(cs);
 
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withQueueQuery(rm, "queue1").build();
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withQueueQuery(rm, "queue1").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    expectedRequest.setQueues(Sets.newHashSet("queue1"));
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      expectedRequest.setQueues(Sets.newHashSet("queue1"));
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -231,22 +237,26 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidLimitQuery() {
-    GetApplicationsRequest request =
-        ApplicationsRequestBuilder.create().withLimit("bla").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request =
+          ApplicationsRequestBuilder.create().withLimit("bla").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidNegativeLimitQuery() {
-    GetApplicationsRequest request =
-        ApplicationsRequestBuilder.create().withLimit("-10").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request =
+          ApplicationsRequestBuilder.create().withLimit("-10").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -277,22 +287,26 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidStartedTimeBeginQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStartedTimeBegin("bla").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStartedTimeBegin("bla").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidNegativeStartedTimeBeginQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStartedTimeBegin("-1").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStartedTimeBegin("-1").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -323,22 +337,26 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidStartedTimeEndQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStartedTimeEnd("bla").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStartedTimeEnd("bla").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidNegativeStartedTimeEndQuery() {
-    GetApplicationsRequest request =
-        ApplicationsRequestBuilder.create().withStartedTimeEnd("-1").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request =
+          ApplicationsRequestBuilder.create().withStartedTimeEnd("-1").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -369,22 +387,26 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidFinishedTimeBeginQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withFinishTimeBegin("bla").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withFinishTimeBegin("bla").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidNegativeFinishedTimeBeginQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withFinishTimeBegin("-1").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withFinishTimeBegin("-1").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -415,22 +437,26 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidFinishTimeEndQuery() {
-    GetApplicationsRequest request =
-        ApplicationsRequestBuilder.create().withFinishTimeEnd("bla").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request =
+          ApplicationsRequestBuilder.create().withFinishTimeEnd("bla").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidNegativeFinishedTimeEndQuery() {
-    GetApplicationsRequest request =
-        ApplicationsRequestBuilder.create().withFinishTimeEnd("-1").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request =
+          ApplicationsRequestBuilder.create().withFinishTimeEnd("-1").build();
 
-    GetApplicationsRequest expectedRequest = getDefaultRequest();
-    assertEquals(expectedRequest, request);
+      GetApplicationsRequest expectedRequest = getDefaultRequest();
+      assertEquals(expectedRequest, request);
+    });
   }
 
   @Test
@@ -453,10 +479,12 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidStartTimeRangeQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withStartedTimeBegin("2000").withStartedTimeEnd("1000").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+          .withStartedTimeBegin("2000").withStartedTimeEnd("1000").build();
+    });
   }
 
   @Test
@@ -469,10 +497,12 @@ public class TestApplicationsRequestBuilder {
     assertEquals(expectedRequest, request);
   }
 
-  @Test(expected = BadRequestException.class)
+  @Test
   public void testRequestWithInvalidFinishTimeRangeQuery() {
-    GetApplicationsRequest request = ApplicationsRequestBuilder.create()
-        .withFinishTimeBegin("2000").withFinishTimeEnd("1000").build();
+    assertThrows(BadRequestException.class, () -> {
+      GetApplicationsRequest request = ApplicationsRequestBuilder.create()
+           .withFinishTimeBegin("2000").withFinishTimeEnd("1000").build();
+    });
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestNodesPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestNodesPage.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Map;
@@ -29,9 +32,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.NodesPage.NodesBlock
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.Binder;
 import com.google.inject.Injector;
@@ -57,7 +59,7 @@ public class TestNodesPage {
 
   private Injector injector;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setUpInternal(false);
   }
@@ -87,11 +89,8 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer,
-        Mockito.times(numberOfActualTableHeaders + numberOfThInMetricsTable))
-        .print("<th");
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
-        .print("<td");
+    verify(writer, times(numberOfActualTableHeaders + numberOfThInMetricsTable)).print("<th");
+    verify(writer, times(numberOfThInMetricsTable)).print("<td");
   }
   
   @Test
@@ -102,10 +101,10 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer,
-        Mockito.times(numberOfActualTableHeaders + numberOfThInMetricsTable))
+    verify(writer,
+        times(numberOfActualTableHeaders + numberOfThInMetricsTable))
         .print("<th");
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
   }
 
@@ -138,11 +137,11 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer,
-        Mockito.times(numberOfActualTableHeaders
+    verify(writer,
+        times(numberOfActualTableHeaders
             + numberOfThInMetricsTable + 2))
         .print("<th");
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
   }
 
@@ -153,9 +152,9 @@ public class TestNodesPage {
     nodesBlock.render();
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
-    Mockito.verify(writer, Mockito.times(1)).print("<script");
+    verify(writer, times(1)).print("<script");
   }
   
   @Test
@@ -166,7 +165,7 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
   }
   
@@ -178,7 +177,7 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
   }
 
@@ -206,10 +205,10 @@ public class TestNodesPage {
     PrintWriter writer = injector.getInstance(PrintWriter.class);
     WebAppTests.flushOutput(injector);
 
-    Mockito.verify(writer, Mockito.times(
+    verify(writer, times(
         numberOfActualTableHeaders + numberOfThInMetricsTable +
             numberOfThForOpportunisticContainers)).print("<th");
-    Mockito.verify(writer, Mockito.times(numberOfThInMetricsTable))
+    verify(writer, times(numberOfThInMetricsTable))
         .print("<td");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebApp.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.MockNodes.newResource;
 import static org.apache.hadoop.yarn.webapp.Params.TITLE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -70,8 +71,7 @@ import org.apache.hadoop.yarn.util.StringHelper;
 import org.apache.hadoop.yarn.webapp.WebApps;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import com.google.inject.Binder;
@@ -126,7 +126,7 @@ public class TestRMWebApp {
     Map<String, String> moreParams =
         rmViewInstance.context().requestContext().moreParams();
     String appsTableColumnsMeta = moreParams.get("ui.dataTables.apps.init");
-    Assert.assertTrue(appsTableColumnsMeta.indexOf("natural") != -1);
+    assertTrue(appsTableColumnsMeta.indexOf("natural") != -1);
   }
 
   @Test
@@ -184,14 +184,14 @@ public class TestRMWebApp {
     String tableInit = WebPageUtils.appsTableInit(true);
     for (String tableLine : tableInit.split("\\n")) {
       if (tableLine.contains("parseHadoopID")) {
-        assertTrue(tableLine + " should have id " + colsId,
-            tableLine.contains(colsId.toString()));
+        assertTrue(tableLine.contains(colsId.toString()),
+            tableLine + " should have id " + colsId);
       } else if (tableLine.contains("renderHadoopDate")) {
-        assertTrue(tableLine + " should have dates " + colsTime,
-            tableLine.contains(colsTime.toString()));
+        assertTrue(tableLine.contains(colsTime.toString()),
+            tableLine + " should have dates " + colsTime);
       } else if (tableLine.contains("parseHadoopProgress")) {
-        assertTrue(tableLine + " should have progress " + colsProgress,
-            tableLine.contains(colsProgress.toString()));
+        assertTrue(tableLine.contains(colsProgress.toString()),
+            tableLine + " should have progress " + colsProgress);
       }
     }
   }
@@ -316,7 +316,7 @@ public class TestRMWebApp {
       when(clientRMService.getApplications(any(GetApplicationsRequest.class)))
           .thenReturn(response);
     } catch (YarnException e) {
-      Assert.fail("Exception is not expected.");
+      fail("Exception is not expected.");
     }
     return clientRMService;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebAppFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebAppFairScheduler.java
@@ -44,8 +44,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.ClientToAMTokenSec
 import org.apache.hadoop.yarn.server.resourcemanager.security.NMTokenSecretManagerInRM;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,6 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -111,7 +111,7 @@ public class TestRMWebAppFairScheduler {
     try {
       fsViewInstance.render();
     } catch (Exception e) {
-      Assert.fail("Failed to render FairSchedulerPage: " +
+      fail("Failed to render FairSchedulerPage: " +
           StringUtils.stringifyException(e));
     }
     WebAppTests.flushOutput(injector);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServiceAppsNodelabel.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -56,8 +56,7 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
@@ -106,7 +105,7 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
         nodeLabelManager = rm.getRMContext().getNodeLabelManager();
         nodeLabelManager.addToCluserNodeLabels(labels);
       } catch (Exception e) {
-        Assert.fail();
+        fail();
       }
       final HttpServletRequest request = mock(HttpServletRequest.class);
       final HttpServletResponse response = mock(HttpServletResponse.class);
@@ -155,13 +154,12 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
         .request(MediaType.APPLICATION_JSON).get(Response.class);
     JSONObject json = response.readEntity(JSONObject.class);
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     try {
       apps.getJSONArray("app").getJSONObject(0).getJSONObject("resourceInfo");
       fail("resourceInfo object shouldn't be available for finished apps");
     } catch (Exception e) {
-      assertTrue("resourceInfo shouldn't be available for finished apps",
-          true);
+      assertTrue(true, "resourceInfo shouldn't be available for finished apps");
     }
     rm.stop();
   }
@@ -199,10 +197,10 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
 
     // Verify apps resource
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject jsonObject = apps.getJSONObject("app").getJSONObject("resourceInfo");
     JSONArray jsonArray = jsonObject.getJSONArray("resourceUsagesByPartition");
-    assertEquals("Partition expected is 2", 2, jsonArray.length());
+    assertEquals(2, jsonArray.length(), "Partition expected is 2");
 
     // Default partition resource
     JSONObject defaultPartition = jsonArray.getJSONObject(0);
@@ -224,15 +222,13 @@ public class TestRMWebServiceAppsNodelabel extends JerseyTestBase {
     JSONObject amusedObject = (JSONObject) partition.get("amUsed");
     JSONObject usedObject = (JSONObject) partition.get("used");
     JSONObject reservedObject = (JSONObject) partition.get("reserved");
-    assertEquals("Partition expected", partitionName,
-        partition.get("partitionName"));
-    assertEquals("partition amused", amused, getResource(
-        (int) amusedObject.get("memory"), (int) amusedObject.get("vCores")));
-    assertEquals("partition used", used, getResource(
-        (int) usedObject.get("memory"), (int) usedObject.get("vCores")));
-    assertEquals("partition reserved", reserved,
-        getResource((int) reservedObject.get("memory"),
-            (int) reservedObject.get("vCores")));
+    assertEquals(partitionName, partition.get("partitionName"), "Partition expected");
+    assertEquals(amused, getResource((int) amusedObject.get("memory"),
+        (int) amusedObject.get("vCores")), "partition amused");
+    assertEquals(used, getResource((int) usedObject.get("memory"),
+        (int) usedObject.get("vCores")), "partition used");
+    assertEquals(reserved, getResource((int) reservedObject.get("memory"),
+        (int) reservedObject.get("vCores")), "partition reserved");
   }
 
   @SuppressWarnings("unchecked")

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -19,9 +19,11 @@
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -109,9 +111,8 @@ import org.apache.hadoop.yarn.webapp.dao.QueueConfigInfo;
 import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -161,7 +162,7 @@ public class TestRMWebServices extends JerseyTestBase {
   public TestRMWebServices() {
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void initClusterMetrics() {
     ClusterMetrics clusterMetrics = ClusterMetrics.getMetrics();
     clusterMetrics.incrDecommisionedNMs();
@@ -317,7 +318,7 @@ public class TestRMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("clusterInfo");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -341,9 +342,9 @@ public class TestRMWebServices extends JerseyTestBase {
 
   public void verifyClusterInfo(JSONObject json) throws JSONException,
       Exception {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject info = json.getJSONObject("clusterInfo");
-    assertEquals("incorrect number of elements", 12, info.length());
+    assertEquals(12, info.length(), "incorrect number of elements");
     verifyClusterGeneric(info.getLong("id"), info.getLong("startedOn"),
         info.getString("state"), info.getString("haState"),
         info.getString("haZooKeeperConnectionState"),
@@ -362,14 +363,13 @@ public class TestRMWebServices extends JerseyTestBase {
       String resourceManagerVersionBuiltOn, String resourceManagerBuildVersion,
       String resourceManagerVersion) {
 
-    assertEquals("clusterId doesn't match: ",
-        ResourceManager.getClusterTimeStamp(), clusterid);
-    assertEquals("startedOn doesn't match: ",
-        ResourceManager.getClusterTimeStamp(), startedon);
-    assertTrue("stated doesn't match: " + state,
-        state.matches(STATE.INITED.toString()));
-    assertTrue("HA state doesn't match: " + haState,
-        haState.matches("INITIALIZING"));
+    assertEquals(ResourceManager.getClusterTimeStamp(),
+        clusterid, "clusterId doesn't match: ");
+    assertEquals(ResourceManager.getClusterTimeStamp(),
+        startedon, "startedOn doesn't match: ");
+    assertTrue(state.matches(STATE.INITED.toString()),
+        "stated doesn't match: " + state);
+    assertTrue(haState.matches("INITIALIZING"), "HA state doesn't match: " + haState);
 
     WebServicesTestUtils.checkStringMatch("hadoopVersionBuiltOn",
         VersionInfo.getDate(), hadoopVersionBuiltOn);
@@ -443,7 +443,7 @@ public class TestRMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("clusterMetrics");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -474,9 +474,9 @@ public class TestRMWebServices extends JerseyTestBase {
 
   public void verifyClusterMetricsJSON(JSONObject json) throws JSONException,
       Exception {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject clusterinfo = json.getJSONObject("clusterMetrics");
-    assertEquals("incorrect number of elements", 37, clusterinfo.length());
+    assertEquals(37, clusterinfo.length(), "incorrect number of elements");
     verifyClusterMetrics(
         clusterinfo.getInt("appsSubmitted"), clusterinfo.getInt("appsCompleted"),
         clusterinfo.getInt("reservedMB"), clusterinfo.getInt("availableMB"),
@@ -510,49 +510,38 @@ public class TestRMWebServices extends JerseyTestBase {
         metrics.getAvailableMB() + metrics.getAllocatedMB();
     long totalVirtualCoresExpect =
         metrics.getAvailableVirtualCores() + metrics.getAllocatedVirtualCores();
-    assertEquals("appsSubmitted doesn't match",
-        metrics.getAppsSubmitted(), submittedApps);
-    assertEquals("appsCompleted doesn't match",
-        metrics.getAppsCompleted(), completedApps);
-    assertEquals("reservedMB doesn't match",
-        metrics.getReservedMB(), reservedMB);
-    assertEquals("availableMB doesn't match",
-        metrics.getAvailableMB(), availableMB);
-    assertEquals("allocatedMB doesn't match",
-        metrics.getAllocatedMB(), allocMB);
-    assertEquals("pendingMB doesn't match",
-            metrics.getPendingMB(), pendingMB);
-    assertEquals("reservedVirtualCores doesn't match",
-        metrics.getReservedVirtualCores(), reservedVirtualCores);
-    assertEquals("availableVirtualCores doesn't match",
-        metrics.getAvailableVirtualCores(), availableVirtualCores);
-    assertEquals("pendingVirtualCores doesn't match",
-        metrics.getPendingVirtualCores(), pendingVirtualCores);
-    assertEquals("allocatedVirtualCores doesn't match",
-        metrics.getAllocatedVirtualCores(), allocVirtualCores);
-    assertEquals("totalVirtualCores doesn't match",
-        totalVirtualCoresExpect, totalVirtualCores);
+    assertEquals(metrics.getAppsSubmitted(), submittedApps, "appsSubmitted doesn't match");
+    assertEquals(metrics.getAppsCompleted(), completedApps, "appsCompleted doesn't match");
+    assertEquals(metrics.getReservedMB(), reservedMB, "reservedMB doesn't match");
+    assertEquals(metrics.getAvailableMB(), availableMB, "availableMB doesn't match");
+    assertEquals(metrics.getAllocatedMB(), allocMB, "allocatedMB doesn't match");
+    assertEquals(metrics.getPendingMB(), pendingMB, "pendingMB doesn't match");
+    assertEquals(metrics.getReservedVirtualCores(), reservedVirtualCores,
+        "reservedVirtualCores doesn't match");
+    assertEquals(metrics.getAvailableVirtualCores(), availableVirtualCores,
+        "availableVirtualCores doesn't match");
+    assertEquals(metrics.getPendingVirtualCores(), pendingVirtualCores,
+        "pendingVirtualCores doesn't match");
+    assertEquals(metrics.getAllocatedVirtualCores(), allocVirtualCores,
+        "allocatedVirtualCores doesn't match");
+    assertEquals(totalVirtualCoresExpect, totalVirtualCores, "totalVirtualCores doesn't match");
 
-    assertEquals("containersAllocated doesn't match", 0, containersAlloc);
-    assertEquals("totalMB doesn't match", totalMBExpect, totalMB);
+    assertEquals(0, containersAlloc, "containersAllocated doesn't match");
+    assertEquals(totalMBExpect, totalMB, "totalMB doesn't match");
     assertEquals(
-        "totalNodes doesn't match",
-        clusterMetrics.getNumActiveNMs() + clusterMetrics.getNumLostNMs()
+       clusterMetrics.getNumActiveNMs() + clusterMetrics.getNumLostNMs()
             + clusterMetrics.getNumDecommisionedNMs()
             + clusterMetrics.getNumRebootedNMs()
-            + clusterMetrics.getUnhealthyNMs(), totalNodes);
-    assertEquals("lostNodes doesn't match", clusterMetrics.getNumLostNMs(),
-        lostNodes);
-    assertEquals("unhealthyNodes doesn't match",
-        clusterMetrics.getUnhealthyNMs(), unhealthyNodes);
-    assertEquals("decommissionedNodes doesn't match",
-        clusterMetrics.getNumDecommisionedNMs(), decommissionedNodes);
-    assertEquals("rebootedNodes doesn't match",
-        clusterMetrics.getNumRebootedNMs(), rebootedNodes);
-    assertEquals("activeNodes doesn't match", clusterMetrics.getNumActiveNMs(),
-        activeNodes);
-    assertEquals("shutdownNodes doesn't match",
-        clusterMetrics.getNumShutdownNMs(), shutdownNodes);
+            + clusterMetrics.getUnhealthyNMs(), totalNodes, "totalNodes doesn't match");
+    assertEquals(clusterMetrics.getNumLostNMs(), lostNodes, "lostNodes doesn't match");
+    assertEquals(clusterMetrics.getUnhealthyNMs(), unhealthyNodes,
+        "unhealthyNodes doesn't match");
+    assertEquals(clusterMetrics.getNumDecommisionedNMs(), decommissionedNodes,
+        "decommissionedNodes doesn't match");
+    assertEquals(clusterMetrics.getNumRebootedNMs(), rebootedNodes,
+        "rebootedNodes doesn't match");
+    assertEquals(clusterMetrics.getNumActiveNMs(), activeNodes, "activeNodes doesn't match");
+    assertEquals(clusterMetrics.getNumShutdownNMs(), shutdownNodes, "shutdownNodes doesn't match");
   }
 
   @Test
@@ -614,9 +603,9 @@ public class TestRMWebServices extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesSched = dom.getElementsByTagName("scheduler");
-    assertEquals("incorrect number of elements", 1, nodesSched.getLength());
+    assertEquals(1, nodesSched.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("schedulerInfo");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
 
     for (int i = 0; i < nodes.getLength(); i++) {
       Element element = (Element) nodes.item(i);
@@ -638,13 +627,13 @@ public class TestRMWebServices extends JerseyTestBase {
 
   public void verifyClusterSchedulerFifo(JSONObject json) throws JSONException,
       Exception {
-    assertEquals("incorrect number of elements in: " + json, 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements in: " + json);
     JSONObject info = json.getJSONObject("scheduler");
-    assertEquals("incorrect number of elements in: " + info, 1, info.length());
+    assertEquals(1, info.length(), "incorrect number of elements in: " + info);
     info = info.getJSONObject("schedulerInfo");
 
     LOG.debug("schedulerInfo: {}", info);
-    assertEquals("incorrect number of elements in: " + info, 11, info.length());
+    assertEquals(11, info.length(), "incorrect number of elements in: " + info);
 
     verifyClusterSchedulerFifoGeneric(info.getString("@xsi.type"),
         info.getString("qstate"), (float) info.getDouble("capacity"),
@@ -662,22 +651,19 @@ public class TestRMWebServices extends JerseyTestBase {
       int availNodeCapacity, int totalNodeCapacity, int numContainers)
       throws JSONException, Exception {
 
-    assertEquals("type doesn't match", "fifoScheduler", type);
-    assertEquals("qstate doesn't match", QueueState.RUNNING.toString(), state);
-    assertEquals("capacity doesn't match", 1.0, capacity, 0.0);
-    assertEquals("usedCapacity doesn't match", 0.0, usedCapacity, 0.0);
-    assertEquals(
-        "minQueueMemoryCapacity doesn't match",
-        YarnConfiguration.DEFAULT_RM_SCHEDULER_MINIMUM_ALLOCATION_MB,
-        minQueueCapacity);
-    assertEquals("maxQueueMemoryCapacity doesn't match",
-        YarnConfiguration.DEFAULT_RM_SCHEDULER_MAXIMUM_ALLOCATION_MB,
-        maxQueueCapacity);
-    assertEquals("numNodes doesn't match", 0, numNodes);
-    assertEquals("usedNodeCapacity doesn't match", 0, usedNodeCapacity);
-    assertEquals("availNodeCapacity doesn't match", 0, availNodeCapacity);
-    assertEquals("totalNodeCapacity doesn't match", 0, totalNodeCapacity);
-    assertEquals("numContainers doesn't match", 0, numContainers);
+    assertEquals("fifoScheduler", type, "type doesn't match");
+    assertEquals(QueueState.RUNNING.toString(), state, "qstate doesn't match");
+    assertEquals(1.0, capacity, 0.0, "capacity doesn't match");
+    assertEquals(0.0, usedCapacity, 0.0, "usedCapacity doesn't match");
+    assertEquals(YarnConfiguration.DEFAULT_RM_SCHEDULER_MINIMUM_ALLOCATION_MB,
+        minQueueCapacity, "minQueueMemoryCapacity doesn't match");
+    assertEquals(YarnConfiguration.DEFAULT_RM_SCHEDULER_MAXIMUM_ALLOCATION_MB,
+        maxQueueCapacity, "maxQueueMemoryCapacity doesn't match");
+    assertEquals(0, numNodes, "numNodes doesn't match");
+    assertEquals(0, usedNodeCapacity, "usedNodeCapacity doesn't match");
+    assertEquals(0, availNodeCapacity, "availNodeCapacity doesn't match");
+    assertEquals(0, totalNodeCapacity, "totalNodeCapacity doesn't match");
+    assertEquals(0, numContainers, "numContainers doesn't match");
 
   }
 
@@ -752,7 +738,7 @@ public class TestRMWebServices extends JerseyTestBase {
     } catch (ForbiddenException ae) {
       exceptionThrown = true;
     }
-    assertTrue("ForbiddenException expected", exceptionThrown);
+    assertTrue(exceptionThrown, "ForbiddenException expected");
     exceptionThrown = false;
     when(mockHsr.getUserPrincipal()).thenReturn(new Principal() {
       @Override
@@ -766,7 +752,7 @@ public class TestRMWebServices extends JerseyTestBase {
     } catch (ForbiddenException ae) {
       exceptionThrown = true;
     }
-    assertTrue("ForbiddenException expected", exceptionThrown);
+    assertTrue(exceptionThrown, "ForbiddenException expected");
 
     when(mockHsr.getUserPrincipal()).thenReturn(new Principal() {
       @Override
@@ -790,7 +776,7 @@ public class TestRMWebServices extends JerseyTestBase {
       targetFile = "yarn-scheduler-debug.log";
     }
     File logFile = new File(System.getProperty("yarn.log.dir"), targetFile);
-    assertTrue("scheduler log file doesn't exist", logFile.exists());
+    assertTrue(logFile.exists(), "scheduler log file doesn't exist");
     FileUtils.deleteQuietly(logFile);
   }
 
@@ -854,7 +840,7 @@ public class TestRMWebServices extends JerseyTestBase {
     } catch (ForbiddenException e) {
       caughtException = true;
     }
-    Assert.assertTrue(caughtException);
+    assertTrue(caughtException);
 
     // Case 2: request an unknown ACL causes BAD_REQUEST
     mockHsr = mockHttpServletRequestByUserName("admin");
@@ -864,27 +850,27 @@ public class TestRMWebServices extends JerseyTestBase {
     } catch (BadRequestException e) {
       caughtException = true;
     }
-    Assert.assertTrue(caughtException);
+    assertTrue(caughtException);
 
     // Case 3: get FORBIDDEN for rejected ACL
     mockHsr = mockHttpServletRequestByUserName("admin");
-    Assert.assertFalse(webSvc.checkUserAccessToQueue("queue", "jack",
+    assertFalse(webSvc.checkUserAccessToQueue("queue", "jack",
         QueueACL.SUBMIT_APPLICATIONS.name(), mockHsr).isAllowed());
-    Assert.assertFalse(webSvc.checkUserAccessToQueue("queue", "jack",
+    assertFalse(webSvc.checkUserAccessToQueue("queue", "jack",
         QueueACL.ADMINISTER_QUEUE.name(), mockHsr).isAllowed());
 
     // Case 4: get OK for listed ACLs
     mockHsr = mockHttpServletRequestByUserName("admin");
-    Assert.assertTrue(webSvc.checkUserAccessToQueue("queue", "admin",
+    assertTrue(webSvc.checkUserAccessToQueue("queue", "admin",
         QueueACL.SUBMIT_APPLICATIONS.name(), mockHsr).isAllowed());
-    Assert.assertTrue(webSvc.checkUserAccessToQueue("queue", "admin",
+    assertTrue(webSvc.checkUserAccessToQueue("queue", "admin",
         QueueACL.ADMINISTER_QUEUE.name(), mockHsr).isAllowed());
 
     // Case 5: get OK only for SUBMIT_APP acl for "yarn" user
     mockHsr = mockHttpServletRequestByUserName("admin");
-    Assert.assertTrue(webSvc.checkUserAccessToQueue("queue", "yarn",
+    assertTrue(webSvc.checkUserAccessToQueue("queue", "yarn",
         QueueACL.SUBMIT_APPLICATIONS.name(), mockHsr).isAllowed());
-    Assert.assertFalse(webSvc.checkUserAccessToQueue("queue", "yarn",
+    assertFalse(webSvc.checkUserAccessToQueue("queue", "yarn",
         QueueACL.ADMINISTER_QUEUE.name(), mockHsr).isAllowed());
   }
 
@@ -962,9 +948,9 @@ public class TestRMWebServices extends JerseyTestBase {
         null, null, null, null, null, null, null, emptySet, emptySet,
         null, null);
 
-    assertEquals("Incorrect Number of Apps", 1, appsInfo.getApps().size());
-    assertEquals("Invalid XML Characters Present",
-        "java.lang.Exception: \uFFFD", appsInfo.getApps().get(0).getNote());
+    assertEquals(1, appsInfo.getApps().size(), "Incorrect Number of Apps");
+    assertEquals("java.lang.Exception: \uFFFD", appsInfo.getApps().get(0).getNote(),
+        "Invalid XML Characters Present");
   }
 
   @Test
@@ -987,10 +973,10 @@ public class TestRMWebServices extends JerseyTestBase {
 
   public void verifyClusterUserInfo(ClusterUserInfo userInfo,
             String rmLoginUser, String requestedUser) {
-    assertEquals("rmLoginUser doesn't match: ",
-            rmLoginUser, userInfo.getRmLoginUser());
-    assertEquals("requestedUser doesn't match: ",
-            requestedUser, userInfo.getRequestedUser());
+    assertEquals(rmLoginUser, userInfo.getRmLoginUser(),
+        "rmLoginUser doesn't match: ");
+    assertEquals(requestedUser, userInfo.getRequestedUser(),
+        "requestedUser doesn't match: ");
   }
 
   @Test
@@ -1002,11 +988,11 @@ public class TestRMWebServices extends JerseyTestBase {
     HttpServletRequest mockHsr = prepareServletRequestForValidation();
     Response response = webService
             .validateAndGetSchedulerConfiguration(mutationInfo, mockHsr);
-    Assert.assertEquals(Response.Status.BAD_REQUEST
-            .getStatusCode(), response.getStatus());
-    Assert.assertTrue(response.getEntity().toString()
-            .contains(String.format("Configuration change validation only supported by %s.",
-                MutableConfScheduler.class.getSimpleName())));
+    assertEquals(Response.Status.BAD_REQUEST
+        .getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString()
+        .contains(String.format("Configuration change validation only supported by %s.",
+        MutableConfScheduler.class.getSimpleName())));
   }
 
   @Test
@@ -1025,10 +1011,8 @@ public class TestRMWebServices extends JerseyTestBase {
     HttpServletRequest mockHsr = prepareServletRequestForValidation();
 
     Response response = webService.validateAndGetSchedulerConfiguration(mutationInfo, mockHsr);
-    Assert.assertEquals(Response.Status.BAD_REQUEST
-            .getStatusCode(), response.getStatus());
-    Assert.assertTrue(response.getEntity().toString()
-            .contains("IOException"));
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("IOException"));
   }
 
   @Test
@@ -1057,7 +1041,7 @@ public class TestRMWebServices extends JerseyTestBase {
 
     Response response = webService
         .validateAndGetSchedulerConfiguration(mutationInfo, mockHsr);
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
   private CapacityScheduler prepareCSForValidation(Configuration config)
@@ -1115,7 +1099,7 @@ public class TestRMWebServices extends JerseyTestBase {
       JSONObject json, String expectedSchedulerType) throws Exception {
 
     // why json contains 8 elements because we defined 8 fields
-    assertEquals("incorrect number of elements in: " + json, 8, json.length());
+    assertEquals(8, json.length(), "incorrect number of elements in: " + json);
 
     // 1.Verify that the schedulerType is as expected
     String schedulerType = json.getString("schedulerType");
@@ -1193,31 +1177,31 @@ public class TestRMWebServices extends JerseyTestBase {
         "mock_user", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
     LRUCache<AppsCacheKey, AppsInfo> cache = webSvc.getAppsLRUCache();
-    Assert.assertEquals(1, cache.size());
+    assertEquals(1, cache.size());
     AppsCacheKey appsCacheKey = AppsCacheKey.newInstance(null, emptySet,
         null, "mock_user", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
-    Assert.assertEquals(appsInfo, cache.get(appsCacheKey));
+    assertEquals(appsInfo, cache.get(appsCacheKey));
 
     AppsInfo appsInfo1 = webSvc.getApps(mockHsr, null, emptySet, null,
         "mock_user1", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
-    Assert.assertEquals(2, cache.size());
+    assertEquals(2, cache.size());
     AppsCacheKey appsCacheKey1 = AppsCacheKey.newInstance(null, emptySet,
         null, "mock_user1", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
-    Assert.assertEquals(appsInfo1, cache.get(appsCacheKey1));
+    assertEquals(appsInfo1, cache.get(appsCacheKey1));
 
     AppsInfo appsInfo2 = webSvc.getApps(mockHsr, null, emptySet, null,
         "mock_user2", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
-    Assert.assertEquals(2, cache.size());
+    assertEquals(2, cache.size());
     AppsCacheKey appsCacheKey2 = AppsCacheKey.newInstance(null, emptySet,
         null, "mock_user2", "mock_queue", null, null, null, null, null, emptySet,
         emptySet, null, null);
-    Assert.assertEquals(appsInfo2, cache.get(appsCacheKey2));
+    assertEquals(appsInfo2, cache.get(appsCacheKey2));
     // appsCacheKey have removed
-    Assert.assertNull(cache.get(appsCacheKey));
+    assertNull(cache.get(appsCacheKey));
 
     GenericTestUtils.waitFor(() -> cache.get(appsCacheKey1) == null,
         300, 1000);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServices.java
@@ -528,11 +528,10 @@ public class TestRMWebServices extends JerseyTestBase {
 
     assertEquals(0, containersAlloc, "containersAllocated doesn't match");
     assertEquals(totalMBExpect, totalMB, "totalMB doesn't match");
-    assertEquals(
-       clusterMetrics.getNumActiveNMs() + clusterMetrics.getNumLostNMs()
-            + clusterMetrics.getNumDecommisionedNMs()
-            + clusterMetrics.getNumRebootedNMs()
-            + clusterMetrics.getUnhealthyNMs(), totalNodes, "totalNodes doesn't match");
+    assertEquals(clusterMetrics.getNumActiveNMs() + clusterMetrics.getNumLostNMs()
+        + clusterMetrics.getNumDecommisionedNMs()
+        + clusterMetrics.getNumRebootedNMs()
+        + clusterMetrics.getUnhealthyNMs(), totalNodes, "totalNodes doesn't match");
     assertEquals(clusterMetrics.getNumLostNMs(), lostNodes, "lostNodes doesn't match");
     assertEquals(clusterMetrics.getUnhealthyNMs(), unhealthyNodes,
         "unhealthyNodes doesn't match");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppAttempts.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppAttempts.java
@@ -43,7 +43,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -65,8 +66,8 @@ import java.util.Collection;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.checkStringMatch;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -126,7 +127,8 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testCompletedAppAttempt() throws Exception {
     Configuration conf = rm.getConfig();
     String logServerUrl = "http://localhost:19888/jobhistory/logs";
@@ -167,7 +169,8 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testMultipleAppAttempts() throws Exception {
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 8192);
@@ -197,8 +200,8 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
       am = MockRM.launchAndRegisterAM(app1, rm, amNodeManager);
       numAttempt++;
     }
-    assertEquals("incorrect number of attempts", maxAppAttempts,
-        app1.getAppAttempts().values().size());
+    assertEquals(maxAppAttempts,
+        app1.getAppAttempts().values().size(), "incorrect number of attempts");
     testAppAttemptsHelper(app1.getApplicationId().toString(), app1,
         MediaType.APPLICATION_JSON);
     rm.stop();
@@ -247,7 +250,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -284,7 +287,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -325,7 +328,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
 
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -348,14 +351,14 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject jsonAppAttempts = json.getJSONObject("appAttempts");
-    assertEquals("incorrect number of elements", 1, jsonAppAttempts.length());
+    assertEquals(1, jsonAppAttempts.length(), "incorrect number of elements");
     JSONArray jsonArray = parseJsonAppAttempt(jsonAppAttempts);
 
     Collection<RMAppAttempt> attempts = app.getAppAttempts().values();
-    assertEquals("incorrect number of elements", attempts.size(),
-        jsonArray.length());
+    assertEquals(attempts.size(), jsonArray.length(),
+        "incorrect number of elements");
 
     // Verify these parallel arrays are the same
     int i = 0;
@@ -406,9 +409,9 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("appAttempts");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     NodeList attempt = dom.getElementsByTagName("appAttempt");
-    assertEquals("incorrect number of elements", 1, attempt.getLength());
+    assertEquals(1, attempt.getLength(), "incorrect number of elements");
     verifyAppAttemptsXML(attempt, app1.getCurrentAppAttempt(), user);
     rm.stop();
   }
@@ -435,7 +438,7 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
           String user)
           throws Exception {
 
-    assertEquals("incorrect number of elements", 12, info.length());
+    assertEquals(12, info.length(), "incorrect number of elements");
 
     verifyAppAttemptInfoGeneric(appAttempt, info.getInt("id"),
             info.getLong("startTime"), info.getString("containerId"),
@@ -449,21 +452,19 @@ public class TestRMWebServicesAppAttempts extends JerseyTestBase {
           nodeId, String logsLink, String user, String exportPorts,
           String appAttemptState) {
 
-    assertEquals("id doesn't match", appAttempt.getAppAttemptId()
-            .getAttemptId(), id);
-    assertEquals("startedTime doesn't match", appAttempt.getStartTime(),
-            startTime);
+    assertEquals(appAttempt.getAppAttemptId()
+        .getAttemptId(), id, "id doesn't match");
+    assertEquals(appAttempt.getStartTime(),
+        startTime, "startedTime doesn't match");
     checkStringMatch("containerId", appAttempt
             .getMasterContainer().getId().toString(), containerId);
     checkStringMatch("nodeHttpAddress", appAttempt
             .getMasterContainer().getNodeHttpAddress(), nodeHttpAddress);
     checkStringMatch("nodeId", appAttempt
             .getMasterContainer().getNodeId().toString(), nodeId);
-    assertTrue("logsLink doesn't match ", logsLink.startsWith("http://"));
-    assertTrue(
-            "logsLink doesn't contain user info", logsLink.endsWith("/"
-                    + user));
-    assertEquals("appAttemptState doesn't match", appAttemptState, appAttempt
-            .getAppAttemptState().toString());
+    assertTrue(logsLink.startsWith("http://"), "logsLink doesn't match ");
+    assertTrue(logsLink.endsWith("/" + user), "logsLink doesn't contain user info");
+    assertEquals(appAttemptState, appAttempt.getAppAttemptState().toString(),
+        "appAttemptState doesn't match");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppCustomResourceTypes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppCustomResourceTypes.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.NodeList;
 
 import javax.servlet.http.HttpServletRequest;
@@ -53,7 +53,7 @@ import java.util.ArrayList;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestRMWebServicesCustomResourceTypesCommons.verifyAppInfoJson;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestRMWebServicesCustomResourceTypesCommons.verifyAppsXML;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -137,7 +137,7 @@ public class TestRMWebServicesAppCustomResourceTypes extends JerseyTestBase {
     testCase.verify(document -> {
       NodeList appArray = document
               .getElementsByTagName("app");
-      assertEquals("incorrect number of app elements", 1, appArray.getLength());
+      assertEquals(1, appArray.getLength(), "incorrect number of app elements");
 
       verifyAppsXML(appArray, app1, rm);
     });
@@ -168,7 +168,7 @@ public class TestRMWebServicesAppCustomResourceTypes extends JerseyTestBase {
             new BufferedClientResponse(response));
     testCase.verify(json -> {
       try {
-        assertEquals("incorrect number of app elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of app elements");
         JSONObject app = json.getJSONObject("app");
         verifyAppInfoJson(app, app1, rm);
       } catch (JSONException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
@@ -50,7 +50,7 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -71,9 +71,9 @@ import java.util.ArrayList;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -182,9 +182,9 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesApps = dom.getElementsByTagName("apps");
-    assertEquals("incorrect number of elements", 1, nodesApps.getLength());
+    assertEquals(1, nodesApps.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("app");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     verifyAppsXML(nodes, app1, false);
     rm.stop();
   }
@@ -216,9 +216,9 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesApps = dom.getElementsByTagName("apps");
-    assertEquals("incorrect number of elements", 1, nodesApps.getLength());
+    assertEquals(1, nodesApps.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("app");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     verifyAppsXML(nodes, app1, true);
 
     testAppsHelper("apps/", app1, MediaType.APPLICATION_JSON, true);
@@ -257,9 +257,9 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesApps = dom.getElementsByTagName("apps");
-    assertEquals("incorrect number of elements", 1, nodesApps.getLength());
+    assertEquals(1, nodesApps.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("app");
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -277,13 +277,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject jSONObjectApp = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(jSONObjectApp);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     verifyAppInfo(array.getJSONObject(0), app, hasResourceReq);
 
   }
@@ -303,13 +303,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     verifyAppInfo(array.getJSONObject(0), app1, false);
     rm.stop();
   }
@@ -331,15 +331,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
-    assertEquals("incorrect number of elements", 1, array.length());
-    assertEquals("state not equal to ACCEPTED", "ACCEPTED", array
-        .getJSONObject(0).getString("state"));
+    assertEquals(1, array.length(), "incorrect number of elements");
+    assertEquals("ACCEPTED", array.getJSONObject(0).getString("state"),
+        "state not equal to ACCEPTED");
 
     r = targetWithJsonObject();
     response = r.path("ws").path("v1").path("cluster")
@@ -349,16 +349,17 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
-    assertTrue("both app states of ACCEPTED and KILLED are not present",
+    assertEquals(2, array.length(), "incorrect number of elements");
+    assertTrue(
         (array.getJSONObject(0).getString("state").equals("ACCEPTED") &&
         array.getJSONObject(1).getString("state").equals("KILLED")) ||
         (array.getJSONObject(0).getString("state").equals("KILLED") &&
-        array.getJSONObject(1).getString("state").equals("ACCEPTED")));
+        array.getJSONObject(1).getString("state").equals("ACCEPTED")),
+        "both app states of ACCEPTED and KILLED are not present");
 
     rm.stop();
   }
@@ -380,15 +381,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
-    assertEquals("incorrect number of elements", 1, array.length());
-    assertEquals("state not equal to ACCEPTED", "ACCEPTED", array
-        .getJSONObject(0).getString("state"));
+    assertEquals(1, array.length(), "incorrect number of elements");
+    assertEquals("ACCEPTED", array.getJSONObject(0).getString("state"),
+        "state not equal to ACCEPTED");
 
     r = targetWithJsonObject();
     response = r.path("ws").path("v1").path("cluster")
@@ -398,16 +399,17 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
-    assertTrue("both app states of ACCEPTED and KILLED are not present",
-        (array.getJSONObject(0).getString("state").equals("ACCEPTED") &&
+    assertEquals(2, array.length(), "incorrect number of elements");
+    assertTrue(
+       (array.getJSONObject(0).getString("state").equals("ACCEPTED") &&
         array.getJSONObject(1).getString("state").equals("KILLED")) ||
         (array.getJSONObject(0).getString("state").equals("KILLED") &&
-        array.getJSONObject(1).getString("state").equals("ACCEPTED")));
+        array.getJSONObject(1).getString("state").equals("ACCEPTED")),
+        "both app states of ACCEPTED and KILLED are not present");
 
     rm.stop();
   }
@@ -427,8 +429,8 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("apps is not empty", "", json.get("apps").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("apps").toString(), "apps is not empty");
     rm.stop();
   }
 
@@ -447,8 +449,8 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("apps is not empty", "", json.get("apps").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("apps").toString(), "apps is not empty");
     rm.stop();
   }
 
@@ -472,7 +474,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -508,7 +510,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -538,13 +540,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     verifyAppInfo(array.getJSONObject(0), app1, false);
     rm.stop();
   }
@@ -563,8 +565,8 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("apps is not null", "", json.get("apps").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("apps").toString(), "apps is not null");
     rm.stop();
   }
 
@@ -588,7 +590,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -625,11 +627,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
 
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -649,11 +651,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -678,17 +680,17 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
 
     Set<String> appIds = getApplicationIds(array);
-    assertTrue("Finished app1 should be in the result list!",
-        appIds.contains(app1.getApplicationId().toString()));
-    assertTrue("Finished app2 should be in the result list!",
-        appIds.contains(app2.getApplicationId().toString()));
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertTrue(appIds.contains(app1.getApplicationId().toString()),
+        "Finished app1 should be in the result list!");
+    assertTrue(appIds.contains(app2.getApplicationId().toString()),
+        "Finished app2 should be in the result list!");
+    assertEquals(2, array.length(), "incorrect number of elements");
 
     rm.stop();
   }
@@ -713,20 +715,20 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
 
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
 
     Set<String> appIds = getApplicationIds(array);
-    assertFalse("Running app should not be in the result list!",
-        appIds.contains(runningApp.getApplicationId().toString()));
-    assertTrue("Finished app should be in the result list!",
-        appIds.contains(finishedApp.getApplicationId().toString()));
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertFalse(appIds.contains(runningApp.getApplicationId().toString()),
+        "Running app should not be in the result list!");
+    assertTrue(appIds.contains(finishedApp.getApplicationId().toString()),
+        "Finished app should be in the result list!");
+    assertEquals(1, array.length(), "incorrect number of elements");
 
     rm.stop();
   }
@@ -750,18 +752,18 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
 
     JSONArray array = apps.getJSONArray("app");
 
     Set<String> appIds = getApplicationIds(array);
-    assertTrue("Running app should be in the result list!",
-        appIds.contains(runningApp.getApplicationId().toString()));
-    assertTrue("Finished app should be in the result list!",
-        appIds.contains(finishedApp.getApplicationId().toString()));
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertTrue(appIds.contains(runningApp.getApplicationId().toString()),
+        "Running app should be in the result list!");
+    assertTrue(appIds.contains(finishedApp.getApplicationId().toString()),
+        "Finished app should be in the result list!");
+    assertEquals(2, array.length(), "incorrect number of elements");
 
     rm.stop();
   }
@@ -780,11 +782,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -804,11 +806,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 3, array.length());
+    assertEquals(3, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -828,13 +830,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject app = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(app);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -854,8 +856,8 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("apps is not empty", "", json.get("apps").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("apps").toString(), "apps is not empty");
     rm.stop();
   }
 
@@ -878,11 +880,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -905,13 +907,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject appsJSONObject = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -945,11 +947,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONArray array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 3, array.length());
+    assertEquals(3, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -976,13 +978,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject appsJSONObject = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     rm.stop();
   }
 
@@ -1028,13 +1030,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject appsJSONObject = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     assertEquals("MAPREDUCE",
         array.getJSONObject(0).getString("applicationType"));
 
@@ -1046,11 +1048,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     assertTrue((array.getJSONObject(0).getString("applicationType")
         .equals("YARN") && array.getJSONObject(1).getString("applicationType")
         .equals("MAPREDUCE")) ||
@@ -1066,11 +1068,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     assertTrue((array.getJSONObject(0).getString("applicationType")
         .equals("YARN") && array.getJSONObject(1).getString("applicationType")
         .equals("NON-YARN")) ||
@@ -1085,11 +1087,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 3, array.length());
+    assertEquals(3, array.length(), "incorrect number of elements");
 
     r = targetWithJsonObject();
     response =
@@ -1100,11 +1102,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 3, array.length());
+    assertEquals(3, array.length(), "incorrect number of elements");
 
     r = targetWithJsonObject();
     response =
@@ -1115,13 +1117,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     assertEquals("YARN",
         array.getJSONObject(0).getString("applicationType"));
 
@@ -1133,13 +1135,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     assertEquals("YARN",
         array.getJSONObject(0).getString("applicationType"));
 
@@ -1150,11 +1152,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 3, array.length());
+    assertEquals(3, array.length(), "incorrect number of elements");
 
     r = targetWithJsonObject();
     response = r.path("ws").path("v1").path("cluster").path("apps")
@@ -1163,11 +1165,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     assertTrue((array.getJSONObject(0).getString("applicationType")
         .equals("YARN") && array.getJSONObject(1).getString("applicationType")
         .equals("NON-YARN")) ||
@@ -1184,11 +1186,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     array = apps.getJSONArray("app");
-    assertEquals("incorrect number of elements", 2, array.length());
+    assertEquals(2, array.length(), "incorrect number of elements");
     assertTrue((array.getJSONObject(0).getString("applicationType")
         .equals("YARN") && array.getJSONObject(1).getString("applicationType")
         .equals("MAPREDUCE")) ||
@@ -1216,7 +1218,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -1250,15 +1252,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
 
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     JSONObject appsJSONObject = apps.getJSONObject("app");
     JSONArray array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     JSONObject app = array.getJSONObject(0);
-    assertTrue("resource requests shouldn't exist", !app.has("resourceRequests"));
+    assertTrue(!app.has("resourceRequests"), "resource requests shouldn't exist");
 
     response = r.path("ws").path("v1").path("cluster").path("apps").queryParam("deSelects",
         DeSelectFields.DeSelectType.AM_NODE_LABEL_EXPRESSION.toString())
@@ -1267,15 +1269,16 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
 
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     app = array.getJSONObject(0);
-    assertTrue("AMNodeLabelExpression shouldn't exist", !app.has("amNodeLabelExpression"));
+    assertTrue(!app.has("amNodeLabelExpression"),
+        "AMNodeLabelExpression shouldn't exist");
 
     response = r.path("ws").path("v1").path("cluster").path("apps").queryParam("deSelects",
         DeSelectFields.DeSelectType.TIMEOUTS.toString()).
@@ -1284,15 +1287,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
 
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     app = array.getJSONObject(0);
-    assertTrue("Timeouts shouldn't exist", !app.has("timeouts"));
+    assertTrue(!app.has("timeouts"), "Timeouts shouldn't exist");
     rm.stop();
 
     response =
@@ -1303,15 +1306,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
 
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     app = array.getJSONObject(0);
-    assertTrue("AppNodeLabelExpression shouldn't exist", !app.has("appNodeLabelExpression"));
+    assertTrue(!app.has("appNodeLabelExpression"), "AppNodeLabelExpression shouldn't exist");
     rm.stop();
 
     response =
@@ -1322,15 +1325,15 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
 
     json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
     appsJSONObject = apps.getJSONObject("app");
     array = new JSONArray();
     array.put(appsJSONObject);
-    assertEquals("incorrect number of elements", 1, array.length());
+    assertEquals(1, array.length(), "incorrect number of elements");
     app = array.getJSONObject(0);
-    assertTrue("Resource info shouldn't exist", !app.has("resourceInfo"));
+    assertTrue(!app.has("resourceInfo"), "Resource info shouldn't exist");
     rm.stop();
   }
 
@@ -1388,12 +1391,12 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       JSONObject json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject appsStatInfo = json.getJSONObject("appStatInfo");
-      assertEquals("incorrect number of elements", 1, appsStatInfo.length());
+      assertEquals(1, appsStatInfo.length(), "incorrect number of elements");
       JSONArray statItems = appsStatInfo.getJSONArray("statItem");
-      assertEquals("incorrect number of elements",
-          YarnApplicationState.values().length, statItems.length());
+      assertEquals(YarnApplicationState.values().length, statItems.length(),
+          "incorrect number of elements");
       for (int i = 0; i < YarnApplicationState.values().length; ++i) {
         assertEquals("*", statItems.getJSONObject(0).getString("type"));
         if (statItems.getJSONObject(0).getString("state").equals("ACCEPTED")) {
@@ -1415,13 +1418,13 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       appsStatInfo = json.getJSONObject("appStatInfo");
-      assertEquals("incorrect number of elements", 1, appsStatInfo.length());
+      assertEquals(1, appsStatInfo.length(), "incorrect number of elements");
       JSONObject statItem = appsStatInfo.getJSONObject("statItem");
       statItems = new JSONArray();
       statItems.put(statItem);
-      assertEquals("incorrect number of elements", 1, statItems.length());
+      assertEquals(1, statItems.length(), "incorrect number of elements");
       assertEquals("ACCEPTED", statItems.getJSONObject(0).getString("state"));
       assertEquals("*", statItems.getJSONObject(0).getString("type"));
       assertEquals("2", statItems.getJSONObject(0).getString("count"));
@@ -1435,12 +1438,12 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       appsStatInfo = json.getJSONObject("appStatInfo");
-      assertEquals("incorrect number of elements", 1, appsStatInfo.length());
+      assertEquals(1, appsStatInfo.length(), "incorrect number of elements");
       statItems = appsStatInfo.getJSONArray("statItem");
-      assertEquals("incorrect number of elements",
-          YarnApplicationState.values().length, statItems.length());
+      assertEquals(YarnApplicationState.values().length, statItems.length(),
+          "incorrect number of elements");
       for (int i = 0; i < YarnApplicationState.values().length; ++i) {
         assertEquals("mapreduce", statItems.getJSONObject(0).getString("type"));
         if (statItems.getJSONObject(0).getString("state").equals("ACCEPTED")) {
@@ -1463,9 +1466,9 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       JSONObject exception = json.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String className = exception.getString("javaClassName");
@@ -1487,11 +1490,11 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       appsStatInfo = json.getJSONObject("appStatInfo");
-      assertEquals("incorrect number of elements", 1, appsStatInfo.length());
+      assertEquals(1, appsStatInfo.length(), "incorrect number of elements");
       statItems = appsStatInfo.getJSONArray("statItem");
-      assertEquals("incorrect number of elements", 2, statItems.length());
+      assertEquals(2, statItems.length(), "incorrect number of elements");
       JSONObject statItem1 = statItems.getJSONObject(0);
       JSONObject statItem2 = statItems.getJSONObject(1);
       assertTrue((statItem1.getString("state").equals("ACCEPTED") &&
@@ -1512,9 +1515,9 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
           response.getMediaType().toString());
       json = response.readEntity(JSONObject.class);
-      assertEquals("incorrect number of elements", 1, json.length());
+      assertEquals(1, json.length(), "incorrect number of elements");
       exception = json.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       message = exception.getString("message");
       type = exception.getString("exception");
       className = exception.getString("javaClassName");
@@ -1615,7 +1618,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
           response.getMediaType().toString());
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -1657,7 +1660,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
 
       JSONObject msg = response.readEntity(JSONObject.class);
       JSONObject exception = msg.getJSONObject("RemoteException");
-      assertEquals("incorrect number of elements", 3, exception.length());
+      assertEquals(3, exception.length(), "incorrect number of elements");
       String message = exception.getString("message");
       String type = exception.getString("exception");
       String classname = exception.getString("javaClassName");
@@ -1681,7 +1684,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
 
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     verifyAppInfo(json.getJSONObject("app"), app, false);
   }
 
@@ -1710,7 +1713,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("app");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     verifyAppsXML(nodes, app1, false);
     rm.stop();
   }
@@ -1804,9 +1807,10 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       expectedNumberOfElements++;
       amRPCAddress = info.getString("amRPCAddress");
     }
-    assertEquals("incorrect number of elements", expectedNumberOfElements,
-        info.length());
-    assertEquals("rmClusterId is incorrect", "subCluster1", info.getString("rmClusterId"));
+    assertEquals(expectedNumberOfElements, info.length(),
+        "incorrect number of elements");
+    assertEquals("subCluster1", info.getString("rmClusterId"),
+        "rmClusterId is incorrect");
     verifyAppInfoGeneric(app, info.getString("id"), info.getString("user"),
         info.getString("name"), info.getString("applicationType"),
         info.getString("queue"), info.getInt("priority"),
@@ -1860,63 +1864,54 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     WebServicesTestUtils.checkStringMatch("applicationType",
       app.getApplicationType(), applicationType);
     WebServicesTestUtils.checkStringMatch("queue", app.getQueue(), queue);
-    assertEquals("priority doesn't match", 0, prioirty);
+    assertEquals(0, prioirty, "priority doesn't match");
     WebServicesTestUtils.checkStringMatch("state", app.getState().toString(),
         state);
     WebServicesTestUtils.checkStringMatch("finalStatus", app
         .getFinalApplicationStatus().toString(), finalStatus);
-    assertEquals("progress doesn't match", 0, progress, 0.0);
+    assertEquals( 0, progress, 0.0, "progress doesn't match");
     if ("UNASSIGNED".equals(trackingUI)) {
       WebServicesTestUtils.checkStringMatch("trackingUI", "UNASSIGNED",
           trackingUI);
     }
     WebServicesTestUtils.checkStringEqual("diagnostics",
         app.getDiagnostics().toString(), diagnostics);
-    assertEquals("clusterId doesn't match",
-        ResourceManager.getClusterTimeStamp(), clusterId);
-    assertEquals("startedTime doesn't match", app.getStartTime(), startedTime);
-    assertEquals("finishedTime doesn't match", app.getFinishTime(),
-        finishedTime);
-    assertTrue("elapsed time not greater than 0", elapsedTime > 0);
+    assertEquals(ResourceManager.getClusterTimeStamp(), clusterId,
+        "clusterId doesn't match");
+    assertEquals(app.getStartTime(), startedTime, "startedTime doesn't match");
+    assertEquals(app.getFinishTime(), finishedTime,
+        "finishedTime doesn't match");
+    assertTrue(elapsedTime > 0, "elapsed time not greater than 0");
     WebServicesTestUtils.checkStringMatch("amHostHttpAddress", app
         .getCurrentAppAttempt().getMasterContainer().getNodeHttpAddress(),
         amHostHttpAddress);
-    assertTrue("amContainerLogs doesn't match",
-        amContainerLogs.startsWith("http://"));
-    assertTrue("amContainerLogs doesn't contain user info",
-        amContainerLogs.endsWith("/" + app.getUser()));
-    assertEquals("allocatedMB doesn't match", 1024, allocatedMB);
-    assertEquals("allocatedVCores doesn't match", 1, allocatedVCores);
-    assertEquals("queueUsagePerc doesn't match", 50.0f, queueUsagePerc, 0.01f);
-    assertEquals("clusterUsagePerc doesn't match", 50.0f, clusterUsagePerc, 0.01f);
-    assertEquals("numContainers doesn't match", 1, numContainers);
-    assertEquals("preemptedResourceMB doesn't match", app
-        .getRMAppMetrics().getResourcePreempted().getMemorySize(),
-        preemptedResourceMB);
-    assertEquals("preemptedResourceVCores doesn't match", app
-        .getRMAppMetrics().getResourcePreempted().getVirtualCores(),
-        preemptedResourceVCores);
-    assertEquals("numNonAMContainerPreempted doesn't match", app
-        .getRMAppMetrics().getNumNonAMContainersPreempted(),
-        numNonAMContainerPreempted);
-    assertEquals("numAMContainerPreempted doesn't match", app
-        .getRMAppMetrics().getNumAMContainersPreempted(),
-        numAMContainerPreempted);
-    assertEquals("Log aggregation Status doesn't match", app
-        .getLogAggregationStatusForAppReport().toString(),
-        logAggregationStatus);
-    assertEquals("unmanagedApplication doesn't match", app
-        .getApplicationSubmissionContext().getUnmanagedAM(),
-        unmanagedApplication);
-    assertEquals("unmanagedApplication doesn't match",
-        app.getApplicationSubmissionContext().getNodeLabelExpression(),
-        appNodeLabelExpression);
-    assertEquals("unmanagedApplication doesn't match",
-        app.getAMResourceRequests().get(0).getNodeLabelExpression(),
-        amNodeLabelExpression);
-    assertEquals("amRPCAddress",
-        AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
-        amRPCAddress);
+    assertTrue(amContainerLogs.startsWith("http://"),
+        "amContainerLogs doesn't match");
+    assertTrue(amContainerLogs.endsWith("/" + app.getUser()),
+        "amContainerLogs doesn't contain user info");
+    assertEquals(1024, allocatedMB, "allocatedMB doesn't match");
+    assertEquals(1, allocatedVCores, "allocatedVCores doesn't match");
+    assertEquals(50.0f, queueUsagePerc, 0.01f, "queueUsagePerc doesn't match");
+    assertEquals(50.0f, clusterUsagePerc, 0.01f, "clusterUsagePerc doesn't match");
+    assertEquals(1, numContainers, "numContainers doesn't match");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getMemorySize(),
+        preemptedResourceMB, "preemptedResourceMB doesn't match");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getVirtualCores(),
+        preemptedResourceVCores, "preemptedResourceVCores doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumNonAMContainersPreempted(),
+        numNonAMContainerPreempted, "numNonAMContainerPreempted doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumAMContainersPreempted(),
+        numAMContainerPreempted, "numAMContainerPreempted doesn't match");
+    assertEquals(app.getLogAggregationStatusForAppReport().toString(),
+        logAggregationStatus, "Log aggregation Status doesn't match");
+    assertEquals(app.getApplicationSubmissionContext().getUnmanagedAM(),
+        unmanagedApplication, "unmanagedApplication doesn't match");
+    assertEquals(app.getApplicationSubmissionContext().getNodeLabelExpression(),
+        appNodeLabelExpression, "unmanagedApplication doesn't match");
+    assertEquals(app.getAMResourceRequests().get(0).getNodeLabelExpression(),
+        amNodeLabelExpression, "unmanagedApplication doesn't match");
+    assertEquals(AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
+        amRPCAddress, "amRPCAddress");
   }
 
   public void verifyResourceRequests(JSONArray resourceRequest, RMApp app)
@@ -1944,26 +1939,24 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       String nodeLabelExpression, int numContainers, boolean relaxLocality,
       int priority, String resourceName, long memory, long vCores,
       String executionType, boolean enforceExecutionType) {
-    assertEquals("nodeLabelExpression doesn't match",
-        request.getNodeLabelExpression(), nodeLabelExpression);
-    assertEquals("numContainers doesn't match", request.getNumContainers(),
-        numContainers);
-    assertEquals("relaxLocality doesn't match", request.getRelaxLocality(),
-        relaxLocality);
-    assertEquals("priority does not match", request.getPriority().getPriority(),
-        priority);
-    assertEquals("resourceName does not match", request.getResourceName(),
-        resourceName);
-    assertEquals("memory does not match",
-        request.getCapability().getMemorySize(), memory);
-    assertEquals("vCores does not match",
-        request.getCapability().getVirtualCores(), vCores);
-    assertEquals("executionType does not match",
-        request.getExecutionTypeRequest().getExecutionType().name(),
-        executionType);
-    assertEquals("enforceExecutionType does not match",
-        request.getExecutionTypeRequest().getEnforceExecutionType(),
-        enforceExecutionType);
+    assertEquals(
+       request.getNodeLabelExpression(), nodeLabelExpression, "nodeLabelExpression doesn't match");
+    assertEquals(request.getNumContainers(),
+        numContainers, "numContainers doesn't match");
+    assertEquals(request.getRelaxLocality(),
+        relaxLocality, "relaxLocality doesn't match");
+    assertEquals(request.getPriority().getPriority(),
+        priority, "priority does not match");
+    assertEquals(request.getResourceName(),
+        resourceName, "resourceName does not match");
+    assertEquals(request.getCapability().getMemorySize(), memory,
+        "memory does not match");
+    assertEquals(request.getCapability().getVirtualCores(), vCores,
+        "vCores does not match");
+    assertEquals(request.getExecutionTypeRequest().getExecutionType().name(),
+        executionType, "executionType does not match");
+    assertEquals(request.getExecutionTypeRequest().getEnforceExecutionType(),
+        enforceExecutionType, "enforceExecutionType does not match");
   }
 
   @Test
@@ -2010,22 +2003,22 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
 
     JSONArray array = apps.getJSONArray("app");
 
     Set<String> appIds = getApplicationIds(array);
-    assertTrue("Running app 1 should be in the result list!",
-        appIds.contains(runningApp1.getApplicationId().toString()));
-    assertTrue("Running app 2 should be in the result list!",
-        appIds.contains(runningApp2.getApplicationId().toString()));
-    assertTrue("Running app 1 should be in the result list!",
-        appIds.contains(finishedApp1.getApplicationId().toString()));
-    assertTrue("Running app 1 should be in the result list!",
-        appIds.contains(finishedApp2.getApplicationId().toString()));
-    assertEquals("incorrect number of elements", 4, array.length());
+    assertTrue(appIds.contains(runningApp1.getApplicationId().toString()),
+        "Running app 1 should be in the result list!");
+    assertTrue(appIds.contains(runningApp2.getApplicationId().toString()),
+        "Running app 2 should be in the result list!");
+    assertTrue(appIds.contains(finishedApp1.getApplicationId().toString()),
+        "Running app 1 should be in the result list!");
+    assertTrue(appIds.contains(finishedApp2.getApplicationId().toString()),
+        "Running app 1 should be in the result list!");
+    assertEquals(4, array.length(), "incorrect number of elements");
 
     rm.stop();
   }
@@ -2075,22 +2068,22 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject apps = json.getJSONObject("apps");
-    assertEquals("incorrect number of elements", 1, apps.length());
+    assertEquals(1, apps.length(), "incorrect number of elements");
 
     JSONArray array = apps.getJSONArray("app");
 
     Set<String> appIds = getApplicationIds(array);
-    assertTrue("Running app 1 should be in the result list!",
-        appIds.contains(runningApp1.getApplicationId().toString()));
-    assertTrue("Running app 2 should be in the result list!",
-        appIds.contains(runningApp2.getApplicationId().toString()));
-    assertTrue("Running app 2 should be in the result list!",
-        appIds.contains(finishedApp1.getApplicationId().toString()));
-    assertTrue("Running app 2 should be in the result list!",
-        appIds.contains(finishedApp2.getApplicationId().toString()));
-    assertEquals("incorrect number of elements", 4, array.length());
+    assertTrue(appIds.contains(runningApp1.getApplicationId().toString()),
+        "Running app 1 should be in the result list!");
+    assertTrue(appIds.contains(runningApp2.getApplicationId().toString()),
+        "Running app 2 should be in the result list!");
+    assertTrue(appIds.contains(finishedApp1.getApplicationId().toString()),
+        "Running app 2 should be in the result list!");
+    assertTrue(appIds.contains(finishedApp2.getApplicationId().toString()),
+        "Running app 2 should be in the result list!");
+    assertEquals(4, array.length(), "incorrect number of elements");
 
     rm.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesApps.java
@@ -405,7 +405,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
     array = apps.getJSONArray("app");
     assertEquals(2, array.length(), "incorrect number of elements");
     assertTrue(
-       (array.getJSONObject(0).getString("state").equals("ACCEPTED") &&
+        (array.getJSONObject(0).getString("state").equals("ACCEPTED") &&
         array.getJSONObject(1).getString("state").equals("KILLED")) ||
         (array.getJSONObject(0).getString("state").equals("KILLED") &&
         array.getJSONObject(1).getString("state").equals("ACCEPTED")),
@@ -1869,7 +1869,7 @@ public class TestRMWebServicesApps extends JerseyTestBase {
         state);
     WebServicesTestUtils.checkStringMatch("finalStatus", app
         .getFinalApplicationStatus().toString(), finalStatus);
-    assertEquals( 0, progress, 0.0, "progress doesn't match");
+    assertEquals(0, progress, 0.0, "progress doesn't match");
     if ("UNASSIGNED".equals(trackingUI)) {
       WebServicesTestUtils.checkStringMatch("trackingUI", "UNASSIGNED",
           trackingUI);
@@ -1939,8 +1939,8 @@ public class TestRMWebServicesApps extends JerseyTestBase {
       String nodeLabelExpression, int numContainers, boolean relaxLocality,
       int priority, String resourceName, long memory, long vCores,
       String executionType, boolean enforceExecutionType) {
-    assertEquals(
-       request.getNodeLabelExpression(), nodeLabelExpression, "nodeLabelExpression doesn't match");
+    assertEquals(request.getNodeLabelExpression(), nodeLabelExpression,
+        "nodeLabelExpression doesn't match");
     assertEquals(request.getNumContainers(),
         numContainers, "numContainers doesn't match");
     assertEquals(request.getRelaxLocality(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsCustomResourceTypes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsCustomResourceTypes.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -60,7 +60,7 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp
     .TestRMWebServicesCustomResourceTypesCommons.verifyAppInfoJson;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp
     .TestRMWebServicesCustomResourceTypesCommons.verifyAppsXML;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -135,11 +135,11 @@ public class TestRMWebServicesAppsCustomResourceTypes extends JerseyTestBase {
                     new BufferedClientResponse(response));
     testCase.verify(document -> {
       NodeList apps = document.getElementsByTagName("apps");
-      assertEquals("incorrect number of apps elements", 1, apps.getLength());
+      assertEquals(1, apps.getLength(), "incorrect number of apps elements");
 
       NodeList appArray = ((Element)(apps.item(0)))
               .getElementsByTagName("app");
-      assertEquals("incorrect number of app elements", 1, appArray.getLength());
+      assertEquals(1, appArray.getLength(), "incorrect number of app elements");
 
       verifyAppsXML(appArray, app1, rm);
     });
@@ -171,13 +171,13 @@ public class TestRMWebServicesAppsCustomResourceTypes extends JerseyTestBase {
             new BufferedClientResponse(response));
     testCase.verify(json -> {
       try {
-        assertEquals("incorrect number of apps elements", 1, json.length());
+        assertEquals(1, json.length(), "incorrect number of apps elements");
         JSONObject apps = json.getJSONObject("apps");
-        assertEquals("incorrect number of app elements", 1, apps.length());
+        assertEquals(1, apps.length(), "incorrect number of app elements");
         JSONObject app = apps.getJSONObject("app");
         JSONArray array = new JSONArray();
         array.put(app);
-        assertEquals("incorrect count of app", 1, array.length());
+        assertEquals(1, array.length(), "incorrect count of app");
 
         verifyAppInfoJson(array.getJSONObject(0), app1, rm);
       } catch (JSONException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
@@ -114,13 +114,10 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -141,7 +138,6 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
 public class TestRMWebServicesAppsModification extends JerseyTestBase {
   private static MockRM rm;
 
@@ -334,18 +330,16 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     return new FairTestServletModule(true);
   }
 
-  @Parameters
   public static Collection<Object[]> guiceConfigs() {
-    return Arrays.asList(new Object[][] { { 0 }, { 1 }, { 2 }, { 3 } });
+    return Arrays.asList(new Object[][]{{0}, {1}, {2}, {3}});
   }
 
-  @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  public TestRMWebServicesAppsModification(int run) throws JAXBException {
+  public void initTestRMWebServicesAppsModification(int run) throws Exception {
     switch (run) {
     case 0:
     default:
@@ -365,6 +359,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
       config.register(getSimpleAuthInjectorFair());
       break;
     }
+    setUp();
   }
 
   private boolean isAuthenticationEnabled() {
@@ -392,8 +387,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     return this.constructWebResource(ws, paths);
   }
 
-  @Test
-  public void testSingleAppState() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSingleAppState(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048);
     String[] mediaTypes =
@@ -407,9 +404,8 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
       RMApp app = MockRMAppSubmitter.submit(rm, data);
       amNodeManager.nodeHeartbeat(true);
       Response response =
-          this
-            .constructWebResource("apps", app.getApplicationId().toString(),
-              "state").request(mediaType).get(Response.class);
+          this.constructWebResource("apps", app.getApplicationId().toString(),
+          "state").request(mediaType).get(Response.class);
       assertResponseStatusCode(OK, response.getStatusInfo());
       if (mediaType.contains(MediaType.APPLICATION_JSON)) {
         verifyAppStateJson(response, RMAppState.ACCEPTED);
@@ -420,8 +416,11 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test(timeout = 120000)
-  public void testSingleAppKill() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  @Timeout(value = 120)
+  public void testSingleAppKill(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048);
     String[] mediaTypes =
@@ -502,8 +501,8 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
             } else {
               verifyAppStateXML(response, RMAppState.KILLED);
             }
-            assertTrue("Diagnostic message is incorrect",
-                app.getDiagnostics().toString().contains(diagnostic));
+            assertTrue(
+               app.getDiagnostics().toString().contains(diagnostic), "Diagnostic message is incorrect");
             break;
           }
         }
@@ -513,8 +512,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testSingleAppKillInvalidState() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSingleAppKillInvalidState(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048);
 
@@ -575,7 +576,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     String responseState = json.getJSONObject("appstate").getString("state");
     boolean valid = false;
     for (RMAppState state : states) {
@@ -584,7 +585,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
       }
     }
     String msg = "app state incorrect, got " + responseState;
-    assertTrue(msg, valid);
+    assertTrue(valid, msg);
   }
 
   protected static void verifyAppStateXML(Response response,
@@ -599,7 +600,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("appstate");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     Element element = (Element) nodes.item(0);
     String state = WebServicesTestUtils.getXmlString(element, "state");
     boolean valid = false;
@@ -609,18 +610,20 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
       }
     }
     String msg = "app state incorrect, got " + state;
-    assertTrue(msg, valid);
+    assertTrue(valid, msg);
   }
 
-  @Test(timeout = 60000)
-  public void testSingleAppKillUnauthorized() throws Exception {
-
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  @Timeout(value = 60)
+  public void testSingleAppKillUnauthorized(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     boolean isCapacityScheduler =
         rm.getResourceScheduler() instanceof CapacityScheduler;
     boolean isFairScheduler =
         rm.getResourceScheduler() instanceof FairScheduler;
-    assumeTrue("This test is only supported on Capacity and Fair Scheduler",
-        isCapacityScheduler || isFairScheduler);
+    assumeTrue(isCapacityScheduler || isFairScheduler,
+        "This test is only supported on Capacity and Fair Scheduler");
     // FairScheduler use ALLOCATION_FILE to configure ACL
     if (isCapacityScheduler) {
       // default root queue allows anyone to have admin acl
@@ -660,8 +663,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testSingleAppKillInvalidId() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSingleAppKillInvalidId(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048);
     amNodeManager.nodeHeartbeat(true);
@@ -688,7 +693,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception {
     if (rm != null) {
@@ -738,8 +743,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
   }
 
   // Simple test - just post to /apps/new-application and validate the response
-  @Test
-  public void testGetNewApplication() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testGetNewApplication(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     String mediaTypes[] =
         { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML };
@@ -799,7 +806,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     is.setCharacterStream(new StringReader(response));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("NewApplication");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     Element element = (Element) nodes.item(0);
     String appId = WebServicesTestUtils.getXmlString(element, "application-id");
     assertTrue(!appId.isEmpty());
@@ -818,8 +825,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
 
   // Test to validate the process of submitting apps - test for appropriate
   // errors as well
-  @Test
-  public void testGetNewApplicationAndSubmit() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testGetNewApplicationAndSubmit(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     MockNM amNodeManager = rm.registerNode("127.0.0.1:1234", 2048);
     amNodeManager.nodeHeartbeat(true);
@@ -983,8 +992,8 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     DataInputStream di = new DataInputStream(str);
     cs.readTokenStorageStream(di);
     Text key = new Text("secret1");
-    assertTrue("Secrets missing from credentials object", cs
-        .getAllSecretKeys().contains(key));
+    assertTrue(cs
+        .getAllSecretKeys().contains(key), "Secrets missing from credentials object");
     assertEquals("mysecret", new String(cs.getSecretKey(key), StandardCharsets.UTF_8));
 
     // Check LogAggregationContext
@@ -1060,9 +1069,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     validateResponseStatus(response, BAD_REQUEST);
   }
 
-  @Test
-  public void testAppSubmitBadJsonAndXML() throws Exception {
-
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testAppSubmitBadJsonAndXML(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     // submit a bunch of bad XML and JSON via the
     // REST API and make sure we get error response codes
 
@@ -1107,8 +1117,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testGetAppQueue() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testGetAppQueue(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     boolean isCapacityScheduler =
         rm.getResourceScheduler() instanceof CapacityScheduler;
     rm.start();
@@ -1139,8 +1151,11 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test(timeout = 90000)
-  public void testUpdateAppPriority() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  @Timeout(value = 90)
+  public void testUpdateAppPriority(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
 
     if (!(rm.getResourceScheduler() instanceof CapacityScheduler)) {
       // till the fair scheduler modifications for priority is completed
@@ -1234,9 +1249,11 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test(timeout = 90000)
-  public void testAppMove() throws Exception {
-
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  @Timeout(value = 90)
+  public void testAppMove(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     boolean isCapacityScheduler =
         rm.getResourceScheduler() instanceof CapacityScheduler;
 
@@ -1292,7 +1309,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
         } else {
           verifyAppQueueXML(response, expectedQueue);
         }
-        Assert.assertEquals(expectedQueue, app.getQueue());
+        assertEquals(expectedQueue, app.getQueue());
 
         // check unauthorized
         MockRMAppSubmissionData data =
@@ -1306,10 +1323,10 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
             "queue").request().put(Entity.entity(entity, contentType), Response.class);
         assertResponseStatusCode(Response.Status.FORBIDDEN, response.getStatusInfo());
         if(isCapacityScheduler) {
-          Assert.assertEquals("root.default", app.getQueue());
+          assertEquals("root.default", app.getQueue());
         }
         else {
-          Assert.assertEquals("root.someuser", app.getQueue());
+          assertEquals("root.someuser", app.getQueue());
         }
 
       }
@@ -1335,7 +1352,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject applicationpriority = json.getJSONObject("applicationpriority");
     int responsePriority = applicationpriority.getInt("priority");
     assertEquals(expectedPriority, responsePriority);
@@ -1353,7 +1370,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("applicationpriority");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     Element element = (Element) nodes.item(0);
     int responsePriority = WebServicesTestUtils.getXmlInt(element, "priority");
     assertEquals(expectedPriority, responsePriority);
@@ -1364,7 +1381,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     String responseQueue = json.getJSONObject("appqueue").getString("queue");
     assertEquals(queue, responseQueue);
   }
@@ -1380,15 +1397,17 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("appqueue");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     Element element = (Element) nodes.item(0);
     String responseQueue = WebServicesTestUtils.getXmlString(element, "queue");
     assertEquals(queue, responseQueue);
   }
 
-  @Test(timeout = 90000)
-  public void testUpdateAppTimeout() throws Exception {
-
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  @Timeout(value = 90)
+  public void testUpdateAppTimeout(int run) throws Exception {
+    initTestRMWebServicesAppsModification(run);
     rm.start();
     rm.registerNode("127.0.0.1:1234", 2048);
     String[] mediaTypes =
@@ -1490,7 +1509,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject jsonTimeout = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, jsonTimeout.length());
+    assertEquals(1, jsonTimeout.length(), "incorrect number of elements");
     JSONObject json = jsonTimeout.getJSONObject("timeout");
     verifyAppTimeoutJson(json, type, expireTime, timeOutFromNow);
   }
@@ -1498,7 +1517,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
   protected static void verifyAppTimeoutJson(JSONObject json,
       ApplicationTimeoutType type, String expireTime, long timeOutFromNow)
       throws JSONException {
-    assertEquals("incorrect number of elements", 3, json.length());
+    assertEquals(3, json.length(), "incorrect number of elements");
     assertEquals(type.toString(), json.getString("type"));
     assertEquals(expireTime, json.getString("expiryTime"));
     assertTrue(json.getLong("remainingTimeInSeconds") <= timeOutFromNow);
@@ -1516,7 +1535,7 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("timeout");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     Element element = (Element) nodes.item(0);
     assertEquals(type.toString(),
         WebServicesTestUtils.getXmlString(element, "type"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesAppsModification.java
@@ -501,8 +501,8 @@ public class TestRMWebServicesAppsModification extends JerseyTestBase {
             } else {
               verifyAppStateXML(response, RMAppState.KILLED);
             }
-            assertTrue(
-               app.getDiagnostics().toString().contains(diagnostic), "Diagnostic message is incorrect");
+            assertTrue(app.getDiagnostics().toString().contains(diagnostic),
+                "Diagnostic message is incorrect");
             break;
           }
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDefaultLabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDefaultLabel.java
@@ -102,7 +102,7 @@ public class TestRMWebServicesCapacitySchedDefaultLabel extends JerseyTestBase {
   }
 
   public void initTestRMWebServicesCapacitySchedDefaultLabel(boolean pLegacyQueueMode)
-    throws Exception {
+      throws Exception {
     this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
     setUp();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDefaultLabel.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDefaultLabel.java
@@ -31,11 +31,9 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,16 +51,14 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServic
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
 public class TestRMWebServicesCapacitySchedDefaultLabel extends JerseyTestBase {
 
   private static final QueuePath ROOT = new QueuePath(CapacitySchedulerConfiguration.ROOT);
   private static final QueuePath A = new QueuePath(CapacitySchedulerConfiguration.ROOT + ".a");
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
   private MockRM rm;
   private ResourceConfig config;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
@@ -100,24 +96,27 @@ public class TestRMWebServicesCapacitySchedDefaultLabel extends JerseyTestBase {
     }
   }
 
-  @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  public TestRMWebServicesCapacitySchedDefaultLabel(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  public void initTestRMWebServicesCapacitySchedDefaultLabel(boolean pLegacyQueueMode)
+    throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
+    setUp();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
-  @Test
-  public void testNodeLabelDefaultAPI() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testNodeLabelDefaultAPI(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesCapacitySchedDefaultLabel(pLegacyQueueMode);
     rm.registerNode("h1:1234", 32 * GB, 32);
     Response response = target().path("ws/v1/cluster/scheduler")
         .request(MediaType.APPLICATION_XML).get(Response.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfig.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfig.java
@@ -31,14 +31,13 @@ import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -62,23 +61,28 @@ import static org.mockito.Mockito.when;
  *     root.test_1.test_1_2      2/16      [memory=2048,  vcores=2]       6.25%
  *     root.test_1.test_1_3     12/16      [memory=12288, vcores=12]      37.5%
  */
-@RunWith(Parameterized.class)
 public class TestRMWebServicesCapacitySchedDynamicConfig extends JerseyTestBase {
 
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
 
   private MockRM rm;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
 
   private static final String EXPECTED_FILE_TMPL = "webapp/dynamic-%s-%s.json";
 
-  public TestRMWebServicesCapacitySchedDynamicConfig(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  public void initTestRMWebServicesCapacitySchedDynamicConfig(boolean pLegacyQueueMode)
+      throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
+    setUp();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
   }
 
   @Override
@@ -124,13 +128,15 @@ public class TestRMWebServicesCapacitySchedDynamicConfig extends JerseyTestBase 
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
-  @Test
-  public void testPercentageMode() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testPercentageMode(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesCapacitySchedDynamicConfig(pLegacyQueueMode);
     runTest(EXPECTED_FILE_TMPL, "testPercentageMode", rm, target());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode.java
@@ -31,10 +31,9 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -62,23 +61,28 @@ import static org.mockito.Mockito.when;
  *     root.test_1.test_1_2      2/16      [memory=2048,  vcores=2]       6.25%
  *     root.test_1.test_1_3     12/16      [memory=12288, vcores=12]      37.5%
  */
-@RunWith(Parameterized.class)
 public class TestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode extends JerseyTestBase {
 
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
 
   private MockRM rm;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
 
   private static final String EXPECTED_FILE_TMPL = "webapp/dynamic-%s-%s.json";
 
-  public TestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void initTestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode(
+      boolean pLegacyQueueMode) throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
+    setUp();
   }
 
   @Override
@@ -128,13 +132,15 @@ public class TestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode extends Jer
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
-  @Test
-  public void testAbsoluteMode() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testAbsoluteMode(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesCapacitySchedDynamicConfigAbsoluteMode(pLegacyQueueMode);
     runTest(EXPECTED_FILE_TMPL, "testAbsoluteMode", rm, target());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigWeightMode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigWeightMode.java
@@ -31,10 +31,9 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -61,23 +60,28 @@ import static org.mockito.Mockito.when;
  *     root.test_1.test_1_2      2/16      [memory=2048,  vcores=2]       6.25%
  *     root.test_1.test_1_3     12/16      [memory=12288, vcores=12]      37.5%
  */
-@RunWith(Parameterized.class)
 public class TestRMWebServicesCapacitySchedDynamicConfigWeightMode extends JerseyTestBase {
 
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
 
   private MockRM rm;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
 
   private static final String EXPECTED_FILE_TMPL = "webapp/dynamic-%s-%s.json";
 
-  public TestRMWebServicesCapacitySchedDynamicConfigWeightMode(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  public void initTestRMWebServicesCapacitySchedDynamicConfigWeightMode(
+      boolean pLegacyQueueMode) throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
+    setUp();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
   }
 
   @Override
@@ -126,13 +130,15 @@ public class TestRMWebServicesCapacitySchedDynamicConfigWeightMode extends Jerse
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
-  @Test
-  public void testWeightMode() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testWeightMode(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesCapacitySchedDynamicConfigWeightMode(pLegacyQueueMode);
     runTest(EXPECTED_FILE_TMPL, "testWeightMode", rm, target());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC.java
@@ -33,10 +33,9 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -70,14 +69,12 @@ import static org.mockito.Mockito.when;
  *     root.test_1.test_1_2      2/16      [memory=2048,  vcores=2]       6.25%
  *     root.test_1.test_1_3     12/16      [memory=12288, vcores=12]      37.5%
  */
-@RunWith(Parameterized.class)
 public class TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC extends JerseyTestBase {
 
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
 
   private MockRM rm;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
@@ -86,9 +83,16 @@ public class TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC extends Je
 
   private Configuration conf;
 
-  public TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void initTestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC(
+      boolean pLegacyQueueMode) throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
     backupSchedulerConfigFileInTarget();
+    setUp();
   }
 
   @Override
@@ -135,13 +139,15 @@ public class TestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC extends Je
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
-  @Test
-  public void testWeightModeFlexibleAQC() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testWeightModeFlexibleAQC(boolean pLegacyQueueMode) throws Exception {
+    initTestRMWebServicesCapacitySchedDynamicConfigWeightModeDQC(pLegacyQueueMode);
     // capacity and normalizedWeight are set differently between legacy/non-legacy queue mode
     rm.registerNode("h1:1234", 32 * GB, 32);
     assertJsonResponse(sendRequest(target()),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedMode.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedMode.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -67,7 +67,7 @@ public class TestRMWebServicesCapacitySchedulerMixedMode extends JerseyTestBase 
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentage.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -67,7 +67,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentage
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAndWeight.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAndWeight.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAnd
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAndWeightVector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAndWeightVector.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageAnd
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageVector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageVector.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndPercentageVec
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeight.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeight.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeight
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeightVector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeightVector.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModeAbsoluteAndWeightVector
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeight.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeight.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -65,7 +65,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeight exte
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeightVector.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeightVector.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,7 +66,7 @@ public class TestRMWebServicesCapacitySchedulerMixedModePercentageAndWeightVecto
   private Configuration conf;
   private RMWebServices rmWebServices;
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
@@ -46,11 +46,11 @@ import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,10 +76,10 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServic
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.backupSchedulerConfigFileInTarget;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.restoreSchedulerConfigFileInTarget;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.toJson;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.ORDERING_POLICY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -156,18 +156,18 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
   }
 
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     backupSchedulerConfigFileInTarget();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     restoreSchedulerConfigFileInTarget();
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }
@@ -409,8 +409,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
         .getConfiguration();
     bOrderingPolicy = CapacitySchedulerConfiguration.PREFIX
         + "root.b" + CapacitySchedulerConfiguration.DOT + ORDERING_POLICY;
-    assertNull("Failed to unset Parent Queue OrderingPolicy",
-        newCSConf.get(bOrderingPolicy));
+    assertNull(
+       newCSConf.get(bOrderingPolicy), "Failed to unset Parent Queue OrderingPolicy");
   }
 
   @Test
@@ -453,8 +453,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
         .getConfiguration();
     cOrderingPolicy = CapacitySchedulerConfiguration.PREFIX
         + "root.c" + CapacitySchedulerConfiguration.DOT + ORDERING_POLICY;
-    assertNull("Failed to unset Leaf Queue OrderingPolicy",
-        newCSConf.get(cOrderingPolicy));
+    assertNull(
+       newCSConf.get(cOrderingPolicy), "Failed to unset Leaf Queue OrderingPolicy");
   }
 
   @Test
@@ -477,10 +477,10 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     CapacitySchedulerConfiguration newCSConf =
         ((CapacityScheduler) rm.getResourceScheduler()).getConfiguration();
-    assertEquals("Failed to remove the queue",
-        1, newCSConf.getQueues(ROOT_A).size());
-    assertEquals("Failed to remove the right queue",
-        "a1", newCSConf.getQueues(ROOT_A).get(0));
+    assertEquals(
+       1, newCSConf.getQueues(ROOT_A).size(), "Failed to remove the queue");
+    assertEquals("a1", newCSConf.getQueues(ROOT_A).get(0),
+        "Failed to remove the right queue");
   }
 
   @Test
@@ -520,8 +520,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
 
     // Validate Queue 'mappedqueue' exists before deletion
-    assertNotNull("Failed to setup CapacityScheduler Configuration",
-        cs.getQueue("mappedqueue"));
+    assertNotNull(
+       cs.getQueue("mappedqueue"), "Failed to setup CapacityScheduler Configuration");
 
     // Set state of queue 'mappedqueue' to STOPPED.
     SchedConfUpdateInfo updateInfo = new SchedConfUpdateInfo();
@@ -547,8 +547,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     CapacitySchedulerConfiguration newCSConf =
         ((CapacityScheduler) rm.getResourceScheduler()).getConfiguration();
     assertEquals(4, newCSConf.getQueues(ROOT).size());
-    assertNotNull("CapacityScheduler Configuration is corrupt",
-        cs.getQueue("mappedqueue"));
+    assertNotNull(
+       cs.getQueue("mappedqueue"), "CapacityScheduler Configuration is corrupt");
   }
 
   @Test
@@ -1034,7 +1034,7 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (rm != null) {
       rm.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesConfigurationMutation.java
@@ -409,8 +409,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
         .getConfiguration();
     bOrderingPolicy = CapacitySchedulerConfiguration.PREFIX
         + "root.b" + CapacitySchedulerConfiguration.DOT + ORDERING_POLICY;
-    assertNull(
-       newCSConf.get(bOrderingPolicy), "Failed to unset Parent Queue OrderingPolicy");
+    assertNull(newCSConf.get(bOrderingPolicy),
+        "Failed to unset Parent Queue OrderingPolicy");
   }
 
   @Test
@@ -453,8 +453,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
         .getConfiguration();
     cOrderingPolicy = CapacitySchedulerConfiguration.PREFIX
         + "root.c" + CapacitySchedulerConfiguration.DOT + ORDERING_POLICY;
-    assertNull(
-       newCSConf.get(cOrderingPolicy), "Failed to unset Leaf Queue OrderingPolicy");
+    assertNull(newCSConf.get(cOrderingPolicy),
+        "Failed to unset Leaf Queue OrderingPolicy");
   }
 
   @Test
@@ -477,8 +477,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     CapacitySchedulerConfiguration newCSConf =
         ((CapacityScheduler) rm.getResourceScheduler()).getConfiguration();
-    assertEquals(
-       1, newCSConf.getQueues(ROOT_A).size(), "Failed to remove the queue");
+    assertEquals(1, newCSConf.getQueues(ROOT_A).size(),
+        "Failed to remove the queue");
     assertEquals("a1", newCSConf.getQueues(ROOT_A).get(0),
         "Failed to remove the right queue");
   }
@@ -520,8 +520,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
 
     // Validate Queue 'mappedqueue' exists before deletion
-    assertNotNull(
-       cs.getQueue("mappedqueue"), "Failed to setup CapacityScheduler Configuration");
+    assertNotNull(cs.getQueue("mappedqueue"),
+        "Failed to setup CapacityScheduler Configuration");
 
     // Set state of queue 'mappedqueue' to STOPPED.
     SchedConfUpdateInfo updateInfo = new SchedConfUpdateInfo();
@@ -547,8 +547,8 @@ public class TestRMWebServicesConfigurationMutation extends JerseyTestBase {
     CapacitySchedulerConfiguration newCSConf =
         ((CapacityScheduler) rm.getResourceScheduler()).getConfiguration();
     assertEquals(4, newCSConf.getQueues(ROOT).size());
-    assertNotNull(
-       cs.getQueue("mappedqueue"), "CapacityScheduler Configuration is corrupt");
+    assertNotNull(cs.getQueue("mappedqueue"),
+        "CapacityScheduler Configuration is corrupt");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesContainers.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesContainers.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,8 +50,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.reader.ApplicationSu
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.writer.ApplicationSubmissionContextInfoWriter;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
@@ -106,7 +106,7 @@ public class TestRMWebServicesContainers extends JerseyTestBase {
     }
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCustomResourceTypesCommons.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesCustomResourceTypesCommons.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRMWebServicesCustomResourceTypesCommons {
 
@@ -62,8 +62,8 @@ public class TestRMWebServicesCustomResourceTypesCommons {
       throws JSONException {
     int expectedNumberOfElements = getExpectedNumberOfElements(app);
 
-    assertEquals("incorrect number of elements", expectedNumberOfElements,
-        info.length());
+    assertEquals(expectedNumberOfElements,
+        info.length(), "incorrect number of elements");
 
     AppInfoJsonVerifications.verify(info, app);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -470,8 +470,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
         Element partitionCapacitiesInfo = (Element) capacitiesListInfos.item(0);
         String partitionName = WebServicesTestUtils
             .getXmlString(partitionCapacitiesInfo, "partitionName");
-        assertTrue(
-           partitionName.isEmpty(), "invalid PartitionCapacityInfo");
+        assertTrue(partitionName.isEmpty(), "invalid PartitionCapacityInfo");
         verifyPartitionCapacityInfoXML(partitionCapacitiesInfo, 30, 0, 50, 30,
             0, 50);
       } else if (queueChildElem.getTagName().equals("resources")) {
@@ -610,7 +609,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     assertEquals(capacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "capacity"),
         EPSILON, "capacity doesn't match");
     assertEquals(usedCapacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "usedCapacity"),
-        EPSILON,"capacity doesn't match");
+        EPSILON, "capacity doesn't match");
     assertEquals(maxCapacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "maxCapacity"),
         EPSILON, "capacity doesn't match");
     assertEquals(absoluteCapacity,
@@ -813,14 +812,14 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       JSONObject partitionCapacityInfoJson, float capacity, float usedCapacity,
       float maxCapacity, float absoluteCapacity, float absoluteUsedCapacity,
       float absoluteMaxCapacity) throws JSONException {
-    assertEquals(capacity,
-        (float) partitionCapacityInfoJson.getDouble("capacity"), EPSILON, "capacity doesn't match");
-    assertEquals(usedCapacity,
-        (float) partitionCapacityInfoJson.getDouble("usedCapacity"), EPSILON, "capacity doesn't match");
-    assertEquals(maxCapacity,
-        (float) partitionCapacityInfoJson.getDouble("maxCapacity"), EPSILON, "capacity doesn't match");
-    assertEquals(absoluteCapacity,
-        (float) partitionCapacityInfoJson.getDouble("absoluteCapacity"), EPSILON, "capacity doesn't match");
+    assertEquals(capacity, (float) partitionCapacityInfoJson.getDouble("capacity"),
+        EPSILON, "capacity doesn't match");
+    assertEquals(usedCapacity, (float) partitionCapacityInfoJson.getDouble("usedCapacity"),
+        EPSILON, "capacity doesn't match");
+    assertEquals(maxCapacity, (float) partitionCapacityInfoJson.getDouble("maxCapacity"),
+        EPSILON, "capacity doesn't match");
+    assertEquals(absoluteCapacity, (float) partitionCapacityInfoJson.getDouble("absoluteCapacity"),
+        EPSILON, "capacity doesn't match");
     assertEquals(absoluteUsedCapacity,
         (float) partitionCapacityInfoJson.getDouble("absoluteUsedCapacity"),
         1e-3f, "capacity doesn't match");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesForCSWithPartitions.java
@@ -26,8 +26,9 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTes
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.getFirstSubNodeFromJson;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyNumberOfAllocations;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.createRM;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -77,12 +78,9 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -94,7 +92,6 @@ import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
 
-@RunWith(Parameterized.class)
 public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
   private static final String DEFAULT_PARTITION = "";
   private static final String CAPACITIES = "capacities";
@@ -119,9 +116,8 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
   private MockRM rm;
   private CapacitySchedulerConfiguration csConf;
   private YarnConfiguration conf;
-  private final boolean legacyQueueMode;
+  private boolean legacyQueueMode;
 
-  @Parameterized.Parameters(name = "{index}: legacy-queue-mode={0}")
   public static Collection<Boolean> getParameters() {
     return Arrays.asList(true, false);
   }
@@ -157,7 +153,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
               rm.getRMContext().getNodeLabelManager();
           nodeLabelManager.addToCluserNodeLabels(labels);
         } catch (Exception e) {
-          Assert.fail();
+          fail();
         }
 
         rm.start();
@@ -259,25 +255,28 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     config.setMaximumCapacityByLabel(leafQueueC2Path, LABEL_LY, 75);
   }
 
-  @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (rm != null) {
       rm.stop();
     }
   }
 
-  public TestRMWebServicesForCSWithPartitions(boolean legacyQueueMode) {
-    this.legacyQueueMode = legacyQueueMode;
+  public void initTestRMWebServicesForCSWithPartitions(boolean pLegacyQueueMode)
+      throws Exception {
+    this.legacyQueueMode = pLegacyQueueMode;
+    setUp();
   }
 
-  @Test
-  public void testSchedulerPartitions() throws JSONException, Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testSchedulerPartitions(boolean pLegacyQueueMode) throws JSONException, Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
     WebTarget r = targetWithJsonObject();
     Response response =
         r.path("ws").path("v1").path("cluster").path("scheduler")
@@ -288,8 +287,11 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     verifySchedulerInfoJson(json);
   }
 
-  @Test
-  public void testSchedulerPartitionsSlash() throws JSONException, Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testSchedulerPartitionsSlash(boolean pLegacyQueueMode)
+      throws JSONException, Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
     WebTarget r = targetWithJsonObject();
     Response response =
         r.path("ws").path("v1").path("cluster").path("scheduler/")
@@ -301,8 +303,11 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   }
 
-  @Test
-  public void testSchedulerPartitionsDefault() throws JSONException, Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testSchedulerPartitionsDefault(boolean pLegacyQueueMode)
+      throws JSONException, Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
     WebTarget r = targetWithJsonObject();
     Response response = r.path("ws").path("v1").path("cluster")
         .path("scheduler").request().get(Response.class);
@@ -312,8 +317,11 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     verifySchedulerInfoJson(json);
   }
 
-  @Test
-  public void testSchedulerPartitionsXML() throws JSONException, Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testSchedulerPartitionsXML(boolean pLegacyQueueMode)
+      throws JSONException, Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
     WebTarget r = target();
     Response response =
         r.path("ws").path("v1").path("cluster").path("scheduler")
@@ -329,8 +337,11 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     verifySchedulerInfoXML(dom);
   }
 
-  @Test
-  public void testPartitionInSchedulerActivities() throws Exception {
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{index}: legacy-queue-mode={0}")
+  public void testPartitionInSchedulerActivities(boolean pLegacyQueueMode)
+      throws Exception {
+    initTestRMWebServicesForCSWithPartitions(pLegacyQueueMode);
     RMApp app1 = MockRMAppSubmitter.submit(rm,
         MockRMAppSubmissionData.Builder.createWithMemory(1024, rm)
             .withAppName("app1")
@@ -402,9 +413,9 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
 
   private void verifySchedulerInfoXML(Document dom) throws Exception {
     NodeList scheduler = dom.getElementsByTagName("scheduler");
-    assertEquals("incorrect number of elements", 1, scheduler.getLength());
+    assertEquals(1, scheduler.getLength(), "incorrect number of elements");
     NodeList schedulerInfo = dom.getElementsByTagName("schedulerInfo");
-    assertEquals("incorrect number of elements", 1, schedulerInfo.getLength());
+    assertEquals(1, schedulerInfo.getLength(), "incorrect number of elements");
     for (int i = 0; i < schedulerInfo.getLength(); i++) {
       Element element = (Element) schedulerInfo.item(i);
       NodeList children = element.getChildNodes();
@@ -427,20 +438,19 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
               verifyQueueCInfoXML(qElem2);
               break;
             default:
-              Assert.fail("Unexpected queue" + queue);
+              fail("Unexpected queue" + queue);
             }
           }
         } else if (schedulerInfoElem.getTagName().equals(CAPACITIES)) {
           NodeList capacitiesListInfos = schedulerInfoElem.getChildNodes();
-          assertEquals("incorrect number of partitions", 3,
-              capacitiesListInfos.getLength());
+          assertEquals(3,
+              capacitiesListInfos.getLength(), "incorrect number of partitions");
           for (int k = 0; k < capacitiesListInfos.getLength(); k++) {
             Element partitionCapacitiesInfo =
                 (Element) capacitiesListInfos.item(k);
             String partitionName = WebServicesTestUtils
                 .getXmlString(partitionCapacitiesInfo, "partitionName");
-            assertTrue("invalid PartitionCapacityInfo",
-                CLUSTER_LABELS.contains(partitionName));
+            assertTrue(CLUSTER_LABELS.contains(partitionName), "invalid PartitionCapacityInfo");
             verifyPartitionCapacityInfoXML(partitionCapacitiesInfo, 100, 0, 100,
                 100, 0, 100);
           }
@@ -455,13 +465,13 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       Element queueChildElem = (Element) children.item(j);
       if (queueChildElem.getTagName().equals(CAPACITIES)) {
         NodeList capacitiesListInfos = queueChildElem.getChildNodes();
-        assertEquals("incorrect number of partitions", 1,
-            capacitiesListInfos.getLength());
+        assertEquals(1,
+            capacitiesListInfos.getLength(), "incorrect number of partitions");
         Element partitionCapacitiesInfo = (Element) capacitiesListInfos.item(0);
         String partitionName = WebServicesTestUtils
             .getXmlString(partitionCapacitiesInfo, "partitionName");
-        assertTrue("invalid PartitionCapacityInfo",
-            partitionName.isEmpty());
+        assertTrue(
+           partitionName.isEmpty(), "invalid PartitionCapacityInfo");
         verifyPartitionCapacityInfoXML(partitionCapacitiesInfo, 30, 0, 50, 30,
             0, 50);
       } else if (queueChildElem.getTagName().equals("resources")) {
@@ -471,16 +481,16 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
   }
 
   private void verifyQueueBInfoXML(Element queueElem) {
-    assertEquals("Invalid default Label expression", LABEL_LX,
+    assertEquals(LABEL_LX,
         WebServicesTestUtils.getXmlString(queueElem,
-            "defaultNodeLabelExpression"));
+        "defaultNodeLabelExpression"), "Invalid default Label expression");
     NodeList children = queueElem.getChildNodes();
     for (int j = 0; j < children.getLength(); j++) {
       Element queueChildElem = (Element) children.item(j);
       if (queueChildElem.getTagName().equals(CAPACITIES)) {
         NodeList capacitiesListInfos = queueChildElem.getChildNodes();
-        assertEquals("incorrect number of partitions", 2,
-            capacitiesListInfos.getLength());
+        assertEquals(2,
+            capacitiesListInfos.getLength(), "incorrect number of partitions");
         for (int k = 0; k < capacitiesListInfos.getLength(); k++) {
           Element partitionCapacitiesInfo =
               (Element) capacitiesListInfos.item(k);
@@ -496,13 +506,13 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
                 30, 0, 50);
             break;
           default:
-            Assert.fail("Unexpected partition" + partitionName);
+            fail("Unexpected partition" + partitionName);
           }
         }
       }
     }
-    assertEquals("Node Labels are not matching", LABEL_LX,
-        WebServicesTestUtils.getXmlString(queueElem, "nodeLabels"));
+    assertEquals(LABEL_LX, WebServicesTestUtils.getXmlString(queueElem, "nodeLabels"),
+        "Node Labels are not matching");
   }
 
   private void verifyQueueCInfoXML(Element queueElem) {
@@ -521,9 +531,9 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
           String queue = WebServicesTestUtils.getXmlString(qElem2, "queueName");
           switch (queue) {
           case LEAF_QUEUE_C1:
-            assertEquals("Invalid default Label expression", LABEL_LX,
+            assertEquals(LABEL_LX,
                 WebServicesTestUtils.getXmlString(qElem2,
-                    "defaultNodeLabelExpression"));
+                "defaultNodeLabelExpression"), "Invalid default Label expression");
             NodeList queuec1Children = qElem2.getChildNodes();
             for (int l = 0; l < queuec1Children.getLength(); l++) {
               Element queueC1ChildElem = (Element) queuec1Children.item(l);
@@ -534,9 +544,9 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
             }
             break;
           case LEAF_QUEUE_C2:
-            assertEquals("Invalid default Label expression", LABEL_LY,
+            assertEquals(LABEL_LY,
                 WebServicesTestUtils.getXmlString(qElem2,
-                    "defaultNodeLabelExpression"));
+                "defaultNodeLabelExpression"), "Invalid default Label expression");
             NodeList queuec2Children = qElem2.getChildNodes();
             for (int l = 0; l < queuec2Children.getLength(); l++) {
               Element queueC2ChildElem = (Element) queuec2Children.item(l);
@@ -547,7 +557,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
             }
             break;
           default:
-            Assert.fail("Unexpected queue" + queue);
+            fail("Unexpected queue" + queue);
           }
         }
       }
@@ -559,8 +569,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       float lyCaps, float lyMaxCaps, float lyAbsCaps, float lyAbsMaxCaps,
       float defCaps, float defMaxCaps, float defAbsCaps, float defAbsMaxCaps) {
     NodeList capacitiesListInfos = partitionCapacitiesElem.getChildNodes();
-    assertEquals("incorrect number of partitions", 3,
-        capacitiesListInfos.getLength());
+    assertEquals(3, capacitiesListInfos.getLength(), "incorrect number of partitions");
     for (int k = 0; k < capacitiesListInfos.getLength(); k++) {
       Element partitionCapacitiesInfo = (Element) capacitiesListInfos.item(k);
       String partitionName = WebServicesTestUtils
@@ -579,60 +588,58 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
             defMaxCaps, defAbsCaps, 0, defAbsMaxCaps);
         break;
       default:
-        Assert.fail("Unexpected partition" + partitionName);
+        fail("Unexpected partition" + partitionName);
       }
     }
   }
 
   private void verifyResourceUsageInfoXML(Element queueChildElem) {
     NodeList resourceUsageInfo = queueChildElem.getChildNodes();
-    assertEquals("incorrect number of partitions", 1,
-        resourceUsageInfo.getLength());
+    assertEquals(1, resourceUsageInfo.getLength(), "incorrect number of partitions");
     Element partitionResourceUsageInfo = (Element) resourceUsageInfo.item(0);
     String partitionName = WebServicesTestUtils
         .getXmlString(partitionResourceUsageInfo, "partitionName");
-    assertTrue("invalid PartitionCapacityInfo",
-        DEFAULT_PARTITION.equals(partitionName));
+    assertTrue(DEFAULT_PARTITION.equals(partitionName),
+        "invalid PartitionCapacityInfo");
   }
 
   private void verifyPartitionCapacityInfoXML(Element partitionInfo,
       float capacity, float usedCapacity, float maxCapacity,
       float absoluteCapacity, float absoluteUsedCapacity,
       float absoluteMaxCapacity) {
-    assertEquals("capacity doesn't match", capacity,
-        WebServicesTestUtils.getXmlFloat(partitionInfo, "capacity"), EPSILON);
-    assertEquals("capacity doesn't match", usedCapacity,
-        WebServicesTestUtils.getXmlFloat(partitionInfo, "usedCapacity"), EPSILON);
-    assertEquals("capacity doesn't match", maxCapacity,
-        WebServicesTestUtils.getXmlFloat(partitionInfo, "maxCapacity"), EPSILON);
-    assertEquals("capacity doesn't match", absoluteCapacity,
+    assertEquals(capacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "capacity"),
+        EPSILON, "capacity doesn't match");
+    assertEquals(usedCapacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "usedCapacity"),
+        EPSILON,"capacity doesn't match");
+    assertEquals(maxCapacity, WebServicesTestUtils.getXmlFloat(partitionInfo, "maxCapacity"),
+        EPSILON, "capacity doesn't match");
+    assertEquals(absoluteCapacity,
         WebServicesTestUtils.getXmlFloat(partitionInfo, "absoluteCapacity"),
-        EPSILON);
-    assertEquals("capacity doesn't match", absoluteUsedCapacity,
+        EPSILON, "capacity doesn't match");
+    assertEquals(absoluteUsedCapacity,
         WebServicesTestUtils.getXmlFloat(partitionInfo, "absoluteUsedCapacity"),
-        EPSILON);
-    assertEquals("capacity doesn't match", absoluteMaxCapacity,
+        EPSILON, "capacity doesn't match");
+    assertEquals(absoluteMaxCapacity,
         WebServicesTestUtils.getXmlFloat(partitionInfo, "absoluteMaxCapacity"),
-        EPSILON);
+        EPSILON, "capacity doesn't match");
   }
 
   private void verifySchedulerInfoJson(JSONObject json)
       throws JSONException, Exception {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject info = json.getJSONObject("scheduler");
-    assertEquals("incorrect number of elements", 1, info.length());
+    assertEquals(1, info.length(), "incorrect number of elements");
     info = info.getJSONObject("schedulerInfo");
-    assertEquals("incorrect number of elements", 25, info.length());
+    assertEquals(25, info.length(), "incorrect number of elements");
     JSONObject capacitiesJsonObject = info.getJSONObject(CAPACITIES);
     JSONArray partitionsCapsArray =
         capacitiesJsonObject.getJSONArray(QUEUE_CAPACITIES_BY_PARTITION);
-    assertEquals("incorrect number of elements", CLUSTER_LABELS.size(),
-        partitionsCapsArray.length());
+    assertEquals(CLUSTER_LABELS.size(),
+        partitionsCapsArray.length(), "incorrect number of elements");
     for (int i = 0; i < partitionsCapsArray.length(); i++) {
       JSONObject partitionInfo = partitionsCapsArray.getJSONObject(i);
       String partitionName = partitionInfo.getString("partitionName");
-      assertTrue("Unknown partition received",
-          CLUSTER_LABELS.contains(partitionName));
+      assertTrue(CLUSTER_LABELS.contains(partitionName), "Unknown partition received");
       verifyPartitionCapacityInfoJson(partitionInfo, 100, 0, 100, 100, 0, 100);
     }
     JSONObject jsonQueuesObject = info.getJSONObject("queues");
@@ -673,26 +680,24 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       String partitionName = null;
       switch (queue) {
       case QUEUE_A:
-        assertEquals("incorrect number of partitions", 1,
-            partitionsCapsArray.length());
+        assertEquals(1, partitionsCapsArray.length(), "incorrect number of partitions");
         partitionInfo = partitionsCapsArray.getJSONObject(0);
         partitionName = partitionInfo.getString("partitionName");
         verifyPartitionCapacityInfoJson(partitionInfo, 30, 0, 50, 30, 0, 50);
-        assertEquals("incorrect number of elements", 7,
-            partitionsResourcesArray.getJSONObject(0).length());
-        assertEquals("incorrect number of objects", 1,
-            resourceUsageByPartition.length());
+        assertEquals(7, partitionsResourcesArray.getJSONObject(0).length(),
+            "incorrect number of elements");
+        assertEquals(1, resourceUsageByPartition.length(), "incorrect number of objects");
         break;
       case QUEUE_B:
-        assertEquals("Invalid default Label expression", LABEL_LX,
-            queueJson.getString("defaultNodeLabelExpression"));
-        assertEquals("incorrect number of elements", 7,
-            partitionsResourcesArray.getJSONObject(0).length());
+        assertEquals(LABEL_LX, queueJson.getString("defaultNodeLabelExpression"),
+            "Invalid default Label expression");
+        assertEquals(7, partitionsResourcesArray.getJSONObject(0).length(),
+            "incorrect number of elements");
         verifyAccesibleNodeLabels(queueJson, ImmutableSet.of(LABEL_LX));
-        assertEquals("incorrect number of partitions", 2,
-            partitionsCapsArray.length());
-        assertEquals("incorrect number of objects", 2,
-            resourceUsageByPartition.length());
+        assertEquals(2, partitionsCapsArray.length(),
+            "incorrect number of partitions");
+        assertEquals(2, resourceUsageByPartition.length(),
+            "incorrect number of objects");
         for (int j = 0; j < partitionsCapsArray.length(); j++) {
           partitionInfo = partitionsCapsArray.getJSONObject(j);
           partitionName = partitionInfo.getString("partitionName");
@@ -706,21 +711,21 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
                 50);
             break;
           default:
-            Assert.fail("Unexpected partition" + partitionName);
+            fail("Unexpected partition" + partitionName);
           }
         }
         break;
       case QUEUE_C:
         verifyAccesibleNodeLabels(queueJson,
             ImmutableSet.of(LABEL_LX, LABEL_LY));
-        assertEquals("incorrect number of elements", 4,
-            partitionsResourcesArray.getJSONObject(0).length());
+        assertEquals(4, partitionsResourcesArray.getJSONObject(0).length(),
+            "incorrect number of elements");
         verifyQcPartitionsCapacityInfoJson(partitionsCapsArray, 70, 100, 70,
             100, 100, 100, 100, 100, 40, 50, 40, 50);
         verifySubQueuesOfQc(queueJson);
         break;
       default:
-        Assert.fail("Unexpected queue" + queue);
+        fail("Unexpected queue" + queue);
       }
     }
   }
@@ -734,11 +739,11 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
     } else {
       nodeLabels.put(nodeLabelsObj);
     }
-    assertEquals("number of accessible Node Labels not matching",
-        accesibleNodeLabels.size(), nodeLabels.length());
+    assertEquals(accesibleNodeLabels.size(), nodeLabels.length(),
+        "number of accessible Node Labels not matching");
     for (int i = 0; i < nodeLabels.length(); i++) {
-      assertTrue("Invalid accessible node label : " + nodeLabels.getString(i),
-          accesibleNodeLabels.contains(nodeLabels.getString(i)));
+      assertTrue(accesibleNodeLabels.contains(nodeLabels.getString(i)),
+          "Invalid accessible node label : " + nodeLabels.getString(i));
     }
   }
 
@@ -756,21 +761,21 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       case LEAF_QUEUE_C1:
         verifyAccesibleNodeLabels(queueJson,
             ImmutableSet.of(LABEL_LX, LABEL_LY));
-        assertEquals("Invalid default Label expression", LABEL_LX,
-            queueJson.getString("defaultNodeLabelExpression"));
+        assertEquals(LABEL_LX, queueJson.getString("defaultNodeLabelExpression"),
+            "Invalid default Label expression");
         verifyQcPartitionsCapacityInfoJson(partitionsCapsArray, 40, 100, 28,
             100, 50, 75, 50, 75, 50, 60, 20, 30);
         break;
       case LEAF_QUEUE_C2:
         verifyAccesibleNodeLabels(queueJson,
             ImmutableSet.of(LABEL_LX, LABEL_LY));
-        assertEquals("Invalid default Label expression", LABEL_LY,
-            queueJson.getString("defaultNodeLabelExpression"));
+        assertEquals(LABEL_LY, queueJson.getString("defaultNodeLabelExpression"),
+            "Invalid default Label expression");
         verifyQcPartitionsCapacityInfoJson(partitionsCapsArray, 60, 100, 42,
             100, 50, 75, 50, 75, 50, 70, 20, 35);
         break;
       default:
-        Assert.fail("Unexpected queue" + queue);
+        fail("Unexpected queue" + queue);
       }
     }
   }
@@ -780,8 +785,8 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       float lyCaps, float lyMaxCaps, float lyAbsCaps, float lyAbsMaxCaps,
       float defCaps, float defMaxCaps, float defAbsCaps, float defAbsMaxCaps)
           throws JSONException {
-    assertEquals("incorrect number of partitions", CLUSTER_LABELS.size(),
-        partitionsCapsArray.length());
+    assertEquals(CLUSTER_LABELS.size(), partitionsCapsArray.length(),
+        "incorrect number of partitions");
     for (int j = 0; j < partitionsCapsArray.length(); j++) {
       JSONObject partitionInfo = partitionsCapsArray.getJSONObject(j);
       String partitionName = partitionInfo.getString("partitionName");
@@ -799,7 +804,7 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
             defAbsCaps, 0, defAbsMaxCaps);
         break;
       default:
-        Assert.fail("Unexpected partition" + partitionName);
+        fail("Unexpected partition" + partitionName);
       }
     }
   }
@@ -808,19 +813,19 @@ public class TestRMWebServicesForCSWithPartitions extends JerseyTestBase {
       JSONObject partitionCapacityInfoJson, float capacity, float usedCapacity,
       float maxCapacity, float absoluteCapacity, float absoluteUsedCapacity,
       float absoluteMaxCapacity) throws JSONException {
-    assertEquals("capacity doesn't match", capacity,
-        (float) partitionCapacityInfoJson.getDouble("capacity"), EPSILON);
-    assertEquals("capacity doesn't match", usedCapacity,
-        (float) partitionCapacityInfoJson.getDouble("usedCapacity"), EPSILON);
-    assertEquals("capacity doesn't match", maxCapacity,
-        (float) partitionCapacityInfoJson.getDouble("maxCapacity"), EPSILON);
-    assertEquals("capacity doesn't match", absoluteCapacity,
-        (float) partitionCapacityInfoJson.getDouble("absoluteCapacity"), EPSILON);
-    assertEquals("capacity doesn't match", absoluteUsedCapacity,
+    assertEquals(capacity,
+        (float) partitionCapacityInfoJson.getDouble("capacity"), EPSILON, "capacity doesn't match");
+    assertEquals(usedCapacity,
+        (float) partitionCapacityInfoJson.getDouble("usedCapacity"), EPSILON, "capacity doesn't match");
+    assertEquals(maxCapacity,
+        (float) partitionCapacityInfoJson.getDouble("maxCapacity"), EPSILON, "capacity doesn't match");
+    assertEquals(absoluteCapacity,
+        (float) partitionCapacityInfoJson.getDouble("absoluteCapacity"), EPSILON, "capacity doesn't match");
+    assertEquals(absoluteUsedCapacity,
         (float) partitionCapacityInfoJson.getDouble("absoluteUsedCapacity"),
-        1e-3f);
-    assertEquals("capacity doesn't match", absoluteMaxCapacity,
+        1e-3f, "capacity doesn't match");
+    assertEquals(absoluteMaxCapacity,
         (float) partitionCapacityInfoJson.getDouble("absoluteMaxCapacity"),
-        1e-3f);
+        1e-3f, "capacity doesn't match");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesHttpStaticUserPermissions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesHttpStaticUserPermissions.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -43,9 +43,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ApplicationSubmissionContextInfo;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
@@ -72,7 +72,7 @@ public class TestRMWebServicesHttpStaticUserPermissions {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     try {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), testRootDir);
@@ -83,7 +83,7 @@ public class TestRMWebServicesHttpStaticUserPermissions {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (testMiniKDC != null) {
       testMiniKDC.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodeLabels.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodeLabels.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,9 +67,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
@@ -158,7 +157,7 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }
@@ -435,8 +434,8 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
   private void assertLabelsToNodesInfo(LabelsToNodesInfo labelsToNodesInfo, int size,
       List<Pair<Pair<String, Boolean>, List<String>>> nodeLabelsToNodesList) {
     Map<NodeLabelInfo, NodeIDsInfo> labelsToNodes = labelsToNodesInfo.getLabelsToNodes();
-    assertNotNull("Labels to nodes mapping should not be null.", labelsToNodes);
-    assertEquals("Size of label to nodes mapping is not the expected.", size, labelsToNodes.size());
+    assertNotNull(labelsToNodes, "Labels to nodes mapping should not be null.");
+    assertEquals(size, labelsToNodes.size(), "Size of label to nodes mapping is not the expected.");
 
     for (Pair<Pair<String, Boolean>, List<String>> nodeLabelToNodes : nodeLabelsToNodesList) {
       Pair<String, Boolean> expectedNLData = nodeLabelToNodes.getLeft();
@@ -444,11 +443,12 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
       NodeLabelInfo expectedNLInfo = new NodeLabelInfo(expectedNLData.getLeft(),
           expectedNLData.getRight());
       NodeIDsInfo actualNodes = labelsToNodes.get(expectedNLInfo);
-      assertNotNull(String.format("Node info not found. Expected NodeLabel data: %s",
-          expectedNLData), actualNodes);
+      assertNotNull(actualNodes, String.format("Node info not found. Expected NodeLabel data: %s",
+          expectedNLData));
       for (String expectedNode : expectedNodes) {
-        assertTrue(String.format("Can't find node ID in actual Node IDs list: %s",
-                actualNodes.getNodeIDs()), actualNodes.getNodeIDs().contains(expectedNode));
+        assertTrue(actualNodes.getNodeIDs().contains(expectedNode),
+            String.format("Can't find node ID in actual Node IDs list: %s",
+            actualNodes.getNodeIDs()));
       }
     }
   }
@@ -477,17 +477,17 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
   private void assertNodeLabelsInfoContains(NodeLabelsInfo nodeLabelsInfo,
       Pair<String, Boolean> nlInfo) {
     NodeLabelInfo nodeLabelInfo = new NodeLabelInfo(nlInfo.getLeft(), nlInfo.getRight());
-    assertTrue(String.format("Cannot find nodeLabelInfo '%s' among items of node label info list:" +
-            " %s", nodeLabelInfo, nodeLabelsInfo.getNodeLabelsInfo()),
-        nodeLabelsInfo.getNodeLabelsInfo().contains(nodeLabelInfo));
+    assertTrue(nodeLabelsInfo.getNodeLabelsInfo().contains(nodeLabelInfo),
+        String.format("Cannot find nodeLabelInfo '%s' among items of node label info list:" +
+        " %s", nodeLabelInfo, nodeLabelsInfo.getNodeLabelsInfo()));
   }
 
   private void assertNodeLabelsInfoDoesNotContain(NodeLabelsInfo nodeLabelsInfo, Pair<String,
       Boolean> nlInfo) {
     NodeLabelInfo nodeLabelInfo = new NodeLabelInfo(nlInfo.getLeft(), nlInfo.getRight());
-    assertFalse(String.format("Should have not found nodeLabelInfo '%s' among " +
-        "items of node label info list: %s", nodeLabelInfo, nodeLabelsInfo.getNodeLabelsInfo()),
-        nodeLabelsInfo.getNodeLabelsInfo().contains(nodeLabelInfo));
+    assertFalse(nodeLabelsInfo.getNodeLabelsInfo().contains(nodeLabelInfo),
+        String.format("Should have not found nodeLabelInfo '%s' among " +
+        "items of node label info list: %s", nodeLabelInfo, nodeLabelsInfo.getNodeLabelsInfo()));
   }
 
   private void assertNodeLabelsSize(NodeLabelsInfo nodeLabelsInfo, int expectedSize) {
@@ -622,11 +622,11 @@ public class TestRMWebServicesNodeLabels extends JerseyTestBase {
   private void validateJsonExceptionContent(Response response,
       String expectedMessage)
       throws JSONException {
-    Assert.assertEquals(BAD_REQUEST_CODE, response.getStatus());
+    assertEquals(BAD_REQUEST_CODE, response.getStatus());
     JSONObject msg = response.readEntity(JSONObject.class);
     JSONObject exception = msg.getJSONObject("RemoteException");
     String message = exception.getString("message");
-    assertEquals("incorrect number of elements", 3, exception.length());
+    assertEquals(3, exception.length(), "incorrect number of elements");
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
     WebServicesTestUtils.checkStringMatch("exception type",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesNodes.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 import static org.apache.hadoop.yarn.server.resourcemanager.MockNM.createMockNodeStatus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -100,7 +100,8 @@ import org.apache.hadoop.yarn.webapp.WebServicesTestUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -186,6 +187,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     }
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -237,12 +239,12 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONArray nodeArray = nodes.getJSONArray("node");
     // 3 nodes, including the unhealthy node and the new node.
-    assertEquals("incorrect number of elements", 3, nodeArray.length());
+    assertEquals(3, nodeArray.length(), "incorrect number of elements");
   }
 
   private RMNode getRunningRMNode(String host, int port, int memory) {
@@ -287,14 +289,14 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONObject node = nodes.getJSONObject("node");
     JSONArray nodeArray = new JSONArray();
     nodeArray.put(node);
 
-    assertEquals("incorrect number of elements", 1, nodeArray.length());
+    assertEquals(1, nodeArray.length(), "incorrect number of elements");
     JSONObject info = nodeArray.getJSONObject(0);
 
     verifyNodeInfo(info, rmnode2);
@@ -313,8 +315,8 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("nodes is not empty", "", json.get("nodes").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("nodes").toString(), "nodes is not empty");
   }
 
   @Test
@@ -334,7 +336,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     String json = response.readEntity(String.class);
     JSONObject msg = new JSONObject(json);
     JSONObject exception = msg.getJSONObject("RemoteException");
-    assertEquals("incorrect number of elements", 3, exception.length());
+    assertEquals(3, exception.length(), "incorrect number of elements");
     String message = exception.getString("message");
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
@@ -365,9 +367,9 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONArray nodeArray = nodes.getJSONArray("node");
-    assertEquals("incorrect number of elements", 2, nodeArray.length());
+    assertEquals(2, nodeArray.length(), "incorrect number of elements");
     for (int i = 0; i < nodeArray.length(); ++i) {
       JSONObject info = nodeArray.getJSONObject(i);
       String[] node = info.get("id").toString().split(":");
@@ -399,7 +401,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     JSONObject info = json.getJSONObject("node");
     String id = info.get("id").toString();
 
-    assertEquals("Incorrect Node Information.", "h2:1234", id);
+    assertEquals("h2:1234", id, "Incorrect Node Information.");
 
     RMNode rmNode =
         rm.getRMContext().getInactiveRMNodes().get(rmnode2.getNodeID());
@@ -423,13 +425,13 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONObject node = nodes.getJSONObject("node");
     JSONArray nodeArray = new JSONArray();
     nodeArray.put(node);
-    assertEquals("incorrect number of elements", 1, nodeArray.length());
+    assertEquals(1, nodeArray.length(), "incorrect number of elements");
   }
 
   @Test
@@ -444,8 +446,8 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
-    assertEquals("nodes is not empty", "", json.get("nodes").toString());
+    assertEquals(1, json.length(), "incorrect number of elements");
+    assertEquals("", json.get("nodes").toString(), "nodes is not empty");
   }
 
   public void testNodesHelper(String path, String media) throws JSONException,
@@ -459,11 +461,11 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONArray nodeArray = nodes.getJSONArray("node");
-    assertEquals("incorrect number of elements", 2, nodeArray.length());
+    assertEquals(2, nodeArray.length(), "incorrect number of elements");
     JSONObject info = nodeArray.getJSONObject(0);
     String id = info.get("id").toString();
 
@@ -506,7 +508,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject info = json.getJSONObject("node");
     verifyNodeInfo(info, nm);
   }
@@ -527,7 +529,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject msg = response.readEntity(JSONObject.class);
     JSONObject exception = msg.getJSONObject("RemoteException");
-    assertEquals("incorrect number of elements", 3, exception.length());
+    assertEquals(3, exception.length(), "incorrect number of elements");
     String message = exception.getString("message");
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
@@ -549,7 +551,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject msg = response.readEntity(JSONObject.class);
     JSONObject exception = msg.getJSONObject("RemoteException");
-    assertEquals("incorrect number of elements", 3, exception.length());
+    assertEquals(3, exception.length(), "incorrect number of elements");
     String message = exception.getString("message");
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
@@ -582,11 +584,11 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
   }
 
   private void verifyNonexistNodeException(String message, String type, String classname) {
-    assertTrue("exception message incorrect: " + message,
-        "nodeId, node_invalid:99, is not found".matches(message));
-    assertTrue("exception type incorrect", "NotFoundException".matches(type));
-    assertTrue("exception className incorrect",
-        "org.apache.hadoop.yarn.webapp.NotFoundException".matches(classname));
+    assertTrue("nodeId, node_invalid:99, is not found".matches(message),
+        "exception message incorrect: " + message);
+    assertTrue("NotFoundException".matches(type), "exception type incorrect");
+    assertTrue("org.apache.hadoop.yarn.webapp.NotFoundException".matches(classname),
+        "exception className incorrect");
   }
 
   @Test
@@ -602,7 +604,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject msg = response.readEntity(JSONObject.class);
     JSONObject exception = msg.getJSONObject("RemoteException");
-    assertEquals("incorrect number of elements", 3, exception.length());
+    assertEquals(3, exception.length(), "incorrect number of elements");
     String message = exception.getString("message");
     String type = exception.getString("exception");
     String classname = exception.getString("javaClassName");
@@ -630,9 +632,9 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     InputSource is = new InputSource(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesApps = dom.getElementsByTagName("nodes");
-    assertEquals("incorrect number of elements", 1, nodesApps.getLength());
+    assertEquals(1, nodesApps.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("node");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     verifyNodesXML(nodes, rmnode1);
   }
 
@@ -656,7 +658,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodes = dom.getElementsByTagName("node");
-    assertEquals("incorrect number of elements", 1, nodes.getLength());
+    assertEquals(1, nodes.getLength(), "incorrect number of elements");
     verifyNodesXML(nodes, rmnode1);
   }
 
@@ -678,9 +680,9 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     is.setCharacterStream(new StringReader(xml));
     Document dom = db.parse(is);
     NodeList nodesApps = dom.getElementsByTagName("nodes");
-    assertEquals("incorrect number of elements", 1, nodesApps.getLength());
+    assertEquals(1, nodesApps.getLength(), "incorrect number of elements");
     NodeList nodes = dom.getElementsByTagName("node");
-    assertEquals("incorrect number of elements", 2, nodes.getLength());
+    assertEquals(2, nodes.getLength(), "incorrect number of elements");
   }
   
   @Test
@@ -702,9 +704,9 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONArray nodeArray = nodes.getJSONArray("node");
-    assertEquals("incorrect number of elements", 3, nodeArray.length());
+    assertEquals(3, nodeArray.length(), "incorrect number of elements");
   }
 
   @Test
@@ -734,13 +736,13 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     assertEquals(MediaType.APPLICATION_JSON_TYPE + ";" + JettyUtils.UTF_8,
         response.getMediaType().toString());
     JSONObject json = response.readEntity(JSONObject.class);
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject nodes = json.getJSONObject("nodes");
-    assertEquals("incorrect number of elements", 1, nodes.length());
+    assertEquals(1, nodes.length(), "incorrect number of elements");
     JSONObject jsonNode = nodes.getJSONObject("node");
     JSONArray nodeArray = new JSONArray();
     nodeArray.put(jsonNode);
-    assertEquals("incorrect number of elements", 1, nodeArray.length());
+    assertEquals(1, nodeArray.length(), "incorrect number of elements");
     JSONObject info = nodeArray.getJSONObject(0);
 
     // verify the resource utilization
@@ -801,7 +803,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     JSONObject exception = json.getJSONObject("RemoteException");
     assertEquals("IllegalArgumentException", exception.getString("exception"));
     String msg = exception.getString("message");
-    assertTrue("Wrong message: " + msg, msg.startsWith("Invalid NodeId"));
+    assertTrue(msg.startsWith("Invalid NodeId"), "Wrong message: " + msg);
 
     rm.stop();
   }
@@ -842,7 +844,7 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
 
   public void verifyNodeInfo(JSONObject nodeInfo, RMNode nm)
       throws JSONException, Exception {
-    assertEquals("incorrect number of elements", 23, nodeInfo.length());
+    assertEquals(23, nodeInfo.length(), "incorrect number of elements");
 
     JSONObject resourceInfo = nodeInfo.getJSONObject("resourceUtilization");
     verifyNodeInfoGeneric(nm, nodeInfo.getString("state"),
@@ -901,47 +903,45 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
     if (node.getNodeUtilization() != null) {
       ResourceUtilization nodeResource = ResourceUtilization.newInstance(
           nodePhysicalMemoryMB, nodeVirtualMemoryMB, (float) nodeCPUUsage);
-      assertEquals("nodeResourceUtilization doesn't match",
-          node.getNodeUtilization(), nodeResource);
+      assertEquals(node.getNodeUtilization(), nodeResource,
+          "nodeResourceUtilization doesn't match");
     }
     if (node.getAggregatedContainersUtilization() != null) {
       ResourceUtilization containerResource = ResourceUtilization.newInstance(
           containersPhysicalMemoryMB, containersVirtualMemoryMB,
           (float) containersCPUUsage);
-      assertEquals("containerResourceUtilization doesn't match",
-          node.getAggregatedContainersUtilization(), containerResource);
+      assertEquals(node.getAggregatedContainersUtilization(), containerResource,
+          "containerResourceUtilization doesn't match");
     }
 
     long expectedHealthUpdate = node.getLastHealthReportTime();
-    assertEquals("lastHealthUpdate doesn't match, got: " + lastHealthUpdate
-        + " expected: " + expectedHealthUpdate, expectedHealthUpdate,
-        lastHealthUpdate);
+    assertEquals(expectedHealthUpdate, lastHealthUpdate,
+        "lastHealthUpdate doesn't match, got: " + lastHealthUpdate
+        + " expected: " + expectedHealthUpdate);
 
     if (report != null) {
-      assertEquals("numContainers doesn't match: " + numContainers,
-          report.getNumContainers(), numContainers);
-      assertEquals("usedMemoryMB doesn't match: " + usedMemoryMB, report
-          .getUsedResource().getMemorySize(), usedMemoryMB);
-      assertEquals("availMemoryMB doesn't match: " + availMemoryMB, report
-          .getAvailableResource().getMemorySize(), availMemoryMB);
-      assertEquals("usedVirtualCores doesn't match: " + usedVirtualCores, report
-          .getUsedResource().getVirtualCores(), usedVirtualCores);
-      assertEquals("availVirtualCores doesn't match: " + availVirtualCores, report
-          .getAvailableResource().getVirtualCores(), availVirtualCores);
+      assertEquals(report.getNumContainers(), numContainers,
+          "numContainers doesn't match: " + numContainers);
+      assertEquals(report.getUsedResource().getMemorySize(), usedMemoryMB,
+          "usedMemoryMB doesn't match: " + usedMemoryMB);
+      assertEquals(report.getAvailableResource().getMemorySize(), availMemoryMB,
+          "availMemoryMB doesn't match: " + availMemoryMB);
+      assertEquals(report.getUsedResource().getVirtualCores(), usedVirtualCores,
+          "usedVirtualCores doesn't match: " + usedVirtualCores);
+      assertEquals(report.getAvailableResource().getVirtualCores(), availVirtualCores,
+          "availVirtualCores doesn't match: " + availVirtualCores);
     }
 
     if (opportunisticStatus != null) {
-      assertEquals("numRunningOpportContainers doesn't match: " +
-              numRunningOpportContainers,
-          opportunisticStatus.getRunningOpportContainers(),
+      assertEquals(opportunisticStatus.getRunningOpportContainers(),
+          numRunningOpportContainers, "numRunningOpportContainers doesn't match: " +
           numRunningOpportContainers);
-      assertEquals("usedMemoryOpportGB doesn't match: " + usedMemoryOpportGB,
-          opportunisticStatus.getOpportMemoryUsed(), usedMemoryOpportGB);
-      assertEquals(
-          "usedVirtualCoresOpport doesn't match: " + usedVirtualCoresOpport,
-          opportunisticStatus.getOpportCoresUsed(), usedVirtualCoresOpport);
-      assertEquals("numQueuedContainers doesn't match: " + numQueuedContainers,
-          opportunisticStatus.getQueuedOpportContainers(), numQueuedContainers);
+      assertEquals(opportunisticStatus.getOpportMemoryUsed(), usedMemoryOpportGB,
+          "usedMemoryOpportGB doesn't match: " + usedMemoryOpportGB);
+      assertEquals(opportunisticStatus.getOpportCoresUsed(), usedVirtualCoresOpport,
+          "usedVirtualCoresOpport doesn't match: " + usedVirtualCoresOpport);
+      assertEquals(opportunisticStatus.getQueuedOpportContainers(), numQueuedContainers,
+          "numQueuedContainers doesn't match: " + numQueuedContainers);
     }
   }
 
@@ -1060,8 +1060,8 @@ public class TestRMWebServicesNodes extends JerseyTestBase {
       String nodeId = nodeJson.getString("id");
 
       // Ensure the response contains all nodes info
-      assertTrue("Nodes info should have expected node IDs",
-          expectedAllocationTags.containsKey(nodeId));
+      assertTrue(expectedAllocationTags.containsKey(nodeId),
+          "Nodes info should have expected node IDs");
 
       Map<String, Long> expectedTags = expectedAllocationTags.get(nodeId);
       JSONArray tagsInfo = nodeJson.getJSONObject("allocationTags")

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.toJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseStatusCode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,12 +79,7 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jettison.JettisonFeature;
@@ -92,8 +87,9 @@ import org.glassfish.jersey.jettison.JettisonJaxbContext;
 import org.glassfish.jersey.jettison.JettisonUnmarshaller;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TestRMWebServicesReservation extends JerseyTestBase {
 
   private String webserviceUserName = "testuser";
@@ -275,19 +271,17 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     return new FairTestServletModule(true);
   }
 
-  @Parameters
   public static Collection<Object[]> guiceConfigs() {
     return Arrays.asList(new Object[][] {{0, true}, {1, true}, {2, true},
         {3, true}, {0, false}, {1, false}, {2, false}, {3, false}});
   }
 
-  @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  public TestRMWebServicesReservation(int run, boolean recurrence) {
+  public void initTestRMWebServicesReservation(int run, boolean recurrence) throws Exception {
     enableRecurrence = recurrence;
     switch (run) {
     case 0:
@@ -308,6 +302,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
       config.register(getSimpleAuthInjectorFair());
       break;
     }
+    setUp();
   }
 
   private boolean isAuthenticationEnabled() {
@@ -329,7 +324,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     return this.constructWebResource(target, paths);
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception {
     if (rm != null) {
@@ -338,8 +333,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     super.tearDown();
   }
 
-  @Test
-  public void testSubmitReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSubmitReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -353,8 +350,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testSubmitDuplicateReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSubmitDuplicateReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -382,8 +381,11 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testSubmitDifferentReservationWithSameId() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSubmitDifferentReservationWithSameId(int run, boolean recurrence)
+      throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -412,8 +414,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testFailedSubmitReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testFailedSubmitReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     // setup a cluster too small to accept the reservation
     setupCluster(1);
@@ -427,8 +431,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testUpdateReservation() throws JSONException, Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testUpdateReservation(int run, boolean recurrence) throws JSONException, Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -444,8 +450,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testTimeIntervalRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testTimeIntervalRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -485,9 +493,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testSameTimeIntervalRequestListReservation() throws Exception {
-
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testSameTimeIntervalRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -531,9 +540,12 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
     rm.stop();
   }
-  @Test
-  public void testInvalidTimeIntervalRequestListReservation() throws
-          Exception {
+
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testInvalidTimeIntervalRequestListReservation(int run, boolean recurrence) throws
+      Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -572,8 +584,11 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testInvalidEndTimeRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testInvalidEndTimeRequestListReservation(int run, boolean recurrence)
+      throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -624,8 +639,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testEmptyEndTimeRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testEmptyEndTimeRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -674,8 +691,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testInvalidStartTimeRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testInvalidStartTimeRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -718,8 +737,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testEmptyStartTimeRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testEmptyStartTimeRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -759,8 +780,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testQueueOnlyRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testQueueOnlyRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -791,8 +814,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testEmptyQueueRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testEmptyQueueRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -811,8 +836,11 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testNonExistentQueueRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testNonExistentQueueRequestListReservation(int run, boolean recurrence)
+      throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -832,8 +860,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testReservationIdRequestListReservation() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testReservationIdRequestListReservation(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -873,9 +903,11 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testInvalidReservationIdRequestListReservation() throws
-          Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testInvalidReservationIdRequestListReservation(int run, boolean recurrence)
+      throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -897,8 +929,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testIncludeResourceAllocations() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testIncludeResourceAllocations(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -933,8 +967,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testExcludeResourceAllocations() throws Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testExcludeResourceAllocations(int run, boolean recurrence) throws Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
 
@@ -971,8 +1007,10 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.stop();
   }
 
-  @Test
-  public void testDeleteReservation() throws JSONException, Exception {
+  @MethodSource("guiceConfigs")
+  @ParameterizedTest
+  public void testDeleteReservation(int run, boolean recurrence) throws JSONException, Exception {
+    initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     for (int i = 0; i < 100; i++) {
       MockNM amNodeManager =
@@ -1027,7 +1065,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
         readEntity(JSONObject.class).
         getJSONObject("new-reservation");
 
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     ReservationId rid = null;
     try {
       rid = ReservationId.parseReservationId(json.getString("reservation-id"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
@@ -495,7 +495,8 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
   @MethodSource("guiceConfigs")
   @ParameterizedTest
-  public void testSameTimeIntervalRequestListReservation(int run, boolean recurrence) throws Exception {
+  public void testSameTimeIntervalRequestListReservation(int run, boolean recurrence)
+      throws Exception {
     initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
@@ -693,7 +694,8 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
   @MethodSource("guiceConfigs")
   @ParameterizedTest
-  public void testInvalidStartTimeRequestListReservation(int run, boolean recurrence) throws Exception {
+  public void testInvalidStartTimeRequestListReservation(int run, boolean recurrence)
+      throws Exception {
     initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
@@ -739,7 +741,8 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
   @MethodSource("guiceConfigs")
   @ParameterizedTest
-  public void testEmptyStartTimeRequestListReservation(int run, boolean recurrence) throws Exception {
+  public void testEmptyStartTimeRequestListReservation(int run, boolean recurrence)
+      throws Exception {
     initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);
@@ -862,7 +865,8 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
   @MethodSource("guiceConfigs")
   @ParameterizedTest
-  public void testReservationIdRequestListReservation(int run, boolean recurrence) throws Exception {
+  public void testReservationIdRequestListReservation(int run, boolean recurrence)
+      throws Exception {
     initTestRMWebServicesReservation(run, recurrence);
     rm.start();
     setupCluster(100);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivities.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.reader.NodeLabelsInfoReader;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerState;
@@ -57,7 +57,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeUpdateS
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -99,10 +100,10 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTes
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyNumberOfNodes;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyQueueOrder;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyStateOfAllocations;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -144,7 +145,7 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
   public TestRMWebServicesSchedulerActivities() {
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -866,7 +867,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testInsufficientResourceDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -930,7 +932,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testPlacementConstraintDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler)rm.getResourceScheduler();
@@ -998,7 +1001,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppInsufficientResourceDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -1050,7 +1054,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppPlacementConstraintDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -1108,7 +1113,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppFilterByRequestPrioritiesAndAllocationRequestIds()
       throws Exception {
     rm.start();
@@ -1247,7 +1253,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppLimit() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -1322,7 +1329,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppActions() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -1426,7 +1434,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppSummary() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -1677,7 +1686,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSchedulerBulkActivities() throws Exception {
     rm.start();
 
@@ -1703,8 +1713,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
       JSONObject activitiesJson = restClient.getOutput().getJSONObject(
           FN_SCHEDULER_BULK_ACT_ROOT);
       Object activities = activitiesJson.get(FN_SCHEDULER_ACT_ROOT);
-      assertEquals("Number of activities is wrong", expectedCount,
-          ((JSONArray) activities).length());
+      assertEquals(expectedCount,
+          ((JSONArray) activities).length(), "Number of activities is wrong");
 
 
       // Validate if response does not exceed max 500
@@ -1717,9 +1727,8 @@ public class TestRMWebServicesSchedulerActivities extends JerseyTestBase {
       activitiesJson = restClient.getOutput().getJSONObject(
           FN_SCHEDULER_BULK_ACT_ROOT);
       activities = activitiesJson.get(FN_SCHEDULER_ACT_ROOT);
-      assertEquals("Max Activities Limit does not work",
-          RMWebServices.MAX_ACTIVITIES_COUNT,
-          ((JSONArray) activities).length());
+      assertEquals(RMWebServices.MAX_ACTIVITIES_COUNT,
+          ((JSONArray) activities).length(), "Max Activities Limit does not work");
 
     } finally {
       rm.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled.java
@@ -47,9 +47,9 @@ import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -82,9 +82,10 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTes
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyNumberOfAllocationAttempts;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyNumberOfAllocations;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.ActivitiesTestUtils.verifyStateOfAllocations;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -163,13 +164,14 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     config.setMaximumApplicationMasterResourcePerQueuePercent(b, 100);
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAssignContainer() throws Exception {
     //Start RM so that it accepts app submissions
     rm.start();
@@ -227,7 +229,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSchedulingWithoutPendingRequests()
       throws Exception {
     //Start RM so that it accepts app submissions
@@ -269,7 +272,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppAssignContainer() throws Exception {
     rm.start();
 
@@ -334,7 +338,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testInsufficientResourceDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -420,7 +425,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppInsufficientResourceDiagnostic() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler)rm.getResourceScheduler();
@@ -499,7 +505,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testGroupByDiagnostics() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler) rm.getResourceScheduler();
@@ -528,7 +535,7 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
        */
       params.add(RMWSConsts.GROUP_BY, "NON-EXIST-GROUP-BY");
       JSONObject json = ActivitiesTestUtils.requestWebResource(r, params);
-      Assert.assertTrue(json.getJSONObject(FN_SCHEDULER_ACT_ROOT)
+      assertTrue(json.getJSONObject(FN_SCHEDULER_ACT_ROOT)
           .getString(FN_ACT_DIAGNOSTIC).startsWith("Got invalid groupBy:"));
       params.remove(RMWSConsts.GROUP_BY);
 
@@ -575,7 +582,7 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
           assertEquals("1", reqChild.getString(FN_ACT_COUNT));
           assertNotNull(reqChild.getString(FN_ACT_NODE_IDS));
         } else {
-          Assert.fail("Allocation state should be "
+          fail("Allocation state should be "
               + AllocationState.SKIPPED.name() + " or "
               + AllocationState.RESERVED.name() + "!");
         }
@@ -585,7 +592,8 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
     }
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAppGroupByDiagnostics() throws Exception {
     rm.start();
     CapacityScheduler cs = (CapacityScheduler)rm.getResourceScheduler();
@@ -615,7 +623,7 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
        */
       params.add(RMWSConsts.GROUP_BY, "NON-EXIST-GROUP-BY");
       JSONObject json = ActivitiesTestUtils.requestWebResource(r, params);
-      Assert.assertTrue(json.getJSONObject(FN_APP_ACT_ROOT)
+      assertTrue(json.getJSONObject(FN_APP_ACT_ROOT)
           .getString(FN_ACT_DIAGNOSTIC)
           .startsWith("Got invalid groupBy:"));
       params.remove(RMWSConsts.GROUP_BY);
@@ -674,7 +682,7 @@ public class TestRMWebServicesSchedulerActivitiesWithMultiNodesEnabled
           assertEquals("1", allocationAttemptObj.getString(FN_ACT_COUNT));
           assertNotNull(allocationAttemptObj.getString(FN_ACT_NODE_IDS));
         } else {
-          Assert.fail("Allocation state should be "
+          fail("Allocation state should be "
               + AllocationState.SKIPPED.name() + " or "
               + AllocationState.RESERVED.name() + "!");
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebappAuthentication.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebappAuthentication.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.yarn.server.resourcemanager.webapp;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.TestWebServiceUtil.toJson;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,18 +48,15 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoSchedule
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppState;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ApplicationSubmissionContextInfo;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /* Just a simple test class to ensure that the RM handles the static web user
  * correctly for secure and un-secure modes
  * 
  */
-@RunWith(Parameterized.class)
 public class TestRMWebappAuthentication {
 
   private static MockRM rm;
@@ -93,28 +90,26 @@ public class TestRMWebappAuthentication {
     kerberosConf.setBoolean("mockrm.webapp.enabled", true);
   }
 
-  @Parameters
   public static Collection params() {
-    return Arrays.asList(new Object[][] { { 1, simpleConf },
-        { 2, kerberosConf } });
+    return Arrays.asList(new Object[][]{{1, simpleConf},
+        {2, kerberosConf}});
   }
 
-  public TestRMWebappAuthentication(int run, Configuration conf) {
-    super();
+  public void initTestRMWebappAuthentication(int run, Configuration conf) {
     setupAndStartRM(conf);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     try {
       testMiniKDC = new MiniKdc(MiniKdc.createConf(), testRootDir);
       setupKDC();
     } catch (Exception e) {
-      assertTrue("Couldn't create MiniKDC", false);
+      assertTrue(false, "Couldn't create MiniKDC");
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (testMiniKDC != null) {
       testMiniKDC.stop();
@@ -142,9 +137,10 @@ public class TestRMWebappAuthentication {
   // ensure that in a non-secure cluster users can access
   // the web pages as earlier and submit apps as anonymous
   // user or by identifying themselves
-  @Test
-  public void testSimpleAuth() throws Exception {
-
+  @MethodSource("params")
+  @ParameterizedTest
+  public void testSimpleAuth(int run, Configuration conf) throws Exception {
+    initTestRMWebappAuthentication(run, conf);
     rm.start();
 
     // ensure users can access web pages

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRedirectionErrorPage.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRedirectionErrorPage.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.inject.Binder;
 import com.google.inject.Injector;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestWebServiceUtil.java
@@ -55,7 +55,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.glassfish.jersey.jettison.JettisonJaxbContext;
 import org.glassfish.jersey.jettison.JettisonMarshaller;
-import org.junit.Assert;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -70,7 +69,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerTestUtilities.GB;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class TestWebServiceUtil {
   private static final ObjectMapper MAPPER = new ObjectMapper()
@@ -288,7 +288,7 @@ public final class TestWebServiceUtil {
       }
     } catch (URISyntaxException | IOException e) {
       e.printStackTrace();
-      Assert.fail("overwrite should not fail " + e.getMessage());
+      fail("overwrite should not fail " + e.getMessage());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
@@ -28,11 +28,12 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedule
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.QueueManager;
 import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,7 +65,7 @@ public class TestFairSchedulerQueueInfo {
         new FairSchedulerQueueInfo(testQueue, scheduler);
     Collection<FairSchedulerQueueInfo> childQueues =
         queueInfo.getChildQueues();
-    Assert.assertNotNull(childQueues);
-    Assert.assertEquals("Child QueueInfo was not empty", 0, childQueues.size());
+    assertNotNull(childQueues);
+    assertEquals(0, childQueues.size(), "Child QueueInfo was not empty");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
@@ -81,7 +81,8 @@ public class FairSchedulerJsonVerifications {
   private void verifyResourcesContainCustomResourceTypes(JSONObject queue,
       Set<String> resourceCategories) throws JSONException {
     for (String resourceCategory : resourceCategories) {
-      assertTrue(queue.has(resourceCategory), "Queue " + queue + " does not have resource category key: "
+      assertTrue(queue.has(resourceCategory),
+          "Queue " + queue + " does not have resource category key: "
           + resourceCategory);
       verifyResourceContainsAllCustomResourceTypes(
           queue.getJSONObject(resourceCategory));
@@ -103,9 +104,8 @@ public class FairSchedulerJsonVerifications {
         resourceInformations.getJSONArray("resourceInformation");
 
     // customResources will include vcores / memory as well
-    assertEquals(
-    
-       customResourceTypes.size(), customResources.length() - 2, "Different number of custom resource types found than expected");
+    assertEquals(customResourceTypes.size(), customResources.length() - 2,
+       "Different number of custom resource types found than expected");
 
     for (int i = 0; i < customResources.length(); i++) {
       JSONObject customResource = customResources.getJSONObject(i);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerJsonVerifications.java
@@ -28,9 +28,9 @@ import org.codehaus.jettison.json.JSONObject;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test helper class is primarily used by
@@ -62,8 +62,8 @@ public class FairSchedulerJsonVerifications {
       Set<String> resourceCategories) throws JSONException {
     for (String resourceCategory : resourceCategories) {
       boolean hasResourceCategory = queue.has(resourceCategory);
-      assertTrue("Queue " + queue + " does not have resource category key: "
-          + resourceCategory, hasResourceCategory);
+      assertTrue(hasResourceCategory, "Queue " + queue + " does not have resource category key: "
+          + resourceCategory);
       verifyResourceContainsDefaultResourceTypes(
           queue.getJSONObject(resourceCategory));
     }
@@ -74,15 +74,15 @@ public class FairSchedulerJsonVerifications {
     Object memory = jsonObject.opt("memory");
     Object vCores = jsonObject.opt("vCores");
 
-    assertNotNull("Key 'memory' not found in: " + jsonObject, memory);
-    assertNotNull("Key 'vCores' not found in: " + jsonObject, vCores);
+    assertNotNull(memory, "Key 'memory' not found in: " + jsonObject);
+    assertNotNull(vCores, "Key 'vCores' not found in: " + jsonObject);
   }
 
   private void verifyResourcesContainCustomResourceTypes(JSONObject queue,
       Set<String> resourceCategories) throws JSONException {
     for (String resourceCategory : resourceCategories) {
-      assertTrue("Queue " + queue + " does not have resource category key: "
-          + resourceCategory, queue.has(resourceCategory));
+      assertTrue(queue.has(resourceCategory), "Queue " + queue + " does not have resource category key: "
+          + resourceCategory);
       verifyResourceContainsAllCustomResourceTypes(
           queue.getJSONObject(resourceCategory));
     }
@@ -90,35 +90,34 @@ public class FairSchedulerJsonVerifications {
 
   private void verifyResourceContainsAllCustomResourceTypes(
       JSONObject resourceCategory) throws JSONException {
-    assertTrue("resourceCategory does not have resourceInformations: "
-        + resourceCategory, resourceCategory.has("resourceInformations"));
+    assertTrue(resourceCategory.has("resourceInformations"),
+        "resourceCategory does not have resourceInformations: "
+        + resourceCategory);
 
     JSONObject resourceInformations =
         resourceCategory.getJSONObject("resourceInformations");
-    assertTrue(
+    assertTrue(resourceInformations.has("resourceInformation"),
         "resourceInformations does not have resourceInformation object: "
-            + resourceInformations,
-        resourceInformations.has("resourceInformation"));
+        + resourceInformations);
     JSONArray customResources =
         resourceInformations.getJSONArray("resourceInformation");
 
     // customResources will include vcores / memory as well
     assertEquals(
-        "Different number of custom resource types found than expected",
-        customResourceTypes.size(), customResources.length() - 2);
+    
+       customResourceTypes.size(), customResources.length() - 2, "Different number of custom resource types found than expected");
 
     for (int i = 0; i < customResources.length(); i++) {
       JSONObject customResource = customResources.getJSONObject(i);
-      assertTrue("Resource type does not have name field: " + customResource,
-          customResource.has("name"));
-      assertTrue("Resource type does not have name resourceType field: "
-          + customResource, customResource.has("resourceType"));
-      assertTrue(
-          "Resource type does not have name units field: " + customResource,
-          customResource.has("units"));
-      assertTrue(
-          "Resource type does not have name value field: " + customResource,
-          customResource.has("value"));
+      assertTrue(customResource.has("name"),
+          "Resource type does not have name field: " + customResource);
+      assertTrue(customResource.has("resourceType"),
+          "Resource type does not have name resourceType field: "
+          + customResource);
+      assertTrue(customResource.has("units"),
+          "Resource type does not have name units field: " + customResource);
+      assertTrue(customResource.has("value"),
+          "Resource type does not have name value field: " + customResource);
 
       String name = customResource.getString("name");
       String unit = customResource.getString("units");
@@ -130,12 +129,12 @@ public class FairSchedulerJsonVerifications {
         continue;
       }
 
-      assertTrue("Custom resource type " + name + " not found",
-          customResourceTypes.contains(name));
+      assertTrue(customResourceTypes.contains(name),
+          "Custom resource type " + name + " not found");
       assertEquals("k", unit);
       assertEquals(ResourceTypes.COUNTABLE,
           ResourceTypes.valueOf(resourceType));
-      assertNotNull("Custom resource value " + value + " is null!", value);
+      assertNotNull(value, "Custom resource value " + value + " is null!");
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
@@ -33,9 +33,9 @@ import java.util.Set;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.helper.XmlCustomResourceTypeTestCase.toXml;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlLong;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test helper class is primarily used by
@@ -62,8 +62,8 @@ public class FairSchedulerXmlVerifications {
       Set<String> resourceCategories) {
     for (String resourceCategory : resourceCategories) {
       boolean hasResourceCategory = hasChild(queue, resourceCategory);
-      assertTrue("Queue " + queue + " does not have resource category key: "
-          + resourceCategory, hasResourceCategory);
+      assertTrue(hasResourceCategory, "Queue " + queue + " does not have resource category key: "
+          + resourceCategory);
       verifyResourceContainsDefaultResourceTypes(
               (Element) queue.getElementsByTagName(resourceCategory).item(0));
     }
@@ -74,15 +74,15 @@ public class FairSchedulerXmlVerifications {
     Object memory = opt(element, "memory");
     Object vCores = opt(element, "vCores");
 
-    assertNotNull("Key 'memory' not found in: " + element, memory);
-    assertNotNull("Key 'vCores' not found in: " + element, vCores);
+    assertNotNull(memory, "Key 'memory' not found in: " + element);
+    assertNotNull(vCores, "Key 'vCores' not found in: " + element);
   }
 
   private void verifyResourcesContainCustomResourceTypes(Element queue,
       Set<String> resourceCategories) {
     for (String resourceCategory : resourceCategories) {
-      assertTrue("Queue " + queue + " does not have key for resourceCategory: "
-          + resourceCategory, hasChild(queue, resourceCategory));
+      assertTrue(hasChild(queue, resourceCategory), "Queue " + queue + " does not have key for resourceCategory: "
+          + resourceCategory);
       verifyResourceContainsCustomResourceTypes(
               (Element) queue.getElementsByTagName(resourceCategory).item(0));
     }
@@ -90,11 +90,9 @@ public class FairSchedulerXmlVerifications {
 
   private void verifyResourceContainsCustomResourceTypes(
       Element resourceCategory) {
-    assertEquals(
-        toXml(resourceCategory)
-            + " should have only one resourceInformations child!",
-        1, resourceCategory.getElementsByTagName("resourceInformations")
-            .getLength());
+    assertEquals(1, resourceCategory.getElementsByTagName("resourceInformations")
+        .getLength(), toXml(resourceCategory)
+        + " should have only one resourceInformations child!");
     Element resourceInformations = (Element) resourceCategory
         .getElementsByTagName("resourceInformations").item(0);
 
@@ -102,9 +100,8 @@ public class FairSchedulerXmlVerifications {
         resourceInformations.getElementsByTagName("resourceInformation");
 
     // customResources will include vcores / memory as well
-    assertEquals(
-        "Different number of custom resource types found than expected",
-        customResourceTypes.size(), customResources.getLength() - 2);
+    assertEquals(customResourceTypes.size(), customResources.getLength() - 2,
+        "Different number of custom resource types found than expected");
 
     for (int i = 0; i < customResources.getLength(); i++) {
       Element customResource = (Element) customResources.item(i);
@@ -118,14 +115,13 @@ public class FairSchedulerXmlVerifications {
         continue;
       }
 
-      assertTrue("Custom resource type " + name + " not found",
-          customResourceTypes.contains(name));
+      assertTrue(customResourceTypes.contains(name),
+          "Custom resource type " + name + " not found");
       assertEquals("k", unit);
       assertEquals(ResourceTypes.COUNTABLE,
           ResourceTypes.valueOf(resourceType));
-      assertNotNull("Resource value should not be null for resource type "
-          + resourceType + ", listing xml contents: " + toXml(customResource),
-          value);
+      assertNotNull(value, "Resource value should not be null for resource type "
+          + resourceType + ", listing xml contents: " + toXml(customResource));
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/FairSchedulerXmlVerifications.java
@@ -81,7 +81,8 @@ public class FairSchedulerXmlVerifications {
   private void verifyResourcesContainCustomResourceTypes(Element queue,
       Set<String> resourceCategories) {
     for (String resourceCategory : resourceCategories) {
-      assertTrue(hasChild(queue, resourceCategory), "Queue " + queue + " does not have key for resourceCategory: "
+      assertTrue(hasChild(queue, resourceCategory),
+          "Queue " + queue + " does not have key for resourceCategory: "
           + resourceCategory);
       verifyResourceContainsCustomResourceTypes(
               (Element) queue.getElementsByTagName(resourceCategory).item(0));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairScheduler.java
@@ -39,7 +39,8 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.client.WebTarget;
@@ -47,8 +48,8 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -86,6 +87,7 @@ public class TestRMWebServicesFairScheduler extends JerseyTestBase {
     }
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -149,11 +151,11 @@ public class TestRMWebServicesFairScheduler extends JerseyTestBase {
   }
 
   private void verifyClusterScheduler(JSONObject json) throws JSONException {
-    assertEquals("incorrect number of elements", 1, json.length());
+    assertEquals(1, json.length(), "incorrect number of elements");
     JSONObject info = json.getJSONObject("scheduler");
-    assertEquals("incorrect number of elements", 1, info.length());
+    assertEquals(1, info.length(), "incorrect number of elements");
     info = info.getJSONObject("schedulerInfo");
-    assertEquals("incorrect number of elements", 2, info.length());
+    assertEquals(2, info.length(), "incorrect number of elements");
     JSONObject rootQueue = info.getJSONObject("rootQueue");
     assertEquals("root", rootQueue.getString("queueName"));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairSchedulerCustomResourceTypes.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/fairscheduler/TestRMWebServicesFairSchedulerCustomResourceTypes.java
@@ -43,9 +43,9 @@ import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -58,7 +58,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -106,17 +106,17 @@ public class TestRMWebServicesFairSchedulerCustomResourceTypes
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     CustomResourceTypesConfigurationProvider.reset();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoJsonVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoJsonVerifications.java
@@ -25,7 +25,9 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.checkStringEqual;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.checkStringMatch;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains all value verifications that are needed to verify {@link AppInfo}
@@ -51,75 +53,71 @@ public final class AppInfoJsonVerifications {
     checkStringMatch("applicationType", app.getApplicationType(),
         info.getString("applicationType"));
     checkStringMatch("queue", app.getQueue(), info.getString("queue"));
-    assertEquals("priority doesn't match", 0, info.getInt("priority"));
+    assertEquals(0, info.getInt("priority"), "priority doesn't match");
     checkStringMatch("state", app.getState().toString(),
         info.getString("state"));
     checkStringMatch("finalStatus", app.getFinalApplicationStatus().toString(),
         info.getString("finalStatus"));
-    assertEquals("progress doesn't match", 0,
-        (float) info.getDouble("progress"), 0.0);
+    assertEquals(0, (float) info.getDouble("progress"), 0.0,
+        "progress doesn't match");
     if ("UNASSIGNED".equals(info.getString("trackingUI"))) {
       checkStringMatch("trackingUI", "UNASSIGNED",
           info.getString("trackingUI"));
     }
     checkStringEqual("diagnostics", app.getDiagnostics().toString(),
         info.getString("diagnostics"));
-    assertEquals("clusterId doesn't match",
-        ResourceManager.getClusterTimeStamp(), info.getLong("clusterId"));
-    assertEquals("startedTime doesn't match", app.getStartTime(),
-        info.getLong("startedTime"));
-    assertEquals("finishedTime doesn't match", app.getFinishTime(),
-        info.getLong("finishedTime"));
-    assertTrue("elapsed time not greater than 0",
-        info.getLong("elapsedTime") > 0);
+    assertEquals(ResourceManager.getClusterTimeStamp(), info.getLong("clusterId"),
+        "clusterId doesn't match");
+    assertEquals(app.getStartTime(), info.getLong("startedTime"),
+        "startedTime doesn't match");
+    assertEquals(app.getFinishTime(), info.getLong("finishedTime"),
+        "finishedTime doesn't match");
+    assertTrue(info.getLong("elapsedTime") > 0, "elapsed time not greater than 0");
     checkStringMatch("amHostHttpAddress",
         app.getCurrentAppAttempt().getMasterContainer().getNodeHttpAddress(),
         info.getString("amHostHttpAddress"));
-    assertTrue("amContainerLogs doesn't match",
-        info.getString("amContainerLogs").startsWith("http://"));
-    assertTrue("amContainerLogs doesn't contain user info",
-        info.getString("amContainerLogs").endsWith("/" + app.getUser()));
-    assertEquals("allocatedMB doesn't match", 1024, info.getInt("allocatedMB"));
-    assertEquals("allocatedVCores doesn't match", 1,
-        info.getInt("allocatedVCores"));
-    assertEquals("queueUsagePerc doesn't match", 50.0f,
-        (float) info.getDouble("queueUsagePercentage"), 0.01f);
-    assertEquals("clusterUsagePerc doesn't match", 50.0f,
-        (float) info.getDouble("clusterUsagePercentage"), 0.01f);
-    assertEquals("numContainers doesn't match", 1,
-        info.getInt("runningContainers"));
-    assertNotNull("preemptedResourceSecondsMap should not be null",
-        info.get("preemptedResourceSecondsMap"));
-    assertEquals("preemptedResourceMB doesn't match",
-        app.getRMAppMetrics().getResourcePreempted().getMemorySize(),
-        info.getInt("preemptedResourceMB"));
-    assertEquals("preemptedResourceVCores doesn't match",
-        app.getRMAppMetrics().getResourcePreempted().getVirtualCores(),
-        info.getInt("preemptedResourceVCores"));
-    assertEquals("numNonAMContainerPreempted doesn't match",
-        app.getRMAppMetrics().getNumNonAMContainersPreempted(),
-        info.getInt("numNonAMContainerPreempted"));
-    assertEquals("numAMContainerPreempted doesn't match",
-        app.getRMAppMetrics().getNumAMContainersPreempted(),
-        info.getInt("numAMContainerPreempted"));
-    assertEquals("Log aggregation Status doesn't match",
-        app.getLogAggregationStatusForAppReport().toString(),
-        info.getString("logAggregationStatus"));
-    assertEquals("unmanagedApplication doesn't match",
-        app.getApplicationSubmissionContext().getUnmanagedAM(),
-        info.getBoolean("unmanagedApplication"));
+    assertTrue(info.getString("amContainerLogs").startsWith("http://"),
+        "amContainerLogs doesn't match");
+    assertTrue(info.getString("amContainerLogs").endsWith("/" + app.getUser()),
+        "amContainerLogs doesn't contain user info");
+    assertEquals(1024, info.getInt("allocatedMB"), "allocatedMB doesn't match");
+    assertEquals(1, info.getInt("allocatedVCores"), "allocatedVCores doesn't match");
+    assertEquals(50.0f, (float) info.getDouble("queueUsagePercentage"), 0.01f,
+        "queueUsagePerc doesn't match");
+    assertEquals(50.0f, (float) info.getDouble("clusterUsagePercentage"), 0.01f,
+        "clusterUsagePerc doesn't match");
+    assertEquals(1, info.getInt("runningContainers"),
+        "numContainers doesn't match");
+    assertNotNull(info.get("preemptedResourceSecondsMap"),
+        "preemptedResourceSecondsMap should not be null");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getMemorySize(),
+        info.getInt("preemptedResourceMB"), "preemptedResourceMB doesn't match");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getVirtualCores(),
+        info.getInt("preemptedResourceVCores"),
+        "preemptedResourceVCores doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumNonAMContainersPreempted(),
+        info.getInt("numNonAMContainerPreempted"),
+        "numNonAMContainerPreempted doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumAMContainersPreempted(),
+        info.getInt("numAMContainerPreempted"),
+        "numAMContainerPreempted doesn't match");
+    assertEquals(app.getLogAggregationStatusForAppReport().toString(),
+        info.getString("logAggregationStatus"),
+        "Log aggregation Status doesn't match");
+    assertEquals(app.getApplicationSubmissionContext().getUnmanagedAM(),
+        info.getBoolean("unmanagedApplication"),
+        "unmanagedApplication doesn't match");
 
     if (app.getApplicationSubmissionContext()
         .getNodeLabelExpression() != null) {
-      assertEquals("appNodeLabelExpression doesn't match",
-          app.getApplicationSubmissionContext().getNodeLabelExpression(),
-          info.getString("appNodeLabelExpression"));
+      assertEquals(app.getApplicationSubmissionContext().getNodeLabelExpression(),
+          info.getString("appNodeLabelExpression"),
+          "appNodeLabelExpression doesn't match");
     }
-    assertEquals("amNodeLabelExpression doesn't match",
-        app.getAMResourceRequests().get(0).getNodeLabelExpression(),
-        info.getString("amNodeLabelExpression"));
-    assertEquals("amRPCAddress",
-        AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
-        info.getString("amRPCAddress"));
+    assertEquals(app.getAMResourceRequests().get(0).getNodeLabelExpression(),
+        info.getString("amNodeLabelExpression"),
+        "amNodeLabelExpression doesn't match");
+    assertEquals(AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
+        info.getString("amRPCAddress"), "amRPCAddress");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoXmlVerifications.java
@@ -29,9 +29,9 @@ import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlFloat;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlInt;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlLong;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contains all value verifications that are needed to verify {@link AppInfo}
@@ -60,75 +60,69 @@ public final class AppInfoXmlVerifications {
             app.getApplicationType(), getXmlString(info, "applicationType"));
     checkStringMatch("queue", app.getQueue(),
             getXmlString(info, "queue"));
-    assertEquals("priority doesn't match", 0, getXmlInt(info, "priority"));
+    assertEquals(0, getXmlInt(info, "priority"), "priority doesn't match");
     checkStringMatch("state", app.getState().toString(),
             getXmlString(info, "state"));
     checkStringMatch("finalStatus", app
             .getFinalApplicationStatus().toString(),
             getXmlString(info, "finalStatus"));
-    assertEquals("progress doesn't match", 0, getXmlFloat(info, "progress"),
-        0.0);
+    assertEquals(0, getXmlFloat(info, "progress"),
+        0.0,"progress doesn't match");
     if ("UNASSIGNED".equals(getXmlString(info, "trackingUI"))) {
       checkStringMatch("trackingUI", "UNASSIGNED",
               getXmlString(info, "trackingUI"));
     }
     WebServicesTestUtils.checkStringEqual("diagnostics",
             app.getDiagnostics().toString(), getXmlString(info, "diagnostics"));
-    assertEquals("clusterId doesn't match",
-            ResourceManager.getClusterTimeStamp(),
-            getXmlLong(info, "clusterId"));
-    assertEquals("startedTime doesn't match", app.getStartTime(),
-            getXmlLong(info, "startedTime"));
-    assertEquals("finishedTime doesn't match", app.getFinishTime(),
-            getXmlLong(info, "finishedTime"));
-    assertTrue("elapsed time not greater than 0",
-            getXmlLong(info, "elapsedTime") > 0);
+    assertEquals(ResourceManager.getClusterTimeStamp(),
+        getXmlLong(info, "clusterId"), "clusterId doesn't match");
+    assertEquals(app.getStartTime(),
+        getXmlLong(info, "startedTime"), "startedTime doesn't match");
+    assertEquals(app.getFinishTime(),
+        getXmlLong(info, "finishedTime"), "finishedTime doesn't match");
+    assertTrue(getXmlLong(info, "elapsedTime") > 0,
+        "elapsed time not greater than 0");
     checkStringMatch("amHostHttpAddress", app
                     .getCurrentAppAttempt().getMasterContainer()
                     .getNodeHttpAddress(),
             getXmlString(info, "amHostHttpAddress"));
-    assertTrue("amContainerLogs doesn't match",
-        getXmlString(info, "amContainerLogs").startsWith("http://"));
-    assertTrue("amContainerLogs doesn't contain user info",
-        getXmlString(info, "amContainerLogs").endsWith("/" + app.getUser()));
-    assertEquals("allocatedMB doesn't match", 1024,
-            getXmlInt(info, "allocatedMB"));
-    assertEquals("allocatedVCores doesn't match", 1,
-            getXmlInt(info, "allocatedVCores"));
-    assertEquals("queueUsagePerc doesn't match", 50.0f,
-            getXmlFloat(info, "queueUsagePercentage"), 0.01f);
-    assertEquals("clusterUsagePerc doesn't match", 50.0f,
-            getXmlFloat(info, "clusterUsagePercentage"), 0.01f);
-    assertEquals("numContainers doesn't match", 1,
-        getXmlInt(info, "runningContainers"));
-    assertNotNull("preemptedResourceSecondsMap should not be null",
-            info.getElementsByTagName("preemptedResourceSecondsMap"));
-    assertEquals("preemptedResourceMB doesn't match", app
-                    .getRMAppMetrics().getResourcePreempted().getMemorySize(),
-            getXmlInt(info, "preemptedResourceMB"));
-    assertEquals("preemptedResourceVCores doesn't match", app
-                    .getRMAppMetrics().getResourcePreempted().getVirtualCores(),
-            getXmlInt(info, "preemptedResourceVCores"));
-    assertEquals("numNonAMContainerPreempted doesn't match", app
-                    .getRMAppMetrics().getNumNonAMContainersPreempted(),
-            getXmlInt(info, "numNonAMContainerPreempted"));
-    assertEquals("numAMContainerPreempted doesn't match", app
-                    .getRMAppMetrics().getNumAMContainersPreempted(),
-            getXmlInt(info, "numAMContainerPreempted"));
-    assertEquals("Log aggregation Status doesn't match", app
-                    .getLogAggregationStatusForAppReport().toString(),
-            getXmlString(info, "logAggregationStatus"));
-    assertEquals("unmanagedApplication doesn't match", app
-                    .getApplicationSubmissionContext().getUnmanagedAM(),
-            getXmlBoolean(info, "unmanagedApplication"));
-    assertEquals("unmanagedApplication doesn't match",
-            app.getApplicationSubmissionContext().getNodeLabelExpression(),
-            getXmlString(info, "appNodeLabelExpression"));
-    assertEquals("unmanagedApplication doesn't match",
-            app.getAMResourceRequests().get(0).getNodeLabelExpression(),
-            getXmlString(info, "amNodeLabelExpression"));
-    assertEquals("amRPCAddress",
-            AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
-            getXmlString(info, "amRPCAddress"));
+    assertTrue(getXmlString(info, "amContainerLogs").startsWith("http://"),
+        "amContainerLogs doesn't match");
+    assertTrue(getXmlString(info, "amContainerLogs").endsWith("/" + app.getUser()),
+        "amContainerLogs doesn't contain user info");
+    assertEquals(1024, getXmlInt(info, "allocatedMB"), "allocatedMB doesn't match");
+    assertEquals(1, getXmlInt(info, "allocatedVCores"),
+        "allocatedVCores doesn't match");
+    assertEquals(50.0f, getXmlFloat(info, "queueUsagePercentage"), 0.01f,
+        "queueUsagePerc doesn't match");
+    assertEquals(50.0f, getXmlFloat(info, "clusterUsagePercentage"), 0.01f,
+        "clusterUsagePerc doesn't match");
+    assertEquals(1, getXmlInt(info, "runningContainers"),
+        "numContainers doesn't match");
+    assertNotNull(info.getElementsByTagName("preemptedResourceSecondsMap"),
+        "preemptedResourceSecondsMap should not be null");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getMemorySize(),
+        getXmlInt(info, "preemptedResourceMB"), "preemptedResourceMB doesn't match");
+    assertEquals(app.getRMAppMetrics().getResourcePreempted().getVirtualCores(),
+        getXmlInt(info, "preemptedResourceVCores"), "preemptedResourceVCores doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumNonAMContainersPreempted(),
+        getXmlInt(info, "numNonAMContainerPreempted"), "numNonAMContainerPreempted doesn't match");
+    assertEquals(app.getRMAppMetrics().getNumAMContainersPreempted(),
+        getXmlInt(info, "numAMContainerPreempted"),
+        "numAMContainerPreempted doesn't match");
+    assertEquals(app.getLogAggregationStatusForAppReport().toString(),
+        getXmlString(info, "logAggregationStatus"),
+        "Log aggregation Status doesn't match");
+    assertEquals(app.getApplicationSubmissionContext().getUnmanagedAM(),
+        getXmlBoolean(info, "unmanagedApplication"),
+        "unmanagedApplication doesn't match");
+    assertEquals(app.getApplicationSubmissionContext().getNodeLabelExpression(),
+        getXmlString(info, "appNodeLabelExpression"),
+        "unmanagedApplication doesn't match");
+    assertEquals(app.getAMResourceRequests().get(0).getNodeLabelExpression(),
+        getXmlString(info, "amNodeLabelExpression"),
+        "unmanagedApplication doesn't match");
+    assertEquals(AppInfo.getAmRPCAddressFromRMAppAttempt(app.getCurrentAppAttempt()),
+        getXmlString(info, "amRPCAddress"), "amRPCAddress");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/AppInfoXmlVerifications.java
@@ -67,7 +67,7 @@ public final class AppInfoXmlVerifications {
             .getFinalApplicationStatus().toString(),
             getXmlString(info, "finalStatus"));
     assertEquals(0, getXmlFloat(info, "progress"),
-        0.0,"progress doesn't match");
+        0.0, "progress doesn't match");
     if ("UNASSIGNED".equals(getXmlString(info, "trackingUI"))) {
       checkStringMatch("trackingUI", "UNASSIGNED",
               getXmlString(info, "trackingUI"));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/JsonCustomResourceTypeTestcase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/JsonCustomResourceTypeTestcase.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.MediaType;
 
 import java.util.function.Consumer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class hides the implementation details of how to verify the structure of
@@ -61,7 +61,7 @@ public class JsonCustomResourceTypeTestcase {
     String responseStr = response.getEntity(String.class);
     String exceptMessgae = String.format("HTTP status should be 200, " +
         "status info:{} response as string:{}", response.getStatusInfo(), responseStr);
-    assertEquals(exceptMessgae, 200, response.getStatus());
+    assertEquals(200, response.getStatus(), exceptMessgae);
   }
 
   public void verify(Consumer<JSONObject> verifier) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsJsonVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsJsonVerifications.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Performs value verifications on
@@ -87,10 +87,9 @@ public class ResourceRequestsJsonVerifications {
     Map.Entry<String, Long> resourceEntry =
         resourceAndValue.entrySet().iterator().next();
 
-    assertTrue(
+    assertTrue(expectedResourceTypes.contains(resourceEntry.getKey()),
         "Found resource type: " + resourceEntry.getKey()
-            + " is not in expected resource types: " + expectedResourceTypes,
-        expectedResourceTypes.contains(resourceEntry.getKey()));
+        + " is not in expected resource types: " + expectedResourceTypes);
 
     return resourceAndValue;
   }
@@ -98,37 +97,33 @@ public class ResourceRequestsJsonVerifications {
   private static Map<String, Long> extractCustomResorceTypeValues(
       JSONObject capability, List<String> expectedResourceTypes)
       throws JSONException {
-    assertTrue(
-        "resourceCategory does not have resourceInformations: " + capability,
-        capability.has("resourceInformations"));
+    assertTrue(capability.has("resourceInformations"),
+        "resourceCategory does not have resourceInformations: " + capability);
 
     JSONObject resourceInformations =
         capability.getJSONObject("resourceInformations");
-    assertTrue(
+    assertTrue(resourceInformations.has("resourceInformation"),
         "resourceInformations does not have resourceInformation object: "
-            + resourceInformations,
-        resourceInformations.has("resourceInformation"));
+        + resourceInformations);
     JSONArray customResources =
         resourceInformations.getJSONArray("resourceInformation");
 
     // customResources will include vcores / memory as well
-    assertEquals(
-        "Different number of custom resource types found than expected",
-        expectedResourceTypes.size(), customResources.length() - 2);
+    assertEquals(expectedResourceTypes.size(), customResources.length() - 2,
+        "Different number of custom resource types found than expected");
 
     Map<String, Long> resourceValues = Maps.newHashMap();
     for (int i = 0; i < customResources.length(); i++) {
       JSONObject customResource = customResources.getJSONObject(i);
-      assertTrue("Resource type does not have name field: " + customResource,
-          customResource.has("name"));
-      assertTrue("Resource type does not have name resourceType field: "
-          + customResource, customResource.has("resourceType"));
-      assertTrue(
-          "Resource type does not have name units field: " + customResource,
-          customResource.has("units"));
-      assertTrue(
-          "Resource type does not have name value field: " + customResource,
-          customResource.has("value"));
+      assertTrue(customResource.has("name"),
+          "Resource type does not have name field: " + customResource);
+      assertTrue(customResource.has("resourceType"),
+          "Resource type does not have name resourceType field: "
+          + customResource);
+      assertTrue(customResource.has("units"),
+          "Resource type does not have name units field: " + customResource);
+      assertTrue(customResource.has("value"),
+          "Resource type does not have name value field: " + customResource);
 
       String name = customResource.getString("name");
       String unit = customResource.getString("units");
@@ -140,12 +135,12 @@ public class ResourceRequestsJsonVerifications {
         continue;
       }
 
-      assertTrue("Custom resource type " + name + " not found",
-          expectedResourceTypes.contains(name));
+      assertTrue(expectedResourceTypes.contains(name),
+          "Custom resource type " + name + " not found");
       assertEquals("k", unit);
       assertEquals(ResourceTypes.COUNTABLE,
           ResourceTypes.valueOf(resourceType));
-      assertNotNull("Custom resource value " + value + " is null!", value);
+      assertNotNull(value, "Custom resource value " + value + " is null!");
       resourceValues.put(name, value);
     }
 
@@ -153,38 +148,31 @@ public class ResourceRequestsJsonVerifications {
   }
 
   private void verify() throws JSONException {
-    assertEquals("nodeLabelExpression doesn't match",
-        resourceRequest.getNodeLabelExpression(),
-            requestInfo.getString("nodeLabelExpression"));
-    assertEquals("numContainers doesn't match",
-            resourceRequest.getNumContainers(),
-            requestInfo.getInt("numContainers"));
-    assertEquals("relaxLocality doesn't match",
-            resourceRequest.getRelaxLocality(),
-            requestInfo.getBoolean("relaxLocality"));
-    assertEquals("priority does not match",
-            resourceRequest.getPriority().getPriority(),
-            requestInfo.getInt("priority"));
-    assertEquals("resourceName does not match",
-            resourceRequest.getResourceName(),
-            requestInfo.getString("resourceName"));
-    assertEquals("memory does not match",
-        resourceRequest.getCapability().getMemorySize(),
-            requestInfo.getJSONObject("capability").getLong("memory"));
-    assertEquals("vCores does not match",
-        resourceRequest.getCapability().getVirtualCores(),
-            requestInfo.getJSONObject("capability").getLong("vCores"));
+    assertEquals(resourceRequest.getNodeLabelExpression(),
+        requestInfo.getString("nodeLabelExpression"),
+        "nodeLabelExpression doesn't match");
+    assertEquals(resourceRequest.getNumContainers(),
+        requestInfo.getInt("numContainers"), "numContainers doesn't match");
+    assertEquals(resourceRequest.getRelaxLocality(),
+        requestInfo.getBoolean("relaxLocality"), "relaxLocality doesn't match");
+    assertEquals(resourceRequest.getPriority().getPriority(),
+        requestInfo.getInt("priority"), "priority does not match");
+    assertEquals(resourceRequest.getResourceName(),
+        requestInfo.getString("resourceName"), "resourceName does not match");
+    assertEquals(resourceRequest.getCapability().getMemorySize(),
+        requestInfo.getJSONObject("capability").getLong("memory"), "memory does not match");
+    assertEquals(resourceRequest.getCapability().getVirtualCores(),
+        requestInfo.getJSONObject("capability").getLong("vCores"), "vCores does not match");
 
     verifyAtLeastOneCustomResourceIsSerialized();
 
     JSONObject executionTypeRequest =
-            requestInfo.getJSONObject("executionTypeRequest");
-    assertEquals("executionType does not match",
-        resourceRequest.getExecutionTypeRequest().getExecutionType().name(),
-            executionTypeRequest.getString("executionType"));
-    assertEquals("enforceExecutionType does not match",
-            resourceRequest.getExecutionTypeRequest().getEnforceExecutionType(),
-            executionTypeRequest.getBoolean("enforceExecutionType"));
+        requestInfo.getJSONObject("executionTypeRequest");
+    assertEquals(resourceRequest.getExecutionTypeRequest().getExecutionType().name(),
+        executionTypeRequest.getString("executionType"), "executionType does not match");
+    assertEquals(resourceRequest.getExecutionTypeRequest().getEnforceExecutionType(),
+        executionTypeRequest.getBoolean("enforceExecutionType"),
+        "enforceExecutionType does not match");
   }
 
   /**
@@ -203,11 +191,10 @@ public class ResourceRequestsJsonVerifications {
         resourceFound = true;
         Long resourceValue =
             customResourceTypes.get(expectedCustomResourceType);
-        assertNotNull("Resource value should not be null!", resourceValue);
+        assertNotNull(resourceValue, "Resource value should not be null!");
       }
     }
-    assertTrue("No custom resource type can be found in the response!",
-        resourceFound);
+    assertTrue(resourceFound, "No custom resource type can be found in the response!");
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsXmlVerifications.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/ResourceRequestsXmlVerifications.java
@@ -32,14 +32,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.helper.XmlCustomResourceTypeTestCase.toXml;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlBoolean;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlInt;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlLong;
 import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.getXmlString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Performs value verifications on
@@ -88,9 +88,9 @@ public class ResourceRequestsXmlVerifications {
 
   private static Map<String, Long> extractCustomResorceTypes(Element capability,
       Set<String> expectedResourceTypes) {
-    assertEquals(
-        toXml(capability) + " should have only one resourceInformations child!",
-        1, capability.getElementsByTagName("resourceInformations").getLength());
+    assertEquals(1,
+        capability.getElementsByTagName("resourceInformations").getLength(),
+        toXml(capability) + " should have only one resourceInformations child!");
     Element resourceInformations = (Element) capability
         .getElementsByTagName("resourceInformations").item(0);
 
@@ -98,9 +98,8 @@ public class ResourceRequestsXmlVerifications {
         resourceInformations.getElementsByTagName("resourceInformation");
 
     // customResources will include vcores / memory as well
-    assertEquals(
-        "Different number of custom resource types found than expected",
-        expectedResourceTypes.size(), customResources.getLength() - 2);
+    assertEquals(expectedResourceTypes.size(), customResources.getLength() - 2,
+        "Different number of custom resource types found than expected");
 
     Map<String, Long> resourceTypesAndValues = Maps.newHashMap();
     for (int i = 0; i < customResources.getLength(); i++) {
@@ -115,14 +114,13 @@ public class ResourceRequestsXmlVerifications {
         continue;
       }
 
-      assertTrue("Custom resource type " + name + " not found",
-          expectedResourceTypes.contains(name));
+      assertTrue(expectedResourceTypes.contains(name),
+          "Custom resource type " + name + " not found");
       assertEquals("k", unit);
       assertEquals(ResourceTypes.COUNTABLE,
           ResourceTypes.valueOf(resourceType));
-      assertNotNull("Resource value should not be null for resource type "
-          + resourceType + ", listing xml contents: " + toXml(customResource),
-          value);
+      assertNotNull(value, "Resource value should not be null for resource type "
+          + resourceType + ", listing xml contents: " + toXml(customResource));
       resourceTypesAndValues.put(name, value);
     }
 
@@ -130,48 +128,39 @@ public class ResourceRequestsXmlVerifications {
   }
 
   private void verify() {
-    assertEquals("nodeLabelExpression doesn't match",
-        resourceRequest.getNodeLabelExpression(),
-        getXmlString(requestInfo, "nodeLabelExpression"));
-    assertEquals("numContainers doesn't match",
-        resourceRequest.getNumContainers(),
-        getXmlInt(requestInfo, "numContainers"));
-    assertEquals("relaxLocality doesn't match",
-        resourceRequest.getRelaxLocality(),
-        getXmlBoolean(requestInfo, "relaxLocality"));
-    assertEquals("priority does not match",
-        resourceRequest.getPriority().getPriority(),
-        getXmlInt(requestInfo, "priority"));
-    assertEquals("resourceName does not match",
-        resourceRequest.getResourceName(),
-        getXmlString(requestInfo, "resourceName"));
+    assertEquals(resourceRequest.getNodeLabelExpression(),
+        getXmlString(requestInfo, "nodeLabelExpression"), "nodeLabelExpression doesn't match");
+    assertEquals(resourceRequest.getNumContainers(),
+        getXmlInt(requestInfo, "numContainers"), "numContainers doesn't match");
+    assertEquals(resourceRequest.getRelaxLocality(),
+        getXmlBoolean(requestInfo, "relaxLocality"), "relaxLocality doesn't match");
+    assertEquals(resourceRequest.getPriority().getPriority(),
+        getXmlInt(requestInfo, "priority"), "priority does not match");
+    assertEquals(resourceRequest.getResourceName(),
+        getXmlString(requestInfo, "resourceName"), "resourceName does not match");
     Element capability = (Element) requestInfo
             .getElementsByTagName("capability").item(0);
-    assertEquals("memory does not match",
-        resourceRequest.getCapability().getMemorySize(),
-        getXmlLong(capability, "memory"));
-    assertEquals("vCores does not match",
-        resourceRequest.getCapability().getVirtualCores(),
-        getXmlLong(capability, "vCores"));
+    assertEquals(resourceRequest.getCapability().getMemorySize(),
+        getXmlLong(capability, "memory"), "memory does not match");
+    assertEquals(resourceRequest.getCapability().getVirtualCores(),
+        getXmlLong(capability, "vCores"), "vCores does not match");
 
     for (String expectedCustomResourceType : expectedCustomResourceTypes) {
-      assertTrue(
+      assertTrue(customResourceTypes.containsKey(expectedCustomResourceType),
           "Custom resource type " + expectedCustomResourceType
-              + " cannot be found!",
-          customResourceTypes.containsKey(expectedCustomResourceType));
+          + " cannot be found!");
 
       Long resourceValue = customResourceTypes.get(expectedCustomResourceType);
-      assertNotNull("Resource value should not be null!", resourceValue);
+      assertNotNull(resourceValue, "Resource value should not be null!");
     }
 
     Element executionTypeRequest = (Element) requestInfo
         .getElementsByTagName("executionTypeRequest").item(0);
-    assertEquals("executionType does not match",
-        resourceRequest.getExecutionTypeRequest().getExecutionType().name(),
-        getXmlString(executionTypeRequest, "executionType"));
-    assertEquals("enforceExecutionType does not match",
-        resourceRequest.getExecutionTypeRequest().getEnforceExecutionType(),
-        getXmlBoolean(executionTypeRequest, "enforceExecutionType"));
+    assertEquals(resourceRequest.getExecutionTypeRequest().getExecutionType().name(),
+        getXmlString(executionTypeRequest, "executionType"), "executionType does not match");
+    assertEquals(resourceRequest.getExecutionTypeRequest().getEnforceExecutionType(),
+        getXmlBoolean(executionTypeRequest, "enforceExecutionType"),
+        "enforceExecutionType does not match");
   }
 
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/XmlCustomResourceTypeTestCase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/helper/XmlCustomResourceTypeTestCase.java
@@ -37,7 +37,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class hides the implementation details of how to verify the structure of
@@ -65,9 +65,9 @@ public class XmlCustomResourceTypeTestCase {
 
   private void verifyStatus(BufferedClientResponse response) {
     String responseStr = response.getEntity(String.class);
-    assertEquals("HTTP status should be 200, " +
-        "status info: " + response.getStatusInfo() + " response as string: " + responseStr,
-        200, response.getStatus());
+    assertEquals(200, response.getStatus(), "HTTP status should be 200, " +
+        "status info: " + response.getStatusInfo() +
+        " response as string: " + responseStr);
   }
 
   public void verify(Consumer<Document> verifier) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11262. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-resourcemanager Part5.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

