### PR TITLE
HADOOP-19508. Set charsetEncoder in HadoopArchiveLogs

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -509,6 +509,7 @@ public class HadoopArchiveLogs implements Tool {
       fw = FileWriterWithEncoding.builder()
               .setFile(localScript)
               .setCharset(StandardCharsets.UTF_8)
+              .setCharsetEncoder(StandardCharsets.UTF_8.newEncoder())
               .get();
       fw.write("#!/bin/bash\nset -e\nset -x\n");
       int containerCount = 1;


### PR DESCRIPTION
### Description of PR

HADOOP-19508. Set charsetEncoder in HadoopArchiveLogs.

Set CharsetEncoder in HadoopArchiveLogs so that it works regardless of the system charset defaults.

### How was this patch tested?

On my JDK23 branch, as the failure does not happen on my system, and the CI for this PR won't run on Centos 7.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

