### PR TITLE
YARN-11802. Avoid reflection in TestAsyncDispatcher

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -57,7 +57,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 @Evolving
 public class AsyncDispatcher extends AbstractService implements Dispatcher {
 
-  private static final Logger LOG =
+  protected static final Logger LOG =
       LoggerFactory.getLogger(AsyncDispatcher.class);
   private static final Marker FATAL =
       MarkerFactory.getMarker("FATAL");
@@ -164,13 +164,18 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
             if (printTrigger) {
               //Log the latest dispatch event type
               // may cause the too many events queued
-              LOG.info("Latest dispatch event type: " + event.getType());
+              logTriggered("Latest dispatch event type: " + event.getType());
               printTrigger = false;
             }
           }
         }
       }
     };
+  }
+
+  // This is a separate method to make it overridable for testing
+  protected void logTriggered(String message) {
+    LOG.info(message);
   }
 
   @VisibleForTesting

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/TestAsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/TestAsyncDispatcher.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.yarn.event;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -29,15 +27,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.ReflectionUtils;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.metrics.GenericEventTypeMetrics;
@@ -46,11 +41,9 @@ import static org.apache.hadoop.metrics2.lib.Interns.info;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TestAsyncDispatcher {
@@ -178,19 +171,10 @@ public class TestAsyncDispatcher {
     YarnConfiguration conf = new YarnConfiguration();
     conf.setInt(YarnConfiguration.
         YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD, 5000);
-    Logger log = mock(Logger.class);
-    AsyncDispatcher dispatcher = new AsyncDispatcher();
+    AsyncDispatcherForTest dispatcher = new AsyncDispatcherForTest();
     dispatcher.init(conf);
 
-    Field logger = AsyncDispatcher.class.getDeclaredField("LOG");
-    logger.setAccessible(true);
-    Field modifiers = ReflectionUtils.getModifiersField();
-    modifiers.setAccessible(true);
-    modifiers.setInt(logger, logger.getModifiers() & ~Modifier.FINAL);
-    Object oldLog = logger.get(null);
-
     try {
-      logger.set(null, log);
       dispatcher.register(TestEnum.class, new TestHandler());
       dispatcher.start();
 
@@ -201,11 +185,9 @@ public class TestAsyncDispatcher {
       }
       Thread.sleep(2000);
       //Make sure more than one event to take
-      verify(log, atLeastOnce()).
-          info("Latest dispatch event type: TestEventType");
+      assertEquals(dispatcher.lastTriggered, "Latest dispatch event type: TestEventType");
     } finally {
       //... restore logger object
-      logger.set(null, oldLog);
       dispatcher.stop();
     }
   }
@@ -224,19 +206,10 @@ public class TestAsyncDispatcher {
     YarnConfiguration conf = new YarnConfiguration();
     conf.setInt(YarnConfiguration.
         YARN_DISPATCHER_PRINT_EVENTS_INFO_THRESHOLD, 10);
-    Logger log = mock(Logger.class);
     AsyncDispatcher dispatcher = new AsyncDispatcher();
     dispatcher.init(conf);
 
-    Field logger = AsyncDispatcher.class.getDeclaredField("LOG");
-    logger.setAccessible(true);
-    Field modifiers = ReflectionUtils.getModifiersField();
-    modifiers.setAccessible(true);
-    modifiers.setInt(logger, logger.getModifiers() & ~Modifier.FINAL);
-    Object oldLog = logger.get(null);
-
     try {
-      logger.set(null, log);
       dispatcher.register(TestEnum.class, new TestHandler(0));
       dispatcher.start();
 
@@ -247,8 +220,6 @@ public class TestAsyncDispatcher {
       }
       Thread.sleep(3000);
     } finally {
-      //... restore logger object
-      logger.set(null, oldLog);
       dispatcher.stop();
     }
   }
@@ -419,4 +390,13 @@ public class TestAsyncDispatcher {
     }
 
   }
+
+  private class AsyncDispatcherForTest extends AsyncDispatcher {
+    public String lastTriggered = "";
+    @Override
+    protected void logTriggered(String message) {
+      LOG.info(message);
+      lastTriggered = message;
+    }
+  };
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/TestAsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/TestAsyncDispatcher.java
@@ -185,7 +185,7 @@ public class TestAsyncDispatcher {
       }
       Thread.sleep(2000);
       //Make sure more than one event to take
-      assertEquals(dispatcher.lastTriggered, "Latest dispatch event type: TestEventType");
+      assertEquals(dispatcher.getLastTriggered(), "Latest dispatch event type: TestEventType");
     } finally {
       //... restore logger object
       dispatcher.stop();
@@ -392,11 +392,16 @@ public class TestAsyncDispatcher {
   }
 
   private class AsyncDispatcherForTest extends AsyncDispatcher {
-    public String lastTriggered = "";
+    private String lastTriggered = "";
+
     @Override
     protected void logTriggered(String message) {
       LOG.info(message);
       lastTriggered = message;
+    }
+
+    public String getLastTriggered() {
+      return lastTriggered;
     }
   };
 }


### PR DESCRIPTION
### Description of PR

YARN-11802. Avoid reflection in TestAsyncDispatcher.

Minor refactor of AsyncDispatcher to make it subclassable for testing, so
that we can void reflection in TestAsyncDispatcher, which does work with recent Java versions.

### How was this patch tested?

Ran TestAsyncDispatcher, CI.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

