### PR TITLE
MAPREDUCE-7505. Remove obsolete SecurityManager code from TestPipeApplication

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
@@ -272,8 +272,6 @@ public class TestPipeApplication {
     Submitter.setJavaPartitioner(conf, partitioner.getClass());
 
     assertEquals(PipesPartitioner.class, (Submitter.getJavaPartitioner(conf)));
-    // test going to call main method with System.exit(). Change Security
-    SecurityManager securityManager = System.getSecurityManager();
     // store System.out
     PrintStream oldps = System.out;
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -330,8 +328,6 @@ public class TestPipeApplication {
               + "archives to be unarchived on the compute machines"));
     } finally {
       System.setOut(oldps);
-      // restore
-      System.setSecurityManager(securityManager);
       if (psw != null) {
         // remove password files
         for (File file : psw) {
@@ -381,7 +377,6 @@ public class TestPipeApplication {
 
     } finally {
       System.setOut(oldps);
-      System.setSecurityManager(securityManager);
     }
 
   }


### PR DESCRIPTION
### Description of PR

MAPREDUCE-7505. Remove obsolete SecurityManager code from TestPipeApplication.

Remove leftover SecurityManager calls.
This is needed for compatibility with recent Java versions.

### How was this patch tested?

Ran the test with JDK8 and JDK24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

