### PR TITLE
HDFS-17764. Connection#stop is blocking when FileSystem#close

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -188,7 +188,6 @@ public class Client implements AutoCloseable {
   private final ConcurrentMap<ConnectionId, Connection> connections =
       new ConcurrentHashMap<>();
   private final Object putLock = new Object();
-  private final Object emptyCondition = new Object();
   private final AtomicBoolean running = new AtomicBoolean(true);
 
   private Class<? extends Writable> valueClass;   // class of call values
@@ -1429,20 +1428,7 @@ public class Client implements AutoCloseable {
       conn.rpcRequestThread.interrupt();
       conn.interruptConnectingThread();
     }
-    
-    // wait until all connections are closed
-    synchronized (emptyCondition) {
-      // synchronized the loop to guarantee wait must be notified.
-      while (!connections.isEmpty()) {
-        try {
-          emptyCondition.wait();
-        } catch (InterruptedException e) {
-          LOG.trace(
-              "Interrupted while waiting on all connections to be closed.");
-          Thread.currentThread().interrupt();
-        }
-      }
-    }
+    connections.clear();
   }
 
   /** 
@@ -1635,12 +1621,7 @@ public class Client implements AutoCloseable {
       Call call, int serviceClass, AtomicBoolean fallbackToSimpleAuth)
       throws IOException {
     final Consumer<Connection> removeMethod = c -> {
-      final boolean removed = connections.remove(remoteId, c);
-      if (removed && connections.isEmpty()) {
-        synchronized (emptyCondition) {
-          emptyCondition.notify();
-        }
-      }
+      connections.remove(remoteId, c);
     };
 
     Connection connection;


### PR DESCRIPTION
In normal cases, connections is empty when call stop method. But in some abnormal cases, connections is not empty, in stop method, connection has been interrupted, so emptyCondition.notify will not be called in Connection.removeMethod, and emptyCondition.wait will blocking

![image](https://github.com/user-attachments/assets/d6073ab8-8bd6-4810-9d5e-457a8692c2f9)


![image](https://github.com/user-attachments/assets/0c4a045c-1549-410e-a7f1-c57c6e02d35f)


![image](https://github.com/user-attachments/assets/fa953f05-953e-4589-bb8f-3392da23bcd5)

