### PR TITLE
YARN-11796. Accept extra JDK 17 options in tests

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
@@ -314,6 +314,7 @@ public class TestLinuxContainerExecutorWithMocks {
       List<String> result=readMockParams();
 
       if (Shell.isJavaVersionAtLeast(17)) {
+        // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
         assertTrue(result.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
         assertTrue(result.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestLinuxContainerExecutorWithMocks.java
@@ -53,6 +53,7 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -311,6 +312,12 @@ public class TestLinuxContainerExecutorWithMocks {
           .build());
 
       List<String> result=readMockParams();
+
+      if (Shell.isJavaVersionAtLeast(17)) {
+        assertTrue(result.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+        assertTrue(result.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+      }
+
       assertThat(result).hasSize(26);
       assertThat(result.get(0)).isEqualTo(YarnConfiguration.
           DEFAULT_NM_NONSECURE_MODE_LOCAL_USER);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
@@ -715,6 +715,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertTrue(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
@@ -733,6 +734,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertFalse(javaOpts.contains("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
@@ -752,6 +754,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
@@ -773,6 +776,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
@@ -793,6 +797,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }
@@ -810,6 +815,7 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
     if (Shell.isJavaVersionAtLeast(17)) {
+      // Added by ContainerLocalizer for JDK17+ (MAPREDUCE-7456)
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
       assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/TestContainerLocalizer.java
@@ -751,6 +751,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         " userOption1 userOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
+    if (Shell.isJavaVersionAtLeast(17)) {
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+    }
     assertEquals(4, javaOpts.size());
     assertTrue(javaOpts.get(0).equals("adminOption1"));
     assertTrue(javaOpts.get(1).equals("adminOption2"));
@@ -768,6 +772,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         "adminOption1 adminOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
+    if (Shell.isJavaVersionAtLeast(17)) {
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+    }
     assertEquals(3, javaOpts.size());
     assertTrue(javaOpts.get(0).equals("adminOption1"));
     assertTrue(javaOpts.get(1).equals("adminOption2"));
@@ -784,6 +792,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
         "userOption1 userOption2");
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
+    if (Shell.isJavaVersionAtLeast(17)) {
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+    }
     assertEquals(2, javaOpts.size());
     assertTrue(javaOpts.get(0).equals("userOption1"));
     assertTrue(javaOpts.get(1).equals("userOption2"));
@@ -797,6 +809,10 @@ static DataInputBuffer createFakeCredentials(Random r, int nTok)
     Configuration conf = new Configuration();
     List<String> javaOpts = localizer.getJavaOpts(conf);
 
+    if (Shell.isJavaVersionAtLeast(17)) {
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.dns=ALL-UNNAMED"));
+      assertTrue(javaOpts.remove("--add-exports=java.base/sun.net.util=ALL-UNNAMED"));
+    }
     assertEquals(1, javaOpts.size());
     assertTrue(javaOpts.get(0).equals("-Xmx256m"));
   }


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11796. Accept extra JDK 17 options in tests

Accept options automatically added when run on JDK17+ in relevant tests

### How was this patch tested?

Ran the modified tests with JDK8 and JDK17

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

