### PR TITLE
YARN-11794. hadoop-yarn-csi does not build on included Centos 7 docker image

### DIFF
--- a/dev-support/docker/pkg-resolver/install-yasm.sh
+++ b/dev-support/docker/pkg-resolver/install-yasm.sh
@@ -40,7 +40,7 @@ fi
 
 if [ "$version_to_install" == "1.2.0-4" ]; then
   mkdir -p /tmp/yasm &&
-    curl -L -s -S https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/y/yasm-1.2.0-4.el7.x86_64.rpm \
+    curl -L -s -S https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/y/yasm-1.2.0-4.el7.x86_64.rpm \
       -o /tmp/yasm-1.2.0-4.el7.x86_64.rpm &&
     rpm -Uvh /tmp/yasm-1.2.0-4.el7.x86_64.rpm
 else

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-csi/pom.xml
@@ -27,6 +27,8 @@
 
     <properties>
         <grpc.version>1.69.0</grpc.version>
+        <!-- Last version that works with Centos 7 -->
+        <grpc.plugin.version>1.65.0</grpc.plugin.version>
         <animal-sniffer.version>1.24</animal-sniffer.version>
     </properties>
 
@@ -209,7 +211,7 @@
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${hadoop.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.plugin.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
also fix Centos 7 docker image build

### Description of PR

Revert io.grpc:protoc-gen-grpc-java to 1.65.0 to enable building on Centos 7.
Also backported Centos 7 image build fix from trunk.

### How was this patch tested?

Started Centos7 container.
ran 'mvn clean package -DskipTests'

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

