### PR TITLE
HADOOP-19506. Fix TestThrottledInputStream when bandwidth is equal to throttle limit.

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/util/TestThrottledInputStream.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/util/TestThrottledInputStream.java
@@ -216,7 +216,7 @@ public class TestThrottledInputStream {
       assertEquals(in.getTotalBytesRead(), tmpFile.length());
 
       long bytesPerSec = in.getBytesPerSec();
-      assertTrue(bytesPerSec < maxBPS);
+      assertTrue(bytesPerSec <= maxBPS);
     } finally {
       IOUtils.closeStream(in);
       IOUtils.closeStream(out);


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19506. Fix TestThrottledInputStream when bandwidth is equal to throttle limit.

Accept equals when checking if actual bandwidth conforms to the throttle value set.

### How was this patch tested?

Ran the test on various JVMs

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

