### PR TITLE
HDFS-17766. [ARR] Avoid initializing unused threadPool in RouterAsyncRpcClient.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT;
+import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KERBEROS_PRINCIPAL_HOSTNAME_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KEYTAB_FILE_KEY;
@@ -876,4 +878,10 @@ public class Router extends CompositeService implements
     this.conf = conf;
   }
 
+  @VisibleForTesting
+  public boolean isAsync() {
+    return getRpcServer() != null ? getRpcServer().isAsync() :
+        getConfig() != null ? getConfig().getBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY,
+            DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT) : DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -878,10 +878,4 @@ public class Router extends CompositeService implements
     this.conf = conf;
   }
 
-  @VisibleForTesting
-  public boolean isAsync() {
-    return getRpcServer() != null ? getRpcServer().isAsync() :
-        getConfig() != null ? getConfig().getBoolean(DFS_ROUTER_ASYNC_RPC_ENABLE_KEY,
-            DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT) : DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT;
-  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/Router.java
@@ -19,8 +19,6 @@ package org.apache.hadoop.hdfs.server.federation.router;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_DEFAULT;
-import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_ASYNC_RPC_ENABLE_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KERBEROS_PRINCIPAL_HOSTNAME_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_KEYTAB_FILE_KEY;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -199,8 +199,13 @@ public class RouterRpcClient {
     } else {
       workQueue = new LinkedBlockingQueue<>();
     }
-    this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
-        0L, TimeUnit.MILLISECONDS, workQueue, threadFactory);
+    
+    if (router.getRpcServer().isAsync()) {
+      this.executorService = null;
+    } else {
+      this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
+          0L, TimeUnit.MILLISECONDS, workQueue, threadFactory);
+    }
 
     this.rpcMonitor = monitor;
 
@@ -364,9 +369,11 @@ public class RouterRpcClient {
    */
   public String getAsyncCallerPoolJson() {
     final Map<String, Integer> info = new LinkedHashMap<>();
-    info.put("active", executorService.getActiveCount());
-    info.put("total", executorService.getPoolSize());
-    info.put("max", executorService.getMaximumPoolSize());
+    if (executorService != null) {
+      info.put("active", executorService.getActiveCount());
+      info.put("total", executorService.getPoolSize());
+      info.put("max", executorService.getMaximumPoolSize());
+    }
     return JSON.toString(info);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -227,7 +227,7 @@ public class RouterRpcClient {
     }
     this.lastActiveNNRefreshTimes = new ConcurrentHashMap<>();
   }
-  
+
   protected void initConcurrentCallExecutorService(Configuration conf) {
     int numThreads = conf.getInt(
         RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE,

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -282,7 +282,7 @@ public class RouterRpcClient {
 
   /**
    * Get the executor service used by invoking concurrent calls.
-   * @return
+   * @return the executor service.
    */
   @VisibleForTesting
   public ThreadPoolExecutor getExecutorService() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -128,7 +128,7 @@ public class RouterRpcClient {
   /** Connection pool to the Namenodes per user for performance. */
   private final ConnectionManager connectionManager;
   /** Service to run asynchronous calls. */
-  private final ThreadPoolExecutor executorService;
+  private ThreadPoolExecutor executorService;
   /** Retry policy for router -> NN communication. */
   private final RetryPolicy retryPolicy;
   /** Optional perf monitor. */
@@ -184,29 +184,7 @@ public class RouterRpcClient {
     this.connectionManager.start();
     this.routerRpcFairnessPolicyController =
         FederationUtil.newFairnessPolicyController(conf);
-
-    int numThreads = conf.getInt(
-        RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE,
-        RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE_DEFAULT);
-    ThreadFactory threadFactory = new ThreadFactoryBuilder()
-        .setNameFormat("RPC Router Client-%d")
-        .build();
-    BlockingQueue<Runnable> workQueue;
-    if (conf.getBoolean(
-        RBFConfigKeys.DFS_ROUTER_CLIENT_REJECT_OVERLOAD,
-        RBFConfigKeys.DFS_ROUTER_CLIENT_REJECT_OVERLOAD_DEFAULT)) {
-      workQueue = new ArrayBlockingQueue<>(numThreads);
-    } else {
-      workQueue = new LinkedBlockingQueue<>();
-    }
-    
-    if (router.isAsync()) {
-      this.executorService = null;
-    } else {
-      this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
-          0L, TimeUnit.MILLISECONDS, workQueue, threadFactory);
-    }
-
+    initConcurrentCallExecutorService(conf);
     this.rpcMonitor = monitor;
 
     int maxFailoverAttempts = conf.getInt(
@@ -248,6 +226,25 @@ public class RouterRpcClient {
           activeNNStateIdRefreshPeriodMs);
     }
     this.lastActiveNNRefreshTimes = new ConcurrentHashMap<>();
+  }
+  
+  protected void initConcurrentCallExecutorService(Configuration conf) {
+    int numThreads = conf.getInt(
+        RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE,
+        RBFConfigKeys.DFS_ROUTER_CLIENT_THREADS_SIZE_DEFAULT);
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("RPC Router Client-%d")
+        .build();
+    BlockingQueue<Runnable> workQueue;
+    if (conf.getBoolean(
+        RBFConfigKeys.DFS_ROUTER_CLIENT_REJECT_OVERLOAD,
+        RBFConfigKeys.DFS_ROUTER_CLIENT_REJECT_OVERLOAD_DEFAULT)) {
+      workQueue = new ArrayBlockingQueue<>(numThreads);
+    } else {
+      workQueue = new LinkedBlockingQueue<>();
+    }
+    this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
+        0L, TimeUnit.MILLISECONDS, workQueue, threadFactory);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -200,7 +200,7 @@ public class RouterRpcClient {
       workQueue = new LinkedBlockingQueue<>();
     }
     
-    if (router.getRpcServer().isAsync()) {
+    if (router.isAsync()) {
       this.executorService = null;
     } else {
       this.executorService = new ThreadPoolExecutor(numThreads, numThreads,
@@ -2033,7 +2033,6 @@ public class RouterRpcClient {
     }
     return isUnavailableException(ioe);
   }
-
 
   /**
    * The {@link  ExecutionStatus} class is a utility class used to track the status of

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcClient.java
@@ -281,6 +281,15 @@ public class RouterRpcClient {
   }
 
   /**
+   * Get the executor service used by invoking concurrent calls.
+   * @return
+   */
+  @VisibleForTesting
+  public ThreadPoolExecutor getExecutorService() {
+    return executorService;
+  }
+
+  /**
    * Shutdown the client.
    */
   public void shutdown() {

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -116,6 +116,11 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
     this.rpcMonitor = monitor;
   }
 
+  @Override
+  protected void initConcurrentCallExecutorService(Configuration conf) {
+    // No need to initialize the thread pool for concurrent call. 
+  }
+
   /**
    * Invoke method in all locations and return success if any succeeds.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/async/RouterAsyncRpcClient.java
@@ -118,7 +118,7 @@ public class RouterAsyncRpcClient extends RouterRpcClient{
 
   @Override
   protected void initConcurrentCallExecutorService(Configuration conf) {
-    // No need to initialize the thread pool for concurrent call. 
+    // No need to initialize the thread pool for concurrent call.
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2426,4 +2426,9 @@ public class TestRouterRpc {
     // The audit log should not contain async:true.
     assertFalse(auditLog.getOutput().contains("async:true"));
   }
+
+  @Test
+  public void testConcurrentCallExecutorInitial() {
+    assertNotNull(router.getRouterRpcClient().getExecutorService());
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpc.java
@@ -36,6 +36,7 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Testing the asynchronous RPC functionality of the router.
@@ -83,4 +84,9 @@ public class TestRouterAsyncRpc extends TestRouterRpc {
     assertArrayEquals(group, result);
   }
 
+  @Test
+  @Override
+  public void testConcurrentCallExecutorInitial() {
+    assertNull(rndRouter.getRouterRpcClient().getExecutorService());
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcMultiDestination.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/async/TestRouterAsyncRpcMultiDestination.java
@@ -34,6 +34,7 @@ import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_
 import static org.apache.hadoop.hdfs.server.federation.router.RBFConfigKeys.DFS_ROUTER_FAIRNESS_POLICY_CONTROLLER_CLASS;
 import static org.apache.hadoop.hdfs.server.federation.router.async.utils.AsyncUtil.syncReturn;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Testing the asynchronous RPC functionality of the router with multiple mounts.
@@ -69,5 +70,12 @@ public class TestRouterAsyncRpcMultiDestination extends TestRouterRpcMultiDestin
     rndRouter.getRouter().getRpcServer().getGroupsForUser("user");
     String[] result = syncReturn(String[].class);
     assertArrayEquals(group, result);
+  }
+
+  @Test
+  @Override
+  public void testConcurrentCallExecutorInitial() {
+    MiniRouterDFSCluster.RouterContext rndRouter = super.getRouterContext();
+    assertNull(rndRouter.getRouterRpcClient().getExecutorService());
   }
 }


### PR DESCRIPTION
### Description of PR
Avoid initializing unused threadPool in RouterAsyncRpcClient.
Actually, we use async handler to send rpc to NN rather than the original threadPool.
