### PR TITLE
HADOOP-19438. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-resourceestimator.

### DIFF
--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test {@link ResourceSkyline} class.
@@ -45,7 +45,8 @@ public class TestResourceSkyline {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -54,40 +55,40 @@ public class TestResourceSkyline {
   }
 
   @Test public final void testGetJobId() {
-    Assert.assertNull(resourceSkyline);
+    Assertions.assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals("1", resourceSkyline.getJobId());
+    Assertions.assertEquals("1", resourceSkyline.getJobId());
   }
 
   @Test public final void testGetJobSubmissionTime() {
-    Assert.assertNull(resourceSkyline);
+    Assertions.assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    Assertions.assertEquals(0, resourceSkyline.getJobSubmissionTime());
   }
 
   @Test public final void testGetJobFinishTime() {
-    Assert.assertNull(resourceSkyline);
+    Assertions.assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals(20, resourceSkyline.getJobFinishTime());
+    Assertions.assertEquals(20, resourceSkyline.getJobFinishTime());
   }
 
   @Test public final void testGetKthResource() {
-    Assert.assertNull(resourceSkyline);
+    Assertions.assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(20, 30);
@@ -97,27 +98,27 @@ public class TestResourceSkyline {
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     for (int i = 10; i < 20; i++) {
-      Assert.assertEquals(resource1.getMemorySize(),
+      Assertions.assertEquals(resource1.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(resource1.getVirtualCores(),
+      Assertions.assertEquals(resource1.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     for (int i = 20; i < 30; i++) {
-      Assert.assertEquals(resource2.getMemorySize(),
+      Assertions.assertEquals(resource2.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(resource2.getVirtualCores(),
+      Assertions.assertEquals(resource2.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     // test if resourceSkyline automatically extends the skyline with
     // zero-resource at both ends
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
-    Assert
-        .assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
+    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
+    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
+    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
+    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     resourceSkyline = null;
     resource1 = null;
     resource2 = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
@@ -20,6 +20,9 @@
 
 package org.apache.hadoop.resourceestimator.common.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.TreeMap;
 
 import org.apache.hadoop.yarn.api.records.Resource;
@@ -27,7 +30,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResour
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,40 +57,40 @@ public class TestResourceSkyline {
   }
 
   @Test public final void testGetJobId() {
-    Assertions.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assertions.assertEquals("1", resourceSkyline.getJobId());
+    assertEquals("1", resourceSkyline.getJobId());
   }
 
   @Test public final void testGetJobSubmissionTime() {
-    Assertions.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assertions.assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    assertEquals(0, resourceSkyline.getJobSubmissionTime());
   }
 
   @Test public final void testGetJobFinishTime() {
-    Assertions.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assertions.assertEquals(20, resourceSkyline.getJobFinishTime());
+    assertEquals(20, resourceSkyline.getJobFinishTime());
   }
 
   @Test public final void testGetKthResource() {
-    Assertions.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(20, 30);
@@ -98,23 +100,23 @@ public class TestResourceSkyline {
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     for (int i = 10; i < 20; i++) {
-      Assertions.assertEquals(resource1.getMemorySize(),
+      assertEquals(resource1.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assertions.assertEquals(resource1.getVirtualCores(),
+      assertEquals(resource1.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     for (int i = 20; i < 30; i++) {
-      Assertions.assertEquals(resource2.getMemorySize(),
+      assertEquals(resource2.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assertions.assertEquals(resource2.getVirtualCores(),
+      assertEquals(resource2.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     // test if resourceSkyline automatically extends the skyline with
     // zero-resource at both ends
-    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
-    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
-    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
-    Assertions.assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
+    assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
+    assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
+    assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
+    assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
   }
 
   @AfterEach

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
@@ -20,6 +20,9 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,7 +36,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResour
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -94,31 +96,30 @@ public class TestHistorySkylineSerDe {
     // check if the recurrenceId is correct
     List<ResourceSkyline> resourceSkylineList =
         historySkylineDe.get(recurrenceId);
-    Assertions.assertNotNull(resourceSkylineList);
-    Assertions.assertEquals(1, resourceSkylineList.size());
+    assertNotNull(resourceSkylineList);
+    assertEquals(1, resourceSkylineList.size());
 
     // check if the resourceSkyline is correct
     ResourceSkyline resourceSkylineDe = resourceSkylineList.get(0);
-    Assertions
-        .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assertions.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
+    assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assertions.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assertions.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
@@ -32,10 +32,10 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -56,7 +56,8 @@ public class TestHistorySkylineSerDe {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -93,36 +94,37 @@ public class TestHistorySkylineSerDe {
     // check if the recurrenceId is correct
     List<ResourceSkyline> resourceSkylineList =
         historySkylineDe.get(recurrenceId);
-    Assert.assertNotNull(resourceSkylineList);
-    Assert.assertEquals(1, resourceSkylineList.size());
+    Assertions.assertNotNull(resourceSkylineList);
+    Assertions.assertEquals(1, resourceSkylineList.size());
 
     // check if the resourceSkyline is correct
     ResourceSkyline resourceSkylineDe = resourceSkylineList.get(0);
-    Assert
+    Assertions
         .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assert.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    Assertions.assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    Assertions.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    Assertions.assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     gson = null;
     resourceSkyline = null;
     resourceOverTime.clear();

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
@@ -20,9 +20,10 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,13 +49,14 @@ public class TestResourceSerDe {
         .registerTypeAdapter(Resource.class, new ResourceSerDe()).create();
   }
 
-  @Test public final void testSerialization() {
+  @Test
+  public final void testSerialization() {
     final String json = gson.toJson(resource, new TypeToken<Resource>() {
     }.getType());
     final Resource resourceDe = gson.fromJson(json, new TypeToken<Resource>() {
     }.getType());
-    Assertions.assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
-    Assertions.assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
+    assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
+    assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
   }
 
   @AfterEach

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
@@ -21,10 +21,10 @@
 package org.apache.hadoop.resourceestimator.common.serialization;
 
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -41,7 +41,8 @@ public class TestResourceSerDe {
 
   private Resource resource;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resource = Resource.newInstance(1024 * 100, 100);
     gson = new GsonBuilder()
         .registerTypeAdapter(Resource.class, new ResourceSerDe()).create();
@@ -52,12 +53,12 @@ public class TestResourceSerDe {
     }.getType());
     final Resource resourceDe = gson.fromJson(json, new TypeToken<Resource>() {
     }.getType());
-    Assert.assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
-    Assert
-        .assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
+    Assertions.assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
+    Assertions.assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     resource = null;
     gson = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.TreeMap;
 
 import org.apache.hadoop.resourceestimator.common.api.ResourceSkyline;
@@ -28,7 +30,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResour
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -77,26 +78,25 @@ public class TestResourceSkylineSerDe {
     final ResourceSkyline resourceSkylineDe =
         gson.fromJson(json, new TypeToken<ResourceSkyline>() {
         }.getType());
-    Assertions
-        .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assertions.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
+    assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assertions.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assertions.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -51,7 +51,8 @@ public class TestResourceSkylineSerDe {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -76,31 +77,32 @@ public class TestResourceSkylineSerDe {
     final ResourceSkyline resourceSkylineDe =
         gson.fromJson(json, new TypeToken<ResourceSkyline>() {
         }.getType());
-    Assert
+    Assertions
         .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assert.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    Assertions.assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    Assertions.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    Assertions.assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    Assertions.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      Assertions.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     gson = null;
     resourceSkyline = null;
     resourceOverTime.clear();

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResour
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
@@ -81,6 +82,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     return config;
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -88,24 +88,24 @@ public class TestResourceEstimatorService extends JerseyTest {
 
   private void compareResourceSkyline(final ResourceSkyline skyline1,
       final ResourceSkyline skyline2) {
-    Assert.assertEquals(skyline1.getJobId(), skyline2.getJobId());
-    Assert.assertEquals(skyline1.getJobInputDataSize(),
+    Assertions.assertEquals(skyline1.getJobId(), skyline2.getJobId());
+    Assertions.assertEquals(skyline1.getJobInputDataSize(),
         skyline2.getJobInputDataSize(), 0);
-    Assert.assertEquals(skyline1.getJobSubmissionTime(),
+    Assertions.assertEquals(skyline1.getJobSubmissionTime(),
         skyline2.getJobSubmissionTime());
-    Assert
+    Assertions
         .assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
-    Assert.assertEquals(skyline1.getContainerSpec().getMemorySize(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getMemorySize(),
         skyline2.getContainerSpec().getMemorySize());
-    Assert.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
         skyline2.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList1 = skyline1.getSkylineList();
     final RLESparseResourceAllocation skylineList2 = skyline2.getSkylineList();
     for (int i = (int) skylineList1.getEarliestStartTime();
          i < skylineList1.getLatestNonNullTime(); i++) {
-      Assert.assertEquals(skylineList1.getCapacityAtTime(i).getMemorySize(),
+      Assertions.assertEquals(skylineList1.getCapacityAtTime(i).getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList1.getCapacityAtTime(i).getVirtualCores(),
+      Assertions.assertEquals(skylineList1.getCapacityAtTime(i).getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
   }
@@ -172,7 +172,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     case "tpch_q12_0": {
       final RecurrenceId recurrenceId =
           new RecurrenceId("tpch_q12", "tpch_q12_0");
-      Assert.assertEquals(1, jobHistory.get(recurrenceId).size());
+      Assertions.assertEquals(1, jobHistory.get(recurrenceId).size());
       ResourceSkyline skylineReceive = jobHistory.get(recurrenceId).get(0);
       compareResourceSkyline(skylineReceive, getSkyline1());
       break;
@@ -180,7 +180,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     case "tpch_q12_1": {
       final RecurrenceId recurrenceId =
           new RecurrenceId("tpch_q12", "tpch_q12_1");
-      Assert.assertEquals(1, jobHistory.get(recurrenceId).size());
+      Assertions.assertEquals(1, jobHistory.get(recurrenceId).size());
       ResourceSkyline skylineReceive = jobHistory.get(recurrenceId).get(0);
       compareResourceSkyline(skylineReceive, getSkyline2());
       break;
@@ -195,7 +195,7 @@ public class TestResourceEstimatorService extends JerseyTest {
       final RLESparseResourceAllocation rle2) {
     for (int i = (int) rle1.getEarliestStartTime();
          i < rle1.getLatestNonNullTime(); i++) {
-      Assert.assertEquals(rle1.getCapacityAtTime(i), rle2.getCapacityAtTime(i));
+      Assertions.assertEquals(rle1.getCapacityAtTime(i), rle2.getCapacityAtTime(i));
     }
   }
 
@@ -217,20 +217,20 @@ public class TestResourceEstimatorService extends JerseyTest {
     // then, try to get estimated resource allocation from skyline store
     webResource = target().path(getEstimatedSkylineCommand);
     response = webResource.request().get(String.class);
-    Assert.assertEquals("null", response);
+    Assertions.assertEquals("null", response);
     // then, we call estimator module to make the prediction
     webResource = target().path(makeEstimationCommand);
     response = webResource.request().get(String.class);
     RLESparseResourceAllocation skylineList =
         gson.fromJson(response, new TypeToken<RLESparseResourceAllocation>() {
         }.getType());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         skylineList.getCapacityAtTime(0).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(1058,
+    Assertions.assertEquals(1058,
         skylineList.getCapacityAtTime(10).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(2538,
+    Assertions.assertEquals(2538,
         skylineList.getCapacityAtTime(15).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(2484,
+    Assertions.assertEquals(2484,
         skylineList.getCapacityAtTime(20).getMemorySize() / containerMemAlloc);
     // then, we get estimated resource allocation for tpch_q12
     webResource = target().path(getEstimatedSkylineCommand);
@@ -256,9 +256,9 @@ public class TestResourceEstimatorService extends JerseyTest {
         new TypeToken<Map<RecurrenceId, List<ResourceSkyline>>>() {
         }.getType());
     // jobHistory should only have info for tpch_q12_0
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     final String pipelineId =
         ((RecurrenceId) jobHistory.keySet().toArray()[0]).getRunId();
-    Assert.assertEquals("tpch_q12_0", pipelineId);
+    Assertions.assertEquals("tpch_q12_0", pipelineId);
   }
 }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestInMemoryStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestInMemoryStore.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.resourceestimator.skylinestore.api.SkylineStore;
  * Test {@link InMemoryStore} class.
  */
 public class TestInMemoryStore extends TestSkylineStore {
-  @Override public final SkylineStore createSkylineStore() {
+  @Override
+  public final SkylineStore createSkylineStore() {
     return new InMemoryStore();
   }
 }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
@@ -20,6 +20,12 @@
 
 package org.apache.hadoop.resourceestimator.skylinestore.impl;
 
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +47,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResour
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,18 +75,17 @@ public abstract class TestSkylineStore {
 
   private void compare(final ResourceSkyline skyline1,
       final ResourceSkyline skyline2) {
-    Assertions.assertEquals(skyline1.getJobId(), skyline2.getJobId());
-    Assertions.assertEquals(skyline1.getJobInputDataSize(),
+    assertEquals(skyline1.getJobId(), skyline2.getJobId());
+    assertEquals(skyline1.getJobInputDataSize(),
         skyline2.getJobInputDataSize(), 0);
-    Assertions.assertEquals(skyline1.getJobSubmissionTime(),
+    assertEquals(skyline1.getJobSubmissionTime(),
         skyline2.getJobSubmissionTime());
-    Assertions
-        .assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
-    Assertions.assertEquals(skyline1.getContainerSpec().getMemorySize(),
+    assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
+    assertEquals(skyline1.getContainerSpec().getMemorySize(),
         skyline2.getContainerSpec().getMemorySize());
-    Assertions.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
+    assertEquals(skyline1.getContainerSpec().getVirtualCores(),
         skyline2.getContainerSpec().getVirtualCores());
-    Assertions.assertEquals(true,
+    assertEquals(true,
         skyline2.getSkylineList().equals(skyline1.getSkylineList()));
   }
 
@@ -92,7 +96,7 @@ public abstract class TestSkylineStore {
     skylineStore.addHistory(recurrenceId, resourceSkylines);
     final List<ResourceSkyline> resourceSkylinesGet =
         skylineStore.getHistory(recurrenceId).get(recurrenceId);
-    Assertions.assertTrue(resourceSkylinesGet.contains(resourceSkyline));
+    assertTrue(resourceSkylinesGet.contains(resourceSkyline));
   }
 
   private ResourceSkyline getSkyline(final int n) {
@@ -131,31 +135,31 @@ public abstract class TestSkylineStore {
     // test getHistory {pipelineId, runId}
     Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assertions.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assertions.assertEquals(recurrenceId1, entry.getKey());
+      assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assertions.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
     // test getHistory {pipelineId, *}
     RecurrenceId recurrenceIdTest = new RecurrenceId("FraudDetection", "*");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assertions.assertEquals(2, jobHistory.size());
+    assertEquals(2, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assertions.assertEquals(recurrenceId1.getPipelineId(),
+      assertEquals(recurrenceId1.getPipelineId(),
           entry.getKey().getPipelineId());
       final List<ResourceSkyline> getSkylines = entry.getValue();
       if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-        Assertions.assertEquals(2, getSkylines.size());
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       } else {
-        Assertions.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-        Assertions.assertEquals(2, getSkylines.size());
+        assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline3, getSkylines.get(0));
         compare(resourceSkyline4, getSkylines.get(1));
       }
@@ -163,26 +167,26 @@ public abstract class TestSkylineStore {
     // test getHistory {*, runId}
     recurrenceIdTest = new RecurrenceId("*", "some random runId");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assertions.assertEquals(3, jobHistory.size());
+    assertEquals(3, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
       if (entry.getKey().getPipelineId().equals("FraudDetection")) {
         final List<ResourceSkyline> getSkylines = entry.getValue();
         if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-          Assertions.assertEquals(2, getSkylines.size());
+          assertEquals(2, getSkylines.size());
           compare(resourceSkyline1, getSkylines.get(0));
           compare(resourceSkyline2, getSkylines.get(1));
         } else {
-          Assertions.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-          Assertions.assertEquals(2, getSkylines.size());
+          assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+          assertEquals(2, getSkylines.size());
           compare(resourceSkyline3, getSkylines.get(0));
           compare(resourceSkyline4, getSkylines.get(1));
         }
       } else {
-        Assertions.assertEquals("Random", entry.getKey().getPipelineId());
-        Assertions.assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
+        assertEquals("Random", entry.getKey().getPipelineId());
+        assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
         final List<ResourceSkyline> getSkylines = entry.getValue();
-        Assertions.assertEquals(2, getSkylines.size());
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       }
@@ -190,7 +194,7 @@ public abstract class TestSkylineStore {
     // test getHistory with wrong RecurrenceId
     recurrenceIdTest =
         new RecurrenceId("some random pipelineId", "some random runId");
-    Assertions.assertNull(skylineStore.getHistory(recurrenceIdTest));
+    assertNull(skylineStore.getHistory(recurrenceIdTest));
   }
 
   @Test public final void testGetEstimation() throws SkylineStoreException {
@@ -207,7 +211,7 @@ public abstract class TestSkylineStore {
     final RLESparseResourceAllocation estimation =
         skylineStore.getEstimation("FraudDetection");
     for (int i = 0; i < 50; i++) {
-      Assertions.assertEquals(skylineList2.getCapacityAtTime(i),
+      assertEquals(skylineList2.getCapacityAtTime(i),
           estimation.getCapacityAtTime(i));
     }
   }
@@ -215,7 +219,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testGetNullRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+          assertThrows(NullRecurrenceIdException.class, () -> {
               final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ResourceSkyline resourceSkyline1 = getSkyline(1);
@@ -242,7 +246,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testGetNullPipelineIdException()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullPipelineIdException.class, () -> {
+          assertThrows(NullPipelineIdException.class, () -> {
               skylineStore.getEstimation(null);
           });
       }
@@ -263,12 +267,12 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assertions.assertEquals(recurrenceId, entry.getKey());
+      assertEquals(recurrenceId, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assertions.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
@@ -277,7 +281,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testAddNullRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+          assertThrows(NullRecurrenceIdException.class, () -> {
               final RecurrenceId recurrenceIdNull = null;
               final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
@@ -291,7 +295,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testAddNullResourceSkyline()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullResourceSkylineException.class, () -> {
+          assertThrows(NullResourceSkylineException.class, () -> {
               final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ArrayList<ResourceSkyline> resourceSkylines =
@@ -306,7 +310,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testAddDuplicateRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(DuplicateRecurrenceIdException.class, () -> {
+          assertThrows(DuplicateRecurrenceIdException.class, () -> {
               final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ArrayList<ResourceSkyline> resourceSkylines =
@@ -322,7 +326,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testAddNullPipelineIdException()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullPipelineIdException.class, () -> {
+          assertThrows(NullPipelineIdException.class, () -> {
               final RLESparseResourceAllocation skylineList2 =
         new RLESparseResourceAllocation(resourceOverTime,
             new DefaultResourceCalculator());
@@ -337,7 +341,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testAddNullRLESparseResourceAllocationExceptionException()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullRLESparseResourceAllocationException.class, () -> {
+          assertThrows(NullRLESparseResourceAllocationException.class, () -> {
               skylineStore.addEstimation("FraudDetection", null);
           });
       }
@@ -357,7 +361,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testDeleteNullRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+          assertThrows(NullRecurrenceIdException.class, () -> {
               final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ResourceSkyline resourceSkyline1 = getSkyline(1);
@@ -370,7 +374,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testDeleteRecurrenceIdNotFound()
       throws SkylineStoreException {
-          Assertions.assertThrows(RecurrenceIdNotFoundException.class, () -> {
+          assertThrows(RecurrenceIdNotFoundException.class, () -> {
               final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ResourceSkyline resourceSkyline1 = getSkyline(1);
@@ -397,12 +401,12 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assertions.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assertions.assertEquals(recurrenceId1, entry.getKey());
+      assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assertions.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
@@ -411,7 +415,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testUpdateNullRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+          assertThrows(NullRecurrenceIdException.class, () -> {
               final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
               final ResourceSkyline resourceSkyline1 = getSkyline(1);
@@ -427,7 +431,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testUpdateNullResourceSkyline()
       throws SkylineStoreException {
-          Assertions.assertThrows(NullResourceSkylineException.class, () -> {
+          assertThrows(NullResourceSkylineException.class, () -> {
               final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ArrayList<ResourceSkyline> resourceSkylines =
@@ -446,7 +450,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testUpdateEmptyRecurrenceId()
       throws SkylineStoreException {
-          Assertions.assertThrows(EmptyResourceSkylineException.class, () -> {
+          assertThrows(EmptyResourceSkylineException.class, () -> {
               final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
               final ArrayList<ResourceSkyline> resourceSkylines =
@@ -465,7 +469,7 @@ public abstract class TestSkylineStore {
   @Test
   public final void testUpdateRecurrenceIdNotFound()
       throws SkylineStoreException {
-          Assertions.assertThrows(RecurrenceIdNotFoundException.class, () -> {
+          assertThrows(RecurrenceIdNotFoundException.class, () -> {
               final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
               final ResourceSkyline resourceSkyline1 = getSkyline(1);

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
@@ -238,7 +238,7 @@ public abstract class TestSkylineStore {
               addToStore(recurrenceId3, resourceSkyline2);
               skylineStore.getHistory(null);
           });
-      
+
 
 // try to getHistory with null recurringId
 }
@@ -289,7 +289,7 @@ public abstract class TestSkylineStore {
               resourceSkylines.add(resourceSkyline1);
               skylineStore.addHistory(recurrenceIdNull, resourceSkylines);
           });
-      
+
 }
 
   @Test
@@ -320,7 +320,7 @@ public abstract class TestSkylineStore {
               skylineStore.addHistory(recurrenceId, resourceSkylines);
               skylineStore.addHistory(recurrenceId, resourceSkylines);
           });
-      
+
 }
 
   @Test
@@ -444,7 +444,7 @@ public abstract class TestSkylineStore {
               skylineStore.addHistory(recurrenceId, resourceSkylines);
               skylineStore.updateHistory(recurrenceId, null);
           });
-      
+
 }
 
   @Test

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
@@ -40,10 +40,10 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test {@link SkylineStore} class.
@@ -61,7 +61,8 @@ public abstract class TestSkylineStore {
 
   protected abstract SkylineStore createSkylineStore();
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     skylineStore = createSkylineStore();
     resourceOverTime = new TreeMap<>();
     resource = Resource.newInstance(1024 * 100, 100);
@@ -69,18 +70,18 @@ public abstract class TestSkylineStore {
 
   private void compare(final ResourceSkyline skyline1,
       final ResourceSkyline skyline2) {
-    Assert.assertEquals(skyline1.getJobId(), skyline2.getJobId());
-    Assert.assertEquals(skyline1.getJobInputDataSize(),
+    Assertions.assertEquals(skyline1.getJobId(), skyline2.getJobId());
+    Assertions.assertEquals(skyline1.getJobInputDataSize(),
         skyline2.getJobInputDataSize(), 0);
-    Assert.assertEquals(skyline1.getJobSubmissionTime(),
+    Assertions.assertEquals(skyline1.getJobSubmissionTime(),
         skyline2.getJobSubmissionTime());
-    Assert
+    Assertions
         .assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
-    Assert.assertEquals(skyline1.getContainerSpec().getMemorySize(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getMemorySize(),
         skyline2.getContainerSpec().getMemorySize());
-    Assert.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
         skyline2.getContainerSpec().getVirtualCores());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         skyline2.getSkylineList().equals(skyline1.getSkylineList()));
   }
 
@@ -91,7 +92,7 @@ public abstract class TestSkylineStore {
     skylineStore.addHistory(recurrenceId, resourceSkylines);
     final List<ResourceSkyline> resourceSkylinesGet =
         skylineStore.getHistory(recurrenceId).get(recurrenceId);
-    Assert.assertTrue(resourceSkylinesGet.contains(resourceSkyline));
+    Assertions.assertTrue(resourceSkylinesGet.contains(resourceSkyline));
   }
 
   private ResourceSkyline getSkyline(final int n) {
@@ -130,31 +131,31 @@ public abstract class TestSkylineStore {
     // test getHistory {pipelineId, runId}
     Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1, entry.getKey());
+      Assertions.assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      Assertions.assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
     // test getHistory {pipelineId, *}
     RecurrenceId recurrenceIdTest = new RecurrenceId("FraudDetection", "*");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assert.assertEquals(2, jobHistory.size());
+    Assertions.assertEquals(2, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1.getPipelineId(),
+      Assertions.assertEquals(recurrenceId1.getPipelineId(),
           entry.getKey().getPipelineId());
       final List<ResourceSkyline> getSkylines = entry.getValue();
       if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-        Assert.assertEquals(2, getSkylines.size());
+        Assertions.assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       } else {
-        Assert.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-        Assert.assertEquals(2, getSkylines.size());
+        Assertions.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+        Assertions.assertEquals(2, getSkylines.size());
         compare(resourceSkyline3, getSkylines.get(0));
         compare(resourceSkyline4, getSkylines.get(1));
       }
@@ -162,26 +163,26 @@ public abstract class TestSkylineStore {
     // test getHistory {*, runId}
     recurrenceIdTest = new RecurrenceId("*", "some random runId");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assert.assertEquals(3, jobHistory.size());
+    Assertions.assertEquals(3, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
       if (entry.getKey().getPipelineId().equals("FraudDetection")) {
         final List<ResourceSkyline> getSkylines = entry.getValue();
         if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-          Assert.assertEquals(2, getSkylines.size());
+          Assertions.assertEquals(2, getSkylines.size());
           compare(resourceSkyline1, getSkylines.get(0));
           compare(resourceSkyline2, getSkylines.get(1));
         } else {
-          Assert.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-          Assert.assertEquals(2, getSkylines.size());
+          Assertions.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+          Assertions.assertEquals(2, getSkylines.size());
           compare(resourceSkyline3, getSkylines.get(0));
           compare(resourceSkyline4, getSkylines.get(1));
         }
       } else {
-        Assert.assertEquals("Random", entry.getKey().getPipelineId());
-        Assert.assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
+        Assertions.assertEquals("Random", entry.getKey().getPipelineId());
+        Assertions.assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
         final List<ResourceSkyline> getSkylines = entry.getValue();
-        Assert.assertEquals(2, getSkylines.size());
+        Assertions.assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       }
@@ -189,7 +190,7 @@ public abstract class TestSkylineStore {
     // test getHistory with wrong RecurrenceId
     recurrenceIdTest =
         new RecurrenceId("some random pipelineId", "some random runId");
-    Assert.assertNull(skylineStore.getHistory(recurrenceIdTest));
+    Assertions.assertNull(skylineStore.getHistory(recurrenceIdTest));
   }
 
   @Test public final void testGetEstimation() throws SkylineStoreException {
@@ -206,41 +207,45 @@ public abstract class TestSkylineStore {
     final RLESparseResourceAllocation estimation =
         skylineStore.getEstimation("FraudDetection");
     for (int i = 0; i < 50; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i),
+      Assertions.assertEquals(skylineList2.getCapacityAtTime(i),
           estimation.getCapacityAtTime(i));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testGetNullRecurrenceId()
       throws SkylineStoreException {
-    // addHistory first recurring pipeline
-    final RecurrenceId recurrenceId1 =
+          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    final ResourceSkyline resourceSkyline2 = getSkyline(2);
-    addToStore(recurrenceId1, resourceSkyline2);
-    final RecurrenceId recurrenceId2 =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              final ResourceSkyline resourceSkyline2 = getSkyline(2);
+              addToStore(recurrenceId1, resourceSkyline2);
+              final RecurrenceId recurrenceId2 =
         new RecurrenceId("FraudDetection", "17/06/21 00:00:00");
-    final ResourceSkyline resourceSkyline3 = getSkyline(3);
-    addToStore(recurrenceId2, resourceSkyline3);
-    final ResourceSkyline resourceSkyline4 = getSkyline(4);
-    addToStore(recurrenceId2, resourceSkyline4);
-    // addHistory second recurring pipeline
-    final RecurrenceId recurrenceId3 =
+              final ResourceSkyline resourceSkyline3 = getSkyline(3);
+              addToStore(recurrenceId2, resourceSkyline3);
+              final ResourceSkyline resourceSkyline4 = getSkyline(4);
+              addToStore(recurrenceId2, resourceSkyline4);
+              final RecurrenceId recurrenceId3 =
         new RecurrenceId("Random", "17/06/20 00:00:00");
-    addToStore(recurrenceId3, resourceSkyline1);
-    addToStore(recurrenceId3, resourceSkyline2);
-    // try to getHistory with null recurringId
-    skylineStore.getHistory(null);
-  }
+              addToStore(recurrenceId3, resourceSkyline1);
+              addToStore(recurrenceId3, resourceSkyline2);
+              skylineStore.getHistory(null);
+          });
+      
 
-  @Test(expected = NullPipelineIdException.class)
+// try to getHistory with null recurringId
+}
+
+  @Test
   public final void testGetNullPipelineIdException()
       throws SkylineStoreException {
-    skylineStore.getEstimation(null);
-  }
+          Assertions.assertThrows(NullPipelineIdException.class, () -> {
+              skylineStore.getEstimation(null);
+          });
+      }
 
   @Test public final void testAddNormal() throws SkylineStoreException {
     // addHistory resource skylines to the in-memory store
@@ -258,74 +263,84 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId, entry.getKey());
+      Assertions.assertEquals(recurrenceId, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      Assertions.assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testAddNullRecurrenceId()
       throws SkylineStoreException {
-    // recurrenceId is null
-    final RecurrenceId recurrenceIdNull = null;
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceIdNull = null;
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    skylineStore.addHistory(recurrenceIdNull, resourceSkylines);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceIdNull, resourceSkylines);
+          });
+      
+}
 
-  @Test(expected = NullResourceSkylineException.class)
+  @Test
   public final void testAddNullResourceSkyline()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          Assertions.assertThrows(NullResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    // resourceSkylines is null
-    skylineStore.addHistory(recurrenceId, null);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceId, null);
+          });
+      // resourceSkylines is null
+}
 
-  @Test(expected = DuplicateRecurrenceIdException.class)
+  @Test
   public final void testAddDuplicateRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          Assertions.assertThrows(DuplicateRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    // trying to addHistory duplicate resource skylines
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+          });
+      
+}
 
-  @Test(expected = NullPipelineIdException.class)
+  @Test
   public final void testAddNullPipelineIdException()
       throws SkylineStoreException {
-    final RLESparseResourceAllocation skylineList2 =
+          Assertions.assertThrows(NullPipelineIdException.class, () -> {
+              final RLESparseResourceAllocation skylineList2 =
         new RLESparseResourceAllocation(resourceOverTime,
             new DefaultResourceCalculator());
-    for (int i = 0; i < 5; i++) {
+              for (int i = 0; i < 5; i++) {
       riAdd = new ReservationInterval(i * 10, (i + 1) * 10);
       skylineList2.addInterval(riAdd, resource);
     }
-    skylineStore.addEstimation(null, skylineList2);
-  }
+              skylineStore.addEstimation(null, skylineList2);
+          });
+      }
 
-  @Test(expected = NullRLESparseResourceAllocationException.class)
+  @Test
   public final void testAddNullRLESparseResourceAllocationExceptionException()
       throws SkylineStoreException {
-    skylineStore.addEstimation("FraudDetection", null);
-  }
+          Assertions.assertThrows(NullRLESparseResourceAllocationException.class, () -> {
+              skylineStore.addEstimation("FraudDetection", null);
+          });
+      }
 
   @Test public final void testDeleteNormal() throws SkylineStoreException {
     // addHistory first recurring pipeline
@@ -339,29 +354,33 @@ public abstract class TestSkylineStore {
     skylineStore.deleteHistory(recurrenceId1);
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testDeleteNullRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId1 =
+          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    // try to deleteHistory with null recurringId
-    skylineStore.deleteHistory(null);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              skylineStore.deleteHistory(null);
+          });
+      // try to deleteHistory with null recurringId
+}
 
-  @Test(expected = RecurrenceIdNotFoundException.class)
+  @Test
   public final void testDeleteRecurrenceIdNotFound()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId1 =
+          Assertions.assertThrows(RecurrenceIdNotFoundException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    final RecurrenceId recurrenceIdInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              final RecurrenceId recurrenceIdInvalid =
         new RecurrenceId("Some random pipelineId", "Some random runId");
-    // try to deleteHistory non-existing recurringId
-    skylineStore.deleteHistory(recurrenceIdInvalid);
-  }
+              skylineStore.deleteHistory(recurrenceIdInvalid);
+          });
+      // try to deleteHistory non-existing recurringId
+}
 
   @Test public final void testUpdateNormal() throws SkylineStoreException {
     // addHistory first recurring pipeline
@@ -378,82 +397,91 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1, entry.getKey());
+      Assertions.assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      Assertions.assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testUpdateNullRecurrenceId()
       throws SkylineStoreException {
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          Assertions.assertThrows(NullRecurrenceIdException.class, () -> {
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with null recurringId
-    skylineStore.updateHistory(null, resourceSkylines);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.updateHistory(null, resourceSkylines);
+          });
+      // try to updateHistory with null recurringId
+}
 
-  @Test(expected = NullResourceSkylineException.class)
+  @Test
   public final void testUpdateNullResourceSkyline()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          Assertions.assertThrows(NullResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with null resourceSkylines
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    skylineStore.updateHistory(recurrenceId, null);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.updateHistory(recurrenceId, null);
+          });
+      
+}
 
-  @Test(expected = EmptyResourceSkylineException.class)
+  @Test
   public final void testUpdateEmptyRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          Assertions.assertThrows(EmptyResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    // try to updateHistory with empty resourceSkyline
-    skylineStore.updateHistory(recurrenceId, resourceSkylinesInvalid);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.updateHistory(recurrenceId, resourceSkylinesInvalid);
+          });
+      // try to updateHistory with empty resourceSkyline
+}
 
-  @Test(expected = RecurrenceIdNotFoundException.class)
+  @Test
   public final void testUpdateRecurrenceIdNotFound()
       throws SkylineStoreException {
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          Assertions.assertThrows(RecurrenceIdNotFoundException.class, () -> {
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final RecurrenceId recurrenceIdInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final RecurrenceId recurrenceIdInvalid =
         new RecurrenceId("Some random pipelineId", "Some random runId");
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with non-existing recurringId
-    skylineStore.updateHistory(recurrenceIdInvalid, resourceSkylines);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.updateHistory(recurrenceIdInvalid, resourceSkylines);
+          });
+      // try to updateHistory with non-existing recurringId
+}
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     resourceOverTime.clear();
     resourceOverTime = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.resourceestimator.translator.impl.BaseLogParser;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -46,7 +46,7 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This LPSolver class will make resource estimation using Linear Programming

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.solver.impl;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +37,6 @@ import org.apache.hadoop.resourceestimator.solver.exceptions.SolverException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * This LPSolver class will make resource estimation using Linear Programming
@@ -56,22 +57,20 @@ public abstract class TestSolver {
   @Test
   public void testNullJobHistory()
       throws SolverException, SkylineStoreException {
-    Assertions.assertThrows(InvalidInputException.class, () -> {
+    assertThrows(InvalidInputException.class, () -> {
         solver.solve(null);
     });
     // try to solve with null jobHistory
   }
 
   @Test
-  public void testEmptyJobHistory()
-      throws SolverException, SkylineStoreException {
-          Assertions.assertThrows(InvalidInputException.class, () -> {
-              Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid =
-        new HashMap<RecurrenceId, List<ResourceSkyline>>();
-              solver.solve(jobHistoryInvalid);
-          });
-      // try to solve with emty jobHistory
-}
+  public void testEmptyJobHistory() throws SolverException, SkylineStoreException {
+    // try to solve with empty jobHistory
+    assertThrows(InvalidInputException.class, () -> {
+        Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid = new HashMap<RecurrenceId, List<ResourceSkyline>>();
+        solver.solve(jobHistoryInvalid);
+    });
+  }
 
   @AfterEach
   public final void cleanUp() {

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.resourceestimator.skylinestore.exceptions.SkylineStoreE
 import org.apache.hadoop.resourceestimator.solver.api.Solver;
 import org.apache.hadoop.resourceestimator.solver.exceptions.InvalidInputException;
 import org.apache.hadoop.resourceestimator.solver.exceptions.SolverException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * This LPSolver class will make resource estimation using Linear Programming
@@ -45,28 +46,35 @@ public abstract class TestSolver {
 
   protected abstract Solver createSolver() throws ResourceEstimatorException;
 
-  @Before public void setup()
+  @BeforeEach
+  public void setup()
       throws SolverException, IOException, SkylineStoreException,
       ResourceEstimatorException {
     solver = createSolver();
   }
 
-  @Test(expected = InvalidInputException.class) public void testNullJobHistory()
+  @Test
+  public void testNullJobHistory()
       throws SolverException, SkylineStoreException {
+    Assertions.assertThrows(InvalidInputException.class, () -> {
+        solver.solve(null);
+    });
     // try to solve with null jobHistory
-    solver.solve(null);
   }
 
-  @Test(expected = InvalidInputException.class)
+  @Test
   public void testEmptyJobHistory()
       throws SolverException, SkylineStoreException {
-    Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid =
+          Assertions.assertThrows(InvalidInputException.class, () -> {
+              Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid =
         new HashMap<RecurrenceId, List<ResourceSkyline>>();
-    // try to solve with emty jobHistory
-    solver.solve(jobHistoryInvalid);
-  }
+              solver.solve(jobHistoryInvalid);
+          });
+      // try to solve with emty jobHistory
+}
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     solver.close();
     solver = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.resourceestimator.common.api.RecurrenceId;
 import org.apache.hadoop.resourceestimator.translator.impl.LogParserUtil;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test JobMetaData.
@@ -43,7 +43,8 @@ public class TestJobMetaData {
   private JobMetaData jobMetaData;
   private RecurrenceId recurrenceId;
 
-  @Before public final void setup() throws ParseException {
+  @BeforeEach
+  public final void setup() throws ParseException {
     recurrenceId = new RecurrenceId("Fraud Detection", "17/07/16 16:27:25");
     jobMetaData = new JobMetaData(
         logParserUtil.stringToUnixTimestamp("17/07/16 16:27:25"));
@@ -68,27 +69,27 @@ public class TestJobMetaData {
     final Resource containerAlloc =
         jobMetaData.getResourceSkyline().getContainerSpec();
     final Resource containerAlloc2 = Resource.newInstance(1, 1);
-    Assert.assertEquals(containerAlloc.getMemorySize(),
+    Assertions.assertEquals(containerAlloc.getMemorySize(),
         containerAlloc2.getMemorySize());
-    Assert.assertEquals(containerAlloc.getVirtualCores(),
+    Assertions.assertEquals(containerAlloc.getVirtualCores(),
         containerAlloc2.getVirtualCores());
   }
 
   @Test public final void testGetJobSize() {
-    Assert.assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
+    Assertions.assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
         1024.5, 0);
   }
 
   @Test public final void testGetRecurrenceeId() {
     final RecurrenceId recurrenceIdTest =
         new RecurrenceId("Fraud Detection", "17/07/16 16:27:25");
-    Assert.assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
+    Assertions.assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
   }
 
   @Test public final void testStringToUnixTimestamp() throws ParseException {
     final long submissionTime =
         logParserUtil.stringToUnixTimestamp("17/07/16 16:27:25");
-    Assert.assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
+    Assertions.assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
         submissionTime);
   }
 
@@ -99,22 +100,22 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assert.assertEquals(0,
+      Assertions.assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 15; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 15; k < 605; k++) {
-      Assert.assertEquals(2,
+      Assertions.assertEquals(2,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 605; k < 615; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         skylineList.getCapacityAtTime(615).getVirtualCores() / containerCPU);
   }
 
@@ -144,18 +145,19 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assert.assertEquals(0,
+      Assertions.assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 605; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         skylineList.getCapacityAtTime(605).getVirtualCores() / containerCPU);
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     jobMetaData = null;
     recurrenceId = null;
     logParserUtil = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.translator.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.text.ParseException;
 
 import org.apache.hadoop.resourceestimator.common.api.RecurrenceId;
@@ -27,7 +29,6 @@ import org.apache.hadoop.resourceestimator.translator.impl.LogParserUtil;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,27 +70,27 @@ public class TestJobMetaData {
     final Resource containerAlloc =
         jobMetaData.getResourceSkyline().getContainerSpec();
     final Resource containerAlloc2 = Resource.newInstance(1, 1);
-    Assertions.assertEquals(containerAlloc.getMemorySize(),
+    assertEquals(containerAlloc.getMemorySize(),
         containerAlloc2.getMemorySize());
-    Assertions.assertEquals(containerAlloc.getVirtualCores(),
+    assertEquals(containerAlloc.getVirtualCores(),
         containerAlloc2.getVirtualCores());
   }
 
   @Test public final void testGetJobSize() {
-    Assertions.assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
+    assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
         1024.5, 0);
   }
 
   @Test public final void testGetRecurrenceeId() {
     final RecurrenceId recurrenceIdTest =
         new RecurrenceId("Fraud Detection", "17/07/16 16:27:25");
-    Assertions.assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
+    assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
   }
 
   @Test public final void testStringToUnixTimestamp() throws ParseException {
     final long submissionTime =
         logParserUtil.stringToUnixTimestamp("17/07/16 16:27:25");
-    Assertions.assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
+    assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
         submissionTime);
   }
 
@@ -100,22 +101,22 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assertions.assertEquals(0,
+      assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 15; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 15; k < 605; k++) {
-      Assertions.assertEquals(2,
+      assertEquals(2,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 605; k < 615; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assertions.assertEquals(0,
+    assertEquals(0,
         skylineList.getCapacityAtTime(615).getVirtualCores() / containerCPU);
   }
 
@@ -145,14 +146,14 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assertions.assertEquals(0,
+      assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 605; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assertions.assertEquals(0,
+    assertEquals(0,
         skylineList.getCapacityAtTime(605).getVirtualCores() / containerCPU);
   }
 

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.translator.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
@@ -37,7 +39,6 @@ import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -74,38 +75,36 @@ public class TestNativeParser {
         new RecurrenceId("tpch_q12", "tpch_q12_0");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(1, jobSkylineLists.size());
+    assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assertions.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assertions.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assertions.assertEquals("tpch_q12_0", resourceSkyline.getJobId());
-    Assertions.assertEquals(0, resourceSkyline.getJobSubmissionTime());
-    Assertions.assertEquals(25, resourceSkyline.getJobFinishTime());
-    Assertions
-        .assertEquals(1024, resourceSkyline.getContainerSpec().getMemorySize());
-    Assertions
-        .assertEquals(1, resourceSkyline.getContainerSpec().getVirtualCores());
+    assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    assertEquals("tpch_q12_0", resourceSkyline.getJobId());
+    assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    assertEquals(25, resourceSkyline.getJobFinishTime());
+    assertEquals(1024, resourceSkyline.getContainerSpec().getMemorySize());
+    assertEquals(1, resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
     int k;
     for (k = 0; k < 10; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 10; k < 15; k++) {
-      Assertions.assertEquals(1074,
+      assertEquals(1074,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 15; k < 20; k++) {
-      Assertions.assertEquals(2538,
+      assertEquals(2538,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 20; k < 25; k++) {
-      Assertions.assertEquals(2468,
+      assertEquals(2468,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
-    Assertions.assertEquals(0,
+    assertEquals(0,
         skylineLists.getCapacityAtTime(25).getMemorySize() / 1024);
   }
 

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.resourceestimator.skylinestore.impl.InMemoryStore;
 import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This sample parser will parse the sample log and extract the resource
@@ -49,7 +49,8 @@ public class TestNativeParser {
   private LogParserUtil logParserUtil = new LogParserUtil();
   private SkylineStore skylineStore;
 
-  @Before public final void setup() throws ResourceEstimatorException {
+  @BeforeEach
+  public final void setup() throws ResourceEstimatorException {
     skylineStore = new InMemoryStore();
     final LogParser nativeParser = new BaseLogParser();
     Configuration config = new Configuration();
@@ -73,42 +74,43 @@ public class TestNativeParser {
         new RecurrenceId("tpch_q12", "tpch_q12_0");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobSkylineLists.size());
+    Assertions.assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assert.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals("tpch_q12_0", resourceSkyline.getJobId());
-    Assert.assertEquals(0, resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(25, resourceSkyline.getJobFinishTime());
-    Assert
+    Assertions.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    Assertions.assertEquals("tpch_q12_0", resourceSkyline.getJobId());
+    Assertions.assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    Assertions.assertEquals(25, resourceSkyline.getJobFinishTime());
+    Assertions
         .assertEquals(1024, resourceSkyline.getContainerSpec().getMemorySize());
-    Assert
+    Assertions
         .assertEquals(1, resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
     int k;
     for (k = 0; k < 10; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 10; k < 15; k++) {
-      Assert.assertEquals(1074,
+      Assertions.assertEquals(1074,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 15; k < 20; k++) {
-      Assert.assertEquals(2538,
+      Assertions.assertEquals(2538,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 20; k < 25; k++) {
-      Assert.assertEquals(2468,
+      Assertions.assertEquals(2468,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         skylineLists.getCapacityAtTime(25).getMemorySize() / 1024);
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     logParserUtil = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
@@ -37,10 +37,10 @@ import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This sample parser will parse the sample log and extract the resource
@@ -50,7 +50,8 @@ public class TestRmParser {
   private LogParserUtil logParserUtil = new LogParserUtil();
   private SkylineStore skylineStore;
 
-  @Before public final void setup() throws ResourceEstimatorException {
+  @BeforeEach
+  public final void setup() throws ResourceEstimatorException {
     skylineStore = new InMemoryStore();
     final LogParser rmParser = new BaseLogParser();
     Configuration config = new Configuration();
@@ -76,50 +77,52 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("FraudDetection", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobSkylineLists.size());
+    Assertions.assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assert.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals("application_1497832133857_0330",
+    Assertions.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    Assertions.assertEquals("application_1497832133857_0330",
         resourceSkyline.getJobId());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:18:35"),
         resourceSkyline.getJobFinishTime());
     final Resource resource = Resource.newInstance(1800, 1);
-    Assert.assertEquals(resource.getMemorySize(),
+    Assertions.assertEquals(resource.getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resource.getVirtualCores(),
+    Assertions.assertEquals(resource.getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
 
     int k;
     for (k = 0; k < 142; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 142; k < 345; k++) {
-      Assert.assertEquals(2,
+      Assertions.assertEquals(2,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 345; k < 502; k++) {
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public final void testInvalidDateFormat()
       throws ParseException {
-    logParserUtil.stringToUnixTimestamp("2017.07.16 16:37:45");
-  }
+          Assertions.assertThrows(ParseException.class, () -> {
+              logParserUtil.stringToUnixTimestamp("2017.07.16 16:37:45");
+          });
+      }
 
   @Test public final void testDuplicateJobSubmissionTime()
       throws SkylineStoreException, IOException, ParseException,
@@ -129,7 +132,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:23"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -140,7 +143,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog2.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "2");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInContainerAlloc()
@@ -151,7 +154,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "3");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -164,7 +167,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "4");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -177,7 +180,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "5");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -188,7 +191,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog6.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "6");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testRecurrenceIdNotFoundInJobFinish()
@@ -197,7 +200,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog7.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "7");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInResourceSpec()
@@ -208,10 +211,10 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "8");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1024,
+    Assertions.assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }
@@ -224,15 +227,16 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "9");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1024,
+    Assertions.assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     logParserUtil = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
@@ -20,6 +20,10 @@
 
 package org.apache.hadoop.resourceestimator.translator.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
@@ -38,7 +42,6 @@ import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFou
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +72,8 @@ public class TestRmParser {
     logParserUtil.parseLog(logFile);
   }
 
-  @Test public final void testParse()
+  @Test 
+  public final void testParse()
       throws SkylineStoreException, IOException, ParseException,
       ResourceEstimatorException, DataFieldNotFoundException {
     final String logFile = "src/test/resources/trace/rmLog.txt";
@@ -77,40 +81,40 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("FraudDetection", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(1, jobSkylineLists.size());
+    assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assertions.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assertions.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assertions.assertEquals("application_1497832133857_0330",
+    assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    assertEquals("application_1497832133857_0330",
         resourceSkyline.getJobId());
-    Assertions.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         resourceSkyline.getJobSubmissionTime());
-    Assertions.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:18:35"),
         resourceSkyline.getJobFinishTime());
     final Resource resource = Resource.newInstance(1800, 1);
-    Assertions.assertEquals(resource.getMemorySize(),
+    assertEquals(resource.getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assertions.assertEquals(resource.getVirtualCores(),
+    assertEquals(resource.getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
 
     int k;
     for (k = 0; k < 142; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 142; k < 345; k++) {
-      Assertions.assertEquals(2,
+      assertEquals(2,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 345; k < 502; k++) {
-      Assertions.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
@@ -119,7 +123,7 @@ public class TestRmParser {
   @Test
   public final void testInvalidDateFormat()
       throws ParseException {
-          Assertions.assertThrows(ParseException.class, () -> {
+          assertThrows(ParseException.class, () -> {
               logParserUtil.stringToUnixTimestamp("2017.07.16 16:37:45");
           });
       }
@@ -132,7 +136,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:23"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -143,7 +147,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog2.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "2");
-    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInContainerAlloc()
@@ -154,7 +158,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "3");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(0,
+    assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -167,7 +171,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "4");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(0,
+    assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -180,7 +184,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "5");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -191,7 +195,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog6.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "6");
-    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testRecurrenceIdNotFoundInJobFinish()
@@ -200,7 +204,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog7.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "7");
-    Assertions.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInResourceSpec()
@@ -211,10 +215,10 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "8");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(1024,
+    assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assertions.assertEquals(1,
+    assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }
@@ -227,10 +231,10 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "9");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assertions.assertEquals(1024,
+    assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assertions.assertEquals(1,
+    assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
@@ -72,7 +72,7 @@ public class TestRmParser {
     logParserUtil.parseLog(logFile);
   }
 
-  @Test 
+  @Test
   public final void testParse()
       throws SkylineStoreException, IOException, ParseException,
       ResourceEstimatorException, DataFieldNotFoundException {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19438. Upgrade JUnit from 4 to 5 in hadoop-resourceestimator.

### How was this patch tested?

mvn clean test & Junit Test.


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

