### PR TITLE
HADOOP-19514: SecretManager logs at INFO in bin/hadoop calls

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/SecretManager.java
@@ -123,12 +123,12 @@ public abstract class SecretManager<T extends TokenIdentifier> {
     String algorithm = conf.get(
       CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_KEY,
       CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_GENERATOR_ALGORITHM_DEFAULT);
-    LOG.info("Selected hash algorithm: {}", algorithm);
+    LOG.debug("Selected hash algorithm: {}", algorithm);
     SELECTED_ALGORITHM = algorithm;
     int length = conf.getInt(
       CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_KEY,
       CommonConfigurationKeysPublic.HADOOP_SECURITY_SECRET_MANAGER_KEY_LENGTH_DEFAULT);
-    LOG.info("Selected hash key length:{}", length);
+    LOG.debug("Selected hash key length:{}", length);
     SELECTED_LENGTH = length;
   }
 


### PR DESCRIPTION
### Description of PR

Switch to debug level for logging `SecretManager` configured algorithm and key length. I really wanted to do more improvements in this class, like resolving the configuration in a constructor instead of static initialization and potentially reusing a pre-existing `Configuration` instance. I couldn't find a way to do that while maintaining backward-compatibility, and the class is annotated as public.

### How was this patch tested?

On trunk, build the distro:

```
mvn -o -Pdist -Dtar -DskipTests -DskipShade -Dmaven.javadoc.skip=true clean package
```

Reproduce the bug:

```
cnauroth@d9699e10bb20:/tmp/dist/hadoop-3.5.0-SNAPSHOT$ bin/hadoop s3guard -D fs.s3a.delegation.token.binding=org.apache.hadoop.fs.s3a.auth.delegation.FullCredentialsTokenBinding bucket-info s3a://foo
...
2025-03-25 19:57:26,731 INFO token.SecretManager: Selected hash algorithm: HmacSHA1
2025-03-25 19:57:26,732 INFO token.SecretManager: Selected hash key length:64
...
```

Apply this patch, rebuild the distro and retest. The `SecretManager` logs don't appear. You can get them back by explicitly enabling debug logging:

```
cnauroth@d9699e10bb20:/tmp/dist/hadoop-3.5.0-SNAPSHOT$ bin/hadoop --loglevel DEBUG s3guard -D fs.s3a.delegation.token.binding=org.apache.hadoop.fs.s3a.auth.delegation.FullCredentialsTokenBinding bucket-info s3a://foo
...
2025-03-25 21:29:21,476 DEBUG token.SecretManager: Selected hash algorithm: HmacSHA1
2025-03-25 21:29:21,476 DEBUG token.SecretManager: Selected hash key length:64
...
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

