### PR TITLE
YARN-11795. Skip BaseFederationPoliciesTest.testReinitilializeBad3() on JVMs where Mockito cannot mock ByteBuffers

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.federation.policies;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 import java.nio.ByteBuffer;
@@ -50,6 +51,7 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterRegister
 import org.apache.hadoop.yarn.server.federation.utils.FederationPoliciesTestUtil;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.junit.jupiter.api.Test;
+import org.mockito.exceptions.base.MockitoException;
 
 /**
  * Base class for policies tests, tests for common reinitialization cases.
@@ -100,10 +102,17 @@ public abstract class BaseFederationPoliciesTest {
 
   @Test
   public void testReinitilializeBad3() throws YarnException {
+    ByteBuffer bufTmp = null;
+    try {
+      bufTmp = mock(ByteBuffer.class);
+    } catch (MockitoException e) {
+      assumeTrue(false, "Cannot mock ByteBuffer on Java 19+");
+    }
+    final ByteBuffer buf = bufTmp;
+
     assertThrows(FederationPolicyInitializationException.class, () -> {
       FederationPolicyInitializationContext fpc =
           new FederationPolicyInitializationContext();
-      ByteBuffer buf = mock(ByteBuffer.class);
       fpc.setSubClusterPolicyConfiguration(SubClusterPolicyConfiguration
           .newInstance("queue1", "WrongPolicyName", buf));
       fpc.setFederationSubclusterResolver(


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11795. Skip BaseFederationPoliciesTest.testReinitilializeBad3() on JVMs where Mockito cannot mock ByteBuffers.

Skip BaseFederationPoliciesTest.testReinitilializeBad3() on JVMs where Mockito cannot mock ByteBuffers,
so that the test is skipped in this case instead of failing.

### How was this patch tested?

Verified behaviour on my JDK23 branch

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

