### PR TITLE
HADOOP-19502. Add RegexpSingleline module to checkstyle.xml.

### DIFF
--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -73,6 +73,11 @@
         <property name="max" value="100"/>
     </module>
 
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="severity" value="warn"/>
+    </module>
+
     <module name="TreeWalker">
 
         <module name="SuppressWarningsHolder"/>

--- a/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/hadoop-build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -75,7 +75,7 @@
 
     <module name="RegexpSingleline">
         <property name="format" value="\s+$"/>
-        <property name="severity" value="warn"/>
+        <property name="severity" value="warning"/>
     </module>
 
     <module name="TreeWalker">


### PR DESCRIPTION
### Description of PR
Refer to https://github.com/apache/hadoop/pull/7505
This pr fix the bug of the original version.
The property of severity does not have `warn` value, we should use `warning` instead.

### How was this patch tested? 
![image](https://github.com/user-attachments/assets/d573e960-b8a4-4917-a5d3-feb62dc9f117)


