### PR TITLE
YARN-11805. Skip tests in TestTimelineWriterHBaseDown when InaccessibleObjectException is thrown

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineReaderHBaseDown.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineReaderHBaseDown.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.yarn.server.timelineservice.storage.HBaseStorage
 import static org.apache.hadoop.yarn.server.timelineservice.storage.HBaseStorageMonitor.MONITOR_FILTERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestTimelineReaderHBaseDown {
 
@@ -58,6 +59,13 @@ public class TestTimelineReaderHBaseDown {
       HBaseTimelineReaderImpl htr = getHBaseTimelineReaderImpl(server);
       server.start();
       checkQuery(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -101,6 +109,13 @@ public class TestTimelineReaderHBaseDown {
       // start server and check that it detects hbase is down
       server.start();
       waitForHBaseDown(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -129,6 +144,13 @@ public class TestTimelineReaderHBaseDown {
       // start server and check that it detects hbase is down
       server.start();
       waitForHBaseDown(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -167,6 +189,13 @@ public class TestTimelineReaderHBaseDown {
           return false;
         }
       }, 1000, 150000);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11805. Skip tests in TestTimelineWriterHBaseDown when InaccessibleObjectException is thrown.

HBase tries to hack some optimizations into HDFS via reflection.

However, this hack doesn't work on JDK18+ because of JEP416.

Skip the test if we encounter this HBase problem, as it cannot be fixed from Hadoop.

### How was this patch tested?

Tested on my JDK24 branch.
The issue cannot be reproduced without uncommitted JDK24 fixes.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

