### PR TITLE
YARN-11804. Set surefire argLine in hadoop-yarn-server-timelineservice-hbase-tests

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -550,6 +550,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>0</forkCount>
+          <trimStackTrace>false</trimStackTrace>
+          <argLine>${maven-surefire-plugin.argLine}</argLine>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
### Description of PR

Add missing surefire argLine argument needed for JDK24

### How was this patch tested?

Ran test on JDK24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

