### PR TITLE
YARN-11806. Skip tests that depend on custom SecurityManager when Java doesn't support it

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/TestCGroupsHandlerImpl.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -371,7 +372,11 @@ public class TestCGroupsHandlerImpl extends TestCGroupsHandlerBase {
       assertFalse(cpuCgroupMountDir.delete(), "Could not delete cgroups");
       assertFalse(cpuCgroupMountDir.exists(), "Directory should be deleted");
       SecurityManager manager = System.getSecurityManager();
-      System.setSecurityManager(new MockSecurityManagerDenyWrite());
+      try {
+        System.setSecurityManager(new MockSecurityManagerDenyWrite());
+      } catch (UnsupportedOperationException e) {
+        assumeTrue(false, "Test is skipped because SecurityManager cannot be set (JEP 411)");
+      }
       try {
         cGroupsHandler.initializeCGroupController(
             CGroupsHandler.CGroupController.CPU);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.Candida
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.SimpleCandidateNodeSet;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.util.resource.Resources;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -1103,17 +1104,23 @@ public class TestCapacitySchedulerAsyncScheduling {
   @Test
   @Timeout(value = 30)
   public void testAsyncScheduleThreadExit() throws Exception {
-    // init RM & NM
-    final MockRM rm = new MockRM(conf);
-    rm.start();
-    rm.registerNode("192.168.0.1:1234", 8 * GB);
-    rm.drainEvents();
 
     // Set no exit security manager to catch System.exit
     SecurityManager originalSecurityManager = System.getSecurityManager();
     NoExitSecurityManager noExitSecurityManager =
         new NoExitSecurityManager(originalSecurityManager);
-    System.setSecurityManager(noExitSecurityManager);
+    try {
+      System.setSecurityManager(noExitSecurityManager);
+    } catch (UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false,
+          "Test is skipped because SecurityManager cannot be set (JEP411)");
+    }
+
+    // init RM & NM
+    final MockRM rm = new MockRM(conf);
+    rm.start();
+    rm.registerNode("192.168.0.1:1234", 8 * GB);
+    rm.drainEvents();
 
     // test async-scheduling thread exit
     try{


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11806. Skip tests that depend on custom SecurityManager when Java doesn't support it

Setting SecurityManager is not possible on recent Java versions.
Skip the affected tests instead of erroring out in this case.

### How was this patch tested?

Tested on my JDK24 branch for JDK24, CI for JDK8.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

