### PR TITLE
HDFS-17720.[JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs-rbf Part1.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/RouterHDFSContract.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/RouterHDFSContract.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.contract.AbstractFSContractTestBase;
 import org.apache.hadoop.fs.contract.hdfs.HDFSContract;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * The contract of Router-based Federated HDFS.
@@ -109,7 +109,7 @@ public class RouterHDFSContract extends HDFSContract {
 
   public static FileSystem getFileSystem() throws IOException {
     //assumes cluster is not null
-    Assert.assertNotNull("cluster not created", cluster);
+    Assertions.assertNotNull(cluster, "cluster not created");
     return cluster.getRandomRouter().getFileSystem();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/SecurityConfUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/SecurityConfUtil.java
@@ -30,7 +30,7 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_RPC_BIND_HOST_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DELEGATION_TOKEN_DRIVER_CLASS;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Properties;
@@ -96,8 +96,8 @@ public final class SecurityConfUtil {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
 
     UserGroupInformation.setConfiguration(conf);
-    assertTrue("Expected configuration to enable security",
-        UserGroupInformation.isSecurityEnabled());
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Expected configuration to enable security");
 
     // Setup the keytab
     File keytabFile = new File(baseDir, "test.keytab");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/web/RouterWebHDFSContract.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/fs/contract/router/web/RouterWebHDFSContract.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
 import org.apache.hadoop.hdfs.web.WebHdfsConstants;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +112,7 @@ public class RouterWebHDFSContract extends HDFSContract {
 
   public static FileSystem getFileSystem() throws IOException {
     //assumes cluster is not null
-    Assert.assertNotNull("cluster not created", cluster);
+    Assertions.assertNotNull(cluster, "cluster not created");
 
     // Create a connection to WebHDFS
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/protocolPB/TestAsyncRpcProtocolPBUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/protocolPB/TestAsyncRpcProtocolPBUtil.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.thirdparty.protobuf.BlockingService;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +43,8 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ForkJoinPool;
 
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestAsyncRpcProtocolPBUtil {
   private static final Logger LOG = LoggerFactory.getLogger(TestAsyncRpcProtocolPBUtil.class);
@@ -52,7 +52,7 @@ public class TestAsyncRpcProtocolPBUtil {
   private TestClientProtocolTranslatorPB clientPB;
   private Server rpcServer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     AsyncRpcProtocolPBUtil.setAsyncResponderExecutor(ForkJoinPool.commonPool());
     Configuration conf = new Configuration();
@@ -82,7 +82,7 @@ public class TestAsyncRpcProtocolPBUtil {
     clientPB.ping();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     if (clientPB != null) {
       clientPB.close();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/protocolPB/TestRouterClientSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/protocolPB/TestRouterClientSideTranslatorPB.java
@@ -42,11 +42,11 @@ import org.apache.hadoop.security.protocolPB.RefreshUserMappingsProtocolPB;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolPB;
 import org.apache.hadoop.util.Lists;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -64,9 +64,9 @@ import static org.apache.hadoop.fs.permission.FsAction.READ;
 import static org.apache.hadoop.fs.permission.FsAction.READ_WRITE;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
 import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.aclEntry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRouterClientSideTranslatorPB {
   private static MiniDFSCluster cluster = null;
@@ -80,7 +80,7 @@ public class TestRouterClientSideTranslatorPB {
   private static final String TEST_DIR_PATH = "/test";
   private boolean mode;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     AsyncRpcProtocolPBUtil.setAsyncResponderExecutor(ForkJoinPool.commonPool());
     conf = new HdfsConfiguration();
@@ -98,7 +98,7 @@ public class TestRouterClientSideTranslatorPB {
         createProxy(RefreshUserMappingsProtocolPB.class));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (clientProtocolTranslatorPB != null) {
       clientProtocolTranslatorPB.close();
@@ -117,13 +117,13 @@ public class TestRouterClientSideTranslatorPB {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setAsync() {
     mode = Client.isAsynchronousMode();
     Client.setAsynchronousMode(true);
   }
 
-  @After
+  @AfterEach
   public void unsetAsync() {
     Client.setAsynchronousMode(mode);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/rbfbalance/TestMountTableProcedure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/rbfbalance/TestMountTableProcedure.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.GetMountTableEntr
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.util.Time;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster.RouterContext;
 
 import java.io.ByteArrayOutputStream;
@@ -55,9 +55,9 @@ import java.util.List;
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createNamenodeReport;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.synchronizeRecords;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Basic tests of MountTableProcedure.
@@ -70,7 +70,7 @@ public class TestMountTableProcedure {
   private static List<MountTable> mockMountTable;
   private static StateStoreService stateStore;
 
-  @BeforeClass
+  @BeforeAll
   public static void globalSetUp() throws Exception {
     cluster = new StateStoreDFSCluster(false, 1);
     // Build and start a router with State Store + admin + RPC
@@ -100,12 +100,12 @@ public class TestMountTableProcedure {
         routerSocket);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     cluster.stopRouter(routerContext);
   }
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception {
     assertTrue(
         synchronizeRecords(stateStore, mockMountTable, MountTable.class));

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/FederationTestUtils.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.federation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -124,12 +124,11 @@ public final class FederationTestUtils {
       triggeredException = e;
     }
     if (exceptionClass != null) {
-      assertNotNull("No exception was triggered, expected exception"
-          + exceptionClass.getName(), triggeredException);
+      assertNotNull(triggeredException, "No exception was triggered, expected exception"
+          + exceptionClass.getName());
       assertEquals(exceptionClass, triggeredException.getClass());
     } else {
-      assertNull("Exception was triggered but no exception was expected",
-          triggeredException);
+      assertNull(triggeredException, "Exception was triggered but no exception was expected");
     }
   }
 
@@ -524,7 +523,7 @@ public final class FederationTestUtils {
     GetMountTableEntriesResponse getResponse =
         mountTable.getMountTableEntries(getRequest);
     List<MountTable> entries = getResponse.getEntries();
-    assertEquals("Too many entries: " + entries, 1, entries.size());
+    assertEquals(1, entries.size(), "Too many entries: " + entries);
     assertEquals(mountPoint, entries.get(0).getSourcePath());
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/MiniRouterDFSCluster.java
@@ -48,8 +48,8 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_SAFEMODE_ENABLE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_FILE_RESOLVER_CLIENT_CLASS;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_NAMENODE_RESOLVER_CLIENT_CLASS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestProportionRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestProportionRouterRpcFairnessPolicyController.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 import java.util.concurrent.TimeUnit;
@@ -32,8 +32,8 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_PROPORTION_KEY_PREFIX;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test functionality of {@link ProportionRouterRpcFairnessPolicyController}.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRefreshFairnessPolicyController.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +42,7 @@ import org.apache.hadoop.hdfs.server.federation.router.RouterRpcClient;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRouterRefreshFairnessPolicyController {
 
@@ -53,12 +53,12 @@ public class TestRouterRefreshFairnessPolicyController {
 
   private StateStoreDFSCluster cluster;
 
-  @BeforeClass
+  @BeforeAll
   public static void setLogLevel() {
     GenericTestUtils.setLogLevel(AbstractRouterRpcFairnessPolicyController.LOG, Level.DEBUG);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (cluster != null) {
       cluster.shutdown();
@@ -66,7 +66,7 @@ public class TestRouterRefreshFairnessPolicyController {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     cluster = new StateStoreDFSCluster(false, 2);
     Configuration conf = new RouterConfigBuilder().stateStore().rpc().build();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/fairness/TestRouterRpcFairnessPolicyController.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdfs.server.federation.router.FederationUtil;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
@@ -34,9 +34,9 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_MONITOR_NAMENODE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIR_HANDLER_COUNT_KEY_PREFIX;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test functionality of {@link RouterRpcFairnessPolicyController).
@@ -190,8 +190,7 @@ public class TestRouterRpcFairnessPolicyController {
     String errorMsg = String.format(
         StaticRouterRpcFairnessPolicyController.ERROR_MSG, handlerCount,
         totalDedicatedHandlers);
-    assertTrue("Should contain error message: " + errorMsg,
-        logs.getOutput().contains(errorMsg));
+    assertTrue(logs.getOutput().contains(errorMsg), "Should contain error message: " + errorMsg);
   }
 
   private RouterRpcFairnessPolicyController getFairnessPolicyController(

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestMetricsBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestMetricsBase.java
@@ -25,8 +25,8 @@ import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStor
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.createMockRegistrationForNamenode;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.synchronizeRecords;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,9 +56,9 @@ import org.apache.hadoop.hdfs.server.federation.store.records.StateStoreVersion;
 import org.apache.hadoop.util.Time;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the basic metrics functionality.
@@ -77,7 +77,7 @@ public class TestMetricsBase {
   private List<RouterState> mockRouters;
   private List<String> nameservices;
 
-  @Before
+  @BeforeEach
   public void setupBase() throws Exception {
 
     if (router == null) {
@@ -104,7 +104,7 @@ public class TestMetricsBase {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDownBase() throws IOException {
     if (router != null) {
       router.stop();
@@ -212,7 +212,7 @@ public class TestMetricsBase {
     String jsonString = metrics.getNameservices();
     JSONObject jsonObject = new JSONObject(jsonString);
     Map<String, String> map = getNameserviceStateMap(jsonObject);
-    assertTrue("Cannot find ns0 in: " + jsonString, map.containsKey("ns0"));
+    assertTrue(map.containsKey("ns0"), "Cannot find ns0 in: " + jsonString);
     assertEquals("OBSERVER", map.get("ns0"));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestNameserviceRPCMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestNameserviceRPCMetrics.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MockResolver;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -68,7 +68,7 @@ public class TestNameserviceRPCMetrics {
   /** Filesystem interface to the Namenode. */
   private FileSystem nnFS;
 
-  @BeforeClass
+  @BeforeAll
   public static void globalSetUp() throws Exception {
     cluster = new MiniRouterDFSCluster(false, NUM_SUBCLUSTERS);
     cluster.setNumDatanodesPerNameservice(NUM_DNS);
@@ -88,7 +88,7 @@ public class TestNameserviceRPCMetrics {
 
   }
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception {
     // Create mock locations
     cluster.installMockLocations();
@@ -116,7 +116,7 @@ public class TestNameserviceRPCMetrics {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     cluster.shutdown();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRBFMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRBFMetrics.java
@@ -18,11 +18,11 @@
 package org.apache.hadoop.hdfs.server.federation.metrics;
 
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.getBean;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -42,7 +42,7 @@ import org.apache.hadoop.hdfs.server.federation.store.records.StateStoreVersion;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the JMX interface for the {@link Router}.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRouterClientMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/metrics/TestRouterClientMetrics.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.hdfs.server.federation.MiniRouterDFSCluster;
 import org.apache.hadoop.hdfs.server.federation.MockResolver;
 import org.apache.hadoop.hdfs.server.federation.RouterConfigBuilder;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -68,7 +68,7 @@ public class TestRouterClientMetrics {
   /** Filesystem interface to the Namenode. */
   private FileSystem nnFS;
 
-  @BeforeClass
+  @BeforeAll
   public static void globalSetUp() throws Exception {
     cluster = new MiniRouterDFSCluster(false, NUM_SUBCLUSTERS);
     cluster.setNumDatanodesPerNameservice(NUM_DNS);
@@ -88,7 +88,7 @@ public class TestRouterClientMetrics {
 
   }
 
-  @Before
+  @BeforeEach
   public void testSetup() throws Exception {
     // Create mock locations
     cluster.installMockLocations();
@@ -115,7 +115,7 @@ public class TestRouterClientMetrics {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     cluster.shutdown();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestFederationNamespaceInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestFederationNamespaceInfo.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.resolver;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.TreeSet;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestInitializeMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestInitializeMountTableResolver.java
@@ -18,14 +18,14 @@
 package org.apache.hadoop.hdfs.server.federation.resolver;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMESERVICE_ID;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_NAMESERVICES;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE_ENABLE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test {@link MountTableResolver} initialization.
@@ -45,8 +45,8 @@ public class TestInitializeMountTableResolver {
     conf.set(DFS_ROUTER_DEFAULT_NAMESERVICE, "");
     MountTableResolver mountTable = new MountTableResolver(conf);
     assertEquals("", mountTable.getDefaultNamespace());
-    assertFalse("Default NS should be disabled if default NS is set empty",
-        mountTable.isDefaultNSEnable());
+    assertFalse(mountTable.isDefaultNSEnable(),
+        "Default NS should be disabled if default NS is set empty");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMountTableResolver.java
@@ -20,11 +20,11 @@ package org.apache.hadoop.hdfs.server.federation.resolver;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_MOUNT_TABLE_CACHE_ENABLE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_MOUNT_TABLE_MAX_CACHE_SIZE;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_DEFAULT_NAMESERVICE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,8 +40,8 @@ import org.apache.hadoop.hdfs.server.federation.router.Router;
 import org.apache.hadoop.hdfs.server.federation.store.MountTableStore;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +136,7 @@ public class TestMountTableResolver {
     mountTable.addEntry(multiEntry);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     setupMountTable();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMultipleDestinationResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestMultipleDestinationResolver.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.federation.resolver;
 
 import static org.apache.hadoop.hdfs.server.federation.resolver.order.HashResolver.extractTempFileName;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,8 +33,8 @@ import java.util.TreeSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.resolver.order.DestinationOrder;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the multiple destination resolver.
@@ -43,7 +43,7 @@ public class TestMultipleDestinationResolver {
 
   private MultipleDestinationMountTableResolver resolver;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     Configuration conf = new Configuration();
     resolver = new MultipleDestinationMountTableResolver(conf, null);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/TestNamenodeResolver.java
@@ -26,11 +26,11 @@ import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStor
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.newStateStore;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -43,10 +43,10 @@ import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreUnavailableException;
 import org.apache.hadoop.hdfs.server.federation.store.records.MembershipState;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the basic {@link ActiveNamenodeResolver} functionality.
@@ -56,7 +56,7 @@ public class TestNamenodeResolver {
   private static StateStoreService stateStore;
   private static ActiveNamenodeResolver namenodeResolver;
 
-  @BeforeClass
+  @BeforeAll
   public static void create() throws Exception {
 
     Configuration conf = getStateStoreConfiguration();
@@ -73,13 +73,13 @@ public class TestNamenodeResolver {
     namenodeResolver.setRouterId(ROUTERS[0]);
   }
 
-  @AfterClass
+  @AfterAll
   public static void destroy() throws Exception {
     stateStore.stop();
     stateStore.close();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
     // Wait for state store to connect
     stateStore.loadDriver();
@@ -395,8 +395,8 @@ public class TestNamenodeResolver {
     namenodeResolver.updateActiveNamenode(NAMESERVICES[0], inetAddr);
     FederationNamenodeContext namenode1 = namenodeResolver
         .getNamenodesForNameserviceId(NAMESERVICES[0], false).get(0);
-    assertEquals("The namenode state should be ACTIVE post update.",
-        FederationNamenodeServiceState.ACTIVE, namenode1.getState());
+    assertEquals(FederationNamenodeServiceState.ACTIVE, namenode1.getState(),
+        "The namenode state should be ACTIVE post update.");
   }
 
   @Test
@@ -412,8 +412,8 @@ public class TestNamenodeResolver {
     namenodeResolver.updateActiveNamenode(NAMESERVICES[0], inetAddr);
     FederationNamenodeContext namenode = namenodeResolver
         .getNamenodesForNameserviceId(NAMESERVICES[0], false).get(0);
-    assertEquals("The namenode state should be ACTIVE post update.",
-        FederationNamenodeServiceState.ACTIVE, namenode.getState());
+    assertEquals(FederationNamenodeServiceState.ACTIVE, namenode.getState(),
+        "The namenode state should be ACTIVE post update.");
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestAvailableSpaceResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestAvailableSpaceResolver.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hdfs.server.federation.resolver.order;
 
 import static org.apache.hadoop.hdfs.server.federation.resolver.order.AvailableSpaceResolver.BALANCER_PREFERENCE_DEFAULT;
 import static org.apache.hadoop.hdfs.server.federation.resolver.order.AvailableSpaceResolver.BALANCER_PREFERENCE_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,7 +48,7 @@ import org.apache.hadoop.hdfs.server.federation.store.records.MembershipStats;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.hdfs.server.federation.store.records.impl.pb.MembershipStatsPBImpl;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the {@link AvailableSpaceResolver}.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestLeaderFollowerResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestLeaderFollowerResolver.java
@@ -23,13 +23,13 @@ import org.apache.hadoop.hdfs.server.federation.resolver.PathLocation;
 import org.apache.hadoop.hdfs.server.federation.resolver.RemoteLocation;
 import org.apache.hadoop.hdfs.server.federation.router.Router;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class TestLeaderFollowerResolver {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestLocalResolver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/resolver/order/TestLocalResolver.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.resolver.order;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -42,7 +42,7 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.GetNamenodeRegist
 import org.apache.hadoop.hdfs.server.federation.store.protocol.GetNamenodeRegistrationsResponse;
 import org.apache.hadoop.hdfs.server.federation.store.records.MembershipState;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterHttpDelegationToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/TestRouterHttpDelegationToken.java
@@ -15,9 +15,9 @@
 package org.apache.hadoop.hdfs.server.federation.security;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_HTTP_AUTHENTICATION_TYPE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -59,9 +59,9 @@ import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.server.PseudoAuthenticationHandler;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -111,7 +111,7 @@ public class TestRouterHttpDelegationToken {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration conf = SecurityConfUtil.initSecurity();
     conf.set(RBFConfigKeys.DFS_ROUTER_HTTP_ADDRESS_KEY, "0.0.0.0:0");
@@ -138,7 +138,7 @@ public class TestRouterHttpDelegationToken {
     fs = (WebHdfsFileSystem)FileSystem.get(webURI, conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (router != null) {
       router.stop();
@@ -169,8 +169,7 @@ public class TestRouterHttpDelegationToken {
         getTokenIdentifier(token.getIdentifier());
 
     long t = renewDelegationToken(fs, token);
-    assertTrue(t + " should not be larger than " + tokenId.getMaxDate(),
-        t <= tokenId.getMaxDate());
+    assertTrue(t <= tokenId.getMaxDate(), t + " should not be larger than " + tokenId.getMaxDate());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/FederationStateStoreTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/FederationStateStoreTestUtils.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdfs.server.federation.store;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_STORE_DRIVER_CLASS;
 import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileImpl.FEDERATION_STORE_FILE_DIRECTORY;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreBase.java
@@ -20,16 +20,16 @@ package org.apache.hadoop.hdfs.server.federation.store;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.newStateStore;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.waitStateStore;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Test the basic {@link StateStoreService} {@link MountTableStore}
@@ -48,7 +48,7 @@ public class TestStateStoreBase {
     return conf;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void createBase() throws IOException, InterruptedException {
 
     conf = getStateStoreConfiguration();
@@ -58,7 +58,7 @@ public class TestStateStoreBase {
         TimeUnit.HOURS.toMillis(1));
   }
 
-  @AfterClass
+  @AfterAll
   public static void destroyBase() throws Exception {
     if (stateStore != null) {
       stateStore.stop();
@@ -67,7 +67,7 @@ public class TestStateStoreBase {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setupBase() throws IOException, InterruptedException,
       InstantiationException, IllegalAccessException {
     if (stateStore == null) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreDisabledNameservice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreDisabledNameservice.java
@@ -18,15 +18,15 @@
 package org.apache.hadoop.hdfs.server.federation.store;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.clearRecords;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Set;
 
 import org.apache.hadoop.hdfs.server.federation.store.records.DisabledNameservice;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the basic {@link StateStoreService}
@@ -36,7 +36,7 @@ public class TestStateStoreDisabledNameservice extends TestStateStoreBase {
 
   private static DisabledNameserviceStore disabledStore;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
     disabledStore = getStateStore()
         .getRegisteredRecordStore(DisabledNameserviceStore.class);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMembershipState.java
@@ -24,11 +24,11 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verif
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.clearRecords;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.createMockRegistrationForNamenode;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.synchronizeRecords;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -58,9 +58,9 @@ import org.apache.hadoop.hdfs.server.federation.store.records.MembershipState;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.apache.hadoop.util.Time;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +74,7 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
 
   private static MembershipStore membershipStore;
 
-  @BeforeClass
+  @BeforeAll
   public static void create() {
     // Reduce expirations to 2 seconds
     getConf().setLong(
@@ -86,7 +86,7 @@ public class TestStateStoreMembershipState extends TestStateStoreBase {
         TimeUnit.SECONDS.toMillis(2));
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
 
     membershipStore =

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreMountTable.java
@@ -22,10 +22,10 @@ import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verif
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.clearRecords;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.createMockMountTable;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.synchronizeRecords;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,9 +42,9 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableE
 import org.apache.hadoop.hdfs.server.federation.store.protocol.UpdateMountTableEntryResponse;
 import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.hdfs.server.federation.store.records.QueryResult;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the basic {@link StateStoreService}
@@ -55,14 +55,14 @@ public class TestStateStoreMountTable extends TestStateStoreBase {
   private static List<String> nameservices;
   private static MountTableStore mountStore;
 
-  @BeforeClass
+  @BeforeAll
   public static void create() throws IOException {
     nameservices = new ArrayList<>();
     nameservices.add(NAMESERVICES[0]);
     nameservices.add(NAMESERVICES[1]);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
     mountStore =
         getStateStore().getRegisteredRecordStore(MountTableStore.class);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreRouterState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/TestStateStoreRouterState.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.server.federation.store;
 
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.verifyException;
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.clearRecords;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -39,9 +39,9 @@ import org.apache.hadoop.hdfs.server.federation.store.protocol.RouterHeartbeatRe
 import org.apache.hadoop.hdfs.server.federation.store.records.RouterState;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the basic {@link StateStoreService} {@link RouterStore} functionality.
@@ -50,7 +50,7 @@ public class TestStateStoreRouterState extends TestStateStoreBase {
 
   private static RouterStore routerStore;
 
-  @BeforeClass
+  @BeforeAll
   public static void create() {
     // Reduce expirations to 2 seconds
     getConf().setTimeDuration(
@@ -62,7 +62,7 @@ public class TestStateStoreRouterState extends TestStateStoreBase {
         2, TimeUnit.SECONDS);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
 
     if (routerStore == null) {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreDriverBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreDriverBase.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.federation.store.driver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -51,8 +51,8 @@ import org.apache.hadoop.hdfs.server.federation.store.records.RouterState;
 import org.apache.hadoop.hdfs.server.federation.store.records.StateStoreVersion;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
-import org.junit.After;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ public class TestStateStoreDriverBase {
     return stateStore;
   }
 
-  @After
+  @AfterEach
   public void cleanMetrics() {
     if (stateStore != null) {
       StateStoreMetrics metrics = stateStore.getMetrics();
@@ -91,7 +91,7 @@ public class TestStateStoreDriverBase {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownCluster() {
     if (stateStore != null) {
       stateStore.stop();
@@ -184,7 +184,7 @@ public class TestStateStoreDriverBase {
       Object data1 = getField(original, key);
       Object data2 = getField(committed, key);
       if (assertEquals) {
-        assertEquals("Field " + key + " does not match", data1, data2);
+        assertEquals(data1, data2, "Field " + key + " does not match");
       } else if (!data1.equals(data2)) {
         ret = false;
       }
@@ -347,8 +347,8 @@ public class TestStateStoreDriverBase {
     // Verify no update occurred, all original records are unchanged
     QueryResult<T> newRecords = driver.get(clazz);
     assertEquals(10, newRecords.getRecords().size());
-    assertEquals("A single entry was improperly updated in the store", 10,
-        countMatchingEntries(records.getRecords(), newRecords.getRecords()));
+    assertEquals(10, countMatchingEntries(records.getRecords(), newRecords.getRecords()),
+        "A single entry was improperly updated in the store");
 
     // Update the entry (allowing updates)
     assertTrue(driver.put(updatedRecord, true, false));
@@ -358,9 +358,8 @@ public class TestStateStoreDriverBase {
     assertEquals(10, newRecords.getRecords().size());
     T record = records.getRecords().get(0);
     if (record.hasOtherFields()) {
-      assertEquals(
-          "Record of type " + clazz + " not updated in the store", 9,
-          countMatchingEntries(records.getRecords(), newRecords.getRecords()));
+      assertEquals(9, countMatchingEntries(records.getRecords(), newRecords.getRecords()),
+          "Record of type " + clazz + " not updated in the store");
     }
   }
 
@@ -613,8 +612,8 @@ public class TestStateStoreDriverBase {
     driver.getMultiple(MountTable.class, query);
     final Map<String, MutableRate> cacheLoadMetrics = metrics.getCacheLoadMetrics();
     final MutableRate mountTableCache = cacheLoadMetrics.get("CacheMountTableLoad");
-    assertNotNull("CacheMountTableLoad should be present in the state store metrics",
-        mountTableCache);
+    assertNotNull(mountTableCache,
+        "CacheMountTableLoad should be present in the state store metrics");
     return mountTableCache;
   }
 
@@ -623,13 +622,12 @@ public class TestStateStoreDriverBase {
     final MutableRate mountTableCache = getMountTableCache(driver);
     // CacheMountTableLoadNumOps
     final long mountTableCacheLoadNumOps = getMountTableCacheLoadSamples(driver);
-    assertEquals("Num of samples collected should match", numRefresh, mountTableCacheLoadNumOps);
+    assertEquals(numRefresh, mountTableCacheLoadNumOps, "Num of samples collected should match");
     // CacheMountTableLoadAvgTime ms
     final double mountTableCacheLoadAvgTimeMs = mountTableCache.lastStat().mean();
-    assertTrue(
+    assertTrue(mountTableCacheLoadAvgTimeMs > expectedHigherThan,
         "Mean time duration for cache load is expected to be higher than " + expectedHigherThan
-            + " ms." + " Actual value: " + mountTableCacheLoadAvgTimeMs,
-        mountTableCacheLoadAvgTimeMs > expectedHigherThan);
+            + " ms." + " Actual value: " + mountTableCacheLoadAvgTimeMs);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFile.java
@@ -27,25 +27,23 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileImpl;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test the FileSystem (e.g., HDFS) implementation of the State Store driver.
  */
-@RunWith(Parameterized.class)
 public class TestStateStoreFile extends TestStateStoreDriverBase {
 
-  private final String numFileAsyncThreads;
+  private String numFileAsyncThreads;
 
-  public TestStateStoreFile(String numFileAsyncThreads) {
-    this.numFileAsyncThreads = numFileAsyncThreads;
+  public void initTestStateStoreFile(String pBumFileAsyncThreads) throws Exception {
+    this.numFileAsyncThreads = pBumFileAsyncThreads;
+    setupCluster(numFileAsyncThreads);
+    removeAll(getStateStoreDriver());
   }
 
-  @Parameterized.Parameters(name = "numFileAsyncThreads-{0}")
   public static List<String[]> data() {
     return Arrays.asList(new String[][] {{"20"}, {"0"}});
   }
@@ -56,50 +54,60 @@ public class TestStateStoreFile extends TestStateStoreDriverBase {
     getStateStore(conf);
   }
 
-  @Before
   public void startup() throws Exception {
     setupCluster(numFileAsyncThreads);
     removeAll(getStateStoreDriver());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     tearDownCluster();
   }
 
-  @Test
-  public void testInsert()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testInsert(String pBumFileAsyncThreads)
+      throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     testInsert(getStateStoreDriver());
   }
 
-  @Test
-  public void testUpdate()
-      throws IllegalArgumentException, ReflectiveOperationException,
-      IOException, SecurityException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUpdate(String pBumFileAsyncThreads)
+      throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     testPut(getStateStoreDriver());
   }
 
-  @Test
-  public void testDelete()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDelete(String pBumFileAsyncThreads)
+      throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     testRemove(getStateStoreDriver());
   }
 
-  @Test
-  public void testFetchErrors()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testFetchErrors(String pBumFileAsyncThreads)
+      throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     testFetchErrors(getStateStoreDriver());
   }
 
-  @Test
-  public void testMetrics()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testMetrics(String pBumFileAsyncThreads)
+      throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     testMetrics(getStateStoreDriver());
   }
 
-  @Test
-  public void testCacheLoadMetrics() throws IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testCacheLoadMetrics(String pBumFileAsyncThreads) throws Exception {
+    initTestStateStoreFile(pBumFileAsyncThreads);
     // inject value of CacheMountTableLoad as -1 initially, if tests get CacheMountTableLoadAvgTime
     // value as -1 ms, that would mean no other sample with value >= 0 would have been received and
     // hence this would be failure to assert that mount table avg load time is higher than -1

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFileBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFileBase.java
@@ -18,13 +18,13 @@
 package org.apache.hadoop.hdfs.server.federation.store.driver;
 
 import static org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileBaseImpl.isOldTempRecord;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the State Store file based implementation.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreFileSystem.java
@@ -29,11 +29,9 @@ import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFile
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreFileSystemImpl;
 import org.apache.hadoop.hdfs.server.federation.store.records.MembershipState;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.stubbing.Answer;
 
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.FEDERATION_STORE_FS_ASYNC_THREADS;
@@ -46,15 +44,16 @@ import static org.mockito.Mockito.spy;
 /**
  * Test the FileSystem (e.g., HDFS) implementation of the State Store driver.
  */
-@RunWith(Parameterized.class)
 public class TestStateStoreFileSystem extends TestStateStoreDriverBase {
 
   private static MiniDFSCluster dfsCluster;
 
-  private final String numFsAsyncThreads;
+  private String numFsAsyncThreads;
 
-  public TestStateStoreFileSystem(String numFsAsyncThreads) {
-    this.numFsAsyncThreads = numFsAsyncThreads;
+  public void initTestStateStoreFileSystem(String pNumFsAsyncThreads) throws Exception {
+    this.numFsAsyncThreads = pNumFsAsyncThreads;
+    setupCluster(numFsAsyncThreads);
+    removeAll(getStateStoreDriver());
   }
 
   private static void setupCluster(String numFsAsyncThreads) throws Exception {
@@ -71,18 +70,16 @@ public class TestStateStoreFileSystem extends TestStateStoreDriverBase {
     getStateStore(conf);
   }
 
-  @Parameterized.Parameters(name = "numFsAsyncThreads-{0}")
   public static List<String[]> data() {
     return Arrays.asList(new String[][] {{"20"}, {"0"}});
   }
 
-  @Before
   public void startup() throws Exception {
     setupCluster(numFsAsyncThreads);
     removeAll(getStateStoreDriver());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     tearDownCluster();
     if (dfsCluster != null) {
@@ -91,39 +88,50 @@ public class TestStateStoreFileSystem extends TestStateStoreDriverBase {
     }
   }
 
-  @Test
-  public void testInsert()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testInsert(String pNumFsAsyncThreads)
+      throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     testInsert(getStateStoreDriver());
   }
 
-  @Test
-  public void testUpdate() throws IllegalArgumentException, IOException,
-      SecurityException, ReflectiveOperationException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testUpdate(String pNumFsAsyncThreads) throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     testPut(getStateStoreDriver());
   }
 
-  @Test
-  public void testDelete()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testDelete(String pNumFsAsyncThreads)
+      throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     testRemove(getStateStoreDriver());
   }
 
-  @Test
-  public void testFetchErrors()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testFetchErrors(String pNumFsAsyncThreads)
+      throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     testFetchErrors(getStateStoreDriver());
   }
 
-  @Test
-  public void testMetrics()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testMetrics(String pNumFsAsyncThreads)
+      throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     testMetrics(getStateStoreDriver());
   }
 
-  @Test
-  public void testInsertWithErrorDuringWrite()
-      throws IllegalArgumentException, IllegalAccessException, IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testInsertWithErrorDuringWrite(String pNumFsAsyncThreads)
+      throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     StateStoreFileBaseImpl driver = spy((StateStoreFileBaseImpl)getStateStoreDriver());
     doAnswer((Answer<BufferedWriter>) a -> {
       BufferedWriter writer = (BufferedWriter) a.callRealMethod();
@@ -135,8 +143,10 @@ public class TestStateStoreFileSystem extends TestStateStoreDriverBase {
     testInsertWithErrorDuringWrite(driver, MembershipState.class);
   }
 
-  @Test
-  public void testCacheLoadMetrics() throws IOException {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testCacheLoadMetrics(String pNumFsAsyncThreads) throws Exception {
+    initTestStateStoreFileSystem(pNumFsAsyncThreads);
     // inject value of CacheMountTableLoad as -1 initially, if tests get CacheMountTableLoadAvgTime
     // value as -1 ms, that would mean no other sample with value >= 0 would have been received and
     // hence this would be failure to assert that mount table avg load time is higher than -1

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreMySQL.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreMySQL.java
@@ -24,10 +24,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.store.driver.impl.StateStoreMySQLImpl;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.*;
 
@@ -37,7 +37,7 @@ import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStor
 public class TestStateStoreMySQL extends TestStateStoreDriverBase {
   private static final String CONNECTION_URL = "jdbc:derby:memory:StateStore";
 
-  @BeforeClass
+  @BeforeAll
   public static void initDatabase() throws Exception {
     Connection connection =  DriverManager.getConnection(CONNECTION_URL + ";create=true");
     Statement s =  connection.createStatement();
@@ -52,12 +52,12 @@ public class TestStateStoreMySQL extends TestStateStoreDriverBase {
     getStateStore(conf);
   }
 
-  @Before
+  @BeforeEach
   public void startup() throws IOException {
     removeAll(getStateStoreDriver());
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupDatabase() {
     try {
       DriverManager.getConnection(CONNECTION_URL + ";drop=true");

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/driver/TestStateStoreZK.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.federation.store.driver;
 
 import static org.apache.hadoop.hdfs.server.federation.store.FederationStateStoreTestUtils.getStateStoreConfiguration;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,10 +42,10 @@ import org.apache.hadoop.hdfs.server.federation.store.records.MountTable;
 import org.apache.hadoop.hdfs.server.federation.store.records.RouterState;
 import org.apache.hadoop.util.Time;
 import org.apache.zookeeper.CreateMode;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the ZooKeeper implementation of the State Store driver.
@@ -56,7 +56,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
   private static CuratorFramework curatorFramework;
   private static String baseZNode;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCluster() throws Exception {
     curatorTestingServer = new TestingServer();
     curatorTestingServer.start();
@@ -81,7 +81,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     getStateStore(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownCluster() {
     curatorFramework.close();
     try {
@@ -90,7 +90,7 @@ public class TestStateStoreZK extends TestStateStoreDriverBase {
     }
   }
 
-  @Before
+  @BeforeEach
   public void startup() throws IOException {
     removeAll(getStateStoreDriver());
     StateStoreZooKeeperImpl stateStoreZooKeeper = (StateStoreZooKeeperImpl) getStateStoreDriver();

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMembershipState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMembershipState.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.hdfs.server.federation.store.records;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.apache.hadoop.hdfs.server.federation.resolver.FederationNamenodeServiceState;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the Membership State records.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMountTable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestMountTable.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdfs.server.federation.store.records;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdfs.server.federation.resolver.order.DestinationOrder;
 import org.apache.hadoop.hdfs.server.federation.router.RouterQuotaUsage;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the Mount Table entry in the State Store.

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/store/records/TestRouterState.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.federation.store.records;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,7 +31,7 @@ import org.apache.hadoop.hdfs.server.federation.router.RouterServiceState;
 import org.apache.hadoop.hdfs.server.federation.store.StateStoreService;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreDriver;
 import org.apache.hadoop.hdfs.server.federation.store.driver.StateStoreSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the Router State records.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
JIRA: [HDFS-17720](https://issues.apache.org/jira/browse/HDFS-17720). [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs-rbf Part1.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

