### PR TITLE
[HADOOP-18652][HADOOP-18856] Properly support root bucket paths in Path.suffix 

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
@@ -467,7 +467,7 @@ public class Path
   public Path suffix(String suffix) {
     Path parent = getParent();
     if (parent == null) {
-      return new Path("/", getName() + suffix);
+      return new Path(uri.getScheme(), uri.getAuthority(), "/" + getName() + suffix);
     }
 
     return new Path(parent, getName() + suffix);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestPath.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestPath.java
@@ -539,4 +539,16 @@ public class TestPath {
     Assert.assertNull(root.getParent());
     Assert.assertEquals(new Path("/bar"), root.suffix("bar"));
   }
+
+  @Test(timeout = 30000)
+  public void testSchemeAndAuthorityForSuffixFromRoot() {
+    Path rootBucketPath = new Path("s3://foo");
+    Path rootBucketPathWithSlash = new Path("s3://foo/");
+    Assert.assertNull(rootBucketPath.getParent());
+    Assert.assertNull(rootBucketPathWithSlash.getParent());
+    Assert.assertEquals(new Path("s3://foo/bar"), rootBucketPath.suffix("bar"));
+    Assert.assertEquals(new Path("s3://foo/bar"), rootBucketPath.suffix("/bar"));
+    Assert.assertEquals(new Path("s3://foo/bar"), rootBucketPathWithSlash.suffix("bar"));
+    Assert.assertEquals(new Path("s3://foo/bar"), rootBucketPathWithSlash.suffix("/bar"));
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The existing implementation of `Path.suffix` drops the scheme and authority of the path when it's a root path. For example, `new Path("s3://foo").suffix("/bar")` is expected to return a path for `s3://foo/bar`, but the current implementation returns `/bar`.

Originally, `.suffix` threw an NPE when called on a root path. https://github.com/apache/hadoop/pull/5653 made it so that no NPE was thrown, but unintentionally dropped the scheme and authority of the path.

This PR fixes the implementation such that `.suffix` works with root bucket paths. This will help resolve [HADOOP-18856](https://issues.apache.org/jira/browse/HADOOP-18856) as well.

### How was this patch tested?
Added a new test


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

