### PR TITLE
YARN-11803. Skip SecurityManager tests in TestJavaSandboxLinuxContainerRuntime when SecurityManager is not available

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
@@ -73,11 +73,11 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.RUN_AS_USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER_LOCAL_DIRS;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/TestJavaSandboxLinuxContainerRuntime.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.net.SocketPermission;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,10 +73,12 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.RUN_AS_USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER;
 import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.runtime.LinuxContainerRuntimeConstants.USER_LOCAL_DIRS;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -266,18 +269,30 @@ public class TestJavaSandboxLinuxContainerRuntime {
 
   @Test
   public void testGrant() throws Exception {
-    FilePermission grantPermission =
-        new FilePermission(grantFile.getAbsolutePath(), "read");
-    securityManager.checkPermission(grantPermission);
+    try {
+      FilePermission grantPermission =
+          new FilePermission(grantFile.getAbsolutePath(), "read");
+      securityManager.checkPermission(grantPermission);
+      //Expected
+    } catch (AccessControlException e) {
+      assertTrue(false, "Permission should have been granted");
+    } catch (SecurityException e) {
+      assumeTrue(false, "SecurityManager is non-functional (i.e. Java 24+)");
+    }
   }
 
   @Test
   public void testDeny() throws Exception {
-    assertThrows(java.security.AccessControlException.class, () -> {
+    try {
       FilePermission denyPermission =
           new FilePermission(denyFile.getAbsolutePath(), "read");
       securityManager.checkPermission(denyPermission);
-    });
+      fail("Should have thrown AccessControlException");
+    } catch (AccessControlException e) {
+      //Expected
+    } catch (SecurityException e) {
+      assumeTrue(false, "SecurityManager is non-functional (i.e. Java 24+)");
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11803. Skip SecurityManager tests in TestJavaSandboxLinuxContainerRuntime when SecurityManager is not available.

Java 24 unconditionally throws SecurityException for securityManager.checkPermission().
Skip the test when SecurityException is thrown.
(For actual failed permissions checks AccessControlException is thrown)

### How was this patch tested?

Ran test withJava 24 and 17

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

