### PR TITLE
#HADOOP-19520 Fix preservedEntries count in CopyCommitter when preser…

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyCommitter.java
@@ -359,6 +359,8 @@ public class CopyCommitter extends FileOutputCommitter {
         taskAttemptContext.progress();
         taskAttemptContext.setStatus("Preserving status on directory entries. [" +
             sourceReader.getPosition() * 100 / totalLen + "%]");
+
+        preservedEntries++;
       }
     } finally {
       IOUtils.closeStream(sourceReader);


### PR DESCRIPTION
…ving directory attributes

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The preservedEntries parameter is not updated when preserve dir is running and is always 0.


### How was this patch tested?
The log output of the existing test case TestCopyCommitter.testPreserveStatus can check the problem
before:
![image](https://github.com/user-attachments/assets/03800085-40a1-464c-90cc-c4e788396d64)
after:
![image](https://github.com/user-attachments/assets/e3ffd3ac-4596-427a-822c-b7643d5175d2)


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

