### PR TITLE
YARN-11797. Fix tests trying to connect to 0.0.0.0

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -216,7 +216,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
     WebAppProxyServer webAppProxyServer = new WebAppProxyServer();
     try {
-      conf.set(YarnConfiguration.PROXY_ADDRESS, "0.0.0.0:9099");
+      conf.set(YarnConfiguration.PROXY_ADDRESS, "localhost:9099");
       cluster.init(conf);
       cluster.start();
       getAdminService(0).transitionToActive(req);
@@ -231,7 +231,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
       // send httpRequest with fakeApplicationId
       // expect to get "Not Found" response and 404 response code
-      URL wrongUrl = new URL("http://0.0.0.0:9099/proxy/" + fakeAppId);
+      URL wrongUrl = new URL("http://localhost:9099/proxy/" + fakeAppId);
       HttpURLConnection proxyConn = (HttpURLConnection) wrongUrl
           .openConnection();
 
@@ -258,7 +258,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
     // send httpRequest with fakeApplicationId
     // expect to get "Not Found" response and 404 response code
-    URL wrongUrl = new URL("http://0.0.0.0:18088/proxy/" + fakeAppId);
+    URL wrongUrl = new URL("http://localhost:18088/proxy/" + fakeAppId);
     HttpURLConnection proxyConn = (HttpURLConnection) wrongUrl
         .openConnection();
 
@@ -286,8 +286,8 @@ public class TestRMFailover extends ClientBaseWithFixes {
     cluster.init(conf);
     cluster.start();
     getAdminService(0).transitionToActive(req);
-    String rm1Url = "http://0.0.0.0:18088";
-    String rm2Url = "http://0.0.0.0:28088";
+    String rm1Url = "http://localhost:18088";
+    String rm2Url = "http://localhost:28088";
 
     String redirectURL = getRedirectURL(rm2Url);
     // if uri is null, RMWebAppFilter will append a slash at the trail of the redirection url

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/HATestUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/HATestUtil.java
@@ -29,7 +29,7 @@ public class HATestUtil {
   public static void setRpcAddressForRM(String rmId, int base,
       Configuration conf) throws IOException {
     for (String confKey : YarnConfiguration.getServiceAddressConfKeys(conf)) {
-      setConfForRM(rmId, confKey, "0.0.0.0:" + ServerSocketUtil.getPort(base +
+      setConfForRM(rmId, confKey, "localhost:" + ServerSocketUtil.getPort(base +
           YarnConfiguration.getRMDefaultPortNumber(confKey, conf), 10), conf);
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestMiniYarnCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestMiniYarnCluster.java
@@ -136,18 +136,18 @@ public class TestMiniYarnCluster {
       Configuration conf1 = cluster.getResourceManager(0).getConfig(),
           conf2 = cluster.getResourceManager(1).getConfig();
       assertFalse(conf1 == conf2);
-      assertEquals("0.0.0.0:18032",
+      assertEquals("localhost:18032",
           conf1.get(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS,
               RM1_NODE_ID)));
-      assertEquals("0.0.0.0:28032",
+      assertEquals("localhost:28032",
           conf1.get(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS,
               RM2_NODE_ID)));
       assertEquals("rm1", conf1.get(YarnConfiguration.RM_HA_ID));
 
-      assertEquals("0.0.0.0:18032",
+      assertEquals("localhost:18032",
           conf2.get(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS,
               RM1_NODE_ID)));
-      assertEquals("0.0.0.0:28032",
+      assertEquals("localhost:28032",
           conf2.get(HAUtil.addSuffix(YarnConfiguration.RM_ADDRESS,
               RM2_NODE_ID)));
       assertEquals("rm2", conf2.get(YarnConfiguration.RM_HA_ID));


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11797. Fix tests trying to connect to 0.0.0.0

Fix tests that time out because they try to connect to 0.0.0.0, which times out on JDK11+

### How was this patch tested?

Ran the tests on Java 8 and later Java versions

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

