### PR TITLE
HADOOP-19499. Handle JDK-8225499 IpAddr.toString() format changes in …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterNamenodeHeartbeat.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeConte
 import org.apache.hadoop.net.MockDomainNameResolver;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.Service.STATE;
+import org.apache.hadoop.util.Shell;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -216,18 +217,34 @@ public class TestRouterNamenodeHeartbeat {
 
   @Test
   public void testNamenodeHeartbeatServiceHAServiceProtocolProxy(){
-    testNamenodeHeartbeatServiceHAServiceProtocol(
-        "test-ns", "nn", 1000, -1, -1, 1003,
-        "host01.test:1000", "host02.test:1000");
-    testNamenodeHeartbeatServiceHAServiceProtocol(
-        "test-ns", "nn", 1000, 1001, -1, 1003,
-        "host01.test:1001", "host02.test:1001");
-    testNamenodeHeartbeatServiceHAServiceProtocol(
-        "test-ns", "nn", 1000, -1, 1002, 1003,
-        "host01.test:1002", "host02.test:1002");
-    testNamenodeHeartbeatServiceHAServiceProtocol(
-        "test-ns", "nn", 1000, 1001, 1002, 1003,
-        "host01.test:1002", "host02.test:1002");
+    // JDK-8225499. The string format of unresolved address has been changed.
+    if (Shell.isJavaVersionAtLeast(14)) {
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, -1, -1, 1003,
+          "host01.test/<unresolved>:1000", "host02.test/<unresolved>:1000");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, 1001, -1, 1003,
+          "host01.test/<unresolved>:1001", "host02.test/<unresolved>:1001");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, -1, 1002, 1003,
+          "host01.test/<unresolved>:1002", "host02.test/<unresolved>:1002");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, 1001, 1002, 1003,
+          "host01.test/<unresolved>:1002", "host02.test/<unresolved>:1002");
+    } else {
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, -1, -1, 1003,
+          "host01.test:1000", "host02.test:1000");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, 1001, -1, 1003,
+          "host01.test:1001", "host02.test:1001");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, -1, 1002, 1003,
+          "host01.test:1002", "host02.test:1002");
+      testNamenodeHeartbeatServiceHAServiceProtocol(
+          "test-ns", "nn", 1000, 1001, 1002, 1003,
+          "host01.test:1002", "host02.test:1002");
+    }
   }
 
   private void testNamenodeHeartbeatServiceHAServiceProtocol(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestJobEndNotifier.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.mapreduce.v2.app.rm.ContainerAllocator;
 import org.apache.hadoop.mapreduce.v2.app.rm.ContainerAllocatorEvent;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
+import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.junit.jupiter.api.Test;
@@ -124,20 +125,38 @@ public class TestJobEndNotifier extends JobEndNotifier {
         "Proxy shouldn't be set because port wasn't numeric");
     conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "somehost:1000");
     setConf(conf);
-    assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
-        "Proxy should have been set but wasn't ");
-    conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "socks@somehost:1000");
-    setConf(conf);
-    assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
-        "Proxy should have been socks but wasn't ");
-    conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "SOCKS@somehost:1000");
-    setConf(conf);
-    assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
-        "Proxy should have been socks but wasn't ");
-    conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "sfafn@somehost:1000");
-    setConf(conf);
-    assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
-        "Proxy should have been http but wasn't ");
+    // JDK-8225499. The string format of unresolved address has been changed.
+    if (Shell.isJavaVersionAtLeast(14)) {
+      assertEquals("HTTP @ somehost/<unresolved>:1000", proxyToUse.toString(),
+          "Proxy should have been set but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "socks@somehost:1000");
+      setConf(conf);
+      assertEquals("SOCKS @ somehost/<unresolved>:1000", proxyToUse.toString(),
+          "Proxy should have been socks but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "SOCKS@somehost:1000");
+      setConf(conf);
+      assertEquals("SOCKS @ somehost/<unresolved>:1000", proxyToUse.toString(),
+          "Proxy should have been socks but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "sfafn@somehost:1000");
+      setConf(conf);
+      assertEquals("HTTP @ somehost/<unresolved>:1000", proxyToUse.toString(),
+          "Proxy should have been http but wasn't ");
+    } else {
+      assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
+          "Proxy should have been set but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "socks@somehost:1000");
+      setConf(conf);
+      assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
+          "Proxy should have been socks but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "SOCKS@somehost:1000");
+      setConf(conf);
+      assertEquals("SOCKS @ somehost:1000", proxyToUse.toString(),
+          "Proxy should have been socks but wasn't ");
+      conf.set(MRJobConfig.MR_JOB_END_NOTIFICATION_PROXY, "sfafn@somehost:1000");
+      setConf(conf);
+      assertEquals("HTTP @ somehost:1000", proxyToUse.toString(),
+          "Proxy should have been http but wasn't ");
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of PR

Change the expected IPaddr strings according to the JDK version in some tests

### How was this patch tested?

Ran the changed tests on JDK8 and JDK17.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

