### PR TITLE
HADOOP-19521. Fix time unit mismatch in method updateDeferredMetrics.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
@@ -415,7 +415,7 @@ public class ProtobufRpcEngine implements RpcEngine {
         long deltaNanos = Time.monotonicNowNanos() - call.getStartHandleTimestampNanos();
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredResponse(RpcWritable.wrap(message));
-        server.updateDeferredMetrics(call, methodName, deltaNanos);
+        server.updateDeferredMetrics(call, methodName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
 
       @Override
@@ -424,7 +424,7 @@ public class ProtobufRpcEngine implements RpcEngine {
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredError(t);
         String detailedMetricsName = t.getClass().getSimpleName();
-        server.updateDeferredMetrics(call, detailedMetricsName, deltaNanos);
+        server.updateDeferredMetrics(call, detailedMetricsName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine.java
@@ -424,7 +424,8 @@ public class ProtobufRpcEngine implements RpcEngine {
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredError(t);
         String detailedMetricsName = t.getClass().getSimpleName();
-        server.updateDeferredMetrics(call, detailedMetricsName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
+        server.updateDeferredMetrics(call, detailedMetricsName,
+            TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
@@ -456,7 +456,8 @@ public class ProtobufRpcEngine2 implements RpcEngine {
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredError(t);
         String detailedMetricsName = t.getClass().getSimpleName();
-        server.updateDeferredMetrics(call, detailedMetricsName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
+        server.updateDeferredMetrics(call, detailedMetricsName,
+            TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/ProtobufRpcEngine2.java
@@ -447,7 +447,7 @@ public class ProtobufRpcEngine2 implements RpcEngine {
         long deltaNanos = Time.monotonicNowNanos() - call.getStartHandleTimestampNanos();
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredResponse(RpcWritable.wrap(message));
-        server.updateDeferredMetrics(call, methodName, deltaNanos);
+        server.updateDeferredMetrics(call, methodName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
 
       @Override
@@ -456,7 +456,7 @@ public class ProtobufRpcEngine2 implements RpcEngine {
         updateProcessingDetails(call, deltaNanos);
         call.setDeferredError(t);
         String detailedMetricsName = t.getClass().getSimpleName();
-        server.updateDeferredMetrics(call, detailedMetricsName, deltaNanos);
+        server.updateDeferredMetrics(call, detailedMetricsName, TimeUnit.NANOSECONDS.toMillis(deltaNanos));
       }
     }
 


### PR DESCRIPTION
### Description of PR
Fix time unit mismatch in method updateDeferredMetrics.

The time unit of passed param is nanos. But rpcmetrics's is mills.

![image](https://github.com/user-attachments/assets/cc9ddd01-e988-4743-9efc-c0e48e08701d)
