### PR TITLE
HADOOP-19509.  Add a config entry to make IPC.Client checkAsyncCall off by default.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -355,9 +355,6 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   public static final String  IPC_CLIENT_ASYNC_CALLS_MAX_KEY =
       "ipc.client.async.calls.max";
   public static final int     IPC_CLIENT_ASYNC_CALLS_MAX_DEFAULT = 100;
-  public static final String  IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY =
-      "ipc.client.async.calls.check.enable";
-  public static final boolean IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_DEFAULT = false;
   public static final String  IPC_CLIENT_FALLBACK_TO_SIMPLE_AUTH_ALLOWED_KEY = "ipc.client.fallback-to-simple-auth-allowed";
   public static final boolean IPC_CLIENT_FALLBACK_TO_SIMPLE_AUTH_ALLOWED_DEFAULT = false;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeys.java
@@ -355,6 +355,9 @@ public class CommonConfigurationKeys extends CommonConfigurationKeysPublic {
   public static final String  IPC_CLIENT_ASYNC_CALLS_MAX_KEY =
       "ipc.client.async.calls.max";
   public static final int     IPC_CLIENT_ASYNC_CALLS_MAX_DEFAULT = 100;
+  public static final String  IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY =
+      "ipc.client.async.calls.check.enable";
+  public static final boolean IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_DEFAULT = false;
   public static final String  IPC_CLIENT_FALLBACK_TO_SIMPLE_AUTH_ALLOWED_KEY = "ipc.client.fallback-to-simple-auth-allowed";
   public static final boolean IPC_CLIENT_FALLBACK_TO_SIMPLE_AUTH_ALLOWED_DEFAULT = false;
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -203,7 +203,13 @@ public class Client implements AutoCloseable {
   private final boolean bindToWildCardAddress;
   private final byte[] clientId;
   private final int maxAsyncCalls;
+  private boolean asyncCallCheckEabled;
   private final AtomicInteger asyncCallCounter = new AtomicInteger(0);
+
+  @VisibleForTesting
+  public int getAsyncCallCounter() {
+    return asyncCallCounter.get();
+  }
 
   /**
    * set the ping interval value in configuration
@@ -1371,6 +1377,9 @@ public class Client implements AutoCloseable {
     this.maxAsyncCalls = conf.getInt(
         CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_KEY,
         CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_DEFAULT);
+    this.asyncCallCheckEabled = conf.getBoolean(
+        CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY,
+        CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_DEFAULT);
   }
 
   /**
@@ -1386,6 +1395,11 @@ public class Client implements AutoCloseable {
   public String toString() {
     return getClass().getSimpleName() + "-"
         + StringUtils.byteToHexString(clientId);
+  }
+
+  @VisibleForTesting
+  public void setAsyncCallCheckEabled(boolean enabled) {
+    this.asyncCallCheckEabled = enabled;
   }
 
   /** Return the socket factory of this client
@@ -1460,7 +1474,7 @@ public class Client implements AutoCloseable {
   }
 
   private void checkAsyncCall() throws IOException {
-    if (isAsynchronousMode()) {
+    if (isAsynchronousMode() && asyncCallCheckEabled) {
       if (asyncCallCounter.incrementAndGet() > maxAsyncCalls) {
         String errMsg = String.format(
             "Exceeded limit of max asynchronous calls: %d, " +
@@ -1518,7 +1532,7 @@ public class Client implements AutoCloseable {
         throw ioe;
       }
     } catch (Exception e) {
-      if (isAsynchronousMode()) {
+      if (isAsynchronousMode() && asyncCallCheckEabled) {
         releaseAsyncCall();
       }
       throw e;
@@ -1527,7 +1541,9 @@ public class Client implements AutoCloseable {
     if (isAsynchronousMode()) {
       CompletableFuture<Writable> result = call.rpcResponseFuture.handle(
           (rpcResponse, e) -> {
-            releaseAsyncCall();
+            if (asyncCallCheckEabled) {
+              releaseAsyncCall();
+            }
             if (e != null) {
               IOException ioe = (IOException) e;
               throw new CompletionException(warpIOException(ioe, connection));

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -202,13 +202,22 @@ public class Client implements AutoCloseable {
   private final boolean fallbackAllowed;
   private final boolean bindToWildCardAddress;
   private final byte[] clientId;
-  private final int maxAsyncCalls;
-  private boolean asyncCallCheckEabled;
+  private int maxAsyncCalls;
   private final AtomicInteger asyncCallCounter = new AtomicInteger(0);
 
   @VisibleForTesting
   public int getAsyncCallCounter() {
     return asyncCallCounter.get();
+  }
+
+  @VisibleForTesting
+  public void setMaxAsyncCalls(int limits) {
+    this.maxAsyncCalls = limits;
+  }
+
+  @VisibleForTesting
+  public boolean isAsyncCallCheckEabled() {
+    return maxAsyncCalls >= 0;
   }
 
   /**
@@ -1377,9 +1386,6 @@ public class Client implements AutoCloseable {
     this.maxAsyncCalls = conf.getInt(
         CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_KEY,
         CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_DEFAULT);
-    this.asyncCallCheckEabled = conf.getBoolean(
-        CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY,
-        CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_DEFAULT);
   }
 
   /**
@@ -1395,11 +1401,6 @@ public class Client implements AutoCloseable {
   public String toString() {
     return getClass().getSimpleName() + "-"
         + StringUtils.byteToHexString(clientId);
-  }
-
-  @VisibleForTesting
-  public void setAsyncCallCheckEabled(boolean enabled) {
-    this.asyncCallCheckEabled = enabled;
   }
 
   /** Return the socket factory of this client
@@ -1474,7 +1475,7 @@ public class Client implements AutoCloseable {
   }
 
   private void checkAsyncCall() throws IOException {
-    if (isAsynchronousMode() && asyncCallCheckEabled) {
+    if (isAsynchronousMode() && isAsyncCallCheckEabled()) {
       if (asyncCallCounter.incrementAndGet() > maxAsyncCalls) {
         String errMsg = String.format(
             "Exceeded limit of max asynchronous calls: %d, " +
@@ -1532,7 +1533,7 @@ public class Client implements AutoCloseable {
         throw ioe;
       }
     } catch (Exception e) {
-      if (isAsynchronousMode() && asyncCallCheckEabled) {
+      if (isAsynchronousMode() && isAsyncCallCheckEabled()) {
         releaseAsyncCall();
       }
       throw e;
@@ -1541,7 +1542,7 @@ public class Client implements AutoCloseable {
     if (isAsynchronousMode()) {
       CompletableFuture<Writable> result = call.rpcResponseFuture.handle(
           (rpcResponse, e) -> {
-            if (asyncCallCheckEabled) {
+            if (isAsyncCallCheckEabled()) {
               releaseAsyncCall();
             }
             if (e != null) {

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2405,6 +2405,16 @@ The switch to turn S3A auditing on or off.
 
 <!-- ipc properties -->
 <property>
+  <name>ipc.client.async.calls.check.enable</name>
+  <value>false</value>
+  <description>
+    Whether property ipc.client.async.calls.max is effective or not.
+    If true, use ipc.client.async.calls.max to limit the number of outstanding async calls.
+    If false, ipc.client.async.calls.max is ignored.
+  </description>
+</property>
+
+<property>
   <name>ipc.client.async.calls.max</name>
   <value>100</value>
   <description>

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2405,20 +2405,11 @@ The switch to turn S3A auditing on or off.
 
 <!-- ipc properties -->
 <property>
-  <name>ipc.client.async.calls.check.enable</name>
-  <value>false</value>
-  <description>
-    Whether property ipc.client.async.calls.max is effective or not.
-    If true, use ipc.client.async.calls.max to limit the number of outstanding async calls.
-    If false, ipc.client.async.calls.max is ignored.
-  </description>
-</property>
-
-<property>
   <name>ipc.client.async.calls.max</name>
   <value>100</value>
   <description>
     Define the maximum number of outstanding async calls.
+    If negative, there is no limit on the number of outstanding async calls.
   </description>
 </property>
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -38,7 +38,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -64,8 +68,9 @@ public class TestAsyncIPC {
   public void setupConf() {
     conf = new Configuration();
     conf.setInt(CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_KEY, 10000);
+    conf.setBoolean(CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY, true);
     Client.setPingInterval(conf, TestIPC.PING_INTERVAL);
-    // set asynchronous mode for main thread
+    // Set asynchronous mode for main thread.
     Client.setAsynchronousMode(true);
   }
 
@@ -78,17 +83,19 @@ public class TestAsyncIPC {
         new HashMap<Integer, Future<LongWritable>>();
     Map<Integer, Long> expectedValues = new HashMap<Integer, Long>();
 
-    public AsyncCaller(Client client, InetSocketAddress server, int count) {
+    public AsyncCaller(Client client, InetSocketAddress server, int count,
+        boolean checkAsyncCallEnabled) {
       this.client = client;
+      client.setAsyncCallCheckEabled(checkAsyncCallEnabled);
       this.server = server;
       this.count = count;
-      // set asynchronous mode, since AsyncCaller extends Thread
+      // Set asynchronous mode, since AsyncCaller extends Thread.
       Client.setAsynchronousMode(true);
     }
 
     @Override
     public void run() {
-      // in case Thread#Start is called, which will spawn new thread
+      // In case Thread#Start is called, which will spawn new thread.
       Client.setAsynchronousMode(true);
       for (int i = 0; i < count; i++) {
         try {
@@ -227,7 +234,7 @@ public class TestAsyncIPC {
       this.client = client;
       this.server = server;
       this.count = count;
-      // set asynchronous mode, since AsyncLimitlCaller extends Thread
+      // Set asynchronous mode, since AsyncLimitlCaller extends Thread.
       Client.setAsynchronousMode(true);
       this.callerId = callerId;
     }
@@ -287,10 +294,17 @@ public class TestAsyncIPC {
 
   @Test
   @Timeout(value = 60)
+  public void testAsyncCallCheckDisabled() throws IOException, InterruptedException,
+      ExecutionException {
+    internalTestAsyncCall(3, true, 2, 5, 10, false);
+  }
+
+  @Test
+  @Timeout(value = 60)
   public void testAsyncCall() throws IOException, InterruptedException,
       ExecutionException {
-    internalTestAsyncCall(3, false, 2, 5, 100);
-    internalTestAsyncCall(3, true, 2, 5, 10);
+    internalTestAsyncCall(3, false, 2, 5, 100, true);
+    internalTestAsyncCall(3, true, 2, 5, 10, true);
   }
 
   @Test
@@ -301,7 +315,8 @@ public class TestAsyncIPC {
   }
 
   public void internalTestAsyncCall(int handlerCount, boolean handlerSleep,
-      int clientCount, int callerCount, int callCount) throws IOException,
+      int clientCount, int callerCount, int callCount,
+      boolean checkAsyncCallEnabled) throws IOException,
       InterruptedException, ExecutionException {
     Server server = new TestIPC.TestServer(handlerCount, handlerSleep, conf);
     InetSocketAddress addr = NetUtils.getConnectAddress(server);
@@ -314,10 +329,14 @@ public class TestAsyncIPC {
 
     AsyncCaller[] callers = new AsyncCaller[callerCount];
     for (int i = 0; i < callerCount; i++) {
-      callers[i] = new AsyncCaller(clients[i % clientCount], addr, callCount);
+      callers[i] = new AsyncCaller(clients[i % clientCount], addr, callCount,
+          checkAsyncCallEnabled);
       callers[i].start();
     }
     for (int i = 0; i < callerCount; i++) {
+      if (!checkAsyncCallEnabled) {
+        assertEquals(0, clients[i % clientCount].getAsyncCallCounter());
+      }
       callers[i].join();
       callers[i].assertReturnValues();
     }
@@ -340,7 +359,7 @@ public class TestAsyncIPC {
     int asyncCallCount = client.getAsyncCallCount();
 
     try {
-      AsyncCaller caller = new AsyncCaller(client, addr, callCount);
+      AsyncCaller caller = new AsyncCaller(client, addr, callCount, true);
       caller.run();
       caller.assertReturnValues();
       caller.assertReturnValues();
@@ -364,7 +383,7 @@ public class TestAsyncIPC {
     final Client client = new Client(LongWritable.class, conf);
 
     try {
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, true);
       caller.run();
       caller.assertReturnValues(10, TimeUnit.MILLISECONDS);
     } finally {
@@ -463,7 +482,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 4);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 4, true);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -501,7 +520,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, true);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -538,7 +557,7 @@ public class TestAsyncIPC {
     try {
       InetSocketAddress addr = NetUtils.getConnectAddress(server);
       server.start();
-      final AsyncCaller caller = new AsyncCaller(client, addr, 10);
+      final AsyncCaller caller = new AsyncCaller(client, addr, 10, true);
       caller.run();
       caller.assertReturnValues();
     } finally {
@@ -580,7 +599,7 @@ public class TestAsyncIPC {
       server.start();
       AsyncCaller[] callers = new AsyncCaller[callerCount];
       for (int i = 0; i < callerCount; ++i) {
-        callers[i] = new AsyncCaller(client, addr, perCallerCallCount);
+        callers[i] = new AsyncCaller(client, addr, perCallerCallCount, true);
         callers[i].start();
       }
       for (int i = 0; i < callerCount; ++i) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -85,7 +85,10 @@ public class TestAsyncIPC {
     AsyncCaller(Client client, InetSocketAddress server, int count,
         boolean checkAsyncCallEnabled) {
       this.client = client;
-      client.setMaxAsyncCalls(-1);
+      // Disable checkAsyncCall.
+      if (!checkAsyncCallEnabled) {
+        this.client.setMaxAsyncCalls(-1);
+      }
       this.server = server;
       this.count = count;
       // Set asynchronous mode, since AsyncCaller extends Thread.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -83,7 +83,7 @@ public class TestAsyncIPC {
         new HashMap<Integer, Future<LongWritable>>();
     Map<Integer, Long> expectedValues = new HashMap<Integer, Long>();
 
-    public AsyncCaller(Client client, InetSocketAddress server, int count,
+    AsyncCaller(Client client, InetSocketAddress server, int count,
         boolean checkAsyncCallEnabled) {
       this.client = client;
       client.setAsyncCallCheckEabled(checkAsyncCallEnabled);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestAsyncIPC.java
@@ -68,7 +68,6 @@ public class TestAsyncIPC {
   public void setupConf() {
     conf = new Configuration();
     conf.setInt(CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_MAX_KEY, 10000);
-    conf.setBoolean(CommonConfigurationKeys.IPC_CLIENT_ASYNC_CALLS_CHECK_ENABLE_KEY, true);
     Client.setPingInterval(conf, TestIPC.PING_INTERVAL);
     // Set asynchronous mode for main thread.
     Client.setAsynchronousMode(true);
@@ -86,7 +85,7 @@ public class TestAsyncIPC {
     AsyncCaller(Client client, InetSocketAddress server, int count,
         boolean checkAsyncCallEnabled) {
       this.client = client;
-      client.setAsyncCallCheckEabled(checkAsyncCallEnabled);
+      client.setMaxAsyncCalls(-1);
       this.server = server;
       this.count = count;
       // Set asynchronous mode, since AsyncCaller extends Thread.


### PR DESCRIPTION
### Description of PR

HADOOP-19509

  Add a config entry to make IPC.Client checkAsyncCall off by default.
  In my practice, when enable aysnc router rpc, we must adjust `ipc.client.async.calls.max` much larger. If not, we will get AsyncCallLimitExceededException exception frequently. 

  The original purpose of method checkAsyncCall is to prevent Out-of-Memory from occurring on the client, we should make it not throttle router async rpc request.  And we should make checkAsyncCall default by false unless user really know what they are doing and turn on this switch.

  BTW, we use other mechanisms  to prevent OOM from occurring on the hdfs router. please see [HDFS-17713](https://issues.apache.org/jira/browse/HDFS-17713)

### How was this patch tested?
Add unit test.