### PR TITLE
HADOOP-19526. Skip tests in Hadoop common that depend on SecurityManager if the JVM does not support it

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.tools;
 import java.io.IOException;
 import java.util.Random;
 
+import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -471,7 +472,7 @@ public class DistCp extends Configured implements Tool {
       LOG.error("Couldn't complete DistCp operation: ", e);
       exitCode = DistCpConstants.UNKNOWN_ERROR;
     }
-    System.exit(exitCode);
+    ExitUtil.terminate(exitCode);
   }
 
   /**

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -38,6 +38,7 @@ import java.security.Permission;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
@@ -66,7 +67,11 @@ public class TestExternalCall {
   public void setup() {
 
     securityManager = System.getSecurityManager();
-    System.setSecurityManager(new NoExitSecurityManager());
+    try {
+      System.setSecurityManager(new NoExitSecurityManager());
+    } catch (UnsupportedOperationException e) {
+      assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");
+    }
     try {
       fs = FileSystem.get(getConf());
       root = new Path("target/tmp").makeQualified(fs.getUri(),
@@ -79,10 +84,16 @@ public class TestExternalCall {
 
   @AfterEach
   public void tearDown() {
-    System.setSecurityManager(securityManager);
+    try {
+      System.setSecurityManager(securityManager);
+    } catch (UnsupportedOperationException e) {
+      // JUnit 5 calls @AfterEach even if @BeforeEach has thrown TestAbortedException
+      // The test has already been already skipped
+    }
   }
+
 /**
- * test methods run end execute of DistCp class. silple copy file
+ * test methods run end execute of DistCp class. simple copy file
  * @throws Exception 
  */
   @Test

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -66,8 +66,8 @@ public class TestExternalCall {
   @BeforeEach
   public void setup() {
 
-    securityManager = System.getSecurityManager();
     try {
+      securityManager = System.getSecurityManager();
       System.setSecurityManager(new NoExitSecurityManager());
     } catch (UnsupportedOperationException e) {
       assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -34,12 +34,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.Permission;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestExternalCall.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Cluster;
 import org.apache.hadoop.mapreduce.JobSubmissionFiles;
 import org.apache.hadoop.tools.util.TestDistCpUtils;
+import org.apache.hadoop.util.ExitUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,13 +66,11 @@ public class TestExternalCall {
 
   @BeforeEach
   public void setup() {
+    ExitUtil.disableSystemExit();
+    ExitUtil.disableSystemHalt();
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
 
-    try {
-      securityManager = System.getSecurityManager();
-      System.setSecurityManager(new NoExitSecurityManager());
-    } catch (UnsupportedOperationException e) {
-      assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");
-    }
     try {
       fs = FileSystem.get(getConf());
       root = new Path("target/tmp").makeQualified(fs.getUri(),
@@ -84,12 +83,8 @@ public class TestExternalCall {
 
   @AfterEach
   public void tearDown() {
-    try {
-      System.setSecurityManager(securityManager);
-    } catch (UnsupportedOperationException e) {
-      // JUnit 5 calls @AfterEach even if @BeforeEach has thrown TestAbortedException
-      // The test has already been already skipped
-    }
+    ExitUtil.resetFirstExitException();
+    ExitUtil.resetFirstHaltException();
   }
 
 /**
@@ -147,7 +142,7 @@ public class TestExternalCall {
       DistCp.main(arg);
       fail();
 
-    } catch (ExitException t) {
+    } catch (ExitUtil.ExitException t) {
       assertTrue(fs.exists(target));
       assertEquals(t.status, 0);
       assertEquals(
@@ -186,33 +181,4 @@ public class TestExternalCall {
   }
 
 
-  private SecurityManager securityManager;
-
-  protected static class ExitException extends SecurityException {
-    private static final long serialVersionUID = -1982617086752946683L;
-    public final int status;
-
-    public ExitException(int status) {
-      super("There is no escape!");
-      this.status = status;
-    }
-  }
-
-  private static class NoExitSecurityManager extends SecurityManager {
-    @Override
-    public void checkPermission(Permission perm) {
-      // allow anything.
-    }
-
-    @Override
-    public void checkPermission(Permission perm, Object context) {
-      // allow anything.
-    }
-
-    @Override
-    public void checkExit(int status) {
-      super.checkExit(status);
-      throw new ExitException(status);
-    }
-  }
 }

--- a/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
+++ b/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
@@ -181,8 +181,6 @@ public class TestGridmixSubmission extends CommonJobTest {
   @Timeout(value = 100)
   public void testMain() throws Exception {
 
-    SecurityManager securityManager = System.getSecurityManager();
-
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     final PrintStream out = new PrintStream(bytes);
     final PrintStream oldOut = System.out;
@@ -197,7 +195,6 @@ public class TestGridmixSubmission extends CommonJobTest {
       ExitUtil.resetFirstExitException();
     } finally {
       System.setErr(oldOut);
-      System.setSecurityManager(securityManager);
     }
     String print = bytes.toString();
     // should be printed tip in std error stream


### PR DESCRIPTION
### Description of PR

Skip tests in Hadoop common that depend on SecurityManager if the JVM does not support it
Required for recent Java versions.

### How was this patch tested?

On my JDK24 branch, plus CI for JDK8

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

