### PR TITLE
HADOOP-19398: Upgrade Dockerfile base to jammy

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -104,10 +104,10 @@ pipeline {
                     '''
                 }
 
-                dir("${WORKSPACE}/ubuntu-focal") {
+                dir("${WORKSPACE}/ubuntu-jammy") {
                     sh '''#!/usr/bin/env bash
 
-                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/ubuntu-focal
+                    cp -Rp ${WORKSPACE}/src ${WORKSPACE}/ubuntu-jammy
                     '''
                 }
             }
@@ -251,12 +251,12 @@ pipeline {
             }
         }
 
-        // We want to use Ubuntu Focal as our main CI and thus, this stage
+        // We want to use Ubuntu Jammy as our main CI and thus, this stage
         // isn't optional (runs for all the PRs).
-        stage ('precommit-run Ubuntu focal') {
+        stage ('precommit-run Ubuntu jammy') {
             environment {
-                SOURCEDIR = "${WORKSPACE}/ubuntu-focal/src"
-                PATCHDIR = "${WORKSPACE}/ubuntu-focal/out"
+                SOURCEDIR = "${WORKSPACE}/ubuntu-jammy/src"
+                PATCHDIR = "${WORKSPACE}/ubuntu-jammy/out"
                 DOCKERFILE = "${SOURCEDIR}/dev-support/docker/Dockerfile"
                 IS_OPTIONAL = 0
             }
@@ -281,8 +281,8 @@ pipeline {
                                               usernameVariable: 'GITHUB_USER')]) {
                             sh '''#!/usr/bin/env bash
 
-                            # Copy the artifacts of Ubuntu focal build to workspace
-                            cp -Rp "${WORKSPACE}/ubuntu-focal/out" "${WORKSPACE}"
+                            # Copy the artifacts of Ubuntu jammy build to workspace
+                            cp -Rp "${WORKSPACE}/ubuntu-jammy/out" "${WORKSPACE}"
 
                             # Send Github status
                             chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"

--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -508,16 +508,16 @@ function dockermode
     echo "RUN groupadd --non-unique -g ${group_id} ${user_name}; exit 0;"
     echo "RUN useradd -g ${group_id} -u ${user_id} -m ${user_name}; exit 0;"
     echo "RUN chown -R ${user_name} /home/${user_name}; exit 0;"
-    echo "ENV HOME /home/${user_name}"
+    echo "ENV HOME=/home/${user_name}"
     echo "RUN mkdir -p /maven"
     echo "RUN chown -R ${user_name} /maven"
 
     # we always force build with the OpenJDK JDK
     # but with the correct version
     if [[ "$CPU_ARCH" = "aarch64" || "$CPU_ARCH" = "arm64" ]]; then
-      echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-arm64"
+      echo "ENV JAVA_HOME=/usr/lib/jvm/java-${JVM_VERSION}-openjdk-arm64"
     else
-      echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-amd64"
+      echo "ENV JAVA_HOME=/usr/lib/jvm/java-${JVM_VERSION}-openjdk-amd64"
     fi
 
     echo "USER ${user_name}"

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 WORKDIR /root
 
@@ -45,7 +45,7 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends python3 \
-    && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal) \
+    && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:jammy) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -83,11 +83,11 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION true
 # Install packages
 ####
 RUN pkg-resolver/install-common-pkgs.sh
-RUN pkg-resolver/install-spotbugs.sh ubuntu:focal
-RUN pkg-resolver/install-boost.sh ubuntu:focal
-RUN pkg-resolver/install-protobuf.sh ubuntu:focal
-RUN pkg-resolver/install-hadolint.sh ubuntu:focal
-RUN pkg-resolver/install-intel-isa-l.sh ubuntu:focal
+RUN pkg-resolver/install-spotbugs.sh ubuntu:jammy
+RUN pkg-resolver/install-boost.sh ubuntu:jammy
+RUN pkg-resolver/install-protobuf.sh ubuntu:jammy
+RUN pkg-resolver/install-hadolint.sh ubuntu:jammy
+RUN pkg-resolver/install-intel-isa-l.sh ubuntu:jammy
 
 ###
 # Everything past this point is either not needed for testing or breaks Yetus.

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -29,8 +29,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_TERSE true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_TERSE=true
 
 ######
 # Platform package dependency resolver
@@ -56,28 +56,28 @@ ENV PYTHONIOENCODING=utf-8
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/usr
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 #######
 # Set env vars for SpotBugs 4.2.2
 #######
-ENV SPOTBUGS_HOME /opt/spotbugs
+ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
 # Set env vars for Google Protobuf 3.21.12
 #######
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
 ###
 # Avoid out of memory errors in builds
 ###
-ENV MAVEN_OPTS -Xms256m -Xmx3072m
+ENV MAVEN_OPTS="-Xms256m -Xmx3072m"
 
 # Skip gpg verification when downloading Yetus via yetus-wrapper
-ENV HADOOP_SKIP_YETUS_VERIFICATION true
+ENV HADOOP_SKIP_YETUS_VERIFICATION=true
 
 ####
 # Install packages

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -29,8 +29,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_TERSE true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_TERSE=true
 
 ######
 # Platform package dependency resolver
@@ -56,31 +56,31 @@ ENV PYTHONIOENCODING=utf-8
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/usr
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-arm64
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64
 
 #######
 # Set env vars for SpotBugs 4.2.2
 #######
-ENV SPOTBUGS_HOME /opt/spotbugs
+ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
 # Set env vars for Google Protobuf 3.21.12
 #######
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
 ###
 # Avoid out of memory errors in builds
 ###
-ENV MAVEN_OPTS -Xms256m -Xmx3072m
+ENV MAVEN_OPTS="-Xms256m -Xmx3072m"
 
 # Skip gpg verification when downloading Yetus via yetus-wrapper
-ENV HADOOP_SKIP_YETUS_VERIFICATION true
+ENV HADOOP_SKIP_YETUS_VERIFICATION=true
 
 # Force PhantomJS to be in 'headless' mode, do not connect to Xwindow
-ENV QT_QPA_PLATFORM offscreen
+ENV QT_QPA_PLATFORM=offscreen
 
 ####
 # Install packages

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -17,7 +17,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 WORKDIR /root
 
@@ -45,7 +45,7 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 # hadolint ignore=DL3008,SC2046
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends python3 \
-    && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:focal::arch64) \
+    && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:jammy::arch64) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -86,9 +86,9 @@ ENV QT_QPA_PLATFORM offscreen
 # Install packages
 ####
 RUN pkg-resolver/install-common-pkgs.sh
-RUN pkg-resolver/install-spotbugs.sh ubuntu:focal::arch64
-RUN pkg-resolver/install-boost.sh ubuntu:focal::arch64
-RUN pkg-resolver/install-protobuf.sh ubuntu:focal::arch64
+RUN pkg-resolver/install-spotbugs.sh ubuntu:jammy::arch64
+RUN pkg-resolver/install-boost.sh ubuntu:jammy::arch64
+RUN pkg-resolver/install-protobuf.sh ubuntu:jammy::arch64
 
 ###
 # Everything past this point is either not needed for testing or breaks Yetus.

--- a/dev-support/docker/Dockerfile_centos_7
+++ b/dev-support/docker/Dockerfile_centos_7
@@ -61,37 +61,37 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Set the environment variables needed for CMake
 # to find and use GCC 9 for compilation
 ######
-ENV GCC_HOME "/opt/rh/devtoolset-9"
-ENV CC "${GCC_HOME}/root/usr/bin/gcc"
-ENV CXX "${GCC_HOME}/root/usr/bin/g++"
-ENV SHLVL 1
-ENV LD_LIBRARY_PATH "${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:${GCC_HOME}/root/usr/lib64/dyninst:${GCC_HOME}/root/usr/lib/dyninst:${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:/usr/lib:/usr/lib64"
-ENV PCP_DIR "${GCC_HOME}/root"
-ENV MANPATH "${GCC_HOME}/root/usr/share/man:"
-ENV PATH "${GCC_HOME}/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ENV PKG_CONFIG_PATH "${GCC_HOME}/root/usr/lib64/pkgconfig"
-ENV INFOPATH "${GCC_HOME}/root/usr/share/info"
+ENV GCC_HOME="/opt/rh/devtoolset-9"
+ENV CC="${GCC_HOME}/root/usr/bin/gcc"
+ENV CXX="${GCC_HOME}/root/usr/bin/g++"
+ENV SHLVL=1
+ENV LD_LIBRARY_PATH="${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:${GCC_HOME}/root/usr/lib64/dyninst:${GCC_HOME}/root/usr/lib/dyninst:${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:/usr/lib:/usr/lib64"
+ENV PCP_DIR="${GCC_HOME}/root"
+ENV MANPATH="${GCC_HOME}/root/usr/share/man:"
+ENV PATH="${GCC_HOME}/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PKG_CONFIG_PATH="${GCC_HOME}/root/usr/lib64/pkgconfig"
+ENV INFOPATH="${GCC_HOME}/root/usr/share/info"
 
 # TODO: Set locale
 
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /opt/maven
-ENV PATH "${PATH}:${MAVEN_HOME}/bin"
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
 
 #######
 # Set env vars for SpotBugs
 #######
-ENV SPOTBUGS_HOME /opt/spotbugs
+ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
 # Set env vars for Google Protobuf 3.21.12
 #######
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
 ######
 # Install packages

--- a/dev-support/docker/Dockerfile_centos_8
+++ b/dev-support/docker/Dockerfile_centos_8
@@ -69,42 +69,42 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Set the environment variables needed for CMake
 # to find and use GCC 9 for compilation
 ######
-ENV GCC_HOME "/opt/rh/gcc-toolset-9"
-ENV CC "${GCC_HOME}/root/usr/bin/gcc"
-ENV CXX "${GCC_HOME}/root/usr/bin/g++"
-ENV MODULES_RUN_QUARANTINE "LD_LIBRARY_PATH LD_PRELOAD"
-ENV MODULES_CMD "/usr/share/Modules/libexec/modulecmd.tcl"
-ENV SHLVL 1
-ENV MODULEPATH "/etc/scl/modulefiles:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles"
-ENV MODULEPATH_modshare "/usr/share/modulefiles:1:/usr/share/Modules/modulefiles:1:/etc/modulefiles:1"
-ENV MODULESHOME "/usr/share/Modules"
-ENV LD_LIBRARY_PATH "${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:${GCC_HOME}/root/usr/lib64/dyninst:${GCC_HOME}/root/usr/lib/dyninst:${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:/usr/lib:/usr/lib64"
-ENV PCP_DIR "${GCC_HOME}/root"
-ENV MANPATH "${GCC_HOME}/root/usr/share/man::"
-ENV PATH "${GCC_HOME}/root/usr/bin:/usr/share/Modules/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ENV PKG_CONFIG_PATH "${GCC_HOME}/root/usr/lib64/pkgconfig"
-ENV INFOPATH "${GCC_HOME}/root/usr/share/info"
+ENV GCC_HOME="/opt/rh/gcc-toolset-9"
+ENV CC="${GCC_HOME}/root/usr/bin/gcc"
+ENV CXX="${GCC_HOME}/root/usr/bin/g++"
+ENV MODULES_RUN_QUARANTINE="LD_LIBRARY_PATH LD_PRELOAD"
+ENV MODULES_CMD="/usr/share/Modules/libexec/modulecmd.tcl"
+ENV SHLVL=1
+ENV MODULEPATH="/etc/scl/modulefiles:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles"
+ENV MODULEPATH_modshare="/usr/share/modulefiles:1:/usr/share/Modules/modulefiles:1:/etc/modulefiles:1"
+ENV MODULESHOME="/usr/share/Modules"
+ENV LD_LIBRARY_PATH="${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:${GCC_HOME}/root/usr/lib64/dyninst:${GCC_HOME}/root/usr/lib/dyninst:${GCC_HOME}/root/usr/lib64:${GCC_HOME}/root/usr/lib:/usr/lib:/usr/lib64"
+ENV PCP_DIR="${GCC_HOME}/root"
+ENV MANPATH="${GCC_HOME}/root/usr/share/man::"
+ENV PATH="${GCC_HOME}/root/usr/bin:/usr/share/Modules/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PKG_CONFIG_PATH="${GCC_HOME}/root/usr/lib64/pkgconfig"
+ENV INFOPATH="${GCC_HOME}/root/usr/share/info"
 
 # TODO: Set locale
 
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /opt/maven
-ENV PATH "${PATH}:${MAVEN_HOME}/bin"
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
 
 #######
 # Set env vars for SpotBugs
 #######
-ENV SPOTBUGS_HOME /opt/spotbugs
+ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
 # Set env vars for Google Protobuf 3.21.12
 #######
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
 ######
 # Install packages

--- a/dev-support/docker/Dockerfile_debian_10
+++ b/dev-support/docker/Dockerfile_debian_10
@@ -29,8 +29,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_TERSE true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_TERSE=true
 
 ######
 # Platform package dependency resolver
@@ -56,28 +56,28 @@ RUN apt-get -q update \
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/usr
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 #######
 # Set env vars for SpotBugs 4.2.2
 #######
-ENV SPOTBUGS_HOME /opt/spotbugs
+ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
 # Set env vars for Google Protobuf 3.21.12
 #######
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
 
 ###
 # Avoid out of memory errors in builds
 ###
-ENV MAVEN_OPTS -Xms256m -Xmx3072m
+ENV MAVEN_OPTS="-Xms256m -Xmx3072m"
 
 # Skip gpg verification when downloading Yetus via yetus-wrapper
-ENV HADOOP_SKIP_YETUS_VERIFICATION true
+ENV HADOOP_SKIP_YETUS_VERIFICATION=true
 
 ####
 # Install packages

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -115,12 +115,12 @@ COPY pkg-resolver pkg-resolver
 ## Install Python 3.11.8.
 # The Python installation steps below are derived from -
 # https://github.com/docker-library/python/blob/105d6f34e7d70aad6f8c3e249b8208efa591916a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
-ENV PYTHONIOENCODING UTF-8
-ENV PYTHON_VERSION 3.11.8
-ENV PYTHON_PIP_VERSION 24.0
-ENV PYTHON_SETUPTOOLS_VERSION 65.5.1
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/dbf0c85f76fb6e1ab42aa672ffca6f0a675d9ee4/public/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 dfe9fd5c28dc98b5ac17979a953ea550cec37ae1b47a5116007395bfacff2ab9
+ENV PYTHONIOENCODING=UTF-8
+ENV PYTHON_VERSION=3.11.8
+ENV PYTHON_PIP_VERSION=24.0
+ENV PYTHON_SETUPTOOLS_VERSION=65.5.1
+ENV PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/dbf0c85f76fb6e1ab42aa672ffca6f0a675d9ee4/public/get-pip.py
+ENV PYTHON_GET_PIP_SHA256=dfe9fd5c28dc98b5ac17979a953ea550cec37ae1b47a5116007395bfacff2ab9
 RUN powershell Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 RUN powershell pkg-resolver\install-python.ps1
 RUN powershell pkg-resolver\install-pip.ps1
@@ -137,10 +137,10 @@ RUN powershell Remove-Item -Force "C:\secpol.cfg" -Confirm:$false
 
 # Login as HadoopBuilder and set the necessary environment and PATH variables.
 USER HadoopBuilder
-ENV PROTOBUF_HOME "C:\vcpkg\installed\x64-windows"
-ENV JAVA_HOME "C:\Java\zulu8.62.0.19-ca-jdk8.0.332-win_x64"
-ENV MAVEN_OPTS '-Xmx2048M -Xss128M'
-ENV IS_WINDOWS 1
+ENV PROTOBUF_HOME="C:\vcpkg\installed\x64-windows"
+ENV JAVA_HOME="C:\Java\zulu8.62.0.19-ca-jdk8.0.332-win_x64"
+ENV MAVEN_OPTS="-Xmx2048M -Xss128M"
+ENV IS_WINDOWS=1
 RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN setx PATH "%PATH%;%JAVA_HOME%\bin"
 RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -1,20 +1,20 @@
 {
   "ant": {
     "debian:10": "ant",
-    "ubuntu:focal": "ant",
-    "ubuntu:focal::arch64": "ant",
+    "ubuntu:jammy": "ant",
+    "ubuntu:jammy::arch64": "ant",
     "centos:7": "ant",
     "centos:8": "ant"
   },
   "apt-utils": {
     "debian:10": "apt-utils",
-    "ubuntu:focal": "apt-utils",
-    "ubuntu:focal::arch64": "apt-utils"
+    "ubuntu:jammy": "apt-utils",
+    "ubuntu:jammy::arch64": "apt-utils"
   },
   "automake": {
     "debian:10": "automake",
-    "ubuntu:focal": "automake",
-    "ubuntu:focal::arch64": "automake",
+    "ubuntu:jammy": "automake",
+    "ubuntu:jammy::arch64": "automake",
     "centos:7": "automake",
     "centos:8": "automake"
   },
@@ -23,13 +23,13 @@
   },
   "bats": {
     "debian:10": "bats",
-    "ubuntu:focal": "bats",
-    "ubuntu:focal::arch64": "bats"
+    "ubuntu:jammy": "bats",
+    "ubuntu:jammy::arch64": "bats"
   },
   "build-essential": {
     "debian:10": "build-essential",
-    "ubuntu:focal": "build-essential",
-    "ubuntu:focal::arch64": "build-essential",
+    "ubuntu:jammy": "build-essential",
+    "ubuntu:jammy::arch64": "build-essential",
     "centos:7": "build-essential"
   },
   "bzip2": {
@@ -37,11 +37,11 @@
       "bzip2",
       "libbz2-dev"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "bzip2",
       "libbz2-dev"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "bzip2",
       "libbz2-dev"
     ],
@@ -56,25 +56,25 @@
   },
   "clang": {
     "debian:10": "clang",
-    "ubuntu:focal": "clang",
-    "ubuntu:focal::arch64": "clang",
+    "ubuntu:jammy": "clang",
+    "ubuntu:jammy::arch64": "clang",
     "centos:7": "clang",
     "centos:8": "clang"
   },
   "cmake": {
-    "ubuntu:focal": "cmake",
-    "ubuntu:focal::arch64": "cmake"
+    "ubuntu:jammy": "cmake",
+    "ubuntu:jammy::arch64": "cmake"
   },
   "curl": {
     "debian:10": [
       "curl",
       "libcurl4-openssl-dev"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "curl",
       "libcurl4-openssl-dev"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "curl",
       "libcurl4-openssl-dev"
     ],
@@ -89,8 +89,8 @@
   },
   "doxygen": {
     "debian:10": "doxygen",
-    "ubuntu:focal": "doxygen",
-    "ubuntu:focal::arch64": "doxygen",
+    "ubuntu:jammy": "doxygen",
+    "ubuntu:jammy::arch64": "doxygen",
     "centos:7": "doxygen"
   },
   "dnf": {
@@ -101,11 +101,11 @@
       "fuse",
       "libfuse-dev"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "fuse",
       "libfuse-dev"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "fuse",
       "libfuse-dev"
     ],
@@ -127,11 +127,11 @@
         "g++"
       ]
     },
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "gcc",
       "g++"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "gcc",
       "g++"
     ],
@@ -145,36 +145,36 @@
   },
   "git": {
     "debian:10": "git",
-    "ubuntu:focal": "git",
-    "ubuntu:focal::arch64": "git",
+    "ubuntu:jammy": "git",
+    "ubuntu:jammy::arch64": "git",
     "centos:8": "git"
   },
   "gnupg-agent": {
     "debian:10": "gnupg-agent",
-    "ubuntu:focal": "gnupg-agent",
-    "ubuntu:focal::arch64": "gnupg-agent"
+    "ubuntu:jammy": "gnupg-agent",
+    "ubuntu:jammy::arch64": "gnupg-agent"
   },
   "hugo": {
     "debian:10": "hugo",
-    "ubuntu:focal": "hugo",
-    "ubuntu:focal::arch64": "hugo"
+    "ubuntu:jammy": "hugo",
+    "ubuntu:jammy::arch64": "hugo"
   },
   "libbcprov-java": {
     "debian:10": "libbcprov-java",
-    "ubuntu:focal": "libbcprov-java",
-    "ubuntu:focal::arch64": "libbcprov-java"
+    "ubuntu:jammy": "libbcprov-java",
+    "ubuntu:jammy::arch64": "libbcprov-java"
   },
   "libtool": {
     "debian:10": "libtool",
-    "ubuntu:focal": "libtool",
-    "ubuntu:focal::arch64": "libtool",
+    "ubuntu:jammy": "libtool",
+    "ubuntu:jammy::arch64": "libtool",
     "centos:7": "libtool",
     "centos:8": "libtool"
   },
   "openssl": {
     "debian:10": "libssl-dev",
-    "ubuntu:focal": "libssl-dev",
-    "ubuntu:focal::arch64": "libssl-dev",
+    "ubuntu:jammy": "libssl-dev",
+    "ubuntu:jammy::arch64": "libssl-dev",
     "centos:7": "openssl-devel",
     "centos:8": "openssl-devel"
   },
@@ -189,26 +189,26 @@
       "libprotobuf-dev",
       "libprotoc-dev"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "libprotobuf-dev",
       "libprotoc-dev"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "libprotobuf-dev",
       "libprotoc-dev"
     ]
   },
   "sasl": {
     "debian:10": "libsasl2-dev",
-    "ubuntu:focal": "libsasl2-dev",
-    "ubuntu:focal::arch64": "libsasl2-dev",
+    "ubuntu:jammy": "libsasl2-dev",
+    "ubuntu:jammy::arch64": "libsasl2-dev",
     "centos:7": "cyrus-sasl-devel",
     "centos:8": "cyrus-sasl-devel"
   },
   "snappy": {
     "debian:10": "libsnappy-dev",
-    "ubuntu:focal": "libsnappy-dev",
-    "ubuntu:focal::arch64": "libsnappy-dev",
+    "ubuntu:jammy": "libsnappy-dev",
+    "ubuntu:jammy::arch64": "libsnappy-dev",
     "centos:7": "snappy-devel"
   },
   "zlib": {
@@ -216,11 +216,11 @@
       "libzstd-dev",
       "zlib1g-dev"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "libzstd-dev",
       "zlib1g-dev"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "libzstd-dev",
       "zlib1g-dev"
     ],
@@ -235,8 +235,8 @@
   },
   "locales": {
     "debian:10": "locales",
-    "ubuntu:focal": "locales",
-    "ubuntu:focal::arch64": "locales"
+    "ubuntu:jammy": "locales",
+    "ubuntu:jammy::arch64": "locales"
   },
   "libtirpc-devel": {
     "centos:7": "libtirpc-devel",
@@ -247,24 +247,24 @@
   },
   "make": {
     "debian:10": "make",
-    "ubuntu:focal": "make",
-    "ubuntu:focal::arch64": "make",
+    "ubuntu:jammy": "make",
+    "ubuntu:jammy::arch64": "make",
     "centos:7": "make",
     "centos:8": "make"
   },
   "maven": {
     "debian:10": "maven",
-    "ubuntu:focal": "maven",
-    "ubuntu:focal::arch64": "maven"
+    "ubuntu:jammy": "maven",
+    "ubuntu:jammy::arch64": "maven"
   },
   "java": {
     "debian:10": "openjdk-11-jdk",
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"
@@ -272,15 +272,15 @@
   },
   "pinentry-curses": {
     "debian:10": "pinentry-curses",
-    "ubuntu:focal": "pinentry-curses",
-    "ubuntu:focal::arch64": "pinentry-curses",
+    "ubuntu:jammy": "pinentry-curses",
+    "ubuntu:jammy::arch64": "pinentry-curses",
     "centos:7": "pinentry-curses",
     "centos:8": "pinentry-curses"
   },
   "pkg-config": {
     "debian:10": "pkg-config",
-    "ubuntu:focal": "pkg-config",
-    "ubuntu:focal::arch64": "pkg-config",
+    "ubuntu:jammy": "pkg-config",
+    "ubuntu:jammy::arch64": "pkg-config",
     "centos:8": "pkg-config"
   },
   "python": {
@@ -291,14 +291,14 @@
       "python3-setuptools",
       "python3-wheel"
     ],
-    "ubuntu:focal": [
+    "ubuntu:jammy": [
       "python3",
       "python3-pip",
       "python3-pkg-resources",
       "python3-setuptools",
       "python3-wheel"
     ],
-    "ubuntu:focal::arch64": [
+    "ubuntu:jammy::arch64": [
       "python2.7",
       "python3",
       "python3-pip",
@@ -321,15 +321,15 @@
   },
   "rsync": {
     "debian:10": "rsync",
-    "ubuntu:focal": "rsync",
-    "ubuntu:focal::arch64": "rsync",
+    "ubuntu:jammy": "rsync",
+    "ubuntu:jammy::arch64": "rsync",
     "centos:7": "rsync",
     "centos:8": "rsync"
   },
   "shellcheck": {
     "debian:10": "shellcheck",
-    "ubuntu:focal": "shellcheck",
-    "ubuntu:focal::arch64": "shellcheck"
+    "ubuntu:jammy": "shellcheck",
+    "ubuntu:jammy::arch64": "shellcheck"
   },
   "shasum": {
     "centos:7": "perl-Digest-SHA",
@@ -337,26 +337,26 @@
   },
   "software-properties-common": {
     "debian:10": "software-properties-common",
-    "ubuntu:focal": "software-properties-common",
-    "ubuntu:focal::arch64": "software-properties-common"
+    "ubuntu:jammy": "software-properties-common",
+    "ubuntu:jammy::arch64": "software-properties-common"
   },
   "sudo": {
     "debian:10": "sudo",
-    "ubuntu:focal": "sudo",
-    "ubuntu:focal::arch64": "sudo",
+    "ubuntu:jammy": "sudo",
+    "ubuntu:jammy::arch64": "sudo",
     "centos:7": "sudo",
     "centos:8": "sudo"
   },
   "valgrind": {
     "debian:10": "valgrind",
-    "ubuntu:focal": "valgrind",
-    "ubuntu:focal::arch64": "valgrind",
+    "ubuntu:jammy": "valgrind",
+    "ubuntu:jammy::arch64": "valgrind",
     "centos:7": "valgrind",
     "centos:8": "valgrind"
   },
   "yasm": {
     "debian:10": "yasm",
-    "ubuntu:focal": "yasm",
-    "ubuntu:focal::arch64": "yasm"
+    "ubuntu:jammy": "yasm",
+    "ubuntu:jammy::arch64": "yasm"
   }
 }

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -299,7 +299,6 @@
       "python3-wheel"
     ],
     "ubuntu:jammy::arch64": [
-      "python2.7",
       "python3",
       "python3-pip",
       "python3-pkg-resources",

--- a/dev-support/docker/pkg-resolver/platforms.json
+++ b/dev-support/docker/pkg-resolver/platforms.json
@@ -1,6 +1,6 @@
 [
-  "ubuntu:focal",
-  "ubuntu:focal::arch64",
+  "ubuntu:jammy",
+  "ubuntu:jammy::arch64",
   "centos:7",
   "centos:8",
   "debian:10"

--- a/dev-support/jenkins.sh
+++ b/dev-support/jenkins.sh
@@ -18,7 +18,7 @@
 
 # This script is called from the Jenkinsfile, which ultimately runs
 # the CI through Yetus.
-# We use Ubuntu Focal as the main platform for building Hadoop, thus
+# We use Ubuntu Jammy as the main platform for building Hadoop, thus
 # it runs for all the PRs. Additionally, we also ensure that
 # Hadoop builds across the supported platforms whenever there's a change
 # in any of the C/C++ files, C/C++ build files or platform changes.

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -75,7 +75,7 @@ RUN rm -f /var/log/faillog /var/log/lastlog
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
 RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME} -d "${DOCKER_HOME_DIR}"
 RUN echo "${USER_NAME} ALL=NOPASSWD: ALL" > "/etc/sudoers.d/hadoop-build-${USER_ID}"
-ENV HOME "${DOCKER_HOME_DIR}"
+ENV HOME="${DOCKER_HOME_DIR}"
 
 UserSpecificDocker
 


### PR DESCRIPTION
### Description of PR

Upgrade the base image of the Ubuntu Dockerfiles used for CI and local development.

### How was this patch tested?

1. Created and started the build env: `./start-build-env.sh`
2. Built native profile (within the container): `mvn clean install -Pnative -DskipTests` 

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

