### PR TITLE
HADOOP-19501. Skip tests that depend on SecurityManager if the JVM does not support it

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
@@ -592,7 +592,10 @@ public class TestDFSShell {
 
                 firstTime = false;
                 copy2ndFileThread.start();
-                try {Thread.sleep(5000);} catch (InterruptedException e) {}
+                try {
+                  Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                }
               }
             }
           }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
@@ -599,9 +599,7 @@ public class TestDFSShell {
         }
       });
     } catch (UnsupportedOperationException e) {
-      // Test is skipped because SecurityManager cannot be set (JEP411)
-      // TODO add message when migrating to Junit 5
-      assumeTrue(false);
+      assumeTrue("Test is skipped because SecurityManager cannot be set (JEP 411)", false);
     }
     show("copy local " + f1 + " to remote " + dst);
     dfs.copyFromLocalFile(false, false, new Path(f1.getPath()), dst);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
@@ -85,6 +85,7 @@ import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.aclEntry;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 import static org.hamcrest.core.StringContains.containsString;
 
 /**
@@ -576,26 +577,32 @@ public class TestDFSShell {
     //use SecurityManager to pause the copying of f1 and begin copying f2
     SecurityManager sm = System.getSecurityManager();
     System.out.println("SecurityManager = " + sm);
-    System.setSecurityManager(new SecurityManager() {
-      private boolean firstTime = true;
+    try {
+      System.setSecurityManager(new SecurityManager() {
+        private boolean firstTime = true;
 
-      @Override
-      public void checkPermission(Permission perm) {
-        if (firstTime) {
-          Thread t = Thread.currentThread();
-          if (!t.toString().contains("DataNode")) {
-            String s = "" + Arrays.asList(t.getStackTrace());
-            if (s.contains("FileUtil.copyContent")) {
-              //pause at FileUtil.copyContent
+        @Override
+        public void checkPermission(Permission perm) {
+          if (firstTime) {
+            Thread t = Thread.currentThread();
+            if (!t.toString().contains("DataNode")) {
+              String s = "" + Arrays.asList(t.getStackTrace());
+              if (s.contains("FileUtil.copyContent")) {
+                //pause at FileUtil.copyContent
 
-              firstTime = false;
-              copy2ndFileThread.start();
-              try {Thread.sleep(5000);} catch (InterruptedException e) {}
+                firstTime = false;
+                copy2ndFileThread.start();
+                try {Thread.sleep(5000);} catch (InterruptedException e) {}
+              }
             }
           }
         }
-      }
-    });
+      });
+    } catch (UnsupportedOperationException e) {
+      // Test is skipped because SecurityManager cannot be set (JEP411)
+      // TODO add message when migrating to Junit 5
+      assumeTrue(false);
+    }
     show("copy local " + f1 + " to remote " + dst);
     dfs.copyFromLocalFile(false, false, new Path(f1.getPath()), dst);
     show("done");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
@@ -85,7 +85,7 @@ public class TestDatanodeRegistration {
     } catch (UnsupportedOperationException e) {
       assumeTrue("Test is skipped because SecurityManager cannot be set (JEP 411)", false);
     }
-    
+
     MiniDFSCluster cluster = null;
     try {
       HdfsConfiguration conf = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
@@ -83,9 +83,7 @@ public class TestDatanodeRegistration {
     try {
       System.setSecurityManager(sm);
     } catch (UnsupportedOperationException e) {
-      // Test is skipped because SecurityManager cannot be set (JEP411)
-      // TODO add message when migrating to Junit 5
-      assumeTrue(false);
+      assumeTrue("Test is skipped because SecurityManager cannot be set (JEP 411)", false);
     }
     
     MiniDFSCluster cluster = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDatanodeRegistration.java
@@ -48,6 +48,7 @@ import java.security.Permission;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -79,7 +80,13 @@ public class TestDatanodeRegistration {
   @Test
   public void testDNSLookups() throws Exception {
     MonitorDNS sm = new MonitorDNS();
-    System.setSecurityManager(sm);
+    try {
+      System.setSecurityManager(sm);
+    } catch (UnsupportedOperationException e) {
+      // Test is skipped because SecurityManager cannot be set (JEP411)
+      // TODO add message when migrating to Junit 5
+      assumeTrue(false);
+    }
     
     MiniDFSCluster cluster = null;
     try {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
@@ -272,8 +272,6 @@ public class TestPipeApplication {
     Submitter.setJavaPartitioner(conf, partitioner.getClass());
 
     assertEquals(PipesPartitioner.class, (Submitter.getJavaPartitioner(conf)));
-    // test going to call main method with System.exit(). Change Security
-    SecurityManager securityManager = System.getSecurityManager();
     // store System.out
     PrintStream oldps = System.out;
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -330,8 +328,6 @@ public class TestPipeApplication {
               + "archives to be unarchived on the compute machines"));
     } finally {
       System.setOut(oldps);
-      // restore
-      System.setSecurityManager(securityManager);
       if (psw != null) {
         // remove password files
         for (File file : psw) {
@@ -381,7 +377,6 @@ public class TestPipeApplication {
 
     } finally {
       System.setOut(oldps);
-      System.setSecurityManager(securityManager);
     }
 
   }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -70,8 +70,7 @@ public class TestExternalCall {
     try {
       System.setSecurityManager(new NoExitSecurityManager());
     } catch (UnsupportedOperationException e) {
-      assumeTrue(false,
-          "Test is skipped because SecurityManager cannot be set (JEP411)");
+      assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");
     }
     try {
       fs = FileSystem.get(getConf());

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -84,10 +84,16 @@ public class TestExternalCall {
 
   @AfterEach
   public void tearDown() {
-    System.setSecurityManager(securityManager);
+    try {
+      System.setSecurityManager(securityManager);
+    } catch (UnsupportedOperationException e) {
+      // JUnit 5 calls @AfterEach even if @BeforeEach has thrown TestAbortedException
+      // The test has already been already skipped
+    }
   }
+
 /**
- * test methods run end execute of DistCp class. silple copy file
+ * test methods run end execute of DistCp class. simple copy file
  * @throws Exception 
  */
   @Test

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -38,6 +38,7 @@ import java.security.Permission;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
@@ -66,7 +67,12 @@ public class TestExternalCall {
   public void setup() {
 
     securityManager = System.getSecurityManager();
-    System.setSecurityManager(new NoExitSecurityManager());
+    try {
+      System.setSecurityManager(new NoExitSecurityManager());
+    } catch (UnsupportedOperationException e) {
+      assumeTrue(false,
+          "Test is skipped because SecurityManager cannot be set (JEP411)");
+    }
     try {
       fs = FileSystem.get(getConf());
       root = new Path("target/tmp").makeQualified(fs.getUri(),

--- a/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
+++ b/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
@@ -174,8 +174,6 @@ public class TestGridmixSubmission extends CommonJobTest {
   @Test (timeout=100000)
   public void testMain() throws Exception {
 
-    SecurityManager securityManager = System.getSecurityManager();
-
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     final PrintStream out = new PrintStream(bytes);
     final PrintStream oldOut = System.out;
@@ -190,7 +188,6 @@ public class TestGridmixSubmission extends CommonJobTest {
       ExitUtil.resetFirstExitException();
     } finally {
       System.setErr(oldOut);
-      System.setSecurityManager(securityManager);
     }
     String print = bytes.toString();
     // should be printed tip in std error stream

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
@@ -375,8 +375,7 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       try {
         System.setSecurityManager(new MockSecurityManagerDenyWrite());
       } catch (UnsupportedOperationException e) {
-        assumeTrue(false,
-            "Test is skipped because SecurityManager cannot be set (JEP411)");
+        assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");
       }
       try {
         cGroupsHandler.initializeCGroupController(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -371,7 +372,12 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       assertFalse(cpuCgroupMountDir.delete(), "Could not delete cgroups");
       assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
       SecurityManager manager = System.getSecurityManager();
-      System.setSecurityManager(new MockSecurityManagerDenyWrite());
+      try {
+        System.setSecurityManager(new MockSecurityManagerDenyWrite());
+      } catch (UnsupportedOperationException e) {
+        assumeTrue(false,
+            "Test is skipped because SecurityManager cannot be set (JEP411)");
+      }
       try {
         cGroupsHandler.initializeCGroupController(
             CGroupsHandler.CGroupController.CPU);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.Candida
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.SimpleCandidateNodeSet;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -1113,7 +1114,11 @@ public class TestCapacitySchedulerAsyncScheduling {
     SecurityManager originalSecurityManager = System.getSecurityManager();
     NoExitSecurityManager noExitSecurityManager =
         new NoExitSecurityManager(originalSecurityManager);
-    System.setSecurityManager(noExitSecurityManager);
+    try {
+      System.setSecurityManager(noExitSecurityManager);
+    } catch (UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP411)");
+    }
 
     // test async-scheduling thread exit
     try{

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -1117,11 +1117,7 @@ public class TestCapacitySchedulerAsyncScheduling {
     try {
       System.setSecurityManager(noExitSecurityManager);
     } catch (UnsupportedOperationException e) {
-<<<<<<< HEAD
       Assumptions.assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP411)");
-=======
-      Assume.assumeTrue("Test is skipped because SecurityManager cannot be set (JEP 411)", false);
->>>>>>> 8b7539aec9f5 (ass messages to Junit4 assumptions)
     }
 
     // test async-scheduling thread exit

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -1117,7 +1117,8 @@ public class TestCapacitySchedulerAsyncScheduling {
     try {
       System.setSecurityManager(noExitSecurityManager);
     } catch (UnsupportedOperationException e) {
-      Assumptions.assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP411)");
+      Assumptions.assumeTrue(false,
+          "Test is skipped because SecurityManager cannot be set (JEP411)");
     }
 
     // test async-scheduling thread exit

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -1117,7 +1117,11 @@ public class TestCapacitySchedulerAsyncScheduling {
     try {
       System.setSecurityManager(noExitSecurityManager);
     } catch (UnsupportedOperationException e) {
+<<<<<<< HEAD
       Assumptions.assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP411)");
+=======
+      Assume.assumeTrue("Test is skipped because SecurityManager cannot be set (JEP 411)", false);
+>>>>>>> 8b7539aec9f5 (ass messages to Junit4 assumptions)
     }
 
     // test async-scheduling thread exit

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -1104,11 +1104,6 @@ public class TestCapacitySchedulerAsyncScheduling {
   @Test
   @Timeout(value = 30)
   public void testAsyncScheduleThreadExit() throws Exception {
-    // init RM & NM
-    final MockRM rm = new MockRM(conf);
-    rm.start();
-    rm.registerNode("192.168.0.1:1234", 8 * GB);
-    rm.drainEvents();
 
     // Set no exit security manager to catch System.exit
     SecurityManager originalSecurityManager = System.getSecurityManager();
@@ -1120,6 +1115,12 @@ public class TestCapacitySchedulerAsyncScheduling {
       Assumptions.assumeTrue(false,
           "Test is skipped because SecurityManager cannot be set (JEP411)");
     }
+
+    // init RM & NM
+    final MockRM rm = new MockRM(conf);
+    rm.start();
+    rm.registerNode("192.168.0.1:1234", 8 * GB);
+    rm.drainEvents();
 
     // test async-scheduling thread exit
     try{


### PR DESCRIPTION
### Description of PR

Due to JEP411 / JEP486 SecurityManager is either completely removed or has to be explicitly re-enabled in newer Java versions.

This patch adds assume() methods to those tests, so that they are skipped instead of erroring out when the
JVM does not let them set the SecurityManager.

A few tests have already been converted not to require SecurityManager, but the SecurityManager setting code
has not been removed. In those cases I have simply removed the SecurityManager-related calls.

### How was this patch tested?

This was tested in my JDK23 branch with JDK23, and the standard CI checks for older Javas.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

