### PR TITLE
HADOOP-19439. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-rumen.

### DIFF
--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistograms.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistograms.java
@@ -34,10 +34,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.*;
-@Ignore
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Disabled
 public class TestHistograms {
 
   /**
@@ -71,7 +73,7 @@ public class TestHistograms {
       if (fileName.startsWith("input")) {
         String testName = fileName.substring("input".length());
         Path goldFilePath = new Path(rootInputFile, "gold"+testName);
-        assertTrue("Gold file dies not exist", lfs.exists(goldFilePath));
+        assertTrue(lfs.exists(goldFilePath), "Gold file dies not exist");
         LoggedDiscreteCDF newResult = histogramFileToCDF(filePath, lfs);
         System.out.println("Testing a Histogram for " + fileName);
         FSDataInputStream goldStream = lfs.open(goldFilePath);
@@ -107,11 +109,11 @@ public class TestHistograms {
     List<Long> typeProbeData = new HistogramRawTestData().getData();
 
     assertTrue(
-        "The data attribute of a jackson-reconstructed HistogramRawTestData "
+    
+       measurements.getClass() == typeProbeData.getClass(), "The data attribute of a jackson-reconstructed HistogramRawTestData "
             + " should be a " + typeProbeData.getClass().getName()
             + ", like a virgin HistogramRawTestData, but it's a "
-            + measurements.getClass().getName(),
-        measurements.getClass() == typeProbeData.getClass());
+            + measurements.getClass().getName());
 
     for (int j = 0; j < measurements.size(); ++j) {
       hist.enter(measurements.get(j));

--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistograms.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestHistograms.java
@@ -108,12 +108,11 @@ public class TestHistograms {
     List<Long> measurements = data.getData();
     List<Long> typeProbeData = new HistogramRawTestData().getData();
 
-    assertTrue(
-    
-       measurements.getClass() == typeProbeData.getClass(), "The data attribute of a jackson-reconstructed HistogramRawTestData "
-            + " should be a " + typeProbeData.getClass().getName()
-            + ", like a virgin HistogramRawTestData, but it's a "
-            + measurements.getClass().getName());
+    assertTrue(measurements.getClass() == typeProbeData.getClass(),
+        "The data attribute of a jackson-reconstructed HistogramRawTestData "
+        + " should be a " + typeProbeData.getClass().getName()
+        + ", like a virgin HistogramRawTestData, but it's a "
+        + measurements.getClass().getName());
 
     for (int j = 0; j < measurements.size(); ++j) {
       hist.enter(measurements.get(j));

--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestPiecewiseLinearInterpolation.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestPiecewiseLinearInterpolation.java
@@ -115,8 +115,8 @@ public class TestPiecewiseLinearInterpolation {
 
     System.out.println("Cumulative error is " + RMSNormalizedError);
 
-    assertTrue(
-       RMSNormalizedError <= maximumRelativeError, "The RMS relative error per bucket, " + RMSNormalizedError
+    assertTrue(RMSNormalizedError <= maximumRelativeError,
+        "The RMS relative error per bucket, " + RMSNormalizedError
         + ", exceeds our tolerance of " + maximumRelativeError);
 
   }

--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestPiecewiseLinearInterpolation.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestPiecewiseLinearInterpolation.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.tools.rumen;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestPiecewiseLinearInterpolation {
 
@@ -115,9 +115,9 @@ public class TestPiecewiseLinearInterpolation {
 
     System.out.println("Cumulative error is " + RMSNormalizedError);
 
-    assertTrue("The RMS relative error per bucket, " + RMSNormalizedError
-        + ", exceeds our tolerance of " + maximumRelativeError,
-        RMSNormalizedError <= maximumRelativeError);
+    assertTrue(
+       RMSNormalizedError <= maximumRelativeError, "The RMS relative error per bucket, " + RMSNormalizedError
+        + ", exceeds our tolerance of " + maximumRelativeError);
 
   }
 }

--- a/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestRandomSeedGenerator.java
+++ b/hadoop-tools/hadoop-rumen/src/test/java/org/apache/hadoop/tools/rumen/TestRandomSeedGenerator.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.tools.rumen;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.tools.rumen.RandomSeedGenerator.getSeed;
 
 public class TestRandomSeedGenerator {
@@ -28,13 +28,13 @@ public class TestRandomSeedGenerator {
     long masterSeed1 = 42;
     long masterSeed2 = 43;
     
-    assertTrue("Deterministic seeding",
-        getSeed("stream1", masterSeed1) == getSeed("stream1", masterSeed1));
-    assertTrue("Deterministic seeding",
-        getSeed("stream2", masterSeed2) == getSeed("stream2", masterSeed2));
-    assertTrue("Different streams", 
-        getSeed("stream1", masterSeed1) != getSeed("stream2", masterSeed1));
-    assertTrue("Different master seeds",
-        getSeed("stream1", masterSeed1) != getSeed("stream1", masterSeed2));
+    assertTrue(getSeed("stream1", masterSeed1) == getSeed("stream1", masterSeed1),
+        "Deterministic seeding");
+    assertTrue(getSeed("stream2", masterSeed2) == getSeed("stream2", masterSeed2),
+        "Deterministic seeding");
+    assertTrue(getSeed("stream1", masterSeed1) != getSeed("stream2", masterSeed1),
+        "Different streams");
+    assertTrue(getSeed("stream1", masterSeed1) != getSeed("stream1", masterSeed2),
+        "Different master seeds");
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19439. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-rumen.

### How was this patch tested?

mvn clean test & junit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

