### PR TITLE
HADOOP-19495. Add JDK 24 to Ubuntu 20.04 docker development images

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -44,9 +44,14 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 ######
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
+    && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
     && apt-get -q install -y --no-install-recommends python3 \
+    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
+    && wget -q -O - https://packages.adoptium.net/artifactory/api/gpg/key/public > /etc/apt/trusted.gpg.d/adoptium.asc  \
+    && apt-get -q update \
     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal) \
     && apt-get clean \
+    && update-java-alternatives -s java-1.8.0-openjdk-amd64 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -44,9 +44,14 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 ######
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
+    && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
     && apt-get -q install -y --no-install-recommends python3 \
+    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
+    && wget -q -O - https://packages.adoptium.net/artifactory/api/gpg/key/public > /etc/apt/trusted.gpg.d/adoptium.asc  \
+    && apt-get -q update \
     && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal::arch64) \
     && apt-get clean \
+    && update-java-alternatives -s java-1.8.0-openjdk-arm64 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -260,11 +260,13 @@
   "java": {
     "debian:10": "openjdk-11-jdk",
     "ubuntu:focal": [
+      "temurin-24-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"
     ],
     "ubuntu:focal::arch64": [
+      "temurin-24-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"


### PR DESCRIPTION
### Description of PR

Adds JDK24 to Ubuntu 20.04 development docker images.
Also sets the default JDK to 1.8 to be consistent with the existing JAVA_HOME setting

This patch does not change the JDK used by default (apart from setting up java/javac alternatives to be consistent with JAVA_HOME), but adds the possibility to easily switch to JDK24 for testing.

### How was this patch tested?

Ran start-build-env.sh on x86_64 and ARM hosts, and checked that JDK24 is present and working.
Also checked that the java and javac command on the PATH and JAVA_HOME point to the same 1.8 JDK.

### For code changes:

- [X ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
