### PR TITLE
YARN-11267. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-router.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -200,6 +200,10 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jettison</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/dao/WeightedPolicyInfo.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -52,8 +53,11 @@ public class WeightedPolicyInfo {
   private static final Logger LOG =
       LoggerFactory.getLogger(WeightedPolicyInfo.class);
   private static ObjectMapper mapper = new ObjectMapper();
+  @JsonProperty("routerPolicyWeights")
   private Map<SubClusterIdInfo, Float> routerPolicyWeights = new HashMap<>();
+  @JsonProperty("amrmPolicyWeights")
   private Map<SubClusterIdInfo, Float> amrmPolicyWeights = new HashMap<>();
+  @JsonProperty("headroomAlpha")
   private float headroomAlpha;
 
   public WeightedPolicyInfo() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterIdInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/records/SubClusterIdInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.store.records;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -55,6 +56,7 @@ public class SubClusterIdInfo {
    * Get the sub-cluster identifier as {@link SubClusterId}.
    * @return the sub-cluster id.
    */
+  @JsonProperty("id")
   public SubClusterId toId() {
     return SubClusterId.newInstance(id);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/DefaultRMAdminRequestInterceptor.java
@@ -23,7 +23,6 @@ import java.security.PrivilegedExceptionAction;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.StandbyException;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.client.ClientRMProxy;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
@@ -86,7 +85,6 @@ public class DefaultRMAdminRequestInterceptor
   private static final Logger LOG =
       LoggerFactory.getLogger(DefaultRMAdminRequestInterceptor.class);
   private ResourceManagerAdministrationProtocol rmAdminProxy;
-  private UserGroupInformation user = null;
 
   @Override
   public void init(String userName) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouter.java
@@ -17,9 +17,11 @@
  */
 package org.apache.hadoop.yarn.server.router;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -34,9 +36,7 @@ import org.apache.hadoop.yarn.webapp.WebApp;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -107,7 +107,7 @@ public class TestRouter {
     for (Class<?> protocolClass : manager.getProtocolsWithAcls()) {
       AccessControlList accessList = manager.getProtocolsAcls(protocolClass);
       if (protocolClass == protocol) {
-        Assert.assertEquals(accessList.getAclString(), aclString);
+        assertEquals(accessList.getAclString(), aclString);
       }
     }
   }
@@ -149,42 +149,42 @@ public class TestRouter {
     CrossOriginFilter filter = (CrossOriginFilter) holder.getFilter();
 
     // 1. Simulate [example.com] for access
-    HttpServletRequest mockReq = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(mockReq.getHeader("Origin")).thenReturn("example.com");
-    Mockito.when(mockReq.getHeader("Access-Control-Request-Method")).thenReturn("GET");
-    Mockito.when(mockReq.getHeader("Access-Control-Request-Headers"))
+    HttpServletRequest mockReq = mock(HttpServletRequest.class);
+    when(mockReq.getHeader("Origin")).thenReturn("example.com");
+    when(mockReq.getHeader("Access-Control-Request-Method")).thenReturn("GET");
+    when(mockReq.getHeader("Access-Control-Request-Headers"))
         .thenReturn("X-Requested-With");
 
     // Objects to verify interactions based on request
     HttpServletResponseForRouterTest mockRes = new HttpServletResponseForRouterTest();
-    FilterChain mockChain = Mockito.mock(FilterChain.class);
+    FilterChain mockChain = mock(FilterChain.class);
 
     // Object under test
     filter.doFilter(mockReq, mockRes, mockChain);
 
     // Why is 5, because when Filter passes,
     // CrossOriginFilter will set 5 values to Map
-    Assert.assertEquals(5, mockRes.getHeaders().size());
+    assertEquals(5, mockRes.getHeaders().size());
     String allowResult = mockRes.getHeader("Access-Control-Allow-Credentials");
-    Assert.assertEquals("true", allowResult);
+    assertEquals("true", allowResult);
 
     // 2. Simulate [example.org] for access
-    HttpServletRequest mockReq2 = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(mockReq2.getHeader("Origin")).thenReturn("example.org");
-    Mockito.when(mockReq2.getHeader("Access-Control-Request-Method")).thenReturn("GET");
-    Mockito.when(mockReq2.getHeader("Access-Control-Request-Headers"))
+    HttpServletRequest mockReq2 = mock(HttpServletRequest.class);
+    when(mockReq2.getHeader("Origin")).thenReturn("example.org");
+    when(mockReq2.getHeader("Access-Control-Request-Method")).thenReturn("GET");
+    when(mockReq2.getHeader("Access-Control-Request-Headers"))
         .thenReturn("X-Requested-With");
 
     // Objects to verify interactions based on request
     HttpServletResponseForRouterTest mockRes2 = new HttpServletResponseForRouterTest();
-    FilterChain mockChain2 = Mockito.mock(FilterChain.class);
+    FilterChain mockChain2 = mock(FilterChain.class);
 
     // Object under test
     filter.doFilter(mockReq2, mockRes2, mockChain2);
 
     // Why is 0, because when the Filter fails,
     // CrossOriginFilter will not set any value
-    Assert.assertEquals(0, mockRes2.getHeaders().size());
+    assertEquals(0, mockRes2.getHeaders().size());
 
     router.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterAuditLogger.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.yarn.server.router;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,9 +38,8 @@ import org.apache.hadoop.thirdparty.protobuf.RpcController;
 import org.apache.hadoop.thirdparty.protobuf.ServiceException;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -56,7 +56,8 @@ public class TestRouterAuditLogger {
   private static final ApplicationId APPID = mock(ApplicationId.class);
   private static final SubClusterId SUBCLUSTERID = mock(SubClusterId.class);
 
-  @Before public void setUp() throws Exception {
+  @BeforeEach
+  public void setUp() throws Exception {
     when(APPID.toString()).thenReturn("app_1");
     when(SUBCLUSTERID.toString()).thenReturn("sc0");
   }
@@ -202,8 +203,8 @@ public class TestRouterAuditLogger {
             throws ServiceException {
       // Ensure clientId is received
       byte[] clientId = Server.getClientId();
-      Assert.assertNotNull(clientId);
-      Assert.assertEquals(ClientId.BYTE_LENGTH, clientId.length);
+      assertNotNull(clientId);
+      assertEquals(ClientId.BYTE_LENGTH, clientId.length);
       // test with ip set
       testSuccessLogFormat(true);
       testFailureLogFormat(true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterMetrics.java
@@ -17,9 +17,10 @@
  */
 package org.apache.hadoop.yarn.server.router;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,23 +41,22 @@ public class TestRouterMetrics {
 
   private static final Double ASSERT_DOUBLE_DELTA = 0.01;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
 
     LOG.info("Test: aggregate metrics are initialized correctly");
 
-    Assert.assertEquals(0, metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(0, metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(0,
-        metrics.getNumSucceededAppAttemptsRetrieved());
+    assertEquals(0, metrics.getNumSucceededAppsCreated());
+    assertEquals(0, metrics.getNumSucceededAppsSubmitted());
+    assertEquals(0, metrics.getNumSucceededAppsKilled());
+    assertEquals(0, metrics.getNumSucceededAppsRetrieved());
+    assertEquals(0, metrics.getNumSucceededAppAttemptsRetrieved());
 
-    Assert.assertEquals(0, metrics.getAppsFailedCreated());
-    Assert.assertEquals(0, metrics.getAppsFailedSubmitted());
-    Assert.assertEquals(0, metrics.getAppsFailedKilled());
-    Assert.assertEquals(0, metrics.getAppsFailedRetrieved());
-    Assert.assertEquals(0,
+    assertEquals(0, metrics.getAppsFailedCreated());
+    assertEquals(0, metrics.getAppsFailedSubmitted());
+    assertEquals(0, metrics.getAppsFailedKilled());
+    assertEquals(0, metrics.getAppsFailedRetrieved());
+    assertEquals(0,
         metrics.getAppAttemptsFailedRetrieved());
 
     LOG.info("Test: aggregate metrics are updated correctly");
@@ -73,15 +73,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getNewApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsCreated(), 0);
 
     goodSubCluster.getNewApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsCreated());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsCreated(), 0);
   }
 
   /**
@@ -94,7 +94,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getNewApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedCreated());
   }
 
   /**
@@ -108,15 +108,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.submitApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsSubmitted(), 0);
 
     goodSubCluster.submitApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsSubmitted());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsSubmitted(), 0);
   }
 
   /**
@@ -129,7 +129,7 @@ public class TestRouterMetrics {
 
     badSubCluster.submitApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedSubmitted());
   }
 
   /**
@@ -143,15 +143,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.forceKillApplication(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
+    assertEquals(100, metrics.getLatencySucceededAppsKilled(), 0);
 
     goodSubCluster.forceKillApplication(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsKilled());
-    Assert.assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
+    assertEquals(150, metrics.getLatencySucceededAppsKilled(), 0);
   }
 
   /**
@@ -164,7 +164,7 @@ public class TestRouterMetrics {
 
     badSubCluster.forceKillApplication();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedKilled());
   }
 
   /**
@@ -178,15 +178,15 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
+    assertEquals(100, metrics.getLatencySucceededGetAppReport(), 0);
 
     goodSubCluster.getApplicationReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
+    assertEquals(150, metrics.getLatencySucceededGetAppReport(), 0);
   }
 
   /**
@@ -199,7 +199,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationReport();
 
-    Assert.assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
+    assertEquals(totalBadbefore + 1, metrics.getAppsFailedRetrieved());
   }
 
   /**
@@ -214,16 +214,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationAttemptReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assert.assertEquals(100,
+    assertEquals(100,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
 
     goodSubCluster.getApplicationAttemptReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptReportRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppAttemptReport(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -238,7 +238,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationAttemptReport();
 
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppAttemptReportFailedRetrieved());
   }
 
@@ -253,16 +253,16 @@ public class TestRouterMetrics {
 
     goodSubCluster.getApplicationsReport(100);
 
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
+    assertEquals(100, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
 
     goodSubCluster.getApplicationsReport(200);
 
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMultipleAppsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
+    assertEquals(150, metrics.getLatencySucceededMultipleGetAppReport(),
         0);
   }
 
@@ -277,7 +277,7 @@ public class TestRouterMetrics {
 
     badSubCluster.getApplicationsReport();
 
-    Assert.assertEquals(totalBadbefore + 1,
+    assertEquals(totalBadbefore + 1,
         metrics.getMultipleAppsFailedRetrieved());
   }
 
@@ -289,14 +289,14 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterMetrics() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterMetricsRetrieved();
     goodSubCluster.getClusterMetrics(100);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assert.assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    assertEquals(100, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
     goodSubCluster.getClusterMetrics(200);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterMetricsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
+    assertEquals(150, metrics.getLatencySucceededGetClusterMetricsRetrieved(),
         0);
   }
 
@@ -308,7 +308,7 @@ public class TestRouterMetrics {
   public void testGetClusterMetricsFailed() {
     long totalBadbefore = metrics.getClusterMetricsFailedRetrieved();
     badSubCluster.getClusterMetrics();
-    Assert.assertEquals(totalBadbefore + 1,
+    assertEquals(totalBadbefore + 1,
         metrics.getClusterMetricsFailedRetrieved());
   }
 
@@ -1011,12 +1011,12 @@ public class TestRouterMetrics {
   public void testSucceededGetClusterNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodesRetrieved();
     goodSubCluster.getClusterNodes(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetClusterNodesRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodes(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetClusterNodesRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetClusterNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1024,19 +1024,19 @@ public class TestRouterMetrics {
   public void testGetClusterNodesFailed() {
     long totalBadBefore = metrics.getClusterNodesFailedRetrieved();
     badSubCluster.getClusterNodes();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetNodeToLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetNodeToLabelsRetrieved();
     goodSubCluster.getNodeToLabels(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodeToLabels(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetNodeToLabelsRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetNodeToLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1044,19 +1044,19 @@ public class TestRouterMetrics {
   public void testGetNodeToLabelsFailed() {
     long totalBadBefore = metrics.getNodeToLabelsFailedRetrieved();
     badSubCluster.getNodeToLabels();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getNodeToLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededLabelsToNodes() {
     long totalGoodBefore = metrics.getNumSucceededGetLabelsToNodesRetrieved();
     goodSubCluster.getLabelToNodes(150);
-    Assert.assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assert.assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    assertEquals(totalGoodBefore + 1, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    assertEquals(150, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getLabelToNodes(300);
-    Assert.assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
+    assertEquals(totalGoodBefore + 2, metrics.getNumSucceededGetLabelsToNodesRetrieved());
+    assertEquals(225, metrics.getLatencySucceededGetLabelsToNodesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1064,21 +1064,21 @@ public class TestRouterMetrics {
   public void testGetLabelsToNodesFailed() {
     long totalBadBefore = metrics.getLabelsToNodesFailedRetrieved();
     badSubCluster.getLabelToNodes();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getLabelsToNodesFailedRetrieved());
   }
 
   @Test
   public void testSucceededClusterNodeLabels() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeLabelsRetrieved();
     goodSubCluster.getClusterNodeLabels(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeLabels(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeLabelsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetClusterNodeLabelsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1086,21 +1086,21 @@ public class TestRouterMetrics {
   public void testClusterNodeLabelsFailed() {
     long totalBadBefore = metrics.getGetClusterNodeLabelsFailedRetrieved();
     badSubCluster.getClusterNodeLabels();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGetClusterNodeLabelsFailedRetrieved());
   }
 
   @Test
   public void testSucceededQueueUserAcls() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueUserAclsRetrieved();
     goodSubCluster.getQueueUserAcls(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetQueueUserAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueUserAcls(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueUserAclsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetQueueUserAclsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1108,20 +1108,20 @@ public class TestRouterMetrics {
   public void testQueueUserAclsFailed() {
     long totalBadBefore = metrics.getQueueUserAclsFailedRetrieved();
     badSubCluster.getQueueUserAcls();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getQueueUserAclsFailedRetrieved());
   }
   @Test
   public void testSucceededListReservations() {
     long totalGoodBefore = metrics.getNumSucceededListReservationsRetrieved();
     goodSubCluster.getListReservations(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListReservationsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservations(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededListReservationsRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1129,21 +1129,21 @@ public class TestRouterMetrics {
   public void testListReservationsFailed() {
     long totalBadBefore = metrics.getListReservationsFailedRetrieved();
     badSubCluster.getListReservations();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getListReservationsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetApplicationAttempts() {
     long totalGoodBefore = metrics.getNumSucceededAppAttemptsRetrieved();
     goodSubCluster.getApplicationAttempts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getApplicationAttempts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAppAttemptsRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededAppAttemptRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1151,21 +1151,21 @@ public class TestRouterMetrics {
   public void testGetApplicationAttemptsFailed() {
     long totalBadBefore = metrics.getAppAttemptsFailedRetrieved();
     badSubCluster.getApplicationAttempts();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getAppAttemptsFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainerReport() {
     long totalGoodBefore = metrics.getNumSucceededGetContainerReportRetrieved();
     goodSubCluster.getContainerReport(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetContainerReportRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainerReport(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainerReportRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetContainerReportRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1173,21 +1173,21 @@ public class TestRouterMetrics {
   public void testGetContainerReportFailed() {
     long totalBadBefore = metrics.getContainerReportFailedRetrieved();
     badSubCluster.getContainerReport();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getContainerReportFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetContainers() {
     long totalGoodBefore = metrics.getNumSucceededGetContainersRetrieved();
     goodSubCluster.getContainers(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetContainersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getContainers(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetContainersRetrieved());
-    Assert.assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
+    assertEquals(225, metrics.getLatencySucceededGetContainersRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
 
@@ -1195,21 +1195,21 @@ public class TestRouterMetrics {
   public void testGetContainersFailed() {
     long totalBadBefore = metrics.getContainersFailedRetrieved();
     badSubCluster.getContainers();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getContainersFailedRetrieved());
   }
 
   @Test
   public void testSucceededGetResourceTypeInfo() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceTypeInfoRetrieved();
     goodSubCluster.getResourceTypeInfo(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceTypeInfo(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceTypeInfoRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceTypeInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1217,21 +1217,21 @@ public class TestRouterMetrics {
   public void testGetResourceTypeInfoFailed() {
     long totalBadBefore = metrics.getGetResourceTypeInfoRetrieved();
     badSubCluster.getResourceTypeInfo();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGetResourceTypeInfoRetrieved());
   }
 
   @Test
   public void testSucceededFailApplicationAttempt() {
     long totalGoodBefore = metrics.getNumSucceededFailAppAttemptRetrieved();
     goodSubCluster.getFailApplicationAttempt(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFailApplicationAttempt(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededFailAppAttemptRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededFailAppAttemptRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1239,21 +1239,21 @@ public class TestRouterMetrics {
   public void testFailApplicationAttemptFailed() {
     long totalBadBefore = metrics.getFailApplicationAttemptFailedRetrieved();
     badSubCluster.getFailApplicationAttempt();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getFailApplicationAttemptFailedRetrieved());
   }
 
   @Test
   public void testSucceededUpdateApplicationPriority() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppPriorityRetrieved();
     goodSubCluster.getUpdateApplicationPriority(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationPriority(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppPriorityRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1261,7 +1261,7 @@ public class TestRouterMetrics {
   public void testUpdateApplicationPriorityFailed() {
     long totalBadBefore = metrics.getUpdateApplicationPriorityFailedRetrieved();
     badSubCluster.getUpdateApplicationPriority();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationPriorityFailedRetrieved());
   }
 
@@ -1269,14 +1269,14 @@ public class TestRouterMetrics {
   public void testSucceededUpdateAppTimeoutsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppTimeoutsRetrieved();
     goodSubCluster.getUpdateApplicationTimeouts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateApplicationTimeouts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppTimeoutsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1284,7 +1284,7 @@ public class TestRouterMetrics {
   public void testUpdateAppTimeoutsFailed() {
     long totalBadBefore = metrics.getUpdateApplicationTimeoutsFailedRetrieved();
     badSubCluster.getUpdateApplicationTimeouts();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateApplicationTimeoutsFailedRetrieved());
   }
 
@@ -1292,14 +1292,14 @@ public class TestRouterMetrics {
   public void testSucceededSignalToContainerRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSignalToContainerRetrieved();
     goodSubCluster.getSignalToContainerTimeouts(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSignalToContainerTimeouts(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSignalToContainerRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSignalToContainerRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1307,7 +1307,7 @@ public class TestRouterMetrics {
   public void testSignalToContainerFailed() {
     long totalBadBefore = metrics.getSignalToContainerFailedRetrieved();
     badSubCluster.getSignalContainer();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSignalToContainerFailedRetrieved());
   }
 
@@ -1315,14 +1315,14 @@ public class TestRouterMetrics {
   public void testSucceededGetQueueInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetQueueInfoRetrieved();
     goodSubCluster.getQueueInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getQueueInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetQueueInfoRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetQueueInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1330,7 +1330,7 @@ public class TestRouterMetrics {
   public void testGetQueueInfoFailed() {
     long totalBadBefore = metrics.getQueueInfoFailedRetrieved();
     badSubCluster.getQueueInfo();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getQueueInfoFailedRetrieved());
   }
 
@@ -1338,14 +1338,14 @@ public class TestRouterMetrics {
   public void testSucceededMoveApplicationAcrossQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved();
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.moveApplicationAcrossQueuesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMoveApplicationAcrossQueuesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededMoveApplicationAcrossQueuesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1353,7 +1353,7 @@ public class TestRouterMetrics {
   public void testMoveApplicationAcrossQueuesRetrievedFailed() {
     long totalBadBefore = metrics.getMoveApplicationAcrossQueuesFailedRetrieved();
     badSubCluster.moveApplicationAcrossQueuesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getMoveApplicationAcrossQueuesFailedRetrieved());
   }
 
@@ -1361,14 +1361,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfilesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfilesRetrieved();
     goodSubCluster.getResourceProfilesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfilesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfilesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceProfilesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1376,7 +1376,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfilesRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfilesFailedRetrieved();
     badSubCluster.getResourceProfilesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getResourceProfilesFailedRetrieved());
   }
 
@@ -1384,14 +1384,14 @@ public class TestRouterMetrics {
   public void testSucceededGetResourceProfileRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetResourceProfileRetrieved();
     goodSubCluster.getResourceProfileRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getResourceProfileRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetResourceProfileRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetResourceProfileRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1399,7 +1399,7 @@ public class TestRouterMetrics {
   public void testGetResourceProfileRetrievedFailed() {
     long totalBadBefore = metrics.getResourceProfileFailedRetrieved();
     badSubCluster.getResourceProfileFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getResourceProfileFailedRetrieved());
   }
 
@@ -1407,14 +1407,14 @@ public class TestRouterMetrics {
   public void testSucceededGetAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAttributesToNodesRetrieved();
     goodSubCluster.getAttributesToNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAttributesToNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAttributesToNodesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1422,7 +1422,7 @@ public class TestRouterMetrics {
   public void testGetAttributesToNodesRetrievedFailed() {
     long totalBadBefore = metrics.getAttributesToNodesFailedRetrieved();
     badSubCluster.getAttributesToNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAttributesToNodesFailedRetrieved());
   }
 
@@ -1430,14 +1430,14 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterNodeAttributesRetrieved();
     goodSubCluster.getClusterNodeAttributesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterNodeAttributesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterNodeAttributesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterNodeAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1445,7 +1445,7 @@ public class TestRouterMetrics {
   public void testGetClusterNodeAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getClusterNodeAttributesFailedRetrieved();
     badSubCluster.getClusterNodeAttributesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getClusterNodeAttributesFailedRetrieved());
   }
 
@@ -1453,14 +1453,14 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNodesToAttributesRetrieved();
     goodSubCluster.getNodesToAttributesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNodesToAttributesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNodesToAttributesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetNodesToAttributesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1468,7 +1468,7 @@ public class TestRouterMetrics {
   public void testGetNodesToAttributesRetrievedFailed() {
     long totalBadBefore = metrics.getNodesToAttributesFailedRetrieved();
     badSubCluster.getNodesToAttributesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNodesToAttributesFailedRetrieved());
   }
 
@@ -1476,14 +1476,14 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetNewReservationRetrieved();
     goodSubCluster.getNewReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNewReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetNewReservationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetNewReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1491,7 +1491,7 @@ public class TestRouterMetrics {
   public void testGetNewReservationRetrievedFailed() {
     long totalBadBefore = metrics.getNewReservationFailedRetrieved();
     badSubCluster.getNewReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNewReservationFailedRetrieved());
   }
 
@@ -1499,14 +1499,14 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSubmitReservationRetrieved();
     goodSubCluster.getSubmitReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSubmitReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSubmitReservationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSubmitReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1514,7 +1514,7 @@ public class TestRouterMetrics {
   public void testGetSubmitReservationRetrievedFailed() {
     long totalBadBefore = metrics.getSubmitReservationFailedRetrieved();
     badSubCluster.getSubmitReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSubmitReservationFailedRetrieved());
   }
 
@@ -1522,14 +1522,14 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateReservationRetrieved();
     goodSubCluster.getUpdateReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateReservationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1537,7 +1537,7 @@ public class TestRouterMetrics {
   public void testGetUpdateReservationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateReservationFailedRetrieved();
     badSubCluster.getUpdateReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateReservationFailedRetrieved());
   }
 
@@ -1545,14 +1545,14 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteReservationRetrieved();
     goodSubCluster.getDeleteReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeleteReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteReservationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeleteReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1560,7 +1560,7 @@ public class TestRouterMetrics {
   public void testGetDeleteReservationRetrievedFailed() {
     long totalBadBefore = metrics.getDeleteReservationFailedRetrieved();
     badSubCluster.getDeleteReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeleteReservationFailedRetrieved());
   }
 
@@ -1568,14 +1568,14 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListReservationRetrieved();
     goodSubCluster.getListReservationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListReservationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListReservationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListReservationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededListReservationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1583,7 +1583,7 @@ public class TestRouterMetrics {
   public void testGetListReservationRetrievedFailed() {
     long totalBadBefore = metrics.getListReservationFailedRetrieved();
     badSubCluster.getListReservationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getListReservationFailedRetrieved());
   }
 
@@ -1591,14 +1591,14 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppActivitiesRetrieved();
     goodSubCluster.getAppActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppActivitiesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1606,7 +1606,7 @@ public class TestRouterMetrics {
   public void testGetAppActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getAppActivitiesFailedRetrieved();
     badSubCluster.getAppActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppActivitiesFailedRetrieved());
   }
 
@@ -1614,14 +1614,14 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppStatisticsRetrieved();
     goodSubCluster.getAppStatisticsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppStatisticsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppStatisticsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppStatisticsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1629,7 +1629,7 @@ public class TestRouterMetrics {
   public void testGetAppStatisticsRetrievedFailed() {
     long totalBadBefore = metrics.getAppStatisticsFailedRetrieved();
     badSubCluster.getAppStatisticsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppStatisticsFailedRetrieved());
   }
 
@@ -1637,14 +1637,14 @@ public class TestRouterMetrics {
   public void testGetAppPriorityLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppPriorityRetrieved();
     goodSubCluster.getAppPriorityRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppPriorityRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppPriorityRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1652,7 +1652,7 @@ public class TestRouterMetrics {
   public void testGetAppPriorityRetrievedFailed() {
     long totalBadBefore = metrics.getAppPriorityFailedRetrieved();
     badSubCluster.getAppPriorityFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppPriorityFailedRetrieved());
   }
 
@@ -1660,14 +1660,14 @@ public class TestRouterMetrics {
   public void testGetAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppQueueRetrieved();
     goodSubCluster.getAppQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppQueueRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1675,7 +1675,7 @@ public class TestRouterMetrics {
   public void testGetAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getAppQueueFailedRetrieved();
     badSubCluster.getAppQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppQueueFailedRetrieved());
   }
 
@@ -1683,14 +1683,14 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateAppQueueRetrieved();
     goodSubCluster.getUpdateQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateAppQueueRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateAppQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1698,7 +1698,7 @@ public class TestRouterMetrics {
   public void testUpdateAppQueueRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateAppQueueFailedRetrieved();
     badSubCluster.getUpdateQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateAppQueueFailedRetrieved());
   }
 
@@ -1706,14 +1706,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutRetrieved();
     goodSubCluster.getAppTimeoutRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1721,7 +1721,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutFailedRetrieved();
     badSubCluster.getAppTimeoutFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutFailedRetrieved());
   }
 
@@ -1729,14 +1729,14 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsLatencyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetAppTimeoutsRetrieved();
     goodSubCluster.getAppTimeoutsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getAppTimeoutsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetAppTimeoutsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetAppTimeoutsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1744,7 +1744,7 @@ public class TestRouterMetrics {
   public void testGetAppTimeoutsRetrievedFailed() {
     long totalBadBefore = metrics.getAppTimeoutsFailedRetrieved();
     badSubCluster.getAppTimeoutsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getAppTimeoutsFailedRetrieved());
   }
 
@@ -1752,14 +1752,14 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetRMNodeLabelsRetrieved();
     goodSubCluster.getRMNodeLabelsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRMNodeLabelsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetRMNodeLabelsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetRMNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1767,7 +1767,7 @@ public class TestRouterMetrics {
   public void testGetRMNodeLabelsRetrievedFailed() {
     long totalBadBefore = metrics.getRMNodeLabelsFailedRetrieved();
     badSubCluster.getRMNodeLabelsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getRMNodeLabelsFailedRetrieved());
   }
 
@@ -1775,14 +1775,14 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckUserAccessToQueueRetrieved();
     goodSubCluster.getCheckUserAccessToQueueRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckUserAccessToQueueRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckUserAccessToQueueRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededCheckUserAccessToQueueRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1790,7 +1790,7 @@ public class TestRouterMetrics {
   public void testCheckUserAccessToQueueRetrievedFailed() {
     long totalBadBefore = metrics.getCheckUserAccessToQueueFailedRetrieved();
     badSubCluster.getCheckUserAccessToQueueFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getCheckUserAccessToQueueFailedRetrieved());
   }
 
@@ -1798,14 +1798,14 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetDelegationTokenRetrieved();
     goodSubCluster.getGetDelegationTokenRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGetDelegationTokenRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetDelegationTokenRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1813,7 +1813,7 @@ public class TestRouterMetrics {
   public void testGetDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getDelegationTokenFailedRetrieved();
     badSubCluster.getDelegationTokenFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDelegationTokenFailedRetrieved());
   }
 
@@ -1821,14 +1821,14 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRenewDelegationTokenRetrieved();
     goodSubCluster.getRenewDelegationTokenRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRenewDelegationTokenRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRenewDelegationTokenRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRenewDelegationTokenRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1836,7 +1836,7 @@ public class TestRouterMetrics {
   public void testRenewDelegationTokenRetrievedFailed() {
     long totalBadBefore = metrics.getRenewDelegationTokenFailedRetrieved();
     badSubCluster.getRenewDelegationTokenFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getRenewDelegationTokenFailedRetrieved());
   }
 
@@ -1844,14 +1844,14 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshAdminAclsRetrieved();
     goodSubCluster.getRefreshAdminAclsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshAdminAclsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshAdminAclsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshAdminAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1859,7 +1859,7 @@ public class TestRouterMetrics {
   public void testRefreshAdminAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshAdminAclsFailedRetrieved();
     badSubCluster.getRefreshAdminAclsFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshAdminAclsFailedRetrieved());
   }
 
@@ -1867,14 +1867,14 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshServiceAclsRetrieved();
     goodSubCluster.getRefreshServiceAclsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshServiceAclsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshServiceAclsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshServiceAclsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1882,7 +1882,7 @@ public class TestRouterMetrics {
   public void testRefreshServiceAclsRetrievedFailed() {
     long totalBadBefore = metrics.getNumRefreshServiceAclsFailedRetrieved();
     badSubCluster.getRefreshServiceAclsFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumRefreshServiceAclsFailedRetrieved());
   }
 
@@ -1890,14 +1890,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodesRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1905,7 +1905,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodesRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodesFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodesFailedRetrieved());
   }
 
@@ -1913,14 +1913,14 @@ public class TestRouterMetrics {
   public void testReplaceLabelsOnNodeRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededReplaceLabelsOnNodeRetrieved();
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getNumSucceededReplaceLabelsOnNodeRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededReplaceLabelsOnNodeRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededReplaceLabelsOnNodeRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1928,7 +1928,7 @@ public class TestRouterMetrics {
   public void testReplaceLabelOnNodeRetrievedFailed() {
     long totalBadBefore = metrics.getNumReplaceLabelsOnNodeFailedRetrieved();
     badSubCluster.getReplaceLabelsOnNodeFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getNumReplaceLabelsOnNodeFailedRetrieved());
   }
 
@@ -1936,14 +1936,14 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDumpSchedulerLogsRetrieved();
     goodSubCluster.getDumpSchedulerLogsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDumpSchedulerLogsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDumpSchedulerLogsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDumpSchedulerLogsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1951,7 +1951,7 @@ public class TestRouterMetrics {
   public void testDumpSchedulerLogsRetrievedFailed() {
     long totalBadBefore = metrics.getDumpSchedulerLogsFailedRetrieved();
     badSubCluster.getDumpSchedulerLogsFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDumpSchedulerLogsFailedRetrieved());
   }
 
@@ -1959,14 +1959,14 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetActivitiesRetrieved();
     goodSubCluster.getActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetActivitiesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1974,7 +1974,7 @@ public class TestRouterMetrics {
   public void testGetActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getActivitiesFailedRetrieved();
     badSubCluster.getActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getActivitiesFailedRetrieved());
   }
 
@@ -1982,14 +1982,14 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetBulkActivitiesRetrieved();
     goodSubCluster.getBulkActivitiesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBulkActivitiesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetBulkActivitiesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetBulkActivitiesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -1997,7 +1997,7 @@ public class TestRouterMetrics {
   public void testGetBulkActivitiesRetrievedFailed() {
     long totalBadBefore = metrics.getBulkActivitiesFailedRetrieved();
     badSubCluster.getBulkActivitiesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getBulkActivitiesFailedRetrieved());
   }
 
@@ -2005,14 +2005,14 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeregisterSubClusterRetrieved();
     goodSubCluster.getDeregisterSubClusterRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getDeregisterSubClusterRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeregisterSubClusterRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeregisterSubClusterRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2020,7 +2020,7 @@ public class TestRouterMetrics {
   public void testDeregisterSubClusterRetrievedFailed() {
     long totalBadBefore = metrics.getDeregisterSubClusterFailedRetrieved();
     badSubCluster.getDeregisterSubClusterFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeregisterSubClusterFailedRetrieved());
   }
 
@@ -2028,14 +2028,14 @@ public class TestRouterMetrics {
   public void testAddToClusterNodeLabelsRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededAddToClusterNodeLabelsRetrieved();
     goodSubCluster.addToClusterNodeLabelsRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.addToClusterNodeLabelsRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededAddToClusterNodeLabelsRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededAddToClusterNodeLabelsRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2043,7 +2043,7 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getSchedulerConfigurationFailedRetrieved();
     badSubCluster.getSchedulerConfigurationFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2051,14 +2051,14 @@ public class TestRouterMetrics {
   public void testGetSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetSchedulerConfigurationRetrieved();
     goodSubCluster.getSchedulerConfigurationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSchedulerConfigurationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetSchedulerConfigurationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2066,7 +2066,7 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateSchedulerConfigurationFailedRetrieved();
     badSubCluster.updateSchedulerConfigurationFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getUpdateSchedulerConfigurationFailedRetrieved());
   }
 
@@ -2074,14 +2074,14 @@ public class TestRouterMetrics {
   public void testUpdateSchedulerConfigurationRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved();
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateSchedulerConfigurationRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateSchedulerConfigurationRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateSchedulerConfigurationRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2089,21 +2089,21 @@ public class TestRouterMetrics {
   public void testGetClusterInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterInfoFailedRetrieved();
     badSubCluster.getClusterInfoFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterInfoRetrieved();
     goodSubCluster.getClusterInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterInfoRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2111,21 +2111,21 @@ public class TestRouterMetrics {
   public void testGetClusterUserInfoRetrievedFailed() {
     long totalBadBefore = metrics.getClusterUserInfoFailedRetrieved();
     badSubCluster.getClusterUserInfoFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getClusterUserInfoFailedRetrieved());
   }
 
   @Test
   public void testGetClusterUserInfoRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
     goodSubCluster.getClusterUserInfoRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getClusterUserInfoRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetClusterUserInfoRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetClusterUserInfoRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2133,21 +2133,21 @@ public class TestRouterMetrics {
   public void testUpdateNodeResourceRetrievedFailed() {
     long totalBadBefore = metrics.getUpdateNodeResourceFailedRetrieved();
     badSubCluster.getUpdateNodeResourceFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getUpdateNodeResourceFailedRetrieved());
   }
 
   @Test
   public void testUpdateNodeResourceRetrieved() {
-    long totalGoodBefore = metrics.getNumSucceededGetClusterUserInfoRetrieved();
+    long totalGoodBefore = metrics.getNumSucceededUpdateNodeResourceRetrieved();
     goodSubCluster.getUpdateNodeResourceRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getUpdateNodeResourceRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededUpdateNodeResourceRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededUpdateNodeResourceRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2155,21 +2155,21 @@ public class TestRouterMetrics {
   public void testRefreshNodesResourcesRetrievedFailed() {
     long totalBadBefore = metrics.getRefreshNodesResourcesFailedRetrieved();
     badSubCluster.getRefreshNodesResourcesFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getRefreshNodesResourcesFailedRetrieved());
   }
 
   @Test
   public void testRefreshNodesResourcesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshNodesResourcesRetrieved();
     goodSubCluster.getRefreshNodesResourcesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshNodesResourcesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshNodesResourcesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshNodesResourcesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2177,7 +2177,7 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesFailedRetrieved() {
     long totalBadBefore = metrics.getCheckForDecommissioningNodesFailedRetrieved();
     badSubCluster.getCheckForDecommissioningNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getCheckForDecommissioningNodesFailedRetrieved());
   }
 
@@ -2185,14 +2185,14 @@ public class TestRouterMetrics {
   public void testCheckForDecommissioningNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededCheckForDecommissioningNodesRetrieved();
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getCheckForDecommissioningNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededCheckForDecommissioningNodesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededCheckForDecommissioningNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2200,21 +2200,21 @@ public class TestRouterMetrics {
   public void testRefreshClusterMaxPriorityFailedRetrieved() {
     long totalBadBefore = metrics.getRefreshClusterMaxPriorityFailedRetrieved();
     badSubCluster.getRefreshClusterMaxPriorityFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getRefreshClusterMaxPriorityFailedRetrieved());
   }
 
   @Test
   public void testRefreshClusterMaxPriorityRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved();
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getRefreshClusterMaxPriorityRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededRefreshClusterMaxPriorityRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededRefreshClusterMaxPriorityRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2222,21 +2222,21 @@ public class TestRouterMetrics {
   public void testGetMapAttributesToNodesFailedRetrieved() {
     long totalBadBefore = metrics.getMapAttributesToNodesFailedRetrieved();
     badSubCluster.getMapAttributesToNodesFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getMapAttributesToNodesFailedRetrieved());
   }
 
   @Test
   public void testGetMapAttributesToNodesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededMapAttributesToNodesRetrieved();
     goodSubCluster.getMapAttributesToNodesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getMapAttributesToNodesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededMapAttributesToNodesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededMapAttributesToNodesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2244,21 +2244,21 @@ public class TestRouterMetrics {
   public void testGetGroupsForUserFailedRetrieved() {
     long totalBadBefore = metrics.getGroupsForUserFailedRetrieved();
     badSubCluster.getGroupsForUserFailed();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getGroupsForUserFailedRetrieved());
   }
 
   @Test
   public void testGetGroupsForUserRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetGroupsForUsersRetrieved();
     goodSubCluster.getGroupsForUsersRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getGroupsForUsersRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetGroupsForUsersRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetGroupsForUsersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2266,21 +2266,21 @@ public class TestRouterMetrics {
   public void testSaveFederationQueuePolicyFailedRetrieved() {
     long totalBadBefore = metrics.getSaveFederationQueuePolicyFailedRetrieved();
     badSubCluster.getSaveFederationQueuePolicyFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
+    assertEquals(totalBadBefore + 1, metrics.getSaveFederationQueuePolicyFailedRetrieved());
   }
 
   @Test
   public void testSaveFederationQueuePolicyRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededSaveFederationQueuePolicyRetrieved();
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getSaveFederationQueuePolicyRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededSaveFederationQueuePolicyRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededSaveFederationQueuePolicyRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2288,7 +2288,7 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getBatchSaveFederationQueuePoliciesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getBatchSaveFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2296,15 +2296,15 @@ public class TestRouterMetrics {
   public void testGetBatchSaveFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved();
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.getBatchSaveFederationQueuePoliciesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededBatchSaveFederationQueuePoliciesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededBatchSaveFederationQueuePoliciesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }
@@ -2313,7 +2313,7 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesFailedRetrieved() {
     long totalBadBefore = metrics.getListFederationQueuePoliciesFailedRetrieved();
     badSubCluster.getListFederationQueuePoliciesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getListFederationQueuePoliciesFailedRetrieved());
   }
 
@@ -2321,14 +2321,14 @@ public class TestRouterMetrics {
   public void testListFederationQueuePoliciesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved();
     goodSubCluster.getListFederationQueuePoliciesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getListFederationQueuePoliciesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededListFederationQueuePoliciesFailedRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededListFederationQueuePoliciesRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2336,7 +2336,7 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersFailedRetrieved() {
     long totalBadBefore = metrics.getFederationSubClustersFailedRetrieved();
     badSubCluster.getFederationSubClustersFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getFederationSubClustersFailedRetrieved());
   }
 
@@ -2344,14 +2344,14 @@ public class TestRouterMetrics {
   public void testGetFederationSubClustersRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededGetFederationSubClustersRetrieved();
     goodSubCluster.getFederationSubClustersRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
     goodSubCluster.getFederationSubClustersRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededGetFederationSubClustersRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededGetFederationSubClustersRetrieved(), ASSERT_DOUBLE_DELTA);
   }
 
@@ -2359,7 +2359,7 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesFailedRetrieved() {
     long totalBadBefore = metrics.getDeleteFederationPoliciesByQueuesRetrieved();
     badSubCluster.getDeleteFederationPoliciesByQueuesFailedRetrieved();
-    Assert.assertEquals(totalBadBefore + 1,
+    assertEquals(totalBadBefore + 1,
         metrics.getDeleteFederationPoliciesByQueuesRetrieved());
   }
 
@@ -2367,15 +2367,15 @@ public class TestRouterMetrics {
   public void testDeleteFederationPoliciesByQueuesRetrieved() {
     long totalGoodBefore = metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved();
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(150);
-    Assert.assertEquals(totalGoodBefore + 1,
+    assertEquals(totalGoodBefore + 1,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assert.assertEquals(150,
+    assertEquals(150,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
     goodSubCluster.deleteFederationPoliciesByQueuesRetrieved(300);
-    Assert.assertEquals(totalGoodBefore + 2,
+    assertEquals(totalGoodBefore + 2,
         metrics.getNumSucceededDeleteFederationPoliciesByQueuesRetrieved());
-    Assert.assertEquals(225,
+    assertEquals(225,
         metrics.getLatencySucceededDeleteFederationPoliciesByQueuesRetrieved(),
         ASSERT_DOUBLE_DELTA);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterServerUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterServerUtil.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationReque
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationRequestsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationSubmissionRequestInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ResourceInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.yarn.server.router.webapp.TestFederationInterceptorREST.getReservationSubmissionRequestInfo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestRouterServerUtil {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/TestRouterStoreCommands.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.GetApplicationHome
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestRouterStoreCommands {
 
@@ -41,7 +41,7 @@ public class TestRouterStoreCommands {
   private MemoryFederationStateStore stateStore;
   private FederationStateStoreFacade facade;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
     conf = new YarnConfiguration();
     stateStore = new MemoryFederationStateStore();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/cleaner/TestSubClusterCleaner.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router.cleaner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -29,9 +32,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatRequest;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterHeartbeatResponse;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -48,7 +50,7 @@ public class TestSubClusterCleaner {
   private final static int NUM_SUBCLUSTERS = 4;
   private final static long EXPIRATION_TIME = Time.now() - 5000;
 
-  @Before
+  @BeforeEach
   public void setup() throws YarnException {
     conf = new YarnConfiguration();
     conf.setLong(YarnConfiguration.ROUTER_SUBCLUSTER_EXPIRATION_TIME, 1000);
@@ -93,13 +95,13 @@ public class TestSubClusterCleaner {
     // Step3. All clusters have expired,
     // so the current Federation has no active subClusters.
     int count = facade.getActiveSubClustersCount();
-    Assert.assertEquals(0, count);
+    assertEquals(0, count);
 
     // Step4. Check Active SubCluster Status.
     // We want all subClusters to be SC_LOST.
     subClustersMap.values().forEach(subClusterInfo -> {
       SubClusterState subClusterState = subClusterInfo.getState();
-      Assert.assertEquals(SubClusterState.SC_LOST, subClusterState);
+      assertEquals(SubClusterState.SC_LOST, subClusterState);
     });
   }
 
@@ -121,7 +123,7 @@ public class TestSubClusterCleaner {
 
     // Step4. At this point we should have 2 subClusters that are surviving clusters.
     int count = facade.getActiveSubClustersCount();
-    Assert.assertEquals(2, count);
+    assertEquals(2, count);
 
     // Step5. The result we expect is that SC-0 and SC-1 are in the RUNNING state,
     // and SC-2 and SC-3 are in the SC_LOST state.
@@ -137,7 +139,7 @@ public class TestSubClusterCleaner {
     SubClusterHeartbeatRequest request = SubClusterHeartbeatRequest.newInstance(
         subClusterId, Time.now(), SubClusterState.SC_RUNNING, "test");
     SubClusterHeartbeatResponse response = stateStore.subClusterHeartbeat(request);
-    Assert.assertNotNull(response);
+    assertNotNull(response);
   }
 
   private void expiredSubcluster(String pSubClusterId) {
@@ -153,6 +155,6 @@ public class TestSubClusterCleaner {
     if (subClusterInfo == null) {
       throw new YarnException("subClusterId=" + pSubClusterId + " does not exist.");
     }
-    Assert.assertEquals(expectState, subClusterInfo.getState());
+    assertEquals(expectState, subClusterInfo.getState());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -100,9 +101,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base class for all the RouterClientRMService test cases. It provides utility
@@ -125,7 +125,7 @@ public abstract class BaseRouterClientRMTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterClientRMService getRouterClientRMService() {
-    Assert.assertNotNull(this.clientrmService);
+    assertNotNull(this.clientrmService);
     return this.clientrmService;
   }
 
@@ -154,7 +154,7 @@ public abstract class BaseRouterClientRMTest {
     return schedulerConf;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     this.conf = createConfiguration();
     this.dispatcher = new AsyncDispatcher();
@@ -171,7 +171,7 @@ public abstract class BaseRouterClientRMTest {
     return this.conf;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (clientrmService != null) {
       clientrmService.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/MockClientRequestInterceptor.java
@@ -18,12 +18,13 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.hadoop.yarn.api.protocolrecords.MoveApplicationAcrossQueuesRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.MoveApplicationAcrossQueuesResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.ClientRMService;
 import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
-import org.junit.Assert;
 
 /**
  * This class mocks the ClientRequestInterceptor.
@@ -65,7 +66,7 @@ public class MockClientRequestInterceptor
       // allow plan follower to synchronize
       Thread.sleep(1050);
     } catch (Exception e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
     super.setRMClient(mockRM.getClientRMService());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestApplicationSubmissionContextInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestApplicationSubmissionContextInterceptor.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ApplicationSubmissionContextPB
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.RouterServerUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extends the {@code BaseRouterClientRMTest} and overrides methods in order to

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterClientRMService.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -38,8 +44,7 @@ import org.apache.hadoop.yarn.api.protocolrecords.ReservationUpdateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService.RequestInterceptorChainWrapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,21 +75,20 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(PassThroughClientRequestInterceptor.class.getName(),
+        assertEquals(PassThroughClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockClientRequestInterceptor.class.getName(),
+        assertEquals(MockClientRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    assertEquals(4, index, "The number of interceptors in chain does not match");
   }
 
   /**
@@ -99,46 +103,46 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     LOG.info("testRouterClientRMServiceE2E - Get New Application");
 
     GetNewApplicationResponse responseGetNewApp = getNewApplication(user);
-    Assert.assertNotNull(responseGetNewApp);
+    assertNotNull(responseGetNewApp);
 
     LOG.info("testRouterClientRMServiceE2E - Submit Application");
 
     SubmitApplicationResponse responseSubmitApp =
         submitApplication(responseGetNewApp.getApplicationId(), user);
-    Assert.assertNotNull(responseSubmitApp);
+    assertNotNull(responseSubmitApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Metrics");
 
     GetClusterMetricsResponse responseGetClusterMetrics =
         getClusterMetrics(user);
-    Assert.assertNotNull(responseGetClusterMetrics);
+    assertNotNull(responseGetClusterMetrics);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Nodes");
 
     GetClusterNodesResponse responseGetClusterNodes = getClusterNodes(user);
-    Assert.assertNotNull(responseGetClusterNodes);
+    assertNotNull(responseGetClusterNodes);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue Info");
 
     GetQueueInfoResponse responseGetQueueInfo = getQueueInfo(user);
-    Assert.assertNotNull(responseGetQueueInfo);
+    assertNotNull(responseGetQueueInfo);
 
     LOG.info("testRouterClientRMServiceE2E - Get Queue User");
 
     GetQueueUserAclsInfoResponse responseGetQueueUser = getQueueUserAcls(user);
-    Assert.assertNotNull(responseGetQueueUser);
+    assertNotNull(responseGetQueueUser);
 
     LOG.info("testRouterClientRMServiceE2E - Get Cluster Node");
 
     GetClusterNodeLabelsResponse responseGetClusterNode =
         getClusterNodeLabels(user);
-    Assert.assertNotNull(responseGetClusterNode);
+    assertNotNull(responseGetClusterNode);
 
     LOG.info("testRouterClientRMServiceE2E - Move Application Across Queues");
 
     MoveApplicationAcrossQueuesResponse responseMoveApp =
         moveApplicationAcrossQueues(user, responseGetNewApp.getApplicationId());
-    Assert.assertNotNull(responseMoveApp);
+    assertNotNull(responseMoveApp);
 
     LOG.info("testRouterClientRMServiceE2E - Get New Reservation");
 
@@ -149,25 +153,25 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     ReservationSubmissionResponse responseSubmitReser =
         submitReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseSubmitReser);
+    assertNotNull(responseSubmitReser);
 
     LOG.info("testRouterClientRMServiceE2E - Update Reservation");
 
     ReservationUpdateResponse responseUpdateReser =
         updateReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseUpdateReser);
+    assertNotNull(responseUpdateReser);
 
     LOG.info("testRouterClientRMServiceE2E - Delete Reservation");
 
     ReservationDeleteResponse responseDeleteReser =
         deleteReservation(user, getNewReservationResponse.getReservationId());
-    Assert.assertNotNull(responseDeleteReser);
+    assertNotNull(responseDeleteReser);
 
     LOG.info("testRouterClientRMServiceE2E - Kill Application");
 
     KillApplicationResponse responseKillApp =
         forceKillApplication(responseGetNewApp.getApplicationId(), user);
-    Assert.assertNotNull(responseKillApp);
+    assertNotNull(responseKillApp);
   }
 
   /**
@@ -191,7 +195,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     getNewApplication("test8");
 
     pipelines = super.getRouterClientRMService().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     getNewApplication("test9");
     getNewApplication("test10");
@@ -200,13 +204,13 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -241,7 +245,7 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
                     getRouterClientRMService().getInterceptorChain();
                 ClientRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init client interceptor success for user " + user);
                 return interceptor;
               }
@@ -262,9 +266,9 @@ public class TestRouterClientRMService extends BaseRouterClientRMTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertTrue(client1.interceptor == client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestRouterYarnClientUtils.java
@@ -18,6 +18,11 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -63,8 +68,7 @@ import org.apache.hadoop.yarn.api.records.NodeToAttributeValue;
 import org.apache.hadoop.yarn.api.records.NodeAttributeInfo;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for RouterYarnClientUtils.
@@ -80,14 +84,14 @@ public class TestRouterYarnClientUtils {
     responses.add(getClusterMetricsResponse(2));
     GetClusterMetricsResponse result = RouterYarnClientUtils.merge(responses);
     YarnClusterMetrics resultMetrics = result.getClusterMetrics();
-    Assert.assertEquals(3, resultMetrics.getNumNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumActiveNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumLostNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
-    Assert.assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
+    assertEquals(3, resultMetrics.getNumNodeManagers());
+    assertEquals(3, resultMetrics.getNumActiveNodeManagers());
+    assertEquals(3, resultMetrics.getNumDecommissioningNodeManagers());
+    assertEquals(3, resultMetrics.getNumDecommissionedNodeManagers());
+    assertEquals(3, resultMetrics.getNumLostNodeManagers());
+    assertEquals(3, resultMetrics.getNumRebootedNodeManagers());
+    assertEquals(3, resultMetrics.getNumUnhealthyNodeManagers());
+    assertEquals(3, resultMetrics.getNumShutdownNodeManagers());
   }
 
   public GetClusterMetricsResponse getClusterMetricsResponse(int value) {
@@ -114,16 +118,16 @@ public class TestRouterYarnClientUtils {
     responses.add(getApplicationsResponse(2, false));
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(2, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(2, result.getApplicationList().size());
 
     String appName1 = result.getApplicationList().get(0).getName();
     String appName2 = result.getApplicationList().get(1).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assert.assertEquals(false,
+    assertEquals(false,
         appName1.contains(UnmanagedApplicationManager.APP_NAME));
-    Assert.assertEquals(false,
+    assertEquals(false,
         appName2.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
@@ -139,24 +143,24 @@ public class TestRouterYarnClientUtils {
     // Check response if partial results are enabled
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, true);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApplicationList().size());
     ApplicationReport appReport = result.getApplicationList().iterator().next();
     String appName = appReport.getName();
-    Assert.assertTrue(appName.startsWith(PARTIAL_REPORT));
+    assertTrue(appName.startsWith(PARTIAL_REPORT));
 
     // Check ApplicationResourceUsageReport merge
     ApplicationResourceUsageReport resourceUsageReport =
         appReport.getApplicationResourceUsageReport();
 
-    Assert.assertEquals(2, resourceUsageReport.getNumUsedContainers());
-    Assert.assertEquals(4, resourceUsageReport.getNumReservedContainers());
+    assertEquals(2, resourceUsageReport.getNumUsedContainers());
+    assertEquals(4, resourceUsageReport.getNumReservedContainers());
 
     // Check response if partial results are disabled
     result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result.getApplicationList().isEmpty());
+    assertNotNull(result);
+    assertTrue(result.getApplicationList().isEmpty());
   }
 
   /**
@@ -192,13 +196,13 @@ public class TestRouterYarnClientUtils {
 
     GetApplicationsResponse result = RouterYarnClientUtils.
         mergeApplications(responses, false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApplicationList().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApplicationList().size());
 
     String appName = result.getApplicationList().get(0).getName();
 
     // Check that no Unmanaged applications are added to the result
-    Assert.assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
+    assertFalse(appName.contains(UnmanagedApplicationManager.APP_NAME));
   }
 
   /**
@@ -286,7 +290,7 @@ public class TestRouterYarnClientUtils {
 
     GetNodesToLabelsResponse response = RouterYarnClientUtils.
         mergeNodesToLabelsResponse(responses);
-    Assert.assertEquals(expectedResponse, response.getNodeToLabels());
+    assertEquals(expectedResponse, response.getNodeToLabels());
   }
 
   @Test
@@ -327,7 +331,7 @@ public class TestRouterYarnClientUtils {
 
     GetClusterNodeLabelsResponse response = RouterYarnClientUtils.
         mergeClusterNodeLabelsResponse(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getNodeLabelList()));
   }
 
@@ -388,7 +392,7 @@ public class TestRouterYarnClientUtils {
     GetLabelsToNodesResponse response = RouterYarnClientUtils.
         mergeLabelsToNodes(responses);
 
-    Assert.assertEquals(expectedResponse, response.getLabelsToNodes());
+    assertEquals(expectedResponse, response.getLabelsToNodes());
   }
 
   @Test
@@ -453,7 +457,7 @@ public class TestRouterYarnClientUtils {
 
     GetQueueUserAclsInfoResponse response =
         RouterYarnClientUtils.mergeQueueUserAcls(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
+    assertTrue(CollectionUtils.isEqualCollection(expectedOutput,
         response.getUserAclsInfoList()));
   }
 
@@ -486,7 +490,7 @@ public class TestRouterYarnClientUtils {
 
     ReservationListResponse response =
         RouterYarnClientUtils.mergeReservationsList(responses);
-    Assert.assertEquals(expectedResponse, response.getReservationAllocationState());
+    assertEquals(expectedResponse, response.getReservationAllocationState());
   }
 
   private ReservationListResponse createReservationListResponse(long startTime,
@@ -550,7 +554,7 @@ public class TestRouterYarnClientUtils {
     expectedResponse.add(resourceTypeInfo3);
     GetAllResourceTypeInfoResponse response =
         RouterYarnClientUtils.mergeResourceTypes(responses);
-    Assert.assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
+    assertTrue(CollectionUtils.isEqualCollection(expectedResponse,
         response.getResourceTypeInfo()));
   }
 
@@ -585,8 +589,8 @@ public class TestRouterYarnClientUtils {
     GetAllResourceProfilesResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfilesResponse(responses);
     Resource resource = response.getResourceProfiles().get("maximum");
-    Assert.assertEquals(3, resource.getVirtualCores());
-    Assert.assertEquals(3072, resource.getMemorySize());
+    assertEquals(3, resource.getVirtualCores());
+    assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -619,8 +623,8 @@ public class TestRouterYarnClientUtils {
     GetResourceProfileResponse response =
         RouterYarnClientUtils.mergeClusterResourceProfileResponse(responses);
     Resource resource = response.getResource();
-    Assert.assertEquals(3, resource.getVirtualCores());
-    Assert.assertEquals(3072, resource.getMemorySize());
+    assertEquals(3, resource.getVirtualCores());
+    assertEquals(3072, resource.getMemorySize());
   }
 
   @Test
@@ -663,16 +667,16 @@ public class TestRouterYarnClientUtils {
     GetAttributesToNodesResponse response =
         RouterYarnClientUtils.mergeAttributesToNodesResponse(responses);
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(2, response.getAttributesToNodes().size());
+    assertNotNull(response);
+    assertEquals(2, response.getAttributesToNodes().size());
 
     Map<NodeAttributeKey, List<NodeToAttributeValue>> attrs = response.getAttributesToNodes();
 
     NodeAttributeKey gpuKey = gpu.getAttributeKey();
-    Assert.assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
+    assertEquals(attributeValue1.toString(), attrs.get(gpuKey).get(0).toString());
 
     NodeAttributeKey dockerKey = docker.getAttributeKey();
-    Assert.assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
+    assertEquals(attributeValue2.toString(), attrs.get(dockerKey).get(0).toString());
   }
 
   @Test
@@ -711,12 +715,12 @@ public class TestRouterYarnClientUtils {
     GetClusterNodeAttributesResponse response =
         RouterYarnClientUtils.mergeClusterNodeAttributesResponse(responses);
 
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     Set<NodeAttributeInfo> nodeAttributeInfos = response.getNodeAttributes();
-    Assert.assertEquals(2, nodeAttributeInfos.size());
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
-    Assert.assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
+    assertEquals(2, nodeAttributeInfos.size());
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo1));
+    assertTrue(nodeAttributeInfos.contains(nodeAttributeInfo2));
   }
 
   @Test
@@ -755,14 +759,14 @@ public class TestRouterYarnClientUtils {
     GetNodesToAttributesResponse response =
         RouterYarnClientUtils.mergeNodesToAttributesResponse(responses);
 
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     Map<String, Set<NodeAttribute>> hostToAttrs = response.getNodeToAttributes();
-    Assert.assertNotNull(hostToAttrs);
-    Assert.assertEquals(2, hostToAttrs.size());
-    Assert.assertTrue(hostToAttrs.get("node1").contains(dist));
-    Assert.assertTrue(hostToAttrs.get("node1").contains(gpu));
-    Assert.assertTrue(hostToAttrs.get("node1").contains(os));
-    Assert.assertTrue(hostToAttrs.get("node2").contains(docker));
+    assertNotNull(hostToAttrs);
+    assertEquals(2, hostToAttrs.size());
+    assertTrue(hostToAttrs.get("node1").contains(dist));
+    assertTrue(hostToAttrs.get("node1").contains(gpu));
+    assertTrue(hostToAttrs.get("node1").contains(os));
+    assertTrue(hostToAttrs.get("node2").contains(docker));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestableFederationClientInterceptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.clientrm;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -58,7 +59,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.QueueACLsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +101,7 @@ public class TestableFederationClientInterceptor
           MockNM nm = mockRM.registerNode("127.0.0.1:1234", 8*1024, 4);
           mockNMs.put(subClusterId, nm);
         } catch (Exception e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         mockRMs.put(subClusterId, mockRM);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/BaseRouterRMAdminTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.yarn.server.router.rmadmin;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
@@ -57,9 +59,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeRequ
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base class for all the RouterRMAdminService test cases. It provides utility
@@ -82,11 +83,11 @@ public abstract class BaseRouterRMAdminTest {
   public final static int TEST_MAX_CACHE_SIZE = 10;
 
   protected MockRouterRMAdminService getRouterRMAdminService() {
-    Assert.assertNotNull(this.rmAdminService);
+    assertNotNull(this.rmAdminService);
     return this.rmAdminService;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.conf = createConfiguration();
     this.dispatcher = new AsyncDispatcher();
@@ -120,7 +121,7 @@ public abstract class BaseRouterRMAdminTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (rmAdminService != null) {
       rmAdminService.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestFederationRMAdminInterceptor.java
@@ -81,8 +81,9 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterPolicyCo
 import org.apache.hadoop.yarn.server.federation.store.records.ApplicationHomeSubCluster;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreTestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,8 +100,9 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Extends the FederationRMAdminInterceptor and overrides methods to provide a
@@ -124,6 +126,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
   private FederationStateStoreTestUtil stateStoreUtil;
   private List<SubClusterId> subClusters;
 
+  @BeforeEach
   @Override
   public void setUp() {
 
@@ -151,7 +154,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      fail();
     }
 
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -177,6 +180,7 @@ public class TestFederationRMAdminInterceptor extends BaseRouterRMAdminTest {
     return config;
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/rmadmin/TestRouterRMAdminService.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.rmadmin;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -37,8 +43,7 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RemoveFromClusterNodeLa
 import org.apache.hadoop.yarn.server.api.protocolrecords.ReplaceLabelsOnNodeResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService.RequestInterceptorChainWrapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,22 +74,22 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(
+        assertEquals(
             PassThroughRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockRMAdminRequestInterceptor.class.getName(),
+        assertEquals(MockRMAdminRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    assertEquals(4, index,
+        "The number of interceptors in chain does not match");
   }
 
   /**
@@ -99,82 +104,82 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     LOG.info("testRouterRMAdminServiceE2E - Refresh Queues");
 
     RefreshQueuesResponse responseRefreshQueues = refreshQueues(user);
-    Assert.assertNotNull(responseRefreshQueues);
+    assertNotNull(responseRefreshQueues);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes");
 
     RefreshNodesResponse responseRefreshNodes = refreshNodes(user);
-    Assert.assertNotNull(responseRefreshNodes);
+    assertNotNull(responseRefreshNodes);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Super User");
 
     RefreshSuperUserGroupsConfigurationResponse responseRefreshSuperUser =
         refreshSuperUserGroupsConfiguration(user);
-    Assert.assertNotNull(responseRefreshSuperUser);
+    assertNotNull(responseRefreshSuperUser);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh User to Group");
 
     RefreshUserToGroupsMappingsResponse responseRefreshUserToGroup =
         refreshUserToGroupsMappings(user);
-    Assert.assertNotNull(responseRefreshUserToGroup);
+    assertNotNull(responseRefreshUserToGroup);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Admin Acls");
 
     RefreshAdminAclsResponse responseRefreshAdminAcls = refreshAdminAcls(user);
-    Assert.assertNotNull(responseRefreshAdminAcls);
+    assertNotNull(responseRefreshAdminAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Service Acls");
 
     RefreshServiceAclsResponse responseRefreshServiceAcls =
         refreshServiceAcls(user);
-    Assert.assertNotNull(responseRefreshServiceAcls);
+    assertNotNull(responseRefreshServiceAcls);
 
     LOG.info("testRouterRMAdminServiceE2E - Update Node Resource");
 
     UpdateNodeResourceResponse responseUpdateNodeResource =
         updateNodeResource(user);
-    Assert.assertNotNull(responseUpdateNodeResource);
+    assertNotNull(responseUpdateNodeResource);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Nodes Resource");
 
     RefreshNodesResourcesResponse responseRefreshNodesResources =
         refreshNodesResources(user);
-    Assert.assertNotNull(responseRefreshNodesResources);
+    assertNotNull(responseRefreshNodesResources);
 
     LOG.info("testRouterRMAdminServiceE2E - Add To Cluster NodeLabels");
 
     AddToClusterNodeLabelsResponse responseAddToClusterNodeLabels =
         addToClusterNodeLabels(user);
-    Assert.assertNotNull(responseAddToClusterNodeLabels);
+    assertNotNull(responseAddToClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Remove To Cluster NodeLabels");
 
     RemoveFromClusterNodeLabelsResponse responseRemoveFromClusterNodeLabels =
         removeFromClusterNodeLabels(user);
-    Assert.assertNotNull(responseRemoveFromClusterNodeLabels);
+    assertNotNull(responseRemoveFromClusterNodeLabels);
 
     LOG.info("testRouterRMAdminServiceE2E - Replace Labels On Node");
 
     ReplaceLabelsOnNodeResponse responseReplaceLabelsOnNode =
         replaceLabelsOnNode(user);
-    Assert.assertNotNull(responseReplaceLabelsOnNode);
+    assertNotNull(responseReplaceLabelsOnNode);
 
     LOG.info("testRouterRMAdminServiceE2E - Check For Decommissioning Nodes");
 
     CheckForDecommissioningNodesResponse responseCheckForDecom =
         checkForDecommissioningNodes(user);
-    Assert.assertNotNull(responseCheckForDecom);
+    assertNotNull(responseCheckForDecom);
 
     LOG.info("testRouterRMAdminServiceE2E - Refresh Cluster Max Priority");
 
     RefreshClusterMaxPriorityResponse responseRefreshClusterMaxPriority =
         refreshClusterMaxPriority(user);
-    Assert.assertNotNull(responseRefreshClusterMaxPriority);
+    assertNotNull(responseRefreshClusterMaxPriority);
 
     LOG.info("testRouterRMAdminServiceE2E - Get Groups For User");
 
     String[] responseGetGroupsForUser = getGroupsForUser(user);
-    Assert.assertNotNull(responseGetGroupsForUser);
+    assertNotNull(responseGetGroupsForUser);
 
   }
 
@@ -199,7 +204,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     refreshQueues("test8");
 
     pipelines = super.getRouterRMAdminService().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     refreshQueues("test9");
     refreshQueues("test10");
@@ -208,13 +213,13 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
 
     // The cache max size is defined in
     // BaseRouterClientRMTest.TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -249,7 +254,7 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
                     getRouterRMAdminService().getInterceptorChain();
                 RMAdminRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init rm admin interceptor success for user" + user);
                 return interceptor;
               }
@@ -270,9 +275,9 @@ public class TestRouterRMAdminService extends BaseRouterRMAdminTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertTrue(client1.interceptor == client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertTrue(client1.interceptor == client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/AbstractSecureRouterTest.java
@@ -31,19 +31,18 @@ import org.apache.hadoop.yarn.server.resourcemanager.MockRM;
 import org.apache.hadoop.yarn.server.resourcemanager.TestRMRestart;
 import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class AbstractSecureRouterTest {
 
@@ -91,7 +90,7 @@ public abstract class AbstractSecureRouterTest {
   private static ConcurrentHashMap<SubClusterId, MockRM> mockRMs =
       new ConcurrentHashMap<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeSecureRouterTestClass() throws Exception {
     // Sets up the KDC and Principals.
     setupKDCAndPrincipals();
@@ -111,6 +110,8 @@ public abstract class AbstractSecureRouterTest {
     // Router Kerberos KeyTab configuration
     conf.set(YarnConfiguration.ROUTER_PRINCIPAL, ROUTER_LOCALHOST_REALM);
     conf.set(YarnConfiguration.ROUTER_KEYTAB, routerKeytab.getAbsolutePath());
+
+    conf.setInt(YarnConfiguration.FEDERATION_CACHE_TIME_TO_LIVE_SECS, 0);
 
     DefaultMetricsSystem.setMiniClusterMode(true);
   }
@@ -163,9 +164,9 @@ public abstract class AbstractSecureRouterTest {
    * @throws Exception an error occurred.
    */
   public static File createKeytab(String principal, String filename) throws Exception {
-    assertTrue("empty principal", StringUtils.isNotBlank(principal));
-    assertTrue("empty host", StringUtils.isNotBlank(filename));
-    assertNotNull("null KDC", kdc);
+    assertTrue(StringUtils.isNotBlank(principal), "empty principal");
+    assertTrue(StringUtils.isNotBlank(filename), "empty host");
+    assertNotNull(kdc, "null KDC");
     File keytab = new File(kdcWorkDir, filename);
     kdc.createPrincipal(keytab,
         principal,
@@ -180,7 +181,7 @@ public abstract class AbstractSecureRouterTest {
    * @throws Exception an error occurred.
    */
   public synchronized void startSecureRouter() {
-    assertNull("Router is already running", router);
+    assertNull(router, "Router is already running");
     MemoryFederationStateStore stateStore = new MemoryFederationStateStore();
     stateStore.init(getConf());
     FederationStateStoreFacade.getInstance(getConf()).reinitialize(stateStore, getConf());
@@ -219,7 +220,7 @@ public abstract class AbstractSecureRouterTest {
    *
    * @throws Exception an error occurred.
    */
-  @AfterClass
+  @AfterAll
   public static void afterSecureRouterTest() throws Exception {
     LOG.info("teardown of kdc instance.");
     teardownKDC();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestRouterDelegationTokenSecretManager.java
@@ -25,16 +25,15 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.security.RouterDelegationTokenSecretManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class TestRouterDelegationTokenSecretManager extends AbstractSecureRouterTest {
 
@@ -117,7 +116,7 @@ public class TestRouterDelegationTokenSecretManager extends AbstractSecureRouter
         new Text("owner1"), new Text("renewer1"), new Text("realuser1"));
     dtId2.setSequenceNumber(sequenceNumber);
     RMDelegationTokenIdentifier dtId3 = secretManager.getTokenByRouterStoreToken(dtId2);
-    Assert.assertEquals(dtId1, dtId3);
+    assertEquals(dtId1, dtId3);
 
     // query rm-token2 not exists
     sequenceNumber++;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/secure/TestSecureLogins.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.yarn.server.router.secure;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.apache.commons.collections4.MapUtils;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
@@ -35,8 +38,7 @@ import org.apache.hadoop.yarn.server.router.clientrm.FederationClientInterceptor
 import org.apache.hadoop.yarn.server.router.clientrm.RouterClientRMService;
 import org.apache.hadoop.yarn.server.router.rmadmin.DefaultRMAdminRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.rmadmin.RouterRMAdminService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +51,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
 
   @Test
   public void testHasRealm() throws Throwable {
-    Assert.assertNotNull(getRealm());
+    assertNotNull(getRealm());
     LOG.info("Router principal = {}", getPrincipalAndRealm(ROUTER_LOCALHOST));
   }
 
@@ -58,8 +60,8 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     startSecureRouter();
 
     List<Service> services = this.getRouter().getServices();
-    Assert.assertNotNull(services);
-    Assert.assertEquals(3, services.size());
+    assertNotNull(services);
+    assertEquals(3, services.size());
 
     stopSecureRouter();
   }
@@ -78,10 +80,10 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     GetClusterMetricsRequest metricsRequest = GetClusterMetricsRequest.newInstance();
     GetClusterMetricsResponse metricsResponse =
         routerClientRMService.getClusterMetrics(metricsRequest);
-    Assert.assertNotNull(metricsResponse);
+    assertNotNull(metricsResponse);
     YarnClusterMetrics clusterMetrics = metricsResponse.getClusterMetrics();
-    Assert.assertEquals(4, clusterMetrics.getNumNodeManagers());
-    Assert.assertEquals(0, clusterMetrics.getNumLostNodeManagers());
+    assertEquals(4, clusterMetrics.getNumNodeManagers());
+    assertEquals(0, clusterMetrics.getNumLostNodeManagers());
 
     // Stop the Router in Secure Mode
     stopSecureRouter();
@@ -101,7 +103,7 @@ public class TestSecureLogins extends AbstractSecureRouterTest {
     RefreshNodesRequest refreshNodesRequest = RefreshNodesRequest.newInstance();
     RefreshNodesResponse refreshNodesResponse =
         routerRMAdminService.refreshNodes(refreshNodesRequest);
-    Assert.assertNotNull(refreshNodesResponse);
+    assertNotNull(refreshNodesResponse);
 
     // Stop the Router in Secure Mode
     stopSecureRouter();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
@@ -74,7 +74,7 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.AP
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.RESERVATION_NEW;
 import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.ADD_NODE_LABELS;
 import static org.apache.hadoop.yarn.server.router.webapp.TestRouterWebServicesREST.waitWebAppRunning;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFederationSubCluster {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
@@ -58,9 +58,9 @@ import org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterUserInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationSchedulerTypeInfo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -105,9 +105,9 @@ import static org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts.RE
 import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubCluster.format;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.POST;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.PUT;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestYarnFederationWithCapacityScheduler {
 
@@ -117,7 +117,7 @@ public class TestYarnFederationWithCapacityScheduler {
   private static final String SC1_RM_WEB_ADDRESS = "http://localhost:18088";
   private static final String SC2_RM_WEB_ADDRESS = "http://localhost:28088";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp()
       throws IOException, InterruptedException, YarnException, TimeoutException {
     testFederationSubCluster = new TestFederationSubCluster();
@@ -130,7 +130,7 @@ public class TestYarnFederationWithCapacityScheduler {
     subClusters.add("SC-2");
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDown() throws Exception {
     testFederationSubCluster.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/fair/TestYarnFederationWithFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/fair/TestYarnFederationWithFairScheduler.java
@@ -64,9 +64,9 @@ import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationClusterUserInfo;
 import org.apache.hadoop.yarn.server.router.webapp.dao.FederationSchedulerTypeInfo;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -113,9 +113,9 @@ import static org.apache.hadoop.yarn.server.router.subcluster.TestFederationSubC
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.POST;
 import static org.apache.hadoop.yarn.server.router.webapp.HTTPMethods.PUT;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestYarnFederationWithFairScheduler {
   private static TestFederationSubCluster testFederationSubCluster;
@@ -124,7 +124,7 @@ public class TestYarnFederationWithFairScheduler {
   private static final String SC1_RM_WEB_ADDRESS = "http://localhost:38088";
   private static final String SC2_RM_WEB_ADDRESS = "http://localhost:48088";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp()
       throws IOException, InterruptedException, YarnException, TimeoutException {
     testFederationSubCluster = new TestFederationSubCluster();
@@ -137,7 +137,7 @@ public class TestYarnFederationWithFairScheduler {
     subClusters.add("SC-2");
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDown() throws Exception {
     testFederationSubCluster.stop();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/BaseRouterWebServicesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -59,9 +60,8 @@ import org.apache.hadoop.yarn.server.router.webapp.RouterWebServices.RequestInte
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
 /**
@@ -89,7 +89,7 @@ public abstract class BaseRouterWebServicesTest {
 
   private RouterWebServices routerWebService;
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException, IOException {
 
     this.conf = createConfiguration();
@@ -121,7 +121,7 @@ public abstract class BaseRouterWebServicesTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (router != null) {
       router.stop();
@@ -137,7 +137,7 @@ public abstract class BaseRouterWebServicesTest {
   }
 
   protected RouterWebServices getRouterWebServices() {
-    Assert.assertNotNull(this.routerWebService);
+    assertNotNull(this.routerWebService);
     return this.routerWebService;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
@@ -217,7 +217,10 @@ public class MockDefaultRequestInterceptorREST
             applicationCounter.incrementAndGet());
     NewApplication appId =
         new NewApplication(applicationId.toString(), new ResourceInfo());
-    return Response.status(Status.OK).entity(appId).build();
+    Response response = Mockito.mock(Response.class);
+    Mockito.when(response.readEntity(NewApplication.class)).thenReturn(appId);
+    Mockito.when(response.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+    return response;
   }
 
   @Override
@@ -315,7 +318,7 @@ public class MockDefaultRequestInterceptorREST
     NodeInfo node = null;
     SubClusterId subCluster = getSubClusterId();
     String subClusterId = subCluster.getId();
-    if (nodeId.contains(subClusterId) || nodeId.contains("test")) {
+    if (nodeId == null || nodeId.contains(subClusterId) || nodeId.contains("test")) {
       node = new NodeInfo();
       node.setId(nodeId);
       node.setLastHealthUpdate(Integer.parseInt(getSubClusterId().getId()));
@@ -1250,13 +1253,15 @@ public class MockDefaultRequestInterceptorREST
 
   public Response replaceLabelsOnNodes(NodeToLabelsEntryList newNodeToLabels,
       HttpServletRequest hsr) throws IOException {
-    return super.replaceLabelsOnNodes(newNodeToLabels, hsr);
+    return Response.status(Status.OK).entity(
+        "subCluster-0:Success,subCluster-1:Success,subCluster-2:Success,subCluster-3:Success,")
+        .build();
   }
 
   @Override
   public Response replaceLabelsOnNode(Set<String> newNodeLabelsName,
       HttpServletRequest hsr, String nodeId) throws Exception {
-    return super.replaceLabelsOnNode(newNodeLabelsName, hsr, nodeId);
+    return Response.status(Status.OK).entity("subCluster#3:Success;").build();
   }
 
   public ActivitiesInfo getActivities(HttpServletRequest hsr, String nodeId, String groupBy) {
@@ -1355,6 +1360,7 @@ public class MockDefaultRequestInterceptorREST
   @Override
   public Response removeFromClusterNodeLabels(Set<String> oldNodeLabels, HttpServletRequest hsr)
       throws Exception {
+    Response response = Mockito.mock(Response.class);
     // If oldNodeLabels contains ALL, we let all subclusters pass
     if (oldNodeLabels.contains("ALL")) {
       return Response.status(Status.OK).build();
@@ -1362,9 +1368,11 @@ public class MockDefaultRequestInterceptorREST
       SubClusterId subClusterId = getSubClusterId();
       String id = subClusterId.getId();
       if (StringUtils.contains("A0", id)) {
-        return Response.status(Status.OK).build();
+        Mockito.when(response.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+        return response;
       } else {
-        return Response.status(Status.BAD_REQUEST).entity(null).build();
+        Mockito.when(response.getStatus()).thenReturn(HttpServletResponse.SC_BAD_REQUEST);
+        return response;
       }
     }
     throw new YarnException("removeFromClusterNodeLabels Error");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorRESTRetry.java
@@ -18,6 +18,14 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +34,6 @@ import java.util.List;
 import javax.ws.rs.core.Response;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -47,8 +54,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.NodesInfo;
 import org.apache.hadoop.yarn.server.router.clientrm.PassThroughClientRequestInterceptor;
 import org.apache.hadoop.yarn.server.router.clientrm.TestableFederationClientInterceptor;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +88,7 @@ public class TestFederationInterceptorRESTRetry
   private FederationStateStoreTestUtil stateStoreUtil;
   private String user = "test-user";
 
+  @BeforeEach
   @Override
   public void setUp() {
     super.setUpConfig();
@@ -115,6 +124,7 @@ public class TestFederationInterceptorRESTRetry
     interceptor.registerBadSubCluster(bad2);
   }
 
+  @AfterEach
   @Override
   public void tearDown() {
     interceptor.shutdown();
@@ -133,7 +143,7 @@ public class TestFederationInterceptorRESTRetry
       }
     } catch (YarnException e) {
       LOG.error(e.getMessage());
-      Assert.fail();
+      fail();
     }
   }
 
@@ -176,8 +186,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -194,8 +204,8 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     Response response = interceptor.createNewApplication(null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -211,16 +221,16 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(good, bad2));
     Response response = interceptor.createNewApplication(null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(OK, response.getStatus());
+    assertNotNull(response);
+    assertEquals(OK, response.getStatus());
 
     NewApplication newApp = (NewApplication) response.getEntity();
-    Assert.assertNotNull(newApp);
+    assertNotNull(newApp);
 
     ApplicationId appId = ApplicationId.fromString(newApp.getApplicationId());
-    Assert.assertNotNull(appId);
+    assertNotNull(appId);
 
-    Assert.assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
+    assertEquals(Integer.parseInt(good.getId()), appId.getClusterTimestamp());
   }
 
   /**
@@ -242,8 +252,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -263,8 +273,8 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
 
     Response response = interceptor.submitApplication(context, null);
-    Assert.assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
-    Assert.assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    assertEquals(SERVICE_UNAVAILABLE, response.getStatus());
+    assertEquals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         response.getEntity());
   }
 
@@ -285,9 +295,9 @@ public class TestFederationInterceptorRESTRetry
     context.setApplicationId(appId.toString());
     Response response = interceptor.submitApplication(context, null);
 
-    Assert.assertEquals(ACCEPTED, response.getStatus());
+    assertEquals(ACCEPTED, response.getStatus());
 
-    Assert.assertEquals(good,
+    assertEquals(good,
         stateStore
             .getApplicationHomeSubCluster(
                 GetApplicationHomeSubClusterRequest.newInstance(appId))
@@ -306,7 +316,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNull(response);
+    assertNotNull(response);
+    assertTrue(response.getApps().isEmpty());
   }
 
   /**
@@ -320,7 +331,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNull(response);
+    assertNotNull(response);
+    assertTrue(response.getApps().isEmpty());
   }
 
   /**
@@ -334,8 +346,8 @@ public class TestFederationInterceptorRESTRetry
 
     AppsInfo response = interceptor.getApps(null, null, null, null, null, null,
         null, null, null, null, null, null, null, null, null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(1, response.getApps().size());
+    assertNotNull(response);
+    assertEquals(1, response.getApps().size());
   }
 
   /**
@@ -349,10 +361,10 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
     try {
       interceptor.getNode("testGetNodeOneBadSC");
-      Assert.fail();
+      fail();
     } catch (NotFoundException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
+      Throwable cause = e.getCause();
+      assertTrue(cause.getMessage().contains("nodeId, testGetNodeOneBadSC, is not found"));
     }
   }
 
@@ -367,9 +379,10 @@ public class TestFederationInterceptorRESTRetry
 
     try {
       interceptor.getNode("testGetNodeTwoBadSCs");
-      Assert.fail();
+      fail();
     } catch (NotFoundException e) {
-      Assert.assertTrue(e.getMessage()
+      String stackTraceAsString = getStackTraceAsString(e);
+      assertTrue(stackTraceAsString
           .contains("nodeId, testGetNodeTwoBadSCs, is not found"));
     }
   }
@@ -384,9 +397,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodeInfo response = interceptor.getNode(null);
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     // Check if the only node came from Good SubCluster
-    Assert.assertEquals(good.getId(),
+    assertEquals(good.getId(),
         Long.toString(response.getLastHealthUpdate()));
   }
 
@@ -399,8 +412,11 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -412,8 +428,11 @@ public class TestFederationInterceptorRESTRetry
 
     setupCluster(Arrays.asList(bad1, bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -424,8 +443,11 @@ public class TestFederationInterceptorRESTRetry
   public void testGetNodesOneBadOneGood() throws Exception {
     setupCluster(Arrays.asList(good, bad2));
 
-    LambdaTestUtils.intercept(YarnRuntimeException.class, "RM is stopped",
-        () -> interceptor.getNodes(null));
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+
+    assertTrue(getStackTraceAsString(exception).contains("RM is stopped"));
   }
 
   /**
@@ -439,7 +461,7 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     // check if we got an empty metrics
     checkEmptyMetrics(response);
   }
@@ -455,9 +477,9 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     // check if we got an empty metrics
-    Assert.assertEquals(0, response.getAppsSubmitted());
+    assertEquals(0, response.getAppsSubmitted());
   }
 
   /**
@@ -473,56 +495,56 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     ClusterMetricsInfo response = interceptor.getClusterMetricsInfo();
-    Assert.assertNotNull(response);
+    assertNotNull(response);
     checkMetricsFromGoodSC(response);
     // The merge operations is tested in TestRouterWebServiceUtil
   }
 
   private void checkMetricsFromGoodSC(ClusterMetricsInfo response) {
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsSubmitted());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsCompleted());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsPending());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsRunning());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsFailed());
-    Assert.assertEquals(Integer.parseInt(good.getId()),
+    assertEquals(Integer.parseInt(good.getId()),
         response.getAppsKilled());
   }
 
   private void checkEmptyMetrics(ClusterMetricsInfo response) {
-    Assert.assertEquals(0, response.getAppsSubmitted());
-    Assert.assertEquals(0, response.getAppsCompleted());
-    Assert.assertEquals(0, response.getAppsPending());
-    Assert.assertEquals(0, response.getAppsRunning());
-    Assert.assertEquals(0, response.getAppsFailed());
-    Assert.assertEquals(0, response.getAppsKilled());
+    assertEquals(0, response.getAppsSubmitted());
+    assertEquals(0, response.getAppsCompleted());
+    assertEquals(0, response.getAppsPending());
+    assertEquals(0, response.getAppsRunning());
+    assertEquals(0, response.getAppsFailed());
+    assertEquals(0, response.getAppsKilled());
 
-    Assert.assertEquals(0, response.getReservedMB());
-    Assert.assertEquals(0, response.getAvailableMB());
-    Assert.assertEquals(0, response.getAllocatedMB());
+    assertEquals(0, response.getReservedMB());
+    assertEquals(0, response.getAvailableMB());
+    assertEquals(0, response.getAllocatedMB());
 
-    Assert.assertEquals(0, response.getReservedVirtualCores());
-    Assert.assertEquals(0, response.getAvailableVirtualCores());
-    Assert.assertEquals(0, response.getAllocatedVirtualCores());
+    assertEquals(0, response.getReservedVirtualCores());
+    assertEquals(0, response.getAvailableVirtualCores());
+    assertEquals(0, response.getAllocatedVirtualCores());
 
-    Assert.assertEquals(0, response.getContainersAllocated());
-    Assert.assertEquals(0, response.getReservedContainers());
-    Assert.assertEquals(0, response.getPendingContainers());
+    assertEquals(0, response.getContainersAllocated());
+    assertEquals(0, response.getReservedContainers());
+    assertEquals(0, response.getPendingContainers());
 
-    Assert.assertEquals(0, response.getTotalMB());
-    Assert.assertEquals(0, response.getTotalVirtualCores());
-    Assert.assertEquals(0, response.getTotalNodes());
-    Assert.assertEquals(0, response.getLostNodes());
-    Assert.assertEquals(0, response.getUnhealthyNodes());
-    Assert.assertEquals(0, response.getDecommissioningNodes());
-    Assert.assertEquals(0, response.getDecommissionedNodes());
-    Assert.assertEquals(0, response.getRebootedNodes());
-    Assert.assertEquals(0, response.getActiveNodes());
-    Assert.assertEquals(0, response.getShutdownNodes());
+    assertEquals(0, response.getTotalMB());
+    assertEquals(0, response.getTotalVirtualCores());
+    assertEquals(0, response.getTotalNodes());
+    assertEquals(0, response.getLostNodes());
+    assertEquals(0, response.getUnhealthyNodes());
+    assertEquals(0, response.getDecommissioningNodes());
+    assertEquals(0, response.getDecommissionedNodes());
+    assertEquals(0, response.getRebootedNodes());
+    assertEquals(0, response.getActiveNodes());
+    assertEquals(0, response.getShutdownNodes());
   }
 
   @Test
@@ -534,8 +556,10 @@ public class TestFederationInterceptorRESTRetry
     interceptor.setAllowPartialResult(true);
     setupCluster(Arrays.asList(bad2));
 
-    NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assert.assertNotNull(nodesInfo);
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+    assertTrue(exception.getMessage().contains("RM is stopped"));
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -550,8 +574,10 @@ public class TestFederationInterceptorRESTRetry
     interceptor.setAllowPartialResult(true);
     setupCluster(Arrays.asList(bad1, bad2));
 
-    NodesInfo nodesInfo = interceptor.getNodes(null);
-    Assert.assertNotNull(nodesInfo);
+    YarnRuntimeException exception = assertThrows(YarnRuntimeException.class, () -> {
+      interceptor.getNodes(null);
+    });
+    assertTrue(exception.getMessage().contains("RM is stopped"));
 
     // We need to set allowPartialResult=false
     interceptor.setAllowPartialResult(false);
@@ -566,10 +592,10 @@ public class TestFederationInterceptorRESTRetry
     setupCluster(Arrays.asList(good, bad2));
 
     NodesInfo response = interceptor.getNodes(null);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(1, response.getNodes().size());
+    assertNotNull(response);
+    assertEquals(1, response.getNodes().size());
     // Check if the only node came from Good SubCluster
-    Assert.assertEquals(good.getId(),
+    assertEquals(good.getId(),
         Long.toString(response.getNodes().get(0).getLastHealthUpdate()));
 
     // allowPartialResult = false,
@@ -577,5 +603,12 @@ public class TestFederationInterceptorRESTRetry
     interceptor.setAllowPartialResult(false);
 
     setupCluster(Arrays.asList(good, bad2));
+  }
+
+  private String getStackTraceAsString(Exception e) {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    e.printStackTrace(pw);
+    return sw.toString();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationWebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationWebApp.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.webapp.test.WebAppTests;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebAppProxy.java
@@ -44,9 +44,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +59,9 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestRouterWebAppProxy {
 
@@ -79,7 +80,7 @@ public class TestRouterWebAppProxy {
   /**
    * Simple http server. Server should send answer with status 200
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     mockServer = new Server(0);
     ((QueuedThreadPool) mockServer.getThreadPool()).setMaxThreads(20);
@@ -96,7 +97,8 @@ public class TestRouterWebAppProxy {
     LOG.info("Running embedded servlet container at: http://localhost:" + mockServerPort);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testRouterWebAppProxyFed() throws Exception {
 
     Configuration conf = new Configuration();
@@ -132,22 +134,22 @@ public class TestRouterWebAppProxy {
 
     // Mock for application
     ApplicationClientProtocol appManager1 = mock(ApplicationClientProtocol.class);
-    Mockito.when(appManager1.getApplicationReport(GetApplicationReportRequest.newInstance(appId1)))
+    when(appManager1.getApplicationReport(GetApplicationReportRequest.newInstance(appId1)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId1, YarnApplicationState.RUNNING, proxyAppUrl1, appUrl1)));
-    Mockito.when(appManager1.getApplicationReport(GetApplicationReportRequest.newInstance(appId3)))
+    when(appManager1.getApplicationReport(GetApplicationReportRequest.newInstance(appId3)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId3, YarnApplicationState.ACCEPTED, proxyAppUrl2, null)));
 
     ApplicationClientProtocol appManager2 = mock(ApplicationClientProtocol.class);
-    Mockito.when(appManager2.getApplicationReport(GetApplicationReportRequest.newInstance(appId2)))
+    when(appManager2.getApplicationReport(GetApplicationReportRequest.newInstance(appId2)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId2, YarnApplicationState.RUNNING, proxyAppUrl3, appUrl2)));
-    Mockito.when(appManager2.getApplicationReport(GetApplicationReportRequest.newInstance(appId4)))
+    when(appManager2.getApplicationReport(GetApplicationReportRequest.newInstance(appId4)))
         .thenThrow(new ApplicationNotFoundException("APP NOT FOUND"));
 
     ApplicationHistoryProtocol historyManager = mock(ApplicationHistoryProtocol.class);
-    Mockito.when(
+    when(
             historyManager.getApplicationReport(GetApplicationReportRequest.newInstance(appId4)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId4, YarnApplicationState.FINISHED, proxyAppUrl4, null)));
@@ -174,19 +176,19 @@ public class TestRouterWebAppProxy {
     String user = UserGroupInformation.getCurrentUser().getUserName();
     RequestInterceptorChainWrapper wrapper = mock(RequestInterceptorChainWrapper.class);
     FederationClientInterceptor interceptor = mock(FederationClientInterceptor.class);
-    Mockito.when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId1)))
+    when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId1)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId1, YarnApplicationState.RUNNING, proxyAppUrl1, appUrl1)));
-    Mockito.when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId2)))
+    when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId2)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId2, YarnApplicationState.RUNNING, proxyAppUrl2, appUrl2)));
-    Mockito.when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId3)))
+    when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId3)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId3, YarnApplicationState.ACCEPTED, proxyAppUrl3, null)));
-    Mockito.when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId4)))
+    when(interceptor.getApplicationReport(GetApplicationReportRequest.newInstance(appId4)))
         .thenReturn(GetApplicationReportResponse.newInstance(
             newApplicationReport(appId4, YarnApplicationState.FINISHED, proxyAppUrl4, null)));
-    Mockito.when(wrapper.getRootInterceptor()).thenReturn(interceptor);
+    when(wrapper.getRootInterceptor()).thenReturn(interceptor);
     router.getClientRMProxyService().getUserPipelineMap().put(user, wrapper);
     try {
       // set Mocked rm and timeline

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServiceUtil.java
@@ -39,11 +39,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ApplicationStatisticsInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.StatisticsItemInfo;
 import org.apache.hadoop.yarn.server.uam.UnmanagedApplicationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -105,8 +107,8 @@ public class TestRouterWebServiceUtil {
     apps.add(app4);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(4, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(4, result.getApps().size());
 
     List<String> appIds = new ArrayList<String>();
     AppInfo appInfo1 = null, appInfo2 = null, appInfo3 = null, appInfo4 = null;
@@ -126,28 +128,28 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assert.assertTrue(appIds.contains(APPID1.toString()));
-    Assert.assertTrue(appIds.contains(APPID2.toString()));
-    Assert.assertTrue(appIds.contains(APPID3.toString()));
-    Assert.assertTrue(appIds.contains(APPID4.toString()));
+    assertTrue(appIds.contains(APPID1.toString()));
+    assertTrue(appIds.contains(APPID2.toString()));
+    assertTrue(appIds.contains(APPID3.toString()));
+    assertTrue(appIds.contains(APPID4.toString()));
 
     // Check preservations APP1
-    Assert.assertEquals(app1.getState(), appInfo1.getState());
-    Assert.assertEquals(app1.getNumAMContainerPreempted(),
+    assertEquals(app1.getState(), appInfo1.getState());
+    assertEquals(app1.getNumAMContainerPreempted(),
         appInfo1.getNumAMContainerPreempted());
 
     // Check preservations APP2
-    Assert.assertEquals(app2.getState(), appInfo2.getState());
-    Assert.assertEquals(app3.getAllocatedVCores(),
+    assertEquals(app2.getState(), appInfo2.getState());
+    assertEquals(app3.getAllocatedVCores(),
         appInfo3.getAllocatedVCores());
 
     // Check preservations APP3
-    Assert.assertEquals(app3.getState(), appInfo3.getState());
-    Assert.assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
+    assertEquals(app3.getState(), appInfo3.getState());
+    assertEquals(app3.getReservedMB(), appInfo3.getReservedMB());
 
     // Check preservations APP3
-    Assert.assertEquals(app4.getState(), appInfo4.getState());
-    Assert.assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
+    assertEquals(app4.getState(), appInfo4.getState());
+    assertEquals(app3.getAllocatedMB(), appInfo3.getAllocatedMB());
   }
 
   /**
@@ -186,19 +188,19 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assert.assertEquals(APPID1.toString(), app.getAppId());
-    Assert.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assert.assertEquals(value * 3, app.getPreemptedResourceMB());
-    Assert.assertEquals(value * 3, app.getPreemptedResourceVCores());
-    Assert.assertEquals(value * 3, app.getNumNonAMContainerPreempted());
-    Assert.assertEquals(value * 3, app.getNumAMContainerPreempted());
-    Assert.assertEquals(value * 3, app.getPreemptedMemorySeconds());
-    Assert.assertEquals(value * 3, app.getPreemptedVcoreSeconds());
+    assertEquals(APPID1.toString(), app.getAppId());
+    assertEquals(amHost, app.getAMHostHttpAddress());
+    assertEquals(value * 3, app.getPreemptedResourceMB());
+    assertEquals(value * 3, app.getPreemptedResourceVCores());
+    assertEquals(value * 3, app.getNumNonAMContainerPreempted());
+    assertEquals(value * 3, app.getNumAMContainerPreempted());
+    assertEquals(value * 3, app.getPreemptedMemorySeconds());
+    assertEquals(value * 3, app.getPreemptedVcoreSeconds());
   }
 
   private void setAppInfoFinished(AppInfo am, int value) {
@@ -248,21 +250,21 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
 
     AppInfo app = result.getApps().get(0);
 
-    Assert.assertEquals(APPID2.toString(), app.getAppId());
-    Assert.assertEquals(amHost, app.getAMHostHttpAddress());
-    Assert.assertEquals(value * 3, app.getAllocatedMB());
-    Assert.assertEquals(value * 3, app.getAllocatedVCores());
-    Assert.assertEquals(value * 3, app.getReservedMB());
-    Assert.assertEquals(value * 3, app.getReservedVCores());
-    Assert.assertEquals(value * 3, app.getRunningContainers());
-    Assert.assertEquals(value * 3, app.getMemorySeconds());
-    Assert.assertEquals(value * 3, app.getVcoreSeconds());
-    Assert.assertEquals(3, app.getResourceRequests().size());
+    assertEquals(APPID2.toString(), app.getAppId());
+    assertEquals(amHost, app.getAMHostHttpAddress());
+    assertEquals(value * 3, app.getAllocatedMB());
+    assertEquals(value * 3, app.getAllocatedVCores());
+    assertEquals(value * 3, app.getReservedMB());
+    assertEquals(value * 3, app.getReservedVCores());
+    assertEquals(value * 3, app.getRunningContainers());
+    assertEquals(value * 3, app.getMemorySeconds());
+    assertEquals(value * 3, app.getVcoreSeconds());
+    assertEquals(3, app.getResourceRequests().size());
   }
 
   private void setAppInfoRunning(AppInfo am, int value) {
@@ -300,15 +302,15 @@ public class TestRouterWebServiceUtil {
     apps.add(app2);
 
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(0, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(0, result.getApps().size());
 
     // By enabling partial result, the expected result would be a partial report
     // of the 2 UAMs
     AppsInfo result2 = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), true);
-    Assert.assertNotNull(result2);
-    Assert.assertEquals(1, result2.getApps().size());
-    Assert.assertEquals(YarnApplicationState.RUNNING,
+    assertNotNull(result2);
+    assertEquals(1, result2.getApps().size());
+    assertEquals(YarnApplicationState.RUNNING,
         result2.getApps().get(0).getState());
   }
 
@@ -329,8 +331,8 @@ public class TestRouterWebServiceUtil {
 
     // in this case the result does not change if we enable partial result
     AppsInfo result = RouterWebServiceUtil.mergeAppsInfo(apps.getApps(), false);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getApps().size());
+    assertNotNull(result);
+    assertEquals(1, result.getApps().size());
   }
 
   /**
@@ -361,8 +363,8 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assert.assertNotNull(result);
-    Assert.assertEquals(4, result.getNodes().size());
+    assertNotNull(result);
+    assertEquals(4, result.getNodes().size());
 
     List<String> nodesIds = new ArrayList<String>();
 
@@ -370,10 +372,10 @@ public class TestRouterWebServiceUtil {
       nodesIds.add(node.getNodeId());
     }
 
-    Assert.assertTrue(nodesIds.contains(NODE1));
-    Assert.assertTrue(nodesIds.contains(NODE2));
-    Assert.assertTrue(nodesIds.contains(NODE3));
-    Assert.assertTrue(nodesIds.contains(NODE4));
+    assertTrue(nodesIds.contains(NODE1));
+    assertTrue(nodesIds.contains(NODE2));
+    assertTrue(nodesIds.contains(NODE3));
+    assertTrue(nodesIds.contains(NODE4));
   }
 
   /**
@@ -404,13 +406,13 @@ public class TestRouterWebServiceUtil {
 
     NodesInfo result =
         RouterWebServiceUtil.deleteDuplicateNodesInfo(nodes.getNodes());
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.getNodes().size());
+    assertNotNull(result);
+    assertEquals(1, result.getNodes().size());
 
     NodeInfo node = result.getNodes().get(0);
 
-    Assert.assertEquals(NODE1, node.getNodeId());
-    Assert.assertEquals(2, node.getLastHealthUpdate());
+    assertEquals(NODE1, node.getNodeId());
+    assertEquals(2, node.getLastHealthUpdate());
   }
 
   /**
@@ -431,98 +433,98 @@ public class TestRouterWebServiceUtil {
     ClusterMetricsInfo metricsClone = createClusterMetricsClone(metrics);
     RouterWebServiceUtil.mergeMetrics(metrics, metricsResponse);
 
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsSubmitted() + metricsClone.getAppsSubmitted(),
         metrics.getAppsSubmitted());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsCompleted() + metricsClone.getAppsCompleted(),
         metrics.getAppsCompleted());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsPending() + metricsClone.getAppsPending(),
         metrics.getAppsPending());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsRunning() + metricsClone.getAppsRunning(),
         metrics.getAppsRunning());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsFailed() + metricsClone.getAppsFailed(),
         metrics.getAppsFailed());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAppsKilled() + metricsClone.getAppsKilled(),
         metrics.getAppsKilled());
 
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getReservedMB() + metricsClone.getReservedMB(),
         metrics.getReservedMB());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAvailableMB() + metricsClone.getAvailableMB(),
         metrics.getAvailableMB());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAllocatedMB() + metricsClone.getAllocatedMB(),
         metrics.getAllocatedMB());
 
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getReservedVirtualCores()
             + metricsClone.getReservedVirtualCores(),
         metrics.getReservedVirtualCores());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAvailableVirtualCores()
             + metricsClone.getAvailableVirtualCores(),
         metrics.getAvailableVirtualCores());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getAllocatedVirtualCores()
             + metricsClone.getAllocatedVirtualCores(),
         metrics.getAllocatedVirtualCores());
 
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getContainersAllocated()
             + metricsClone.getContainersAllocated(),
         metrics.getContainersAllocated());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getReservedContainers()
             + metricsClone.getReservedContainers(),
         metrics.getReservedContainers());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getPendingContainers()
             + metricsClone.getPendingContainers(),
         metrics.getPendingContainers());
 
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getTotalMB() + metricsClone.getTotalMB(),
         metrics.getTotalMB());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getUtilizedMB() + metricsClone.getUtilizedMB(),
         metrics.getUtilizedMB());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getTotalVirtualCores()
             + metricsClone.getTotalVirtualCores(),
         metrics.getTotalVirtualCores());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getUtilizedVirtualCores() + metricsClone.getUtilizedVirtualCores(),
         metrics.getUtilizedVirtualCores());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getTotalNodes() + metricsClone.getTotalNodes(),
         metrics.getTotalNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getLostNodes() + metricsClone.getLostNodes(),
         metrics.getLostNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getUnhealthyNodes() + metricsClone.getUnhealthyNodes(),
         metrics.getUnhealthyNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getDecommissioningNodes()
             + metricsClone.getDecommissioningNodes(),
         metrics.getDecommissioningNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getDecommissionedNodes()
             + metricsClone.getDecommissionedNodes(),
         metrics.getDecommissionedNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getRebootedNodes() + metricsClone.getRebootedNodes(),
         metrics.getRebootedNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getActiveNodes() + metricsClone.getActiveNodes(),
         metrics.getActiveNodes());
-    Assert.assertEquals(
+    assertEquals(
         metricsResponse.getShutdownNodes() + metricsClone.getShutdownNodes(),
         metrics.getShutdownNodes());
   }
@@ -629,14 +631,14 @@ public class TestRouterWebServiceUtil {
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
     ArrayList<StatisticsItemInfo> statItem = mergeInfo.getStatItems();
 
-    Assert.assertNotNull(statItem);
-    Assert.assertEquals(1, statItem.size());
+    assertNotNull(statItem);
+    assertEquals(1, statItem.size());
 
     StatisticsItemInfo first = statItem.get(0);
 
-    Assert.assertEquals(item1.getCount() + item2.getCount(), first.getCount());
-    Assert.assertEquals(item1.getType(), first.getType());
-    Assert.assertEquals(item1.getState(), first.getState());
+    assertEquals(item1.getCount() + item2.getCount(), first.getCount());
+    assertEquals(item1.getType(), first.getType());
+    assertEquals(item1.getState(), first.getState());
   }
 
   @Test
@@ -662,7 +664,7 @@ public class TestRouterWebServiceUtil {
     ApplicationStatisticsInfo mergeInfo =
         RouterWebServiceUtil.mergeApplicationStatisticsInfo(lists);
 
-    Assert.assertEquals(3, mergeInfo.getStatItems().size());
+    assertEquals(3, mergeInfo.getStatItems().size());
     List<StatisticsItemInfo> mergeInfoStatItems = mergeInfo.getStatItems();
 
     StatisticsItemInfo item1Result = null;
@@ -686,12 +688,12 @@ public class TestRouterWebServiceUtil {
       }
     }
 
-    Assert.assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
-    Assert.assertEquals(item1.getCount(), item1Result.getCount());
-    Assert.assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
-    Assert.assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
-    Assert.assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
-    Assert.assertEquals(item4.getCount(), item3Result.getCount());
+    assertEquals(YarnApplicationState.ACCEPTED, item1Result.getState());
+    assertEquals(item1.getCount(), item1Result.getCount());
+    assertEquals(YarnApplicationState.NEW_SAVING, item2Result.getState());
+    assertEquals((item2.getCount() + item3.getCount()), item2Result.getCount());
+    assertEquals(YarnApplicationState.FINISHED, item3Result.getState());
+    assertEquals(item4.getCount(), item3Result.getCount());
   }
 
   @Test
@@ -702,8 +704,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties = client01.getConfiguration().getProperties();
     int readTimeOut = (int) properties.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut = (int) properties.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut);
-    Assert.assertEquals(30000, connectTimeOut);
+    assertEquals(30000, readTimeOut);
+    assertEquals(30000, connectTimeOut);
     client01.close();
 
     // Case2, set a negative timeout, We'll get the default timeout(30s)
@@ -714,8 +716,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties02 = client02.getConfiguration().getProperties();
     int readTimeOut02 = (int) properties02.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut02 =  (int) properties02.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut02);
-    Assert.assertEquals(30000, connectTimeOut02);
+    assertEquals(30000, readTimeOut02);
+    assertEquals(30000, connectTimeOut02);
     client02.close();
 
     // Case3, Set the maximum value that exceeds the integer
@@ -730,8 +732,8 @@ public class TestRouterWebServiceUtil {
     Map<String, Object> properties03 = client03.getConfiguration().getProperties();
     int readTimeOut03 = (int) properties03.get(ClientProperties.READ_TIMEOUT);
     int connectTimeOut03 = (int) properties03.get(ClientProperties.CONNECT_TIMEOUT);
-    Assert.assertEquals(30000, readTimeOut03);
-    Assert.assertEquals(30000, connectTimeOut03);
+    assertEquals(30000, readTimeOut03);
+    assertEquals(30000, connectTimeOut03);
     client03.close();
   }
 
@@ -748,8 +750,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout = (int) getTimeDuration(conf,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assert.assertEquals(-1, connectTimeOut);
-    Assert.assertEquals(-1, readTimeout);
+    assertEquals(-1, connectTimeOut);
+    assertEquals(-1, readTimeout);
 
     // Case2, Set the maximum value that exceeds the integer.
     // Converted to int, there will be a value out of bounds.
@@ -765,8 +767,8 @@ public class TestRouterWebServiceUtil {
     int readTimeout1 = (int) getTimeDuration(conf1,
         YarnConfiguration.ROUTER_WEBAPP_READ_TIMEOUT,
         YarnConfiguration.DEFAULT_ROUTER_WEBAPP_READ_TIMEOUT);
-    Assert.assertEquals(-2147483648, connectTimeOut1);
-    Assert.assertEquals(-2147483648, readTimeout1);
+    assertEquals(-2147483648, connectTimeOut1);
+    assertEquals(-2147483648, readTimeout1);
   }
 
   private long getTimeDuration(YarnConfiguration conf, String varName, long defaultValue) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServices.java
@@ -18,6 +18,12 @@
 
 package org.apache.hadoop.yarn.server.router.webapp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
@@ -49,8 +55,7 @@ import org.apache.hadoop.yarn.server.router.webapp.RouterWebServices.RequestInte
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,140 +77,140 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
   public void testRouterWebServicesE2E() throws Exception {
 
     ClusterInfo clusterInfo = get(user);
-    Assert.assertNotNull(clusterInfo);
+    assertNotNull(clusterInfo);
 
     ClusterInfo clusterInfo2 = getClusterInfo(user);
-    Assert.assertNotNull(clusterInfo2);
+    assertNotNull(clusterInfo2);
 
     ClusterMetricsInfo clusterMetricsInfo = getClusterMetricsInfo(user);
-    Assert.assertNotNull(clusterMetricsInfo);
+    assertNotNull(clusterMetricsInfo);
 
     SchedulerTypeInfo schedulerTypeInfo = getSchedulerInfo(user);
-    Assert.assertNotNull(schedulerTypeInfo);
+    assertNotNull(schedulerTypeInfo);
 
     String dumpResult = dumpSchedulerLogs(user);
-    Assert.assertNotNull(dumpResult);
+    assertNotNull(dumpResult);
 
     NodesInfo nodesInfo = getNodes(user);
-    Assert.assertNotNull(nodesInfo);
+    assertNotNull(nodesInfo);
 
     NodeInfo nodeInfo = getNode(user);
-    Assert.assertNotNull(nodeInfo);
+    assertNotNull(nodeInfo);
 
     AppsInfo appsInfo = getApps(user);
-    Assert.assertNotNull(appsInfo);
+    assertNotNull(appsInfo);
 
     ActivitiesInfo activitiesInfo = getActivities(user);
-    Assert.assertNotNull(activitiesInfo);
+    assertNotNull(activitiesInfo);
 
     AppActivitiesInfo appActiviesInfo = getAppActivities(user);
-    Assert.assertNotNull(appActiviesInfo);
+    assertNotNull(appActiviesInfo);
 
     ApplicationStatisticsInfo applicationStatisticsInfo =
         getAppStatistics(user);
-    Assert.assertNotNull(applicationStatisticsInfo);
+    assertNotNull(applicationStatisticsInfo);
 
     AppInfo appInfo = getApp(user);
-    Assert.assertNotNull(appInfo);
+    assertNotNull(appInfo);
 
     AppState appState = getAppState(user);
-    Assert.assertNotNull(appState);
+    assertNotNull(appState);
 
     Response response = updateAppState(user);
-    Assert.assertNotNull(response);
+    assertNotNull(response);
 
     NodeToLabelsInfo nodeToLabelsInfo = getNodeToLabels(user);
-    Assert.assertNotNull(nodeToLabelsInfo);
+    assertNotNull(nodeToLabelsInfo);
 
     LabelsToNodesInfo labelsToNodesInfo = getLabelsToNodes(user);
-    Assert.assertNotNull(labelsToNodesInfo);
+    assertNotNull(labelsToNodesInfo);
 
     Response response2 = replaceLabelsOnNodes(user);
-    Assert.assertNotNull(response2);
+    assertNotNull(response2);
 
     Response response3 = replaceLabelsOnNode(user);
-    Assert.assertNotNull(response3);
+    assertNotNull(response3);
 
     NodeLabelsInfo nodeLabelsInfo = getClusterNodeLabels(user);
-    Assert.assertNotNull(nodeLabelsInfo);
+    assertNotNull(nodeLabelsInfo);
 
     Response response4 = addToClusterNodeLabels(user);
-    Assert.assertNotNull(response4);
+    assertNotNull(response4);
 
     Response response5 = removeFromClusterNodeLabels(user);
-    Assert.assertNotNull(response5);
+    assertNotNull(response5);
 
     NodeLabelsInfo nodeLabelsInfo2 = getLabelsOnNode(user);
-    Assert.assertNotNull(nodeLabelsInfo2);
+    assertNotNull(nodeLabelsInfo2);
 
     AppPriority appPriority = getAppPriority(user);
-    Assert.assertNotNull(appPriority);
+    assertNotNull(appPriority);
 
     Response response6 = updateApplicationPriority(user);
-    Assert.assertNotNull(response6);
+    assertNotNull(response6);
 
     AppQueue appQueue = getAppQueue(user);
-    Assert.assertNotNull(appQueue);
+    assertNotNull(appQueue);
 
     Response response7 = updateAppQueue(user);
-    Assert.assertNotNull(response7);
+    assertNotNull(response7);
 
     Response response8 = createNewApplication(user);
-    Assert.assertNotNull(response8);
+    assertNotNull(response8);
 
     Response response9 = submitApplication(user);
-    Assert.assertNotNull(response9);
+    assertNotNull(response9);
 
     Response response10 = postDelegationToken(user);
-    Assert.assertNotNull(response10);
+    assertNotNull(response10);
 
     Response response11 = postDelegationTokenExpiration(user);
-    Assert.assertNotNull(response11);
+    assertNotNull(response11);
 
     Response response12 = cancelDelegationToken(user);
-    Assert.assertNotNull(response12);
+    assertNotNull(response12);
 
     Response response13 = createNewReservation(user);
-    Assert.assertNotNull(response13);
+    assertNotNull(response13);
 
     Response response14 = submitReservation(user);
-    Assert.assertNotNull(response14);
+    assertNotNull(response14);
 
     Response response15 = updateReservation(user);
-    Assert.assertNotNull(response15);
+    assertNotNull(response15);
 
     Response response16 = deleteReservation(user);
-    Assert.assertNotNull(response16);
+    assertNotNull(response16);
 
     Response response17 = listReservation(user);
-    Assert.assertNotNull(response17);
+    assertNotNull(response17);
 
     AppTimeoutInfo appTimeoutInfo = getAppTimeout(user);
-    Assert.assertNotNull(appTimeoutInfo);
+    assertNotNull(appTimeoutInfo);
 
     AppTimeoutsInfo appTimeoutsInfo = getAppTimeouts(user);
-    Assert.assertNotNull(appTimeoutsInfo);
+    assertNotNull(appTimeoutsInfo);
 
     Response response18 = updateApplicationTimeout(user);
-    Assert.assertNotNull(response18);
+    assertNotNull(response18);
 
     AppAttemptsInfo appAttemptsInfo = getAppAttempts(user);
-    Assert.assertNotNull(appAttemptsInfo);
+    assertNotNull(appAttemptsInfo);
 
     AppAttemptInfo appAttemptInfo = getAppAttempt(user);
-    Assert.assertNotNull(appAttemptInfo);
+    assertNotNull(appAttemptInfo);
 
     ContainersInfo containersInfo = getContainers(user);
-    Assert.assertNotNull(containersInfo);
+    assertNotNull(containersInfo);
 
     ContainerInfo containerInfo = getContainer(user);
-    Assert.assertNotNull(containerInfo);
+    assertNotNull(containerInfo);
 
     Response response19 = updateSchedulerConfiguration(user);
-    Assert.assertNotNull(response19);
+    assertNotNull(response19);
 
     Response response20 = getSchedulerConfiguration(user);
-    Assert.assertNotNull(response20);
+    assertNotNull(response20);
   }
 
   /**
@@ -227,21 +232,21 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
       case 1: // Fall to the next case
       case 2:
         // If index is equal to 0,1 or 2 we fall in this check
-        Assert.assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
+        assertEquals(PassThroughRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       case 3:
-        Assert.assertEquals(MockRESTRequestInterceptor.class.getName(),
+        assertEquals(MockRESTRequestInterceptor.class.getName(),
             root.getClass().getName());
         break;
       default:
-        Assert.fail();
+        fail();
       }
       root = root.getNextInterceptor();
       index++;
     }
-    Assert.assertEquals("The number of interceptors in chain does not match", 4,
-        index);
+    assertEquals(4, index,
+        "The number of interceptors in chain does not match");
   }
 
   /**
@@ -262,7 +267,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
 
     Map<String, RequestInterceptorChainWrapper> pipelines =
         getRouterWebServices().getPipelines();
-    Assert.assertEquals(8, pipelines.size());
+    assertEquals(8, pipelines.size());
 
     getInterceptorChain("test9");
     getInterceptorChain("test10");
@@ -270,13 +275,13 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     getInterceptorChain("test11");
 
     // The cache max size is defined in TEST_MAX_CACHE_SIZE
-    Assert.assertEquals(10, pipelines.size());
+    assertEquals(10, pipelines.size());
 
     RequestInterceptorChainWrapper chain = pipelines.get("test1");
-    Assert.assertNotNull("test1 should not be evicted", chain);
+    assertNotNull(chain, "test1 should not be evicted");
 
     chain = pipelines.get("test2");
-    Assert.assertNull("test2 should have been evicted", chain);
+    assertNull(chain, "test2 should have been evicted");
   }
 
   /**
@@ -311,7 +316,7 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
                     getInterceptorChain(user);
                 RESTRequestInterceptor interceptor =
                     wrapper.getRootInterceptor();
-                Assert.assertNotNull(interceptor);
+                assertNotNull(interceptor);
                 LOG.info("init web interceptor success for user" + user);
                 return interceptor;
               }
@@ -332,9 +337,9 @@ public class TestRouterWebServices extends BaseRouterWebServicesTest {
     client1.join();
     client2.join();
 
-    Assert.assertNotNull(client1.interceptor);
-    Assert.assertNotNull(client2.interceptor);
-    Assert.assertSame(client1.interceptor, client2.interceptor);
+    assertNotNull(client1.interceptor);
+    assertNotNull(client2.interceptor);
+    assertSame(client1.interceptor, client2.interceptor);
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestRouterWebServicesREST.java
@@ -69,9 +69,9 @@ import static org.apache.hadoop.yarn.webapp.WebServicesTestUtils.assertResponseS
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getNMWebAppURLWithoutScheme;
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getRMWebAppURLWithScheme;
 import static org.apache.hadoop.yarn.webapp.util.WebAppUtils.getRouterWebAppURLWithScheme;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -129,9 +129,10 @@ import org.apache.hadoop.yarn.server.router.Router;
 import org.apache.hadoop.yarn.server.webapp.WebServices;
 import org.apache.hadoop.yarn.server.webapp.dao.AppsInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -202,7 +203,7 @@ public class TestRouterWebServicesREST {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new YarnConfiguration();
 
@@ -231,7 +232,7 @@ public class TestRouterWebServicesREST {
     waitWebAppRunning(nmAddress, "/ws/v1/node");
   }
 
-  @AfterClass
+  @AfterAll
   public static void stop() throws Exception {
     if (nm != null) {
       nm.stop();
@@ -332,7 +333,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link RMWebServiceProtocol#get()}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testInfoXML() throws Exception {
 
     List<ClusterInfo> responses = performGetCalls(
@@ -353,7 +355,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testClusterInfoXML() throws Exception {
 
     List<ClusterInfo> responses = performGetCalls(
@@ -374,7 +377,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterMetricsInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testMetricsInfoXML() throws Exception {
 
     List<ClusterMetricsInfo> responses = performGetCalls(
@@ -395,7 +399,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getSchedulerInfo()} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSchedulerInfoXML() throws Exception {
 
     List<SchedulerTypeInfo> responses = performGetCalls(
@@ -416,7 +421,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodes(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodesEmptyXML() throws Exception {
 
     List<NodesInfo> responses = performGetCalls(
@@ -437,7 +443,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodes(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodesXML() throws Exception {
 
     List<NodesInfo> responses = performGetCalls(
@@ -458,7 +465,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNode(String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNodeXML() throws Exception {
 
     List<NodeInfo> responses = performGetCalls(
@@ -520,7 +528,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getActivities(HttpServletRequest, String, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testActiviesXML() throws Exception {
 
     List<ActivitiesInfo> responses = performGetCalls(
@@ -538,7 +547,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppActivities} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppActivitiesXML() throws Exception {
 
     String appId = submitApplication();
@@ -558,7 +568,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppStatistics} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppStatisticsXML() throws Exception {
 
     submitApplication();
@@ -582,7 +593,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#dumpSchedulerLogs} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testDumpSchedulerLogsXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -605,7 +617,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#createNewApplication} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNewApplicationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -629,7 +642,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#submitApplication} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSubmitApplicationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -655,7 +669,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getApps} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppsXML() throws Exception {
 
     submitApplication();
@@ -678,7 +693,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getApp} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppXML() throws Exception {
 
     String appId = submitApplication();
@@ -702,7 +718,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppAttempts} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppAttemptXML() throws Exception {
 
     String appId = submitApplication();
@@ -726,7 +743,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppState} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppStateXML() throws Exception {
 
     String appId = submitApplication();
@@ -750,7 +768,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#updateAppState} inside Router.
    */
-  @Test(timeout = 20000000)
+  @Test
+  @Timeout(value = 20000)
   public void testUpdateAppStateXML() throws Exception {
 
     String appId = submitApplication();
@@ -778,7 +797,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppPriority} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppPriorityXML() throws Exception {
 
     String appId = submitApplication();
@@ -801,7 +821,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateApplicationPriority(
    *     AppPriority, HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppPriorityXML() throws Exception {
 
     String appId = submitApplication();
@@ -829,7 +850,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppQueue(HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppQueueXML() throws Exception {
 
     String appId = submitApplication();
@@ -852,7 +874,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateAppQueue(AppQueue, HttpServletRequest, String)}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppQueueXML() throws Exception {
 
     String appId = submitApplication();
@@ -880,7 +903,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppTimeouts} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppTimeoutsXML() throws Exception {
 
     String appId = submitApplication();
@@ -904,7 +928,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getAppTimeout} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAppTimeoutXML() throws Exception {
 
     String appId = submitApplication();
@@ -928,7 +953,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateApplicationTimeout}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateAppTimeoutsXML() throws Exception {
 
     String appId = submitApplication();
@@ -956,7 +982,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#createNewReservation(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testNewReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -981,7 +1008,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#submitReservation(
    *     ReservationSubmissionRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testSubmitReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1010,7 +1038,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#updateReservation(
    *     ReservationUpdateRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testUpdateReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1037,7 +1066,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#deleteReservation(
    *     ReservationDeleteRequestInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testDeleteReservationXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1063,7 +1093,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getNodeToLabels(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetNodeToLabelsXML() throws Exception {
 
     List<NodeToLabelsInfo> responses = performGetCalls(
@@ -1085,7 +1116,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getClusterNodeLabels(HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetClusterNodeLabelsXML() throws Exception {
 
     List<NodeLabelsInfo> responses = performGetCalls(
@@ -1107,7 +1139,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsOnNode(HttpServletRequest, String)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsOnNodeXML() throws Exception {
 
     List<NodeLabelsInfo> responses = performGetCalls(
@@ -1129,7 +1162,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsToNodes(Set<String>)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsMappingEmptyXML() throws Exception {
 
     List<LabelsToNodesInfo> responses = performGetCalls(
@@ -1151,7 +1185,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#getLabelsToNodes(Set<String>)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetLabelsMappingXML() throws Exception {
 
     List<LabelsToNodesInfo> responses = performGetCalls(
@@ -1174,7 +1209,8 @@ public class TestRouterWebServicesREST {
    * {@link RMWebServiceProtocol#addToClusterNodeLabels(
    *     NodeLabelsInfo, HttpServletRequest)} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testAddToClusterNodeLabelsXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1202,7 +1238,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#removeFromClusterNodeLabels} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testRemoveFromClusterNodeLabelsXML()
       throws Exception {
 
@@ -1228,7 +1265,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#replaceLabelsOnNodes} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testReplaceLabelsOnNodesXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1255,7 +1293,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of
    * {@link RMWebServiceProtocol#replaceLabelsOnNode} inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testReplaceLabelsOnNodeXML() throws Exception {
 
     // Test with a wrong HTTP method
@@ -1281,7 +1320,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link WebServices#getAppAttempt}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetAppAttemptXML() throws Exception {
 
     String appId = submitApplication();
@@ -1305,7 +1345,8 @@ public class TestRouterWebServicesREST {
    * This test validates the correctness of {@link WebServices#getContainers}
    * inside Router.
    */
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2)
   public void testGetContainersXML() throws Exception {
 
     String appId = submitApplication();
@@ -1326,7 +1367,8 @@ public class TestRouterWebServicesREST {
         routerResponse.getContainers().size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetAppsMultiThread() throws Exception {
     final int iniNumApps = getNumApps();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/resources/yarn-site.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/resources/yarn-site.xml
@@ -41,7 +41,7 @@
   </property>
   <property>
     <name>yarn.federation.policy-manager-params</name>
-    <value>{"routerPolicyWeights":{"entry":[{"key":{"id":"SC-2"},"value":"0.3"},{"key":{"id":"SC-1"},"value":"0.7"}]},"amrmPolicyWeights":{"entry":[{"key":{"id":"SC-2"},"value":"0.4"},{"key":{"id":"SC-1"},"value":"0.6"}]},"headroomAlpha":"1.0"}</value>
+    <value>{"routerPolicyWeights":{"SC-2":"0.3","SC-1":"0.7"},"amrmPolicyWeights":{"SC-2":"0.4", "SC-1":"0.6"},"headroomAlpha":"1.0"}</value>
   </property>
   <property>
     <name>yarn.resourcemanager.cluster-id</name>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11267. Upgrade JUnit from 4 to 5 in hadoop-yarn-server-router.

### How was this patch tested?

junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

