### PR TITLE
HDFS-17764. Connection#stop is blocking when FileSystem#close

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -188,7 +188,6 @@ public class Client implements AutoCloseable {
   private final ConcurrentMap<ConnectionId, Connection> connections =
       new ConcurrentHashMap<>();
   private final Object putLock = new Object();
-  private final Object emptyCondition = new Object();
   private final AtomicBoolean running = new AtomicBoolean(true);
 
   private Class<? extends Writable> valueClass;   // class of call values
@@ -1429,19 +1428,8 @@ public class Client implements AutoCloseable {
       conn.rpcRequestThread.interrupt();
       conn.interruptConnectingThread();
     }
-    
-    // wait until all connections are closed
-    synchronized (emptyCondition) {
-      // synchronized the loop to guarantee wait must be notified.
-      while (!connections.isEmpty()) {
-        try {
-          emptyCondition.wait();
-        } catch (InterruptedException e) {
-          LOG.trace(
-              "Interrupted while waiting on all connections to be closed.");
-          Thread.currentThread().interrupt();
-        }
-      }
+    for (ConnectionId connectionId : connections.keySet()) {
+      connections.remove(connectionId);
     }
   }
 
@@ -1635,12 +1623,7 @@ public class Client implements AutoCloseable {
       Call call, int serviceClass, AtomicBoolean fallbackToSimpleAuth)
       throws IOException {
     final Consumer<Connection> removeMethod = c -> {
-      final boolean removed = connections.remove(remoteId, c);
-      if (removed && connections.isEmpty()) {
-        synchronized (emptyCondition) {
-          emptyCondition.notify();
-        }
-      }
+      connections.remove(remoteId, c);
     };
 
     Connection connection;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96d2c304-fc87-4d54-8673-12c3d69986ab)

![image](https://github.com/user-attachments/assets/013bce36-8b58-48cb-b3b0-299b7985e10e)

In stop method, connection has been interrupted, so emptyCondition.notify will not be called in Connection.removeMethod, and emptyCondition.wait will blocking
