### PR TITLE
HADOOP-19488 fix the temporary directory creation on Windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestRunJar.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestRunJar.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.util;
 import static org.apache.hadoop.util.RunJar.MATCH_ANY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -195,6 +196,24 @@ public class TestRunJar {
     assertFalse(new File(unjarDir, TestRunJar.FOOBAR_TXT).exists(),
         "unjar dir shouldn't exist at test start");
     return unjarDir;
+  }
+
+  /**
+   * Tests the creation of the temp working directory into which the jars are
+   * unjarred.
+   */
+  @Test
+  public void testCreateWorkDirectory() throws Exception {
+    File workDir = null;
+    try {
+      workDir = RunJar.createWorkDirectory();
+
+      assertNotNull(workDir, "Work directory should exist and not null");
+    } finally {
+      if (workDir != null) {
+        FileUtil.fullyDelete(workDir);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Use ACL-based permissions for Windows instead of POSIX permissions.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Fix Hadoop RunJar for Windows. The Windows filesystem does not recognize the POSIX permissions, and it was causing the directory creation failure. If the filesystem does not support POSIX permissions, switch to using the user-based, ACL-based permissions that work on Windows.

### How was this patch tested?
I added a test to TestRunJar and ran it first to reproduce the bug on Windows. After I changed RunJar.java, I ran TestRunJar on Windows and confirmed it runs successfully.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

