### PR TITLE
HDFS-17758. Make method checkAsyncCall not throttle router async rpc request.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1562,7 +1562,7 @@ public class Client implements AutoCloseable {
   public static boolean isAsynchronousModeAndNotFromRouter() {
     return isAsynchronousMode() && !isAsyncRpcFromRouter();
   }
-  
+
   /**
    * Check if RPC is in asynchronous mode or not.
    *

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -106,6 +106,14 @@ public class Client implements AutoCloseable {
         }
       };
 
+  private static final ThreadLocal<Boolean> ASYNC_RPC_FROM_ROUTER =
+      new ThreadLocal<Boolean>() {
+        @Override
+        protected Boolean initialValue() {
+          return false;
+        }
+      };
+
   @SuppressWarnings("unchecked")
   @Unstable
   public static <T extends Writable> AsyncGet<T, IOException>
@@ -204,6 +212,11 @@ public class Client implements AutoCloseable {
   private final byte[] clientId;
   private final int maxAsyncCalls;
   private final AtomicInteger asyncCallCounter = new AtomicInteger(0);
+
+  @VisibleForTesting
+  public int getAsyncCallCounter() {
+    return asyncCallCounter.get();
+  }
 
   /**
    * set the ping interval value in configuration
@@ -1460,7 +1473,7 @@ public class Client implements AutoCloseable {
   }
 
   private void checkAsyncCall() throws IOException {
-    if (isAsynchronousMode()) {
+    if (isAsynchronousModeAndNotFromRouter()) {
       if (asyncCallCounter.incrementAndGet() > maxAsyncCalls) {
         String errMsg = String.format(
             "Exceeded limit of max asynchronous calls: %d, " +
@@ -1503,6 +1516,7 @@ public class Client implements AutoCloseable {
     call.setAlignmentContext(alignmentContext);
     final Connection connection = getConnection(remoteId, call, serviceClass,
         fallbackToSimpleAuth);
+    final boolean rpcFromRouter = isAsyncRpcFromRouter();
 
     try {
       checkAsyncCall();
@@ -1518,7 +1532,7 @@ public class Client implements AutoCloseable {
         throw ioe;
       }
     } catch (Exception e) {
-      if (isAsynchronousMode()) {
+      if (isAsynchronousModeAndNotFromRouter()) {
         releaseAsyncCall();
       }
       throw e;
@@ -1527,7 +1541,10 @@ public class Client implements AutoCloseable {
     if (isAsynchronousMode()) {
       CompletableFuture<Writable> result = call.rpcResponseFuture.handle(
           (rpcResponse, e) -> {
-            releaseAsyncCall();
+            setAsyncRpcFromRouter(rpcFromRouter);
+            if (!isAsyncRpcFromRouter()) {
+              releaseAsyncCall();
+            }
             if (e != null) {
               IOException ioe = (IOException) e;
               throw new CompletionException(warpIOException(ioe, connection));
@@ -1541,6 +1558,11 @@ public class Client implements AutoCloseable {
     }
   }
 
+  @Unstable
+  public static boolean isAsynchronousModeAndNotFromRouter() {
+    return isAsynchronousMode() && !isAsyncRpcFromRouter();
+  }
+  
   /**
    * Check if RPC is in asynchronous mode or not.
    *
@@ -1562,6 +1584,16 @@ public class Client implements AutoCloseable {
   @Unstable
   public static void setAsynchronousMode(boolean async) {
     asynchronousMode.set(async);
+  }
+
+  @Unstable
+  public static boolean isAsyncRpcFromRouter() {
+    return ASYNC_RPC_FROM_ROUTER.get();
+  }
+
+  @Unstable
+  public static void setAsyncRpcFromRouter(boolean isFromRouter) {
+    ASYNC_RPC_FROM_ROUTER.set(isFromRouter);
   }
 
   private void releaseAsyncCall() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -327,7 +327,7 @@ public class TestAsyncIPC {
       callers[i] = new AsyncCaller(clients[i % clientCount], addr, callCount, fromRouter);
       callers[i].start();
     }
-    
+
     for (int i = 0; i < callerCount; i++) {
       if (fromRouter) {
         assertEquals(0, clients[i % clientCount].getAsyncCallCounter());

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -74,14 +74,16 @@ public class TestAsyncIPC {
     private InetSocketAddress server;
     private int count;
     private boolean failed;
+    private boolean fromRouter;
     Map<Integer, Future<LongWritable>> returnFutures =
         new HashMap<Integer, Future<LongWritable>>();
     Map<Integer, Long> expectedValues = new HashMap<Integer, Long>();
 
-    public AsyncCaller(Client client, InetSocketAddress server, int count) {
+    public AsyncCaller(Client client, InetSocketAddress server, int count, boolean fromRouter) {
       this.client = client;
       this.server = server;
       this.count = count;
+      this.fromRouter = fromRouter;
       // set asynchronous mode, since AsyncCaller extends Thread
       Client.setAsynchronousMode(true);
     }
@@ -90,6 +92,7 @@ public class TestAsyncIPC {
     public void run() {
       // in case Thread#Start is called, which will spawn new thread
       Client.setAsynchronousMode(true);
+      Client.setAsyncRpcFromRouter(this.fromRouter);
       for (int i = 0; i < count; i++) {
         try {
           final long param = TestIPC.RANDOM.nextLong();
@@ -287,10 +290,17 @@ public class TestAsyncIPC {
 
   @Test
   @Timeout(value = 60)
+  public void testMockAsyncCallFromRouter() throws IOException, InterruptedException,
+      ExecutionException {
+    internalTestAsyncCall(3, true, 2, 5, 10, true);
+  }
+
+  @Test
+  @Timeout(value = 60)
   public void testAsyncCall() throws IOException, InterruptedException,
       ExecutionException {
-    internalTestAsyncCall(3, false, 2, 5, 100);
-    internalTestAsyncCall(3, true, 2, 5, 10);
+    internalTestAsyncCall(3, false, 2, 5, 100, false);
+    internalTestAsyncCall(3, true, 2, 5, 10, false);
   }
 
   @Test
@@ -301,7 +311,7 @@ public class TestAsyncIPC {
   }
 
   public void internalTestAsyncCall(int handlerCount, boolean handlerSleep,
-      int clientCount, int callerCount, int callCount) throws IOException,
+      int clientCount, int callerCount, int callCount, boolean fromRouter) throws IOException,
       InterruptedException, ExecutionException {
     Server server = new TestIPC.TestServer(handlerCount, handlerSleep, conf);
     InetSocketAddress addr = NetUtils.getConnectAddress(server);
@@ -314,10 +324,14 @@ public class TestAsyncIPC {
 
     AsyncCaller[] callers = new AsyncCaller[callerCount];
     for (int i = 0; i < callerCount; i++) {
-      callers[i] = new AsyncCaller(clients[i % clientCount], addr, callCount);
+      callers[i] = new AsyncCaller(clients[i % clientCount], addr, callCount, fromRouter);
       callers[i].start();
     }
+    
     for (int i = 0; i < callerCount; i++) {
+      if (fromRouter) {
+        assertEquals(0, clients[i % clientCount].getAsyncCallCounter());
+      }
       callers[i].join();
       callers[i].assertReturnValues();
     }
@@ -340,7 +354,7 @@ public class TestAsyncIPC {
     int asyncCallCount = client.getAsyncCallCount();
 
     try {
-      AsyncCaller caller = new AsyncCaller(client, addr, callCount);
+      AsyncCaller caller = new AsyncCaller(client, addr, callCount, false);
       caller.run();
       caller.assertReturnValues();
       caller.assertReturnValues();
@@ -364,7 +378,7 @@ public class TestAsyncIPC {
     final Client client = new Client(LongWritable.class, conf);
 
     try {
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, false);
       caller.run();
       caller.assertReturnValues(10, TimeUnit.MILLISECONDS);
     } finally {
@@ -463,7 +477,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 4);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 4, false);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -501,7 +515,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, false);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -538,7 +552,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, false);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -580,7 +594,7 @@ public class TestAsyncIPC {
       server.start();
       AsyncCaller[] callers = new AsyncCaller[callerCount];
       for (int i = 0; i < callerCount; ++i) {
-        callers[i] = new AsyncCaller(client, addr, perCallerCallCount);
+        callers[i] = new AsyncCaller(client, addr, perCallerCallCount, false);
         callers[i].start();
       }
       for (int i = 0; i < callerCount; ++i) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -275,8 +275,8 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
       final Object obj, final Object... params) throws IOException {
     try {
       Client.setAsynchronousMode(true);
+      Client.setAsyncRpcFromRouter(true);
       method.invoke(obj, params);
-      Client.setAsynchronousMode(false);
       asyncCatch((AsyncCatchFunction<Object, Throwable>) (o, e) -> {
         handlerInvokeException(namenode, listObserverFirst,
             retryCount, method, obj, e, params);


### PR DESCRIPTION
### Description of PR
In my practice, when enable aysnc router rpc, we must adjust `ipc.client.async.calls.max` larger. If not, we will get AsyncCallLimitExceededException exception. 

The original purpose of method checkAsyncCall is to prevent Out-of-Memory from occurring on the client, we should make it not throttle router async rpc request. 

BTW, we use other mechanisms  to prevent OOM from occurring on the hdfs router. please see [HDFS-17713](https://issues.apache.org/jira/browse/HDFS-17713)

### How was this patch tested?
Add an unit test.