### PR TITLE
HDFS-17756. Fix endlessLoop issue caused by ReplicaMap#mergeAll method.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReplicaMap.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
@@ -164,13 +166,28 @@ class ReplicaMap {
    * Merge all entries from the given replica map into the local replica map.
    */
   void mergeAll(ReplicaMap other) {
-    other.map.forEach(
-        (bp, replicaInfos) -> {
-          replicaInfos.forEach(
-              replicaInfo -> add(bp, replicaInfo)
-          );
+    Set<String> bpList = other.map.keySet();
+    for (String bp : bpList) {
+      checkBlockPool(bp);
+      LightWeightResizableGSet<Block, ReplicaInfo> replicaInfos = other.map.get(bp);
+      HashSet<ReplicaInfo> replicaSet = new HashSet<>();
+      // Can't add to GSet while in another GSet iterator may cause endlessLoop
+      for (ReplicaInfo replicaInfo : replicaInfos) {
+        replicaSet.add(replicaInfo);
+      }
+      try (AutoCloseableLock lock = writeLock.acquire()) {
+        LightWeightResizableGSet<Block, ReplicaInfo> curSet = map.get(bp);
+        if (curSet == null && !replicaSet.isEmpty()) {
+          // Add an entry for block pool if it does not exist already
+          curSet = new LightWeightResizableGSet<>();
+          map.put(bp, curSet);
         }
-    );
+        for (ReplicaInfo replicaInfo : replicaSet) {
+          checkBlock(replicaInfo);
+          curSet.put(replicaInfo);
+        }
+      }
+    }
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -119,6 +120,22 @@ public class TestReplicaMap {
     map.mergeAll(temReplicaMap);
     assertNotNull(map.get(bpid, 1234));
     assertNotNull(map.get(bpid, 5678));
+  }
+
+  @Test
+  public void testMergeAllWithMultipleReplica() {
+    ReplicaMap otherMap = new ReplicaMap(new ReentrantReadWriteLock());
+    for (int i = 1; i <= 10; i++) {
+      Block b = new Block(i, i, i);
+      otherMap.add(bpid, new FinalizedReplica(b, null, null));
+    }
+    ReplicaMap m = new ReplicaMap(new ReentrantReadWriteLock());
+    for (int i = 11; i <= 20; i++) {
+      Block b = new Block(i, i, i);
+      m.add(bpid, new FinalizedReplica(b, null, null));
+    }
+    m.mergeAll(otherMap);
+    assertEquals(20, m.size(bpid));
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

https://issues.apache.org/jira/browse/HDFS-17756

The issue has been fixed in DN metadata fine-grained locks after 3.4.

When using the refreshVolumes method in the DN metadata read-write lock, it will result in endlessLoop.


### How was this patch tested?

Add UT

