### PR TITLE
HADOOP-19525: used java.time.Clock instead of org.apache.hadoop.util.Clock

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/AbstractClock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/AbstractClock.java
@@ -1,0 +1,38 @@
+package org.apache.hadoop.util;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * An abstract base class for Clocks with the following default behavior:
+ * <ul>
+ * <li>Zone-agnostic: always returns UTC, ignoring any other zones</li>
+ * <li>millis-centric: shifts responsibility of subclasses to defining {@link #millis()},
+ * creating an Instant based on it (instead of vice versa as in {@link java.time.Clock})</li>
+ * </ul>
+ * Subclasses that want to change this behavior can either override relevant methods or
+ * subclass {@link java.time.Clock} directly.
+ */
+public abstract class AbstractClock extends Clock {
+
+  @Override
+  public ZoneId getZone() {
+    return UTC;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return this;
+  }
+
+  @Override
+  public abstract long millis();
+
+  @Override
+  public Instant instant() {
+    return Instant.ofEpochMilli(millis());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Clock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Clock.java
@@ -23,9 +23,12 @@ import org.apache.hadoop.classification.InterfaceStability.Stable;
 
 /**
  * A simple clock interface that gives you time.
+ *
+ * @deprecated use {@link java.time.Clock} instead
  */
 @Public
 @Stable
+@Deprecated
 public interface Clock {
 
   long getTime();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/MonotonicClock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/MonotonicClock.java
@@ -31,7 +31,16 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
  */
 @Public
 @Evolving
-public class MonotonicClock implements Clock {
+public class MonotonicClock extends AbstractClock {
+
+  private MonotonicClock() {
+  }
+
+  private static final MonotonicClock INSTANCE = MonotonicClock.get();
+
+  public static MonotonicClock get() {
+    return INSTANCE;
+  }
 
   /**
    * Get current time from some arbitrary time base in the past, counting in
@@ -39,7 +48,9 @@ public class MonotonicClock implements Clock {
    * changes.
    * @return a monotonic clock that counts in milliseconds.
    */
-  public long getTime() {
+  @Override
+  public long millis() {
     return Time.monotonicNow();
   }
+
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SystemClock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SystemClock.java
@@ -27,9 +27,12 @@ import org.apache.hadoop.classification.InterfaceStability.Stable;
  * NOTE: Do not use this to calculate a duration of expire or interval to sleep,
  * because it will be broken by settimeofday. Please use {@link MonotonicClock}
  * instead.
+ *
+ * @deprecated use {@link java.time.Clock#systemUTC()} instead
  */
 @Public
 @Stable
+@Deprecated
 public final class SystemClock implements Clock {
 
   private static final SystemClock INSTANCE = new SystemClock();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/UTCClock.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/UTCClock.java
@@ -27,7 +27,10 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
 /**
  * Implementation of {@link Clock} that gives the current UTC time in
  * milliseconds.
+ *
+ * @deprecated use {@link java.time.Clock#systemUTC()} instead
  */
+@Deprecated
 @Public
 @Evolving
 public class UTCClock implements Clock {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/MapTaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/MapTaskAttemptImpl.java
@@ -30,7 +30,8 @@ import org.apache.hadoop.mapreduce.v2.app.job.impl.TaskAttemptImpl;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
+
+import java.time.Clock;
 
 @SuppressWarnings("rawtypes")
 public class MapTaskAttemptImpl extends TaskAttemptImpl {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/ReduceTaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/ReduceTaskAttemptImpl.java
@@ -29,7 +29,8 @@ import org.apache.hadoop.mapreduce.v2.app.job.impl.TaskAttemptImpl;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
+
+import java.time.Clock;
 
 @SuppressWarnings("rawtypes")
 public class ReduceTaskAttemptImpl extends TaskAttemptImpl {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/TaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/TaskAttemptListenerImpl.java
@@ -224,7 +224,7 @@ public class TaskAttemptListenerImpl extends CompositeService
 
     // tell task to retry later if AM has not heard from RM within the commit
     // window to help avoid double-committing in a split-brain situation
-    long now = context.getClock().getTime();
+    long now = context.getClock().millis();
     if (now - rmHeartbeatHandler.getLastHeartbeatTime() > commitWindowMs) {
       return false;
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/AppContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/AppContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +30,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
-import org.apache.hadoop.util.Clock;
 
 
 /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/MRAppMaster.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -150,8 +151,6 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
@@ -249,7 +248,7 @@ public class MRAppMaster extends CompositeService {
       ContainerId containerId, String nmHost, int nmPort, int nmHttpPort,
       long appSubmitTime) {
     this(applicationAttemptId, containerId, nmHost, nmPort, nmHttpPort,
-        SystemClock.getInstance(), appSubmitTime);
+        Clock.systemUTC(), appSubmitTime);
   }
 
   public MRAppMaster(ApplicationAttemptId applicationAttemptId,
@@ -257,7 +256,7 @@ public class MRAppMaster extends CompositeService {
       Clock clock, long appSubmitTime) {
     super(MRAppMaster.class.getName());
     this.clock = clock;
-    this.startTime = clock.getTime();
+    this.startTime = clock.millis();
     this.appSubmitTime = appSubmitTime;
     this.appAttemptID = applicationAttemptId;
     this.containerID = containerId;
@@ -1280,7 +1279,7 @@ public class MRAppMaster extends CompositeService {
         // send init to speculator only for non-uber jobs. 
         // This won't yet start as dispatcher isn't started yet.
         dispatcher.getEventHandler().handle(
-            new SpeculatorEvent(job.getID(), clock.getTime()));
+            new SpeculatorEvent(job.getID(), clock.millis()));
         LOG.info("MRAppMaster launching normal, non-uberized, multi-container "
             + "job " + job.getID() + ".");
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/TaskAttemptFinishingMonitor.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/TaskAttemptFinishingMonitor.java
@@ -25,7 +25,8 @@ import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptEvent;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptEventType;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.AbstractLivelinessMonitor;
-import org.apache.hadoop.util.SystemClock;
+
+import java.time.Clock;
 
 /**
  * This class generates TA_TIMED_OUT if the task attempt stays in FINISHING
@@ -38,7 +39,7 @@ public class TaskAttemptFinishingMonitor extends
   private EventHandler eventHandler;
 
   public TaskAttemptFinishingMonitor(EventHandler eventHandler) {
-    super("TaskAttemptFinishingMonitor", SystemClock.getInstance());
+    super("TaskAttemptFinishingMonitor", Clock.systemUTC());
     this.eventHandler = eventHandler;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/TaskHeartbeatHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/TaskHeartbeatHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import java.time.Clock;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,7 +35,6 @@ import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptEvent;
 import org.apache.hadoop.mapreduce.v2.app.job.event.TaskAttemptEventType;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,19 +146,19 @@ public class TaskHeartbeatHandler extends AbstractService {
     ReportTime time = runningAttempts.get(attemptID);
     if(time != null) {
       time.reported.compareAndSet(false, true);
-      time.setLastProgress(clock.getTime());
+      time.setLastProgress(clock.millis());
     }
   }
 
   
   public void register(TaskAttemptId attemptID) {
-    runningAttempts.put(attemptID, new ReportTime(clock.getTime()));
+    runningAttempts.put(attemptID, new ReportTime(clock.millis()));
   }
 
   public void unregister(TaskAttemptId attemptID) {
     runningAttempts.remove(attemptID);
     recentlyUnregisteredAttempts.put(attemptID,
-        new ReportTime(clock.getTime()));
+        new ReportTime(clock.millis()));
   }
 
   public boolean hasRecentlyUnregistered(TaskAttemptId attemptID) {
@@ -170,7 +170,7 @@ public class TaskHeartbeatHandler extends AbstractService {
     @Override
     public void run() {
       while (!stopped && !Thread.currentThread().isInterrupted()) {
-        long currentTime = clock.getTime();
+        long currentTime = clock.millis();
         checkRunning(currentTime);
         checkRecentlyUnregistered(currentTime);
         try {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/commit/CommitterEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/commit/CommitterEventHandler.java
@@ -207,13 +207,13 @@ public class CommitterEventHandler extends AbstractService
       threadCommitting.interrupt();
 
       // wait up to configured timeout for commit thread to finish
-      long now = context.getClock().getTime();
+      long now = context.getClock().millis();
       long timeoutTimestamp = now + commitThreadCancelTimeoutMs;
       try {
         while (jobCommitThread == threadCommitting
             && now > timeoutTimestamp) {
           wait(now - timeoutTimestamp);
-          now = context.getClock().getTime();
+          now = context.getClock().millis();
         }
       } catch (InterruptedException e) {
       }
@@ -331,7 +331,7 @@ public class CommitterEventHandler extends AbstractService
     private synchronized void waitForValidCommitWindow()
         throws InterruptedException {
       long lastHeartbeatTime = rmHeartbeatHandler.getLastHeartbeatTime();
-      long now = context.getClock().getTime();
+      long now = context.getClock().millis();
 
       while (now - lastHeartbeatTime > commitWindowMs) {
         rmHeartbeatHandler.runOnNextHeartbeat(new Runnable() {
@@ -345,7 +345,7 @@ public class CommitterEventHandler extends AbstractService
 
         wait();
         lastHeartbeatTime = rmHeartbeatHandler.getLastHeartbeatTime();
-        now = context.getClock().getTime();
+        now = context.getClock().millis();
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,7 +129,6 @@ import org.apache.hadoop.yarn.state.MultipleArcTransition;
 import org.apache.hadoop.yarn.state.SingleArcTransition;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -1097,7 +1097,7 @@ public class JobImpl implements org.apache.hadoop.mapreduce.v2.app.job.Job,
   }
 
   void setFinishTime() {
-    finishTime = clock.getTime();
+    finishTime = clock.millis();
   }
 
   void logJobHistoryFinishedEvent() {
@@ -1676,7 +1676,7 @@ public class JobImpl implements org.apache.hadoop.mapreduce.v2.app.job.Job,
       if (jse.getRecoveredJobStartTime() != -1L) {
         job.startTime = jse.getRecoveredJobStartTime();
       } else {
-        job.startTime = job.clock.getTime();
+        job.startTime = job.clock.millis();
       }
       JobInitedEvent jie =
         new JobInitedEvent(job.oldJobId,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/MapTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/MapTaskImpl.java
@@ -32,7 +32,8 @@ import org.apache.hadoop.mapreduce.v2.app.metrics.MRAppMetrics;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
+
+import java.time.Clock;
 
 @SuppressWarnings({ "rawtypes" })
 public class MapTaskImpl extends TaskImpl {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/ReduceTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/ReduceTaskImpl.java
@@ -31,7 +31,8 @@ import org.apache.hadoop.mapreduce.v2.app.metrics.MRAppMetrics;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
+
+import java.time.Clock;
 
 @SuppressWarnings({ "rawtypes" })
 public class ReduceTaskImpl extends TaskImpl {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -140,7 +141,6 @@ import org.apache.hadoop.yarn.state.MultipleArcTransition;
 import org.apache.hadoop.yarn.state.SingleArcTransition;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.RackResolver;
 import org.apache.hadoop.yarn.util.UnitsConversionUtil;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
@@ -1463,7 +1463,7 @@ public abstract class TaskAttemptImpl implements
     computeRackAndLocality();
     launchTime = taInfo.getStartTime();
     finishTime = (taInfo.getFinishTime() != -1) ?
-        taInfo.getFinishTime() : clock.getTime();
+        taInfo.getFinishTime() : clock.millis();
     shufflePort = taInfo.getShufflePort();
     trackerName = taInfo.getHostname();
     httpPort = taInfo.getHttpPort();
@@ -1597,7 +1597,7 @@ public abstract class TaskAttemptImpl implements
   private void setFinishTime() {
     //set the finish time only if launch time is set
     if (launchTime != 0) {
-      finishTime = clock.getTime();
+      finishTime = clock.millis();
     }
   }
 
@@ -1724,7 +1724,7 @@ public abstract class TaskAttemptImpl implements
     if (null == taskAttempt.container) {
       return;
     }
-    taskAttempt.launchTime = taskAttempt.clock.getTime();
+    taskAttempt.launchTime = taskAttempt.clock.millis();
 
     InetSocketAddress nodeHttpInetAddr =
         NetUtils.createSocketAddr(taskAttempt.container.getNodeHttpAddress());
@@ -1777,7 +1777,7 @@ public abstract class TaskAttemptImpl implements
 
     WrappedProgressSplitsBlock splitsBlock = getProgressSplitBlock();
     if (splitsBlock != null) {
-      long now = clock.getTime();
+      long now = clock.millis();
       long start = getLaunchTime(); // TODO Ensure not 0
 
       if (start != 0 && now - start <= Integer.MAX_VALUE) {
@@ -1996,7 +1996,7 @@ public abstract class TaskAttemptImpl implements
         (TaskAttemptContainerLaunchedEvent) evnt;
 
       //set the launch time
-      taskAttempt.launchTime = taskAttempt.clock.getTime();
+      taskAttempt.launchTime = taskAttempt.clock.millis();
       taskAttempt.shufflePort = event.getShufflePort();
 
       // register it to TaskAttemptListener so that it can start monitoring it.
@@ -2011,7 +2011,7 @@ public abstract class TaskAttemptImpl implements
       taskAttempt.sendLaunchedEvents();
       taskAttempt.eventHandler.handle
           (new SpeculatorEvent
-              (taskAttempt.attemptId, true, taskAttempt.clock.getTime()));
+              (taskAttempt.attemptId, true, taskAttempt.clock.millis()));
       //make remoteTask reference as null as it is no more needed
       //and free up the memory
       taskAttempt.remoteTask = null;
@@ -2443,7 +2443,7 @@ public abstract class TaskAttemptImpl implements
           TaskEventType.T_ATTEMPT_SUCCEEDED));
       taskAttempt.eventHandler.handle
           (new SpeculatorEvent
-              (taskAttempt.reportedStatus, taskAttempt.clock.getTime()));
+              (taskAttempt.reportedStatus, taskAttempt.clock.millis()));
 
     }
   }
@@ -2514,7 +2514,7 @@ public abstract class TaskAttemptImpl implements
       // send event to speculator about the reported status
       taskAttempt.eventHandler.handle
           (new SpeculatorEvent
-              (taskAttempt.reportedStatus, taskAttempt.clock.getTime()));
+              (taskAttempt.reportedStatus, taskAttempt.clock.millis()));
       taskAttempt.updateProgressSplits();
       //if fetch failures are present, send the fetch failure event to job
       //this only will happen in reduce attempt type

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app.job.impl;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,7 +92,6 @@ import org.apache.hadoop.yarn.state.MultipleArcTransition;
 import org.apache.hadoop.yarn.state.SingleArcTransition;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -521,7 +521,7 @@ public abstract class TaskImpl implements Task, EventHandler<TaskEvent> {
 
   private long getFinishTime(TaskAttemptId taId) {
     if (taId == null) {
-      return clock.getTime();
+      return clock.millis();
     }
     long finishTime = 0;
     for (TaskAttempt at : attempts.values()) {
@@ -903,7 +903,7 @@ public abstract class TaskImpl implements Task, EventHandler<TaskEvent> {
     @Override
     public void transition(TaskImpl task, TaskEvent event) {
       task.addAndScheduleAttempt(Avataar.VIRGIN);
-      task.scheduledTime = task.clock.getTime();
+      task.scheduledTime = task.clock.millis();
       task.sendTaskStartedEvent();
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMCommunicator.java
@@ -287,7 +287,7 @@ public abstract class RMCommunicator extends AbstractService
             // TODO: for other exceptions
           }
 
-          lastHeartbeatTime = context.getClock().getTime();
+          lastHeartbeatTime = context.getClock().millis();
           executeHeartbeatCallbacks();
         } catch (InterruptedException e) {
           if (!stopped.get()) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/rm/RMContainerAllocator.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.app.rm;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -83,7 +84,6 @@ import org.apache.hadoop.yarn.exceptions.InvalidLabelResourceRequestException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.RackResolver;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
@@ -628,7 +628,7 @@ public class RMContainerAllocator extends RMContainerRequestor
     if (allocationDelayThresholdMs <= 0)
       return requestMap.size();
     int hangingRequests = 0;
-    long currTime = clock.getTime();
+    long currTime = clock.millis();
     for (ContainerRequest request: requestMap.values()) {
       long delay = currTime - request.requestTimeMs;
       if (delay > allocationDelayThresholdMs)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DefaultSpeculator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.mapreduce.v2.app.speculate;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Clock;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +48,6 @@ import org.apache.hadoop.mapreduce.v2.app.job.event.TaskEventType;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.apache.hadoop.util.Clock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.event.Event;
@@ -193,7 +193,7 @@ public class DefaultSpeculator extends AbstractService implements
             @Override
             public void run() {
               while (!stopped && !Thread.currentThread().isInterrupted()) {
-                long backgroundRunStartTime = clock.getTime();
+                long backgroundRunStartTime = clock.millis();
                 try {
                   int speculations = computeSpeculations();
                   long mininumRecomp
@@ -201,7 +201,7 @@ public class DefaultSpeculator extends AbstractService implements
                                          : soonestRetryAfterNoSpeculate;
 
                   long wait = Math.max(mininumRecomp,
-                        clock.getTime() - backgroundRunStartTime);
+                        clock.millis() - backgroundRunStartTime);
 
                   if (speculations > 0) {
                     LOG.info("We launched " + speculations
@@ -238,7 +238,7 @@ public class DefaultSpeculator extends AbstractService implements
 
   @Override
   public void handleAttempt(TaskAttemptStatus status) {
-    long timestamp = clock.getTime();
+    long timestamp = clock.millis();
     statusUpdate(status, timestamp);
   }
 
@@ -488,7 +488,7 @@ public class DefaultSpeculator extends AbstractService implements
   private int maybeScheduleASpeculation(TaskType type) {
     int successes = 0;
 
-    long now = clock.getTime();
+    long now = clock.millis();
 
     ConcurrentMap<JobId, AtomicInteger> containerNeeds
         = type == TaskType.MAP ? mapContainerNeeds : reduceContainerNeeds;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptFinishingMonitor.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.mapred;
 
 
 import java.io.IOException;
+import java.time.Clock;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -35,7 +36,6 @@ import org.apache.hadoop.mapreduce.v2.app.rm.RMHeartbeatHandler;
 import org.apache.hadoop.mapreduce.v2.util.MRBuilderUtils;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.SystemClock;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,7 +47,7 @@ public class TestTaskAttemptFinishingMonitor {
   @Test
   public void testFinshingAttemptTimeout()
       throws IOException, InterruptedException {
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     Configuration conf = new Configuration();
     conf.setInt(MRJobConfig.TASK_EXIT_TIMEOUT, 100);
     conf.setInt(MRJobConfig.TASK_EXIT_TIMEOUT_CHECK_INTERVAL_MS, 10);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapred/TestTaskAttemptListenerImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -66,7 +67,6 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -312,7 +312,7 @@ public class TestTaskAttemptListenerImpl {
   @Test
   @Timeout(value = 10)
   public void testCommitWindow() throws IOException {
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
 
     configureMocks();
 
@@ -344,7 +344,7 @@ public class TestTaskAttemptListenerImpl {
 
     // verify commit allowed when RM heartbeat is recent
     when(rmHeartbeatHandler.getLastHeartbeatTime())
-      .thenReturn(clock.getTime());
+      .thenReturn(clock.millis());
     canCommit = listener.canCommit(tid);
     assertTrue(canCommit);
     verify(mockTask, times(1)).canCommit(any(TaskAttemptId.class));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
 import java.util.EnumSet;
 
 import org.apache.hadoop.conf.Configuration;
@@ -96,8 +97,6 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,7 +159,7 @@ public class MRApp extends MRAppMaster {
   public MRApp(int maps, int reduces, boolean autoComplete, String testName,
       boolean cleanOnStart, String assignedQueue) {
     this(maps, reduces, autoComplete, testName, cleanOnStart, 1,
-        SystemClock.getInstance(), assignedQueue);
+        Clock.systemUTC(), assignedQueue);
   }
 
   public MRApp(int maps, int reduces, boolean autoComplete, String testName,
@@ -194,13 +193,13 @@ public class MRApp extends MRAppMaster {
   public MRApp(int maps, int reduces, boolean autoComplete, String testName,
       boolean cleanOnStart, int startCount) {
     this(maps, reduces, autoComplete, testName, cleanOnStart, startCount,
-        SystemClock.getInstance(), null);
+        Clock.systemUTC(), null);
   }
 
   public MRApp(int maps, int reduces, boolean autoComplete, String testName,
       boolean cleanOnStart, int startCount, boolean unregistered) {
     this(maps, reduces, autoComplete, testName, cleanOnStart, startCount,
-        SystemClock.getInstance(), unregistered);
+        Clock.systemUTC(), unregistered);
   }
 
   public MRApp(int maps, int reduces, boolean autoComplete, String testName,
@@ -221,14 +220,14 @@ public class MRApp extends MRAppMaster {
       int maps, int reduces, boolean autoComplete, String testName,
       boolean cleanOnStart, int startCount, boolean unregistered) {
     this(appAttemptId, amContainerId, maps, reduces, autoComplete, testName,
-        cleanOnStart, startCount, SystemClock.getInstance(), unregistered, null);
+        cleanOnStart, startCount, Clock.systemUTC(), unregistered, null);
   }
 
   public MRApp(ApplicationAttemptId appAttemptId, ContainerId amContainerId,
       int maps, int reduces, boolean autoComplete, String testName,
       boolean cleanOnStart, int startCount) {
     this(appAttemptId, amContainerId, maps, reduces, autoComplete, testName,
-        cleanOnStart, startCount, SystemClock.getInstance(), true, null);
+        cleanOnStart, startCount, Clock.systemUTC(), true, null);
   }
 
   public MRApp(ApplicationAttemptId appAttemptId, ContainerId amContainerId,
@@ -592,7 +591,7 @@ public class MRApp extends MRAppMaster {
 
     @Override
     public long getLastHeartbeatTime() {
-      return getContext().getClock().getTime();
+      return getContext().getClock().millis();
     }
 
     @Override

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MockAppContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MockAppContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +30,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
-import org.apache.hadoop.util.Clock;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRecovery.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -104,8 +105,6 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -1944,7 +1943,7 @@ public class TestRecovery {
     Token<JobTokenIdentifier> jobToken =
         (Token<JobTokenIdentifier>) mock(Token.class);
     Credentials credentials = null;
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     int appAttemptId = 3;
     MRAppMetrics metrics = mock(MRAppMetrics.class);
     Resource minContainerRequirements = mock(Resource.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestRuntimeEstimators.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.v2.app;
 
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,9 +76,7 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,7 +209,7 @@ public class TestRuntimeEstimators {
                     >= taskTypeSlots(task.getType())) {
             MyTaskAttemptImpl attemptImpl = (MyTaskAttemptImpl)attempt;
             SpeculatorEvent event
-                = new SpeculatorEvent(attempt.getID(), false, clock.getTime());
+                = new SpeculatorEvent(attempt.getID(), false, clock.millis());
             speculator.handle(event);
             attemptImpl.startUp();
           } else {
@@ -221,7 +220,7 @@ public class TestRuntimeEstimators {
             status.progress = attempt.getProgress();
             status.stateString = attempt.getState().name();
             status.taskState = attempt.getState();
-            SpeculatorEvent event = new SpeculatorEvent(status, clock.getTime());
+            SpeculatorEvent event = new SpeculatorEvent(status, clock.millis());
             speculator.handle(event);
           }
         }
@@ -239,7 +238,7 @@ public class TestRuntimeEstimators {
 
       clock.tickMsec(1000L);
 
-      if (clock.getTime() % 10000L == 0L) {
+      if (clock.millis() % 10000L == 0L) {
         speculator.scanForSpeculations();
       }
     }
@@ -586,7 +585,7 @@ public class TestRuntimeEstimators {
     }
 
     void startUp() {
-      startMockTime = clock.getTime();
+      startMockTime = clock.millis();
       overridingState = null;
 
       slotsInUse.addAndGet(taskTypeSlots(myAttemptID.getTaskId().getTaskType()));
@@ -660,7 +659,7 @@ public class TestRuntimeEstimators {
       float runtime = getCodeRuntime();
 
       return Math.min
-          ((float) (clock.getTime() - startMockTime) / (runtime * 1000.0F), 1.0F);
+          ((float) (clock.millis() - startMockTime) / (runtime * 1000.0F), 1.0F);
     }
 
     private float getReduceProgress() {
@@ -679,10 +678,10 @@ public class TestRuntimeEstimators {
       }
 
       if (numberMaps == numberDoneMaps) {
-        shuffleCompletedTime = Math.min(shuffleCompletedTime, clock.getTime());
+        shuffleCompletedTime = Math.min(shuffleCompletedTime, clock.millis());
 
         return Math.min
-            ((float) (clock.getTime() - shuffleCompletedTime)
+            ((float) (clock.millis() - shuffleCompletedTime)
                         / (runtime * 2000.0F) + 0.5F,
              1.0F);
       } else {
@@ -738,11 +737,11 @@ public class TestRuntimeEstimators {
               float hisProgress = otherAttempt.getProgress();
               long hisStartTime = ((MyTaskAttemptImpl)otherAttempt).startMockTime;
               System.out.println("TLTRE:A speculation finished at time "
-                  + clock.getTime()
+                  + clock.millis()
                   + ".  The stalled attempt is at " + (hisProgress * 100.0)
                   + "% progress, and it started at "
                   + hisStartTime + ", which is "
-                  + (clock.getTime() - hisStartTime) + " ago.");
+                  + (clock.millis() - hisStartTime) + " ago.");
               long originalTaskEndEstimate
                   = (hisStartTime
                       + estimator.estimatedRuntime(otherAttempt.getID()));
@@ -750,7 +749,7 @@ public class TestRuntimeEstimators {
                   "TLTRE: We would have expected the original attempt to take "
                   + estimator.estimatedRuntime(otherAttempt.getID())
                   + ", finishing at " + originalTaskEndEstimate);
-              long estimatedSavings = originalTaskEndEstimate - clock.getTime();
+              long estimatedSavings = originalTaskEndEstimate - clock.millis();
               taskTimeSavedBySpeculation.addAndGet(estimatedSavings);
               System.out.println("TLTRE: The task is " + task.getID());
               slotsInUse.addAndGet(- taskTypeSlots(myAttemptID.getTaskId().getTaskType()));
@@ -819,7 +818,7 @@ public class TestRuntimeEstimators {
       public MyAppMaster(Clock clock) {
         super(MyAppMaster.class.getName());
         if (clock == null) {
-          clock = SystemClock.getInstance();
+          clock = Clock.systemUTC();
         }
       this.clock = clock;
       LOG.info("Created MyAppMaster");
@@ -833,7 +832,7 @@ public class TestRuntimeEstimators {
     private final Map<JobId, Job> allJobs;
 
     MyAppContext(int numberMaps, int numberReduces) {
-      myApplicationID = ApplicationId.newInstance(clock.getTime(), 1);
+      myApplicationID = ApplicationId.newInstance(clock.millis(), 1);
 
       myAppAttemptID = ApplicationAttemptId.newInstance(myApplicationID, 0);
       myJobID = recordFactory.newRecordInstance(JobId.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestStagingCleanup.java
@@ -577,7 +577,7 @@ import org.junit.jupiter.api.Timeout;
     return new RMHeartbeatHandler() {
       @Override
       public long getLastHeartbeatTime() {
-        return appContext.getClock().getTime();
+        return appContext.getClock().millis();
       }
       @Override
       public void runOnNextHeartbeat(Runnable callback) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestTaskHeartbeatHandler.java
@@ -38,11 +38,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -53,7 +52,7 @@ public class TestTaskHeartbeatHandler {
   @Test
   public void testTaskTimeout() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
     
     
@@ -87,7 +86,7 @@ public class TestTaskHeartbeatHandler {
   @SuppressWarnings("unchecked")
   public void testTaskTimeoutDisable() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
 
     Configuration conf = new Configuration();
@@ -127,7 +126,7 @@ public class TestTaskHeartbeatHandler {
   @Test
   public void testTaskStuck() throws InterruptedException {
     EventHandler mockHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     TaskHeartbeatHandler hb = new TaskHeartbeatHandler(mockHandler, clock, 1);
 
 
@@ -252,7 +251,7 @@ public class TestTaskHeartbeatHandler {
   private static void verifyTaskTimeoutConfig(final Configuration conf,
       final long expectedTimeout) {
     final TaskHeartbeatHandler hb =
-        new TaskHeartbeatHandler(null, SystemClock.getInstance(), 1);
+        new TaskHeartbeatHandler(null, Clock.systemUTC(), 1);
     hb.init(conf);
 
     assertEquals(hb.getTaskTimeOut(), expectedTimeout,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/commit/TestCommitterEventHandler.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.yarn.event.EventHandler;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileSystem;
@@ -61,8 +62,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -122,7 +121,7 @@ public class TestCommitterEventHandler {
     TestingJobEventHandler jeh = new TestingJobEventHandler();
     dispatcher.register(JobEventType.class, jeh);
 
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     AppContext appContext = mock(AppContext.class);
     ApplicationAttemptId attemptid = ApplicationAttemptId.fromString(
         "appattempt_1234567890000_0001_0");
@@ -154,7 +153,7 @@ public class TestCommitterEventHandler {
         "committer should not have committed");
 
     // set a fresh heartbeat and verify commit completes
-    rmhh.setLastHeartbeatTime(clock.getTime());
+    rmhh.setLastHeartbeatTime(clock.millis());
     timeToWaitMs = 5000;
     while (jeh.numCommitCompletedEvents != 1 && timeToWaitMs > 0) {
       Thread.sleep(10);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -113,7 +114,6 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -818,7 +818,7 @@ public class TestJobImpl {
         .newRecord(ApplicationAttemptId.class), new Configuration(),
         mock(EventHandler.class),
         null, mock(JobTokenSecretManager.class), null,
-        SystemClock.getInstance(), null,
+        Clock.systemUTC(), null,
         mrAppMetrics, null, true, null, 0, null, mockContext, null, null);
     job.handle(diagUpdateEvent);
     String diagnostics = job.getReport().getDiagnostics();
@@ -829,7 +829,7 @@ public class TestJobImpl {
         .newRecord(ApplicationAttemptId.class), new Configuration(),
         mock(EventHandler.class),
         null, mock(JobTokenSecretManager.class), null,
-        SystemClock.getInstance(), null,
+        Clock.systemUTC(), null,
         mrAppMetrics, null, true, null, 0, null, mockContext, null, null);
     job.handle(new JobEvent(jobId, JobEventType.JOB_KILL));
     job.handle(diagUpdateEvent);
@@ -1044,7 +1044,7 @@ public class TestJobImpl {
 
   private static CommitterEventHandler createCommitterEventHandler(
       Dispatcher dispatcher, OutputCommitter committer) {
-    final SystemClock clock = SystemClock.getInstance();
+    final Clock clock = Clock.systemUTC();
     AppContext appContext = mock(AppContext.class);
     when(appContext.getEventHandler()).thenReturn(
         dispatcher.getEventHandler());
@@ -1052,7 +1052,7 @@ public class TestJobImpl {
     RMHeartbeatHandler heartbeatHandler = new RMHeartbeatHandler() {
       @Override
       public long getLastHeartbeatTime() {
-        return clock.getTime();
+        return clock.millis();
       }
       @Override
       public void runOnNextHeartbeat(Runnable callback) {
@@ -1254,7 +1254,7 @@ public class TestJobImpl {
         String user, int numSplits, AppContext appContext) {
       super(jobId, applicationAttemptId, conf, eventHandler,
           null, new JobTokenSecretManager(), new Credentials(),
-          SystemClock.getInstance(), Collections.<TaskId, TaskInfo> emptyMap(),
+          Clock.systemUTC(), Collections.<TaskId, TaskInfo> emptyMap(),
           MRAppMetrics.create(), null, newApiCommitter, user,
           System.currentTimeMillis(), null, appContext, null, null);
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestShuffleProvider.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
 import java.util.Map;
 import java.nio.ByteBuffer;
 
@@ -50,7 +51,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.server.api.AuxiliaryService;
 import org.apache.hadoop.yarn.server.api.ApplicationInitializationContext;
 import org.apache.hadoop.yarn.server.api.ApplicationTerminationContext;
@@ -99,7 +99,7 @@ public class TestShuffleProvider {
         new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
             mock(TaskSplitMetaInfo.class), jobConf, taListener,
             jobToken, credentials,
-            SystemClock.getInstance(), null);
+            Clock.systemUTC(), null);
 
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, taImpl.getID().toString());
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttempt.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -104,9 +105,7 @@ import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
@@ -348,7 +347,7 @@ public class TestTaskAttempt{
 
   public void verifyMillisCounters(Resource containerResource,
       int minContainerSize) throws Exception {
-    Clock actualClock = SystemClock.getInstance();
+    Clock actualClock = Clock.systemUTC();
     ControlledClock clock = new ControlledClock(actualClock);
     clock.setTime(10);
     MRApp app =
@@ -413,7 +412,7 @@ public class TestTaskAttempt{
 
   private TaskAttemptImpl createMapTaskAttemptImplForTest(
       EventHandler eventHandler, TaskSplitMetaInfo taskSplitMetaInfo) {
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     return createMapTaskAttemptImplForTest(eventHandler, taskSplitMetaInfo,
         clock, new JobConf());
   }
@@ -620,7 +619,7 @@ public class TestTaskAttempt{
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
           splits, jobConf, taListener,
           new Token(), new Credentials(),
-          SystemClock.getInstance(), null);
+          Clock.systemUTC(), null);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -677,7 +676,7 @@ public class TestTaskAttempt{
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
           splits, jobConf, taListener,
           new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+          Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.2", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -736,7 +735,7 @@ public class TestTaskAttempt{
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
           splits, jobConf, taListener,
           new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+          Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -801,7 +800,7 @@ public class TestTaskAttempt{
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
           splits, jobConf, taListener,
           new Token(), new Credentials(),
-          SystemClock.getInstance(), appCtx);
+          Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -872,7 +871,7 @@ public class TestTaskAttempt{
 
     TaskAttemptImpl taImpl = new MapTaskAttemptImpl(taskId, 1, eventHandler,
         jobFile, 1, splits, jobConf, taListener,
-        new Token(), new Credentials(), SystemClock.getInstance(), appCtx);
+        new Token(), new Credentials(), Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -929,7 +928,7 @@ public class TestTaskAttempt{
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
         splits, jobConf, taListener,
         mock(Token.class), new Credentials(),
-        SystemClock.getInstance(), appCtx);
+        Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -998,7 +997,7 @@ public class TestTaskAttempt{
 
     TaskAttemptImpl taImpl = new MapTaskAttemptImpl(taskId, 1, eventHandler,
         jobFile, 1, splits, jobConf, taListener,
-        new Token(), new Credentials(), SystemClock.getInstance(), appCtx);
+        new Token(), new Credentials(), Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1047,7 +1046,7 @@ public class TestTaskAttempt{
     TaskAttemptImpl taImpl =
       new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
       splits, jobConf, taListener,mock(Token.class), new Credentials(),
-      SystemClock.getInstance(), appCtx);
+      Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1098,7 +1097,7 @@ public class TestTaskAttempt{
         new MapTaskAttemptImpl(taskId, 1, eventHandler, mock(Path.class), 1,
             mock(TaskSplitMetaInfo.class), new JobConf(),
             mock(TaskAttemptListener.class), mock(Token.class),
-            new Credentials(), SystemClock.getInstance(),
+            new Credentials(), Clock.systemUTC(),
             mock(AppContext.class));
     if (scheduleAttempt) {
       taImpl.handle(new TaskAttemptEvent(taImpl.getID(),
@@ -1161,7 +1160,7 @@ public class TestTaskAttempt{
 
     TaskAttemptImpl taImpl = new MapTaskAttemptImpl(taskId, 1, eventHandler,
         jobFile, 1, splits, jobConf, taListener, new Token(),
-        new Credentials(), SystemClock.getInstance(), appCtx);
+        new Credentials(), Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.2", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1217,7 +1216,7 @@ public class TestTaskAttempt{
 
     TaskAttemptImpl taImpl = new MapTaskAttemptImpl(taskId, 1, eventHandler,
         jobFile, 1, splits, jobConf, taListener, new Token(),
-        new Credentials(), SystemClock.getInstance(), appCtx);
+        new Credentials(), Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.2", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1275,7 +1274,7 @@ public class TestTaskAttempt{
 
     TaskAttemptImpl taImpl = new MapTaskAttemptImpl(taskId, 1, eventHandler,
         jobFile, 1, splits, jobConf, taListener, new Token(),
-        new Credentials(), SystemClock.getInstance(), appCtx);
+        new Credentials(), Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.2", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -1622,7 +1621,7 @@ public class TestTaskAttempt{
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
     TaskSplitMetaInfo taskSplitMetaInfo = new TaskSplitMetaInfo();
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.setLong(MRJobConfig.MAP_RESOURCE_TYPE_PREFIX
         + CUSTOM_RESOURCE_NAME, 7L);
@@ -1640,7 +1639,7 @@ public class TestTaskAttempt{
   public void testReducerCustomResourceTypes() {
     initResourceTypes();
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
         + CUSTOM_RESOURCE_NAME, "3m");
@@ -1657,7 +1656,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerMemoryRequestViaMapreduceReduceMemoryMb() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.setInt(MRJobConfig.REDUCE_MEMORY_MB, 2048);
     TaskAttemptImpl taImpl =
@@ -1671,7 +1670,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerMemoryRequestViaMapreduceReduceResourceMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX +
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY, "2 Gi");
@@ -1686,7 +1685,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerMemoryRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     TaskAttemptImpl taImpl =
         createReduceTaskAttemptImplForTest(eventHandler, clock, new JobConf());
     long memorySize =
@@ -1697,7 +1696,7 @@ public class TestTaskAttempt{
 
   @Test
   public void testReducerMemoryRequestWithoutUnits() {
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     for (String memoryResourceName : ImmutableList.of(
         MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
         MRJobConfig.RESOURCE_TYPE_ALTERNATIVE_NAME_MEMORY)) {
@@ -1725,7 +1724,7 @@ public class TestTaskAttempt{
         TaskAttemptImpl.RESOURCE_REQUEST_CACHE.clear();
         logger.addAppender(testAppender);
         EventHandler eventHandler = mock(EventHandler.class);
-        Clock clock = SystemClock.getInstance();
+        Clock clock = Clock.systemUTC();
         JobConf jobConf = new JobConf();
         jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX + memoryName,
             "3Gi");
@@ -1751,7 +1750,7 @@ public class TestTaskAttempt{
   public void testReducerMemoryRequestMultipleName() {
     assertThrows(IllegalArgumentException.class, ()->{
       EventHandler eventHandler = mock(EventHandler.class);
-      Clock clock = SystemClock.getInstance();
+      Clock clock = Clock.systemUTC();
       JobConf jobConf = new JobConf();
       for (String memoryName : ImmutableList.of(
           MRJobConfig.RESOURCE_TYPE_NAME_MEMORY,
@@ -1766,7 +1765,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerCpuRequestViaMapreduceReduceCpuVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.setInt(MRJobConfig.REDUCE_CPU_VCORES, 3);
     TaskAttemptImpl taImpl =
@@ -1780,7 +1779,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerCpuRequestViaMapreduceReduceResourceVcores() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     JobConf jobConf = new JobConf();
     jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX +
         MRJobConfig.RESOURCE_TYPE_NAME_VCORE, "5");
@@ -1795,7 +1794,7 @@ public class TestTaskAttempt{
   @Test
   public void testReducerCpuRequestDefaultMemory() {
     EventHandler eventHandler = mock(EventHandler.class);
-    Clock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     TaskAttemptImpl taImpl =
         createReduceTaskAttemptImplForTest(eventHandler, clock, new JobConf());
     int vCores =
@@ -1811,7 +1810,7 @@ public class TestTaskAttempt{
     try {
       logger.addAppender(testAppender);
       EventHandler eventHandler = mock(EventHandler.class);
-      Clock clock = SystemClock.getInstance();
+      Clock clock = Clock.systemUTC();
       JobConf jobConf = new JobConf();
       jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX +
           MRJobConfig.RESOURCE_TYPE_NAME_VCORE, "7");
@@ -1861,7 +1860,7 @@ public class TestTaskAttempt{
     assertThrows(IllegalArgumentException.class, () -> {
       initResourceTypes();
       EventHandler eventHandler = mock(EventHandler.class);
-      Clock clock = SystemClock.getInstance();
+      Clock clock = Clock.systemUTC();
       JobConf jobConf = new JobConf();
       jobConf.set(MRJobConfig.REDUCE_RESOURCE_TYPE_PREFIX
           + CUSTOM_RESOURCE_NAME, "3z");
@@ -1994,7 +1993,7 @@ public class TestTaskAttempt{
         new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
             splits, jobConf, taListener,
             mock(Token.class), new Credentials(),
-            SystemClock.getInstance(), appCtx);
+            Clock.systemUTC(), appCtx);
 
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newInstance(appAttemptId, 3);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskAttemptContainerRequest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,7 +60,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.event.EventHandler;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"rawtypes"})
@@ -104,7 +104,7 @@ public class TestTaskAttemptContainerRequest {
         new MapTaskAttemptImpl(taskId, 1, eventHandler, jobFile, 1,
             mock(TaskSplitMetaInfo.class), jobConf, taListener,
             jobToken, credentials,
-            SystemClock.getInstance(), null);
+            Clock.systemUTC(), null);
 
     jobConf.set(MRJobConfig.APPLICATION_ATTEMPT_ID, taImpl.getID().toString());
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestTaskImpl.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,9 +63,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.event.InlineDispatcher;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -246,7 +245,7 @@ public class TestTaskImpl {
     jobToken = (Token<JobTokenIdentifier>) mock(Token.class);
     remoteJobConfFile = mock(Path.class);
     credentials = null;
-    clock = SystemClock.getInstance();
+    clock = Clock.systemUTC();
     metrics = mock(MRAppMetrics.class);  
     dataLocations = new String[1];
     

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMCommunicator.java
@@ -22,10 +22,11 @@ import org.apache.hadoop.mapreduce.v2.app.AppContext;
 import org.apache.hadoop.mapreduce.v2.app.client.ClientService;
 import org.apache.hadoop.mapreduce.v2.app.rm.RMCommunicator.AllocatorRunnable;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.apache.hadoop.util.Clock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.stubbing.Answer;
+
+import java.time.Clock;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -60,7 +61,7 @@ public class TestRMCommunicator {
     doThrow(new RMContainerAllocationException("Test")).doNothing()
         .when(communicator).heartbeat();
 
-    when(mockClock.getTime()).thenReturn(1L).thenThrow(new AssertionError(
+    when(mockClock.millis()).thenReturn(1L).thenThrow(new AssertionError(
         "GetClock called second time, when it should not have since the " +
         "thread should have quit"));
 
@@ -83,7 +84,7 @@ public class TestRMCommunicator {
     doThrow(new YarnRuntimeException("Test")).doNothing()
         .when(communicator).heartbeat();
 
-    when(mockClock.getTime()).thenReturn(1L).thenAnswer(
+    when(mockClock.millis()).thenReturn(1L).thenAnswer(
         (Answer<Long>) invocation -> {
         communicator.stop();
         return 2L;
@@ -94,6 +95,6 @@ public class TestRMCommunicator {
     AllocatorRunnable testRunnable = communicator.new AllocatorRunnable();
     testRunnable.run();
 
-    verify(mockClock, times(2)).getTime();
+    verify(mockClock, times(2)).millis();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/rm/TestRMContainerAllocator.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -152,11 +153,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEv
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.security.AMRMTokenSecretManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -451,7 +450,7 @@ public class TestRMContainerAllocator {
         MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
             0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
     final MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
-        appAttemptId, mockJob, SystemClock.getInstance());
+        appAttemptId, mockJob, Clock.systemUTC());
     // add resources to scheduler
     rm.drainEvents();
 
@@ -508,7 +507,7 @@ public class TestRMContainerAllocator {
         MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
             0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
     MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
-        appAttemptId, mockJob, SystemClock.getInstance());
+        appAttemptId, mockJob, Clock.systemUTC());
     allocator.setMapResourceRequest(Resources.createResource(1024));
     allocator.setReduceResourceRequest(Resources.createResource(1024));
     RMContainerAllocator.AssignedRequests assignedRequests =
@@ -576,16 +575,16 @@ public class TestRMContainerAllocator {
                 new String[] {"h1"}, false, false);
     scheduledRequests.maps.put(mock(TaskAttemptId.class),
         new RMContainerRequestor.ContainerRequest(event1, null,
-                clock.getTime()));
+                clock.millis()));
     assignedRequests.reduces.put(mock(TaskAttemptId.class),
         mock(Container.class));
 
-    clock.setTime(clock.getTime() + 1);
+    clock.setTime(clock.millis() + 1);
     allocator.preemptReducesIfNeeded();
     assertEquals(0, assignedRequests.preemptionWaitingReduces.size(),
         "The reducer is aggressively preempted");
 
-    clock.setTime(clock.getTime() + (preemptThreshold) * 1000);
+    clock.setTime(clock.millis() + (preemptThreshold) * 1000);
     allocator.preemptReducesIfNeeded();
     assertEquals(1, assignedRequests.preemptionWaitingReduces.size(),
         "The reducer is not preempted");
@@ -641,16 +640,16 @@ public class TestRMContainerAllocator {
                 new String[] {"h1"}, false, false);
     scheduledRequests.maps.put(mock(TaskAttemptId.class),
         new RMContainerRequestor.ContainerRequest(event1, null,
-                clock.getTime()));
+                clock.millis()));
     assignedRequests.reduces.put(mock(TaskAttemptId.class),
         mock(Container.class));
 
-    clock.setTime(clock.getTime() + 1);
+    clock.setTime(clock.millis() + 1);
     allocator.preemptReducesIfNeeded();
     assertEquals(0, assignedRequests.preemptionWaitingReduces.size(),
         "The reducer is preempted too soon");
 
-    clock.setTime(clock.getTime() + 1000 * forcePreemptThresholdSecs);
+    clock.setTime(clock.millis() + 1000 * forcePreemptThresholdSecs);
     allocator.preemptReducesIfNeeded();
     assertEquals(1, assignedRequests.preemptionWaitingReduces.size(),
         "The reducer is not preempted");
@@ -680,7 +679,7 @@ public class TestRMContainerAllocator {
         MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
             0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
     final MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
-        appAttemptId, mockJob, SystemClock.getInstance());
+        appAttemptId, mockJob, Clock.systemUTC());
 
     // request to allocate two reduce priority containers
     final String[] locations = new String[] {host};
@@ -729,7 +728,7 @@ public class TestRMContainerAllocator {
     final MockScheduler mockScheduler = new MockScheduler(appAttemptId);
     MyContainerAllocator allocator =
         new MyContainerAllocator(null, conf, appAttemptId, mockJob,
-            SystemClock.getInstance()) {
+            Clock.systemUTC()) {
           @Override
           protected void register() {
           }
@@ -830,7 +829,7 @@ public class TestRMContainerAllocator {
         new MockSchedulerForTimelineCollector(collectorInfo);
     MyContainerAllocator allocator =
         new MyContainerAllocator(null, conf, attemptId, mockJob,
-            SystemClock.getInstance()) {
+            Clock.systemUTC()) {
           @Override
           protected void register() {
           }
@@ -912,7 +911,7 @@ public class TestRMContainerAllocator {
         MRBuilderUtils.newJobReport(jobId, "job", "user", JobState.RUNNING, 0,
             0, 0, 0, 0, 0, 0, "jobfile", null, false, ""));
     MyContainerAllocator allocator = new MyContainerAllocator(rm, conf,
-        appAttemptId, mockJob, SystemClock.getInstance());
+        appAttemptId, mockJob, Clock.systemUTC());
 
     // add resources to scheduler
     MockNM nodeManager1 = rm.registerNode("h1:1234", 1024);
@@ -2753,7 +2752,7 @@ public class TestRMContainerAllocator {
     final Configuration conf = new Configuration();
 
     final MyContainerAllocator allocator = new MyContainerAllocator(null,
-        conf, appAttemptId, mock(Job.class), SystemClock.getInstance()) {
+        conf, appAttemptId, mock(Job.class), Clock.systemUTC()) {
       @Override
       protected void register() {
       }
@@ -2792,7 +2791,7 @@ public class TestRMContainerAllocator {
     final Configuration conf = new Configuration();
 
     final MyContainerAllocator allocator = new MyContainerAllocator(null,
-        conf, appAttemptId, mock(Job.class), SystemClock.getInstance()) {
+        conf, appAttemptId, mock(Job.class), Clock.systemUTC()) {
       @Override
       protected void register() {
       }
@@ -2972,7 +2971,7 @@ public class TestRMContainerAllocator {
     final MockScheduler mockScheduler = new MockScheduler(appAttemptId);
     MyContainerAllocator allocator =
         new MyContainerAllocator(null, conf, appAttemptId, mockJob,
-            SystemClock.getInstance()) {
+            Clock.systemUTC()) {
           @Override
           protected void register() {
           }
@@ -3036,7 +3035,7 @@ public class TestRMContainerAllocator {
 
     final MockScheduler mockScheduler = new MockScheduler(appAttemptId);
     MyContainerAllocator allocator = new MyContainerAllocator(null, conf,
-        appAttemptId, mockJob, SystemClock.getInstance()) {
+        appAttemptId, mockJob, Clock.systemUTC()) {
           @Override
           protected void register() {
           }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/forecast/TestSimpleExponentialForecast.java
@@ -41,14 +41,14 @@ public class TestSimpleExponentialForecast {
     clock.tickMsec(clockTicks);
     SimpleExponentialSmoothing forecaster =
         new SimpleExponentialSmoothing(10000,
-            12, 10000, clock.getTime());
+            12, 10000, clock.millis());
 
 
     double progress = 0.0;
 
     while(progress <= 1.0) {
       clock.tickMsec(clockTicks);
-      forecaster.incorporateReading(clock.getTime(), progress);
+      forecaster.incorporateReading(clock.millis(), progress);
       LOG.info("progress: " + progress + " --> " + forecaster.toString());
       progress += 0.005;
     }
@@ -62,14 +62,14 @@ public class TestSimpleExponentialForecast {
     clock.tickMsec(clockTicks);
     SimpleExponentialSmoothing forecaster =
         new SimpleExponentialSmoothing(800,
-            12, 10000, clock.getTime());
+            12, 10000, clock.millis());
 
     double progress = 0.0;
 
     double[] progressRates = new double[]{0.005, 0.004, 0.002, 0.001};
     while(progress <= 1.0) {
       clock.tickMsec(clockTicks);
-      forecaster.incorporateReading(clock.getTime(), progress);
+      forecaster.incorporateReading(clock.millis(), progress);
       LOG.info("progress: " + progress + " --> " + forecaster.toString());
       progress += progressRates[(int)(progress / 0.25)];
     }
@@ -82,7 +82,7 @@ public class TestSimpleExponentialForecast {
     clock.tickMsec(clockTicks);
     SimpleExponentialSmoothing forecaster =
         new SimpleExponentialSmoothing(800,
-            12, 10000, clock.getTime());
+            12, 10000, clock.millis());
 
     double progress = 0.0;
 
@@ -90,7 +90,7 @@ public class TestSimpleExponentialForecast {
     int progressInd = 0;
     while(progress <= 1.0) {
       clock.tickMsec(clockTicks);
-      forecaster.incorporateReading(clock.getTime(), progress);
+      forecaster.incorporateReading(clock.millis(), progress);
       LOG.info("progress: " + progress + " --> " + forecaster.toString());
       int currInd = progressInd++ > 1000 ? 4 : (int)(progress / 0.25);
       progress += progressRates[currInd];

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/MapAttemptFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/MapAttemptFinishedEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -32,7 +33,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record successful completion of a map attempt.
@@ -110,7 +110,7 @@ public class MapAttemptFinishedEvent implements HistoryEvent {
       int[][] allSplits) {
     this(id, taskType, taskStatus, mapFinishTime, finishTime, hostname, port,
         rackName, state, counters, allSplits,
-        SystemClock.getInstance().getTime());
+        Clock.systemUTC().millis());
   }
 
   /** 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/ReduceAttemptFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/ReduceAttemptFinishedEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -32,7 +33,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record successful completion of a reduce attempt
@@ -110,7 +110,7 @@ public class ReduceAttemptFinishedEvent implements HistoryEvent {
       String state, Counters counters, int[][] allSplits) {
     this(id, taskType, taskStatus, shuffleFinishTime, sortFinishTime,
         finishTime, hostname, port, rackName, state, counters, allSplits,
-        SystemClock.getInstance().getTime());
+        Clock.systemUTC().millis());
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptFinishedEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -31,7 +32,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record successful task completion
@@ -84,7 +84,7 @@ public class TaskAttemptFinishedEvent  implements HistoryEvent {
       String taskStatus, long finishTime, String rackName, String hostname,
       String state, Counters counters) {
     this(id, taskType, taskStatus, finishTime, rackName, hostname, state,
-        counters, SystemClock.getInstance().getTime());
+        counters, Clock.systemUTC().millis());
   }
 
   TaskAttemptFinishedEvent() {}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptUnsuccessfulCompletionEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptUnsuccessfulCompletionEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -33,7 +34,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record unsuccessful (Killed/Failed) completion of task attempts
@@ -110,7 +110,7 @@ public class TaskAttemptUnsuccessfulCompletionEvent implements HistoryEvent {
       int port, String rackName, String error, Counters counters,
       int[][] allSplits) {
     this(id, taskType, status, finishTime, hostname, port, rackName, error,
-        counters, allSplits, SystemClock.getInstance().getTime());
+        counters, allSplits, Clock.systemUTC().millis());
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskFailedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskFailedEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -32,7 +33,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record the failure of a task
@@ -82,7 +82,7 @@ public class TaskFailedEvent implements HistoryEvent {
       String error, String status, TaskAttemptID failedDueToAttempt,
       Counters counters) {
     this(id, finishTime, taskType, error, status, failedDueToAttempt, counters,
-        SystemClock.getInstance().getTime());
+        Clock.systemUTC().millis());
   }
 
   public TaskFailedEvent(TaskID id, long finishTime, 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskFinishedEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.mapreduce.jobhistory;
 
+import java.time.Clock;
 import java.util.Set;
 
 import org.apache.avro.util.Utf8;
@@ -32,7 +33,6 @@ import org.apache.hadoop.mapreduce.util.JobHistoryEventUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineEvent;
 import org.apache.hadoop.yarn.api.records.timelineservice.TimelineMetric;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Event to record the successful completion of a task
@@ -77,7 +77,7 @@ public class TaskFinishedEvent implements HistoryEvent {
   public TaskFinishedEvent(TaskID id, TaskAttemptID attemptId, long finishTime,
           TaskType taskType, String status, Counters counters) {
     this(id, attemptId, finishTime, taskType, status, counters,
-        SystemClock.getInstance().getTime());
+        Clock.systemUTC().millis());
   }
 
   TaskFinishedEvent() {}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryFileManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryFileManager.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.mapreduce.v2.hs;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -73,8 +74,6 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -595,7 +594,7 @@ public class HistoryFileManager extends AbstractService {
     long maxFSWaitTime = conf.getLong(
         JHAdminConfig.MR_HISTORY_MAX_START_WAIT_TIME,
         JHAdminConfig.DEFAULT_MR_HISTORY_MAX_START_WAIT_TIME);
-    createHistoryDirs(SystemClock.getInstance(), 10 * 1000, maxFSWaitTime);
+    createHistoryDirs(Clock.systemUTC(), 10 * 1000, maxFSWaitTime);
 
     maxTasksForLoadedJob = conf.getInt(
         JHAdminConfig.MR_HS_LOADED_JOBS_TASKS_MAX,
@@ -629,11 +628,11 @@ public class HistoryFileManager extends AbstractService {
   @VisibleForTesting
   void createHistoryDirs(Clock clock, long intervalCheckMillis,
       long timeOutMillis) throws IOException {
-    long start = clock.getTime();
+    long start = clock.millis();
     boolean done = false;
     int counter = 0;
     while (!done &&
-        ((timeOutMillis == -1) || (clock.getTime() - start < timeOutMillis))) {
+        ((timeOutMillis == -1) || (clock.millis() - start < timeOutMillis))) {
       done = tryCreatingHistoryDirs(counter++ % 3 == 0); // log every 3 attempts, 30sec
       if (done) {
         break;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/JobHistory.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapreduce.v2.hs;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +51,6 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.security.client.ClientToAMTokenSecretManager;
-import org.apache.hadoop.util.Clock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/TestHistoryFileManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/java/org/apache/hadoop/mapreduce/v2/hs/TestHistoryFileManager.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.mapreduce.v2.hs;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileNotFoundException;
+import java.time.Clock;
 import java.util.UUID;
 import java.util.List;
 
@@ -43,9 +44,7 @@ import org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig;
 import org.apache.hadoop.mapreduce.v2.jobhistory.JobIndexInfo;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -198,7 +197,7 @@ public class TestHistoryFileManager {
       }
     }.start();
     testCreateHistoryDirs(dfsCluster.getConfiguration(0),
-        SystemClock.getInstance());
+        Clock.systemUTC());
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MiniMRCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MiniMRCluster.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.mapred;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Random;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -25,8 +26,6 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.SystemClock;
-import org.apache.hadoop.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,7 +175,7 @@ public class MiniMRCluster {
       String[] hosts, UserGroupInformation ugi, JobConf conf,
       int numTrackerToExclude) throws IOException {
     this(jobTrackerPort, taskTrackerPort, numTaskTrackers, namenode, numDir,
-        racks, hosts, ugi, conf, numTrackerToExclude, SystemClock.getInstance());
+        racks, hosts, ugi, conf, numTrackerToExclude, Clock.systemUTC());
   }
 
   public MiniMRCluster(int jobTrackerPort, int taskTrackerPort,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/UtilsForTests.java
@@ -55,7 +55,6 @@ import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.mapreduce.Cluster.JobTrackerStatus;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
@@ -763,18 +762,6 @@ public class UtilsForTests {
     }
   }
   
-  static class FakeClock implements Clock {
-    long time = 0;
-    
-    public void advance(long millis) {
-      time += millis;
-    }
-
-    @Override
-    public long getTime() {
-      return time;
-    }
-  }
   // Mapper that fails
   static class FailMapper extends MapReduceBase implements
       Mapper<WritableComparable, Writable, WritableComparable, Writable> {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -75,6 +75,7 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.*;
@@ -89,6 +90,7 @@ public class AbfsConfiguration{
 
   private final Configuration rawConfig;
   private final String accountName;
+  private String fsName;
   // Service type identified from URL used to initialize FileSystem.
   private final AbfsServiceType fsConfiguredServiceType;
   private final boolean isSecure;
@@ -486,6 +488,24 @@ public class AbfsConfiguration{
   }
 
   /**
+   * Constructor for AbfsConfiguration for retrieve the FsName.
+   * @param rawConfig used to initialize the configuration.
+   * @param accountName the name of the azure storage account.
+   * @param fsName the name of the file system (container name).
+   * @param fsConfiguredServiceType service type configured for the file system.
+   * @throws IllegalAccessException if the field is not accessible.
+   * @throws IOException if an I/O error occurs.
+   */
+  public AbfsConfiguration(final Configuration rawConfig,
+      String accountName,
+      String fsName,
+      AbfsServiceType fsConfiguredServiceType)
+      throws IllegalAccessException, IOException {
+    this(rawConfig, accountName, fsConfiguredServiceType);
+    this.fsName = fsName;
+  }
+
+  /**
    * Constructor for AbfsConfiguration for default service type i.e. DFS.
    * @param rawConfig used to initialize the configuration.
    * @param accountName the name of the azure storage account.
@@ -591,7 +611,17 @@ public class AbfsConfiguration{
    * @return Account-specific configuration key
    */
   public String accountConf(String key) {
-    return key + "." + accountName;
+    return key + DOT + accountName;
+  }
+
+  /**
+   * Appends the container, account name to a configuration key yielding the
+   * container-specific form.
+   * @param key Account-agnostic configuration key
+   * @return Container-specific configuration key
+   */
+  public String containerConf(String key) {
+    return key + DOT + fsName + DOT + accountName;
   }
 
   /**
@@ -649,17 +679,19 @@ public class AbfsConfiguration{
   }
 
   /**
-   * Returns the account-specific password in string form if it exists, then
+   * Returns the container-specific password if it exists,
+   * else searches for the account-specific password, else finally
    * looks for an account-agnostic value.
    * @param key Account-agnostic configuration key
    * @return value in String form if one exists, else null
    * @throws IOException if parsing fails.
    */
   public String getPasswordString(String key) throws IOException {
-    char[] passchars = rawConfig.getPassword(accountConf(key));
-    if (passchars == null) {
-      passchars = rawConfig.getPassword(key);
-    }
+    char[] passchars = rawConfig.getPassword(containerConf(key)) != null
+        ? rawConfig.getPassword(containerConf(key))
+        : rawConfig.getPassword(accountConf(key)) != null
+            ? rawConfig.getPassword(accountConf(key))
+            : rawConfig.getPassword(key);
     if (passchars != null) {
       return new String(passchars);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -227,7 +227,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
     try {
       this.abfsConfiguration = new AbfsConfiguration(abfsStoreBuilder.configuration,
-          accountName, getAbfsServiceTypeFromUrl());
+          accountName, fileSystemName, getAbfsServiceTypeFromUrl());
     } catch (IllegalAccessException exception) {
       throw new FileSystemOperationUnhandledException(exception);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.FileSystem;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.DOT;
+
 /**
  * Responsible to keep all the Azure Blob File System configurations keys in Hadoop configuration file.
  */
@@ -319,7 +321,11 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ABFS_ENABLE_CHECKSUM_VALIDATION = "fs.azure.enable.checksum.validation";
 
   public static String accountProperty(String property, String account) {
-    return property + "." + account;
+    return property + DOT + account;
+  }
+
+  public static String containerProperty(String property, String fsName, String account) {
+    return property + DOT + fsName + DOT + account;
   }
 
   public static final String FS_AZURE_ENABLE_DELEGATION_TOKEN = "fs.azure.enable.delegation.token";

--- a/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
+++ b/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md
@@ -742,7 +742,7 @@ ADLS Gen 2 storage accounts.
 #### Using Account/Service SAS with ABFS
 
 - **Description**: ABFS allows user to use Account/Service SAS for authenticating
-requests. User can specify them as fixed SAS Token to be used across all the requests.
+  requests. User can specify them as fixed SAS Token to be used across all the requests.
 
 - **Configuration**: To use this method with ABFS Driver, specify the following properties in your `core-site.xml` file:
 
@@ -754,22 +754,41 @@ requests. User can specify them as fixed SAS Token to be used across all the req
         </property>
         ```
 
-    1.  Fixed SAS Token:
-        ```xml
-        <property>
-          <name>fs.azure.sas.fixed.token</name>
-          <value>FIXED_SAS_TOKEN</value>
-        </property>
-        ```
+    2. Account SAS (Fixed SAS Token at Account Level):
+          ```xml
+          <property>
+            <name>fs.azure.sas.fixed.token.ACCOUNT_NAME</name>
+            <value>FIXED_ACCOUNT_SAS_TOKEN</value>
+          </property>
+          ```
 
-    Replace `FIXED_SAS_TOKEN` with fixed Account/Service SAS. You can also
-generate SAS from Azure portal. Account -> Security + Networking -> Shared Access Signature
+    - Replace `FIXED_ACCOUNT_SAS_TOKEN` with fixed Account/Service SAS. You can also
+      generate SAS from Azure portal. Account -> Security + Networking -> Shared Access Signature
+
+    3. Service  SAS (Fixed SAS Token at Container Level):
+        ```xml
+           <property>
+             <name>fs.azure.sas.fixed.token.CONTAINER_NAME.ACCOUNT_NAME</name>
+             <value>FIXED_SAS_TOKEN</value>
+           </property>
+           ```
+
+    - Replace `FIXED_SERVICE_SAS_TOKEN` with fixed Service SAS. You can also
+      generate SAS from Azure portal. Account -> Data storage -> Containers ->
+      right click on your container and select generate SAS ->
+      Give valid permissions and expiry time -> Click on generate SAS and copy
+      the SAS token.
+
 
 - **Security**: Account/Service SAS requires account keys to be used which makes
 them less secure. There is no scope of having delegated access to different users.
 
-*Note:* When `fs.azure.sas.token.provider.type` and `fs.azure.fixed.sas.token`
-are both configured, precedence will be given to the custom token provider implementation.
+*Note:*
+- Preference order for SAS will be:
+  - fs.azure.sas.token.provider.type
+  - fs.azure.sas.fixed.token.CONTAINER_NAME.ACCOUNT_NAME
+  - fs.azure.sas.fixed.token.ACCOUNT_NAME
+  - fs.azure.sas.fixed.token
 
 ## <a name="technical"></a> Technical notes
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/ServiceSASGenerator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/ServiceSASGenerator.java
@@ -37,10 +37,11 @@ public class ServiceSASGenerator extends SASGenerator {
     super(accountKey);
   }
 
+  private String permissions = "racwdl";
   public String getContainerSASWithFullControl(String accountName, String containerName) throws
       InvalidConfigurationValueException {
     accountName = getCanonicalAccountName(accountName);
-    String sp = "rcwdl";
+    String sp = permissions;
     String sv = AuthenticationVersion.Feb20.toString();
     String sr = "c";
     String st = ISO_8601_FORMATTER.format(Instant.now().minus(FIVE_MINUTES));
@@ -95,5 +96,14 @@ public class ServiceSASGenerator extends SASGenerator {
     String stringToSign = sb.toString();
     LOG.debug("Service SAS stringToSign: " + stringToSign.replace("\n", "."));
     return computeHmac256(stringToSign);
+  }
+
+  /**
+   * By default, Container SAS has all the available permissions. Use this to
+   * override the default permissions and set as per the requirements.
+   * @param permissions
+   */
+  public void setPermissions(final String permissions) {
+    this.permissions = permissions;
   }
 }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/api/TestResourceSkyline.java
@@ -20,16 +20,18 @@
 
 package org.apache.hadoop.resourceestimator.common.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.TreeMap;
 
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test {@link ResourceSkyline} class.
@@ -45,7 +47,8 @@ public class TestResourceSkyline {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -54,40 +57,40 @@ public class TestResourceSkyline {
   }
 
   @Test public final void testGetJobId() {
-    Assert.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals("1", resourceSkyline.getJobId());
+    assertEquals("1", resourceSkyline.getJobId());
   }
 
   @Test public final void testGetJobSubmissionTime() {
-    Assert.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    assertEquals(0, resourceSkyline.getJobSubmissionTime());
   }
 
   @Test public final void testGetJobFinishTime() {
-    Assert.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(0, 10);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     resourceSkyline =
         new ResourceSkyline("1", 1024.5, 0, 20, resource1, skylineList);
-    Assert.assertEquals(20, resourceSkyline.getJobFinishTime());
+    assertEquals(20, resourceSkyline.getJobFinishTime());
   }
 
   @Test public final void testGetKthResource() {
-    Assert.assertNull(resourceSkyline);
+    assertNull(resourceSkyline);
     ReservationInterval riAdd = new ReservationInterval(10, 20);
     skylineList.addInterval(riAdd, resource1);
     riAdd = new ReservationInterval(20, 30);
@@ -97,27 +100,27 @@ public class TestResourceSkyline {
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     for (int i = 10; i < 20; i++) {
-      Assert.assertEquals(resource1.getMemorySize(),
+      assertEquals(resource1.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(resource1.getVirtualCores(),
+      assertEquals(resource1.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     for (int i = 20; i < 30; i++) {
-      Assert.assertEquals(resource2.getMemorySize(),
+      assertEquals(resource2.getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(resource2.getVirtualCores(),
+      assertEquals(resource2.getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
     // test if resourceSkyline automatically extends the skyline with
     // zero-resource at both ends
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
-    Assert.assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
-    Assert
-        .assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
+    assertEquals(0, skylineList2.getCapacityAtTime(9).getMemorySize());
+    assertEquals(0, skylineList2.getCapacityAtTime(9).getVirtualCores());
+    assertEquals(0, skylineList2.getCapacityAtTime(30).getMemorySize());
+    assertEquals(0, skylineList2.getCapacityAtTime(30).getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     resourceSkyline = null;
     resource1 = null;
     resource2 = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestHistorySkylineSerDe.java
@@ -20,6 +20,9 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,10 +35,9 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -56,7 +58,8 @@ public class TestHistorySkylineSerDe {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -93,36 +96,36 @@ public class TestHistorySkylineSerDe {
     // check if the recurrenceId is correct
     List<ResourceSkyline> resourceSkylineList =
         historySkylineDe.get(recurrenceId);
-    Assert.assertNotNull(resourceSkylineList);
-    Assert.assertEquals(1, resourceSkylineList.size());
+    assertNotNull(resourceSkylineList);
+    assertEquals(1, resourceSkylineList.size());
 
     // check if the resourceSkyline is correct
     ResourceSkyline resourceSkylineDe = resourceSkylineList.get(0);
-    Assert
-        .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assert.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
+    assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     gson = null;
     resourceSkyline = null;
     resourceOverTime.clear();

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSerDe.java
@@ -20,11 +20,12 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -41,23 +42,25 @@ public class TestResourceSerDe {
 
   private Resource resource;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resource = Resource.newInstance(1024 * 100, 100);
     gson = new GsonBuilder()
         .registerTypeAdapter(Resource.class, new ResourceSerDe()).create();
   }
 
-  @Test public final void testSerialization() {
+  @Test
+  public final void testSerialization() {
     final String json = gson.toJson(resource, new TypeToken<Resource>() {
     }.getType());
     final Resource resourceDe = gson.fromJson(json, new TypeToken<Resource>() {
     }.getType());
-    Assert.assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
-    Assert
-        .assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
+    assertEquals(resource.getMemorySize(), resourceDe.getMemorySize());
+    assertEquals(resource.getVirtualCores(), resourceDe.getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     resource = null;
     gson = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/common/serialization/TestResourceSkylineSerDe.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.common.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.TreeMap;
 
 import org.apache.hadoop.resourceestimator.common.api.ResourceSkyline;
@@ -27,10 +29,9 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -51,7 +52,8 @@ public class TestResourceSkylineSerDe {
   private TreeMap<Long, Resource> resourceOverTime;
   private RLESparseResourceAllocation skylineList;
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     resourceOverTime = new TreeMap<>();
     skylineList = new RLESparseResourceAllocation(resourceOverTime,
         new DefaultResourceCalculator());
@@ -76,31 +78,31 @@ public class TestResourceSkylineSerDe {
     final ResourceSkyline resourceSkylineDe =
         gson.fromJson(json, new TypeToken<ResourceSkyline>() {
         }.getType());
-    Assert
-        .assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
-    Assert.assertEquals(resourceSkylineDe.getJobInputDataSize(),
+    assertEquals(resourceSkylineDe.getJobId(), resourceSkyline.getJobId());
+    assertEquals(resourceSkylineDe.getJobInputDataSize(),
         resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals(resourceSkylineDe.getJobSubmissionTime(),
+    assertEquals(resourceSkylineDe.getJobSubmissionTime(),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(resourceSkylineDe.getJobFinishTime(),
+    assertEquals(resourceSkylineDe.getJobFinishTime(),
         resourceSkyline.getJobFinishTime());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
+    assertEquals(resourceSkylineDe.getContainerSpec().getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList2 =
         resourceSkyline.getSkylineList();
     final RLESparseResourceAllocation skylineListDe =
         resourceSkylineDe.getSkylineList();
     for (int i = 0; i < 20; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getMemorySize(),
           skylineListDe.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
+      assertEquals(skylineList2.getCapacityAtTime(i).getVirtualCores(),
           skylineListDe.getCapacityAtTime(i).getVirtualCores());
     }
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     gson = null;
     resourceSkyline = null;
     resourceOverTime.clear();

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/service/TestResourceEstimatorService.java
@@ -37,8 +37,9 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -81,6 +82,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     return config;
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -88,24 +90,24 @@ public class TestResourceEstimatorService extends JerseyTest {
 
   private void compareResourceSkyline(final ResourceSkyline skyline1,
       final ResourceSkyline skyline2) {
-    Assert.assertEquals(skyline1.getJobId(), skyline2.getJobId());
-    Assert.assertEquals(skyline1.getJobInputDataSize(),
+    Assertions.assertEquals(skyline1.getJobId(), skyline2.getJobId());
+    Assertions.assertEquals(skyline1.getJobInputDataSize(),
         skyline2.getJobInputDataSize(), 0);
-    Assert.assertEquals(skyline1.getJobSubmissionTime(),
+    Assertions.assertEquals(skyline1.getJobSubmissionTime(),
         skyline2.getJobSubmissionTime());
-    Assert
+    Assertions
         .assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
-    Assert.assertEquals(skyline1.getContainerSpec().getMemorySize(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getMemorySize(),
         skyline2.getContainerSpec().getMemorySize());
-    Assert.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
+    Assertions.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
         skyline2.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineList1 = skyline1.getSkylineList();
     final RLESparseResourceAllocation skylineList2 = skyline2.getSkylineList();
     for (int i = (int) skylineList1.getEarliestStartTime();
          i < skylineList1.getLatestNonNullTime(); i++) {
-      Assert.assertEquals(skylineList1.getCapacityAtTime(i).getMemorySize(),
+      Assertions.assertEquals(skylineList1.getCapacityAtTime(i).getMemorySize(),
           skylineList2.getCapacityAtTime(i).getMemorySize());
-      Assert.assertEquals(skylineList1.getCapacityAtTime(i).getVirtualCores(),
+      Assertions.assertEquals(skylineList1.getCapacityAtTime(i).getVirtualCores(),
           skylineList2.getCapacityAtTime(i).getVirtualCores());
     }
   }
@@ -172,7 +174,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     case "tpch_q12_0": {
       final RecurrenceId recurrenceId =
           new RecurrenceId("tpch_q12", "tpch_q12_0");
-      Assert.assertEquals(1, jobHistory.get(recurrenceId).size());
+      Assertions.assertEquals(1, jobHistory.get(recurrenceId).size());
       ResourceSkyline skylineReceive = jobHistory.get(recurrenceId).get(0);
       compareResourceSkyline(skylineReceive, getSkyline1());
       break;
@@ -180,7 +182,7 @@ public class TestResourceEstimatorService extends JerseyTest {
     case "tpch_q12_1": {
       final RecurrenceId recurrenceId =
           new RecurrenceId("tpch_q12", "tpch_q12_1");
-      Assert.assertEquals(1, jobHistory.get(recurrenceId).size());
+      Assertions.assertEquals(1, jobHistory.get(recurrenceId).size());
       ResourceSkyline skylineReceive = jobHistory.get(recurrenceId).get(0);
       compareResourceSkyline(skylineReceive, getSkyline2());
       break;
@@ -195,7 +197,7 @@ public class TestResourceEstimatorService extends JerseyTest {
       final RLESparseResourceAllocation rle2) {
     for (int i = (int) rle1.getEarliestStartTime();
          i < rle1.getLatestNonNullTime(); i++) {
-      Assert.assertEquals(rle1.getCapacityAtTime(i), rle2.getCapacityAtTime(i));
+      Assertions.assertEquals(rle1.getCapacityAtTime(i), rle2.getCapacityAtTime(i));
     }
   }
 
@@ -217,20 +219,20 @@ public class TestResourceEstimatorService extends JerseyTest {
     // then, try to get estimated resource allocation from skyline store
     webResource = target().path(getEstimatedSkylineCommand);
     response = webResource.request().get(String.class);
-    Assert.assertEquals("null", response);
+    Assertions.assertEquals("null", response);
     // then, we call estimator module to make the prediction
     webResource = target().path(makeEstimationCommand);
     response = webResource.request().get(String.class);
     RLESparseResourceAllocation skylineList =
         gson.fromJson(response, new TypeToken<RLESparseResourceAllocation>() {
         }.getType());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         skylineList.getCapacityAtTime(0).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(1058,
+    Assertions.assertEquals(1058,
         skylineList.getCapacityAtTime(10).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(2538,
+    Assertions.assertEquals(2538,
         skylineList.getCapacityAtTime(15).getMemorySize() / containerMemAlloc);
-    Assert.assertEquals(2484,
+    Assertions.assertEquals(2484,
         skylineList.getCapacityAtTime(20).getMemorySize() / containerMemAlloc);
     // then, we get estimated resource allocation for tpch_q12
     webResource = target().path(getEstimatedSkylineCommand);
@@ -256,9 +258,9 @@ public class TestResourceEstimatorService extends JerseyTest {
         new TypeToken<Map<RecurrenceId, List<ResourceSkyline>>>() {
         }.getType());
     // jobHistory should only have info for tpch_q12_0
-    Assert.assertEquals(1, jobHistory.size());
+    Assertions.assertEquals(1, jobHistory.size());
     final String pipelineId =
         ((RecurrenceId) jobHistory.keySet().toArray()[0]).getRunId();
-    Assert.assertEquals("tpch_q12_0", pipelineId);
+    Assertions.assertEquals("tpch_q12_0", pipelineId);
   }
 }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestInMemoryStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestInMemoryStore.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.resourceestimator.skylinestore.api.SkylineStore;
  * Test {@link InMemoryStore} class.
  */
 public class TestInMemoryStore extends TestSkylineStore {
-  @Override public final SkylineStore createSkylineStore() {
+  @Override
+  public final SkylineStore createSkylineStore() {
     return new InMemoryStore();
   }
 }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/skylinestore/impl/TestSkylineStore.java
@@ -20,6 +20,12 @@
 
 package org.apache.hadoop.resourceestimator.skylinestore.impl;
 
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,10 +46,9 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationInterval;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test {@link SkylineStore} class.
@@ -61,7 +66,8 @@ public abstract class TestSkylineStore {
 
   protected abstract SkylineStore createSkylineStore();
 
-  @Before public final void setup() {
+  @BeforeEach
+  public final void setup() {
     skylineStore = createSkylineStore();
     resourceOverTime = new TreeMap<>();
     resource = Resource.newInstance(1024 * 100, 100);
@@ -69,18 +75,17 @@ public abstract class TestSkylineStore {
 
   private void compare(final ResourceSkyline skyline1,
       final ResourceSkyline skyline2) {
-    Assert.assertEquals(skyline1.getJobId(), skyline2.getJobId());
-    Assert.assertEquals(skyline1.getJobInputDataSize(),
+    assertEquals(skyline1.getJobId(), skyline2.getJobId());
+    assertEquals(skyline1.getJobInputDataSize(),
         skyline2.getJobInputDataSize(), 0);
-    Assert.assertEquals(skyline1.getJobSubmissionTime(),
+    assertEquals(skyline1.getJobSubmissionTime(),
         skyline2.getJobSubmissionTime());
-    Assert
-        .assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
-    Assert.assertEquals(skyline1.getContainerSpec().getMemorySize(),
+    assertEquals(skyline1.getJobFinishTime(), skyline2.getJobFinishTime());
+    assertEquals(skyline1.getContainerSpec().getMemorySize(),
         skyline2.getContainerSpec().getMemorySize());
-    Assert.assertEquals(skyline1.getContainerSpec().getVirtualCores(),
+    assertEquals(skyline1.getContainerSpec().getVirtualCores(),
         skyline2.getContainerSpec().getVirtualCores());
-    Assert.assertEquals(true,
+    assertEquals(true,
         skyline2.getSkylineList().equals(skyline1.getSkylineList()));
   }
 
@@ -91,7 +96,7 @@ public abstract class TestSkylineStore {
     skylineStore.addHistory(recurrenceId, resourceSkylines);
     final List<ResourceSkyline> resourceSkylinesGet =
         skylineStore.getHistory(recurrenceId).get(recurrenceId);
-    Assert.assertTrue(resourceSkylinesGet.contains(resourceSkyline));
+    assertTrue(resourceSkylinesGet.contains(resourceSkyline));
   }
 
   private ResourceSkyline getSkyline(final int n) {
@@ -130,31 +135,31 @@ public abstract class TestSkylineStore {
     // test getHistory {pipelineId, runId}
     Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assert.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1, entry.getKey());
+      assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
     // test getHistory {pipelineId, *}
     RecurrenceId recurrenceIdTest = new RecurrenceId("FraudDetection", "*");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assert.assertEquals(2, jobHistory.size());
+    assertEquals(2, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1.getPipelineId(),
+      assertEquals(recurrenceId1.getPipelineId(),
           entry.getKey().getPipelineId());
       final List<ResourceSkyline> getSkylines = entry.getValue();
       if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-        Assert.assertEquals(2, getSkylines.size());
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       } else {
-        Assert.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-        Assert.assertEquals(2, getSkylines.size());
+        assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline3, getSkylines.get(0));
         compare(resourceSkyline4, getSkylines.get(1));
       }
@@ -162,26 +167,26 @@ public abstract class TestSkylineStore {
     // test getHistory {*, runId}
     recurrenceIdTest = new RecurrenceId("*", "some random runId");
     jobHistory = skylineStore.getHistory(recurrenceIdTest);
-    Assert.assertEquals(3, jobHistory.size());
+    assertEquals(3, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
       if (entry.getKey().getPipelineId().equals("FraudDetection")) {
         final List<ResourceSkyline> getSkylines = entry.getValue();
         if (entry.getKey().getRunId().equals("17/06/20 00:00:00")) {
-          Assert.assertEquals(2, getSkylines.size());
+          assertEquals(2, getSkylines.size());
           compare(resourceSkyline1, getSkylines.get(0));
           compare(resourceSkyline2, getSkylines.get(1));
         } else {
-          Assert.assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
-          Assert.assertEquals(2, getSkylines.size());
+          assertEquals(entry.getKey().getRunId(), "17/06/21 00:00:00");
+          assertEquals(2, getSkylines.size());
           compare(resourceSkyline3, getSkylines.get(0));
           compare(resourceSkyline4, getSkylines.get(1));
         }
       } else {
-        Assert.assertEquals("Random", entry.getKey().getPipelineId());
-        Assert.assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
+        assertEquals("Random", entry.getKey().getPipelineId());
+        assertEquals(entry.getKey().getRunId(), "17/06/20 00:00:00");
         final List<ResourceSkyline> getSkylines = entry.getValue();
-        Assert.assertEquals(2, getSkylines.size());
+        assertEquals(2, getSkylines.size());
         compare(resourceSkyline1, getSkylines.get(0));
         compare(resourceSkyline2, getSkylines.get(1));
       }
@@ -189,7 +194,7 @@ public abstract class TestSkylineStore {
     // test getHistory with wrong RecurrenceId
     recurrenceIdTest =
         new RecurrenceId("some random pipelineId", "some random runId");
-    Assert.assertNull(skylineStore.getHistory(recurrenceIdTest));
+    assertNull(skylineStore.getHistory(recurrenceIdTest));
   }
 
   @Test public final void testGetEstimation() throws SkylineStoreException {
@@ -206,41 +211,45 @@ public abstract class TestSkylineStore {
     final RLESparseResourceAllocation estimation =
         skylineStore.getEstimation("FraudDetection");
     for (int i = 0; i < 50; i++) {
-      Assert.assertEquals(skylineList2.getCapacityAtTime(i),
+      assertEquals(skylineList2.getCapacityAtTime(i),
           estimation.getCapacityAtTime(i));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testGetNullRecurrenceId()
       throws SkylineStoreException {
-    // addHistory first recurring pipeline
-    final RecurrenceId recurrenceId1 =
+          assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    final ResourceSkyline resourceSkyline2 = getSkyline(2);
-    addToStore(recurrenceId1, resourceSkyline2);
-    final RecurrenceId recurrenceId2 =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              final ResourceSkyline resourceSkyline2 = getSkyline(2);
+              addToStore(recurrenceId1, resourceSkyline2);
+              final RecurrenceId recurrenceId2 =
         new RecurrenceId("FraudDetection", "17/06/21 00:00:00");
-    final ResourceSkyline resourceSkyline3 = getSkyline(3);
-    addToStore(recurrenceId2, resourceSkyline3);
-    final ResourceSkyline resourceSkyline4 = getSkyline(4);
-    addToStore(recurrenceId2, resourceSkyline4);
-    // addHistory second recurring pipeline
-    final RecurrenceId recurrenceId3 =
+              final ResourceSkyline resourceSkyline3 = getSkyline(3);
+              addToStore(recurrenceId2, resourceSkyline3);
+              final ResourceSkyline resourceSkyline4 = getSkyline(4);
+              addToStore(recurrenceId2, resourceSkyline4);
+              final RecurrenceId recurrenceId3 =
         new RecurrenceId("Random", "17/06/20 00:00:00");
-    addToStore(recurrenceId3, resourceSkyline1);
-    addToStore(recurrenceId3, resourceSkyline2);
-    // try to getHistory with null recurringId
-    skylineStore.getHistory(null);
-  }
+              addToStore(recurrenceId3, resourceSkyline1);
+              addToStore(recurrenceId3, resourceSkyline2);
+              skylineStore.getHistory(null);
+          });
 
-  @Test(expected = NullPipelineIdException.class)
+
+// try to getHistory with null recurringId
+}
+
+  @Test
   public final void testGetNullPipelineIdException()
       throws SkylineStoreException {
-    skylineStore.getEstimation(null);
-  }
+          assertThrows(NullPipelineIdException.class, () -> {
+              skylineStore.getEstimation(null);
+          });
+      }
 
   @Test public final void testAddNormal() throws SkylineStoreException {
     // addHistory resource skylines to the in-memory store
@@ -258,74 +267,84 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId, entry.getKey());
+      assertEquals(recurrenceId, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testAddNullRecurrenceId()
       throws SkylineStoreException {
-    // recurrenceId is null
-    final RecurrenceId recurrenceIdNull = null;
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceIdNull = null;
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    skylineStore.addHistory(recurrenceIdNull, resourceSkylines);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceIdNull, resourceSkylines);
+          });
 
-  @Test(expected = NullResourceSkylineException.class)
+}
+
+  @Test
   public final void testAddNullResourceSkyline()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          assertThrows(NullResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    // resourceSkylines is null
-    skylineStore.addHistory(recurrenceId, null);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceId, null);
+          });
+      // resourceSkylines is null
+}
 
-  @Test(expected = DuplicateRecurrenceIdException.class)
+  @Test
   public final void testAddDuplicateRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          assertThrows(DuplicateRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    // trying to addHistory duplicate resource skylines
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+          });
 
-  @Test(expected = NullPipelineIdException.class)
+}
+
+  @Test
   public final void testAddNullPipelineIdException()
       throws SkylineStoreException {
-    final RLESparseResourceAllocation skylineList2 =
+          assertThrows(NullPipelineIdException.class, () -> {
+              final RLESparseResourceAllocation skylineList2 =
         new RLESparseResourceAllocation(resourceOverTime,
             new DefaultResourceCalculator());
-    for (int i = 0; i < 5; i++) {
+              for (int i = 0; i < 5; i++) {
       riAdd = new ReservationInterval(i * 10, (i + 1) * 10);
       skylineList2.addInterval(riAdd, resource);
     }
-    skylineStore.addEstimation(null, skylineList2);
-  }
+              skylineStore.addEstimation(null, skylineList2);
+          });
+      }
 
-  @Test(expected = NullRLESparseResourceAllocationException.class)
+  @Test
   public final void testAddNullRLESparseResourceAllocationExceptionException()
       throws SkylineStoreException {
-    skylineStore.addEstimation("FraudDetection", null);
-  }
+          assertThrows(NullRLESparseResourceAllocationException.class, () -> {
+              skylineStore.addEstimation("FraudDetection", null);
+          });
+      }
 
   @Test public final void testDeleteNormal() throws SkylineStoreException {
     // addHistory first recurring pipeline
@@ -339,29 +358,33 @@ public abstract class TestSkylineStore {
     skylineStore.deleteHistory(recurrenceId1);
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testDeleteNullRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId1 =
+          assertThrows(NullRecurrenceIdException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    // try to deleteHistory with null recurringId
-    skylineStore.deleteHistory(null);
-  }
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              skylineStore.deleteHistory(null);
+          });
+      // try to deleteHistory with null recurringId
+}
 
-  @Test(expected = RecurrenceIdNotFoundException.class)
+  @Test
   public final void testDeleteRecurrenceIdNotFound()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId1 =
+          assertThrows(RecurrenceIdNotFoundException.class, () -> {
+              final RecurrenceId recurrenceId1 =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    addToStore(recurrenceId1, resourceSkyline1);
-    final RecurrenceId recurrenceIdInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              addToStore(recurrenceId1, resourceSkyline1);
+              final RecurrenceId recurrenceIdInvalid =
         new RecurrenceId("Some random pipelineId", "Some random runId");
-    // try to deleteHistory non-existing recurringId
-    skylineStore.deleteHistory(recurrenceIdInvalid);
-  }
+              skylineStore.deleteHistory(recurrenceIdInvalid);
+          });
+      // try to deleteHistory non-existing recurringId
+}
 
   @Test public final void testUpdateNormal() throws SkylineStoreException {
     // addHistory first recurring pipeline
@@ -378,82 +401,91 @@ public abstract class TestSkylineStore {
     // query the in-memory store
     final Map<RecurrenceId, List<ResourceSkyline>> jobHistory =
         skylineStore.getHistory(recurrenceId1);
-    Assert.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     for (final Map.Entry<RecurrenceId, List<ResourceSkyline>> entry : jobHistory
         .entrySet()) {
-      Assert.assertEquals(recurrenceId1, entry.getKey());
+      assertEquals(recurrenceId1, entry.getKey());
       final List<ResourceSkyline> getSkylines = entry.getValue();
-      Assert.assertEquals(2, getSkylines.size());
+      assertEquals(2, getSkylines.size());
       compare(resourceSkyline1, getSkylines.get(0));
       compare(resourceSkyline2, getSkylines.get(1));
     }
   }
 
-  @Test(expected = NullRecurrenceIdException.class)
+  @Test
   public final void testUpdateNullRecurrenceId()
       throws SkylineStoreException {
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          assertThrows(NullRecurrenceIdException.class, () -> {
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with null recurringId
-    skylineStore.updateHistory(null, resourceSkylines);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.updateHistory(null, resourceSkylines);
+          });
+      // try to updateHistory with null recurringId
+}
 
-  @Test(expected = NullResourceSkylineException.class)
+  @Test
   public final void testUpdateNullResourceSkyline()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          assertThrows(NullResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with null resourceSkylines
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    skylineStore.updateHistory(recurrenceId, null);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.updateHistory(recurrenceId, null);
+          });
 
-  @Test(expected = EmptyResourceSkylineException.class)
+}
+
+  @Test
   public final void testUpdateEmptyRecurrenceId()
       throws SkylineStoreException {
-    final RecurrenceId recurrenceId =
+          assertThrows(EmptyResourceSkylineException.class, () -> {
+              final RecurrenceId recurrenceId =
         new RecurrenceId("FraudDetection", "17/06/20 00:00:00");
-    final ArrayList<ResourceSkyline> resourceSkylines =
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    skylineStore.addHistory(recurrenceId, resourceSkylines);
-    // try to updateHistory with empty resourceSkyline
-    skylineStore.updateHistory(recurrenceId, resourceSkylinesInvalid);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.addHistory(recurrenceId, resourceSkylines);
+              skylineStore.updateHistory(recurrenceId, resourceSkylinesInvalid);
+          });
+      // try to updateHistory with empty resourceSkyline
+}
 
-  @Test(expected = RecurrenceIdNotFoundException.class)
+  @Test
   public final void testUpdateRecurrenceIdNotFound()
       throws SkylineStoreException {
-    final ArrayList<ResourceSkyline> resourceSkylines =
+          assertThrows(RecurrenceIdNotFoundException.class, () -> {
+              final ArrayList<ResourceSkyline> resourceSkylines =
         new ArrayList<ResourceSkyline>();
-    final ResourceSkyline resourceSkyline1 = getSkyline(1);
-    resourceSkylines.add(resourceSkyline1);
-    final RecurrenceId recurrenceIdInvalid =
+              final ResourceSkyline resourceSkyline1 = getSkyline(1);
+              resourceSkylines.add(resourceSkyline1);
+              final RecurrenceId recurrenceIdInvalid =
         new RecurrenceId("Some random pipelineId", "Some random runId");
-    final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
+              final ArrayList<ResourceSkyline> resourceSkylinesInvalid =
         new ArrayList<ResourceSkyline>();
-    resourceSkylinesInvalid.add(null);
-    // try to updateHistory with non-existing recurringId
-    skylineStore.updateHistory(recurrenceIdInvalid, resourceSkylines);
-  }
+              resourceSkylinesInvalid.add(null);
+              skylineStore.updateHistory(recurrenceIdInvalid, resourceSkylines);
+          });
+      // try to updateHistory with non-existing recurringId
+}
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     resourceOverTime.clear();
     resourceOverTime = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestLpSolver.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.resourceestimator.translator.impl.BaseLogParser;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -46,7 +46,7 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This LPSolver class will make resource estimation using Linear Programming

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/solver/impl/TestSolver.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.solver.impl;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -32,9 +34,9 @@ import org.apache.hadoop.resourceestimator.skylinestore.exceptions.SkylineStoreE
 import org.apache.hadoop.resourceestimator.solver.api.Solver;
 import org.apache.hadoop.resourceestimator.solver.exceptions.InvalidInputException;
 import org.apache.hadoop.resourceestimator.solver.exceptions.SolverException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This LPSolver class will make resource estimation using Linear Programming
@@ -45,28 +47,33 @@ public abstract class TestSolver {
 
   protected abstract Solver createSolver() throws ResourceEstimatorException;
 
-  @Before public void setup()
+  @BeforeEach
+  public void setup()
       throws SolverException, IOException, SkylineStoreException,
       ResourceEstimatorException {
     solver = createSolver();
   }
 
-  @Test(expected = InvalidInputException.class) public void testNullJobHistory()
+  @Test
+  public void testNullJobHistory()
       throws SolverException, SkylineStoreException {
+    assertThrows(InvalidInputException.class, () -> {
+        solver.solve(null);
+    });
     // try to solve with null jobHistory
-    solver.solve(null);
   }
 
-  @Test(expected = InvalidInputException.class)
-  public void testEmptyJobHistory()
-      throws SolverException, SkylineStoreException {
-    Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid =
-        new HashMap<RecurrenceId, List<ResourceSkyline>>();
-    // try to solve with emty jobHistory
-    solver.solve(jobHistoryInvalid);
+  @Test
+  public void testEmptyJobHistory() throws SolverException, SkylineStoreException {
+    // try to solve with empty jobHistory
+    assertThrows(InvalidInputException.class, () -> {
+        Map<RecurrenceId, List<ResourceSkyline>> jobHistoryInvalid = new HashMap<RecurrenceId, List<ResourceSkyline>>();
+        solver.solve(jobHistoryInvalid);
+    });
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     solver.close();
     solver = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/api/TestJobMetaData.java
@@ -20,16 +20,17 @@
 
 package org.apache.hadoop.resourceestimator.translator.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.text.ParseException;
 
 import org.apache.hadoop.resourceestimator.common.api.RecurrenceId;
 import org.apache.hadoop.resourceestimator.translator.impl.LogParserUtil;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test JobMetaData.
@@ -43,7 +44,8 @@ public class TestJobMetaData {
   private JobMetaData jobMetaData;
   private RecurrenceId recurrenceId;
 
-  @Before public final void setup() throws ParseException {
+  @BeforeEach
+  public final void setup() throws ParseException {
     recurrenceId = new RecurrenceId("Fraud Detection", "17/07/16 16:27:25");
     jobMetaData = new JobMetaData(
         logParserUtil.stringToUnixTimestamp("17/07/16 16:27:25"));
@@ -68,27 +70,27 @@ public class TestJobMetaData {
     final Resource containerAlloc =
         jobMetaData.getResourceSkyline().getContainerSpec();
     final Resource containerAlloc2 = Resource.newInstance(1, 1);
-    Assert.assertEquals(containerAlloc.getMemorySize(),
+    assertEquals(containerAlloc.getMemorySize(),
         containerAlloc2.getMemorySize());
-    Assert.assertEquals(containerAlloc.getVirtualCores(),
+    assertEquals(containerAlloc.getVirtualCores(),
         containerAlloc2.getVirtualCores());
   }
 
   @Test public final void testGetJobSize() {
-    Assert.assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
+    assertEquals(jobMetaData.getResourceSkyline().getJobInputDataSize(),
         1024.5, 0);
   }
 
   @Test public final void testGetRecurrenceeId() {
     final RecurrenceId recurrenceIdTest =
         new RecurrenceId("Fraud Detection", "17/07/16 16:27:25");
-    Assert.assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
+    assertEquals(recurrenceIdTest, jobMetaData.getRecurrenceId());
   }
 
   @Test public final void testStringToUnixTimestamp() throws ParseException {
     final long submissionTime =
         logParserUtil.stringToUnixTimestamp("17/07/16 16:27:25");
-    Assert.assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
+    assertEquals(jobMetaData.getResourceSkyline().getJobSubmissionTime(),
         submissionTime);
   }
 
@@ -99,22 +101,22 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assert.assertEquals(0,
+      assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 15; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 15; k < 605; k++) {
-      Assert.assertEquals(2,
+      assertEquals(2,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 605; k < 615; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assert.assertEquals(0,
+    assertEquals(0,
         skylineList.getCapacityAtTime(615).getVirtualCores() / containerCPU);
   }
 
@@ -144,18 +146,19 @@ public class TestJobMetaData {
         jobMetaData.getResourceSkyline().getContainerSpec().getVirtualCores();
     int k;
     for (k = 0; k < 5; k++) {
-      Assert.assertEquals(0,
+      assertEquals(0,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
     for (k = 5; k < 605; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineList.getCapacityAtTime(k).getVirtualCores() / containerCPU);
     }
-    Assert.assertEquals(0,
+    assertEquals(0,
         skylineList.getCapacityAtTime(605).getVirtualCores() / containerCPU);
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     jobMetaData = null;
     recurrenceId = null;
     logParserUtil = null;

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestNativeParser.java
@@ -20,6 +20,8 @@
 
 package org.apache.hadoop.resourceestimator.translator.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
@@ -36,10 +38,9 @@ import org.apache.hadoop.resourceestimator.skylinestore.impl.InMemoryStore;
 import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This sample parser will parse the sample log and extract the resource
@@ -49,7 +50,8 @@ public class TestNativeParser {
   private LogParserUtil logParserUtil = new LogParserUtil();
   private SkylineStore skylineStore;
 
-  @Before public final void setup() throws ResourceEstimatorException {
+  @BeforeEach
+  public final void setup() throws ResourceEstimatorException {
     skylineStore = new InMemoryStore();
     final LogParser nativeParser = new BaseLogParser();
     Configuration config = new Configuration();
@@ -73,42 +75,41 @@ public class TestNativeParser {
         new RecurrenceId("tpch_q12", "tpch_q12_0");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobSkylineLists.size());
+    assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assert.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals("tpch_q12_0", resourceSkyline.getJobId());
-    Assert.assertEquals(0, resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(25, resourceSkyline.getJobFinishTime());
-    Assert
-        .assertEquals(1024, resourceSkyline.getContainerSpec().getMemorySize());
-    Assert
-        .assertEquals(1, resourceSkyline.getContainerSpec().getVirtualCores());
+    assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    assertEquals("tpch_q12_0", resourceSkyline.getJobId());
+    assertEquals(0, resourceSkyline.getJobSubmissionTime());
+    assertEquals(25, resourceSkyline.getJobFinishTime());
+    assertEquals(1024, resourceSkyline.getContainerSpec().getMemorySize());
+    assertEquals(1, resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
     int k;
     for (k = 0; k < 10; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 10; k < 15; k++) {
-      Assert.assertEquals(1074,
+      assertEquals(1074,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 15; k < 20; k++) {
-      Assert.assertEquals(2538,
+      assertEquals(2538,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
     for (k = 20; k < 25; k++) {
-      Assert.assertEquals(2468,
+      assertEquals(2468,
           skylineLists.getCapacityAtTime(k).getMemorySize() / 1024);
     }
-    Assert.assertEquals(0,
+    assertEquals(0,
         skylineLists.getCapacityAtTime(25).getMemorySize() / 1024);
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     logParserUtil = null;
   }

--- a/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/test/java/org/apache/hadoop/resourceestimator/translator/impl/TestRmParser.java
@@ -20,6 +20,10 @@
 
 package org.apache.hadoop.resourceestimator.translator.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
@@ -37,10 +41,9 @@ import org.apache.hadoop.resourceestimator.translator.api.LogParser;
 import org.apache.hadoop.resourceestimator.translator.exceptions.DataFieldNotFoundException;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.RLESparseResourceAllocation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This sample parser will parse the sample log and extract the resource
@@ -50,7 +53,8 @@ public class TestRmParser {
   private LogParserUtil logParserUtil = new LogParserUtil();
   private SkylineStore skylineStore;
 
-  @Before public final void setup() throws ResourceEstimatorException {
+  @BeforeEach
+  public final void setup() throws ResourceEstimatorException {
     skylineStore = new InMemoryStore();
     final LogParser rmParser = new BaseLogParser();
     Configuration config = new Configuration();
@@ -68,7 +72,8 @@ public class TestRmParser {
     logParserUtil.parseLog(logFile);
   }
 
-  @Test public final void testParse()
+  @Test
+  public final void testParse()
       throws SkylineStoreException, IOException, ParseException,
       ResourceEstimatorException, DataFieldNotFoundException {
     final String logFile = "src/test/resources/trace/rmLog.txt";
@@ -76,50 +81,52 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("FraudDetection", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1, jobSkylineLists.size());
+    assertEquals(1, jobSkylineLists.size());
     final List<ResourceSkyline> jobHistory = jobSkylineLists.get(recurrenceId);
-    Assert.assertEquals(1, jobHistory.size());
+    assertEquals(1, jobHistory.size());
     final ResourceSkyline resourceSkyline = jobHistory.get(0);
-    Assert.assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
-    Assert.assertEquals("application_1497832133857_0330",
+    assertEquals(0, resourceSkyline.getJobInputDataSize(), 0);
+    assertEquals("application_1497832133857_0330",
         resourceSkyline.getJobId());
-    Assert.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         resourceSkyline.getJobSubmissionTime());
-    Assert.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:18:35"),
         resourceSkyline.getJobFinishTime());
     final Resource resource = Resource.newInstance(1800, 1);
-    Assert.assertEquals(resource.getMemorySize(),
+    assertEquals(resource.getMemorySize(),
         resourceSkyline.getContainerSpec().getMemorySize());
-    Assert.assertEquals(resource.getVirtualCores(),
+    assertEquals(resource.getVirtualCores(),
         resourceSkyline.getContainerSpec().getVirtualCores());
     final RLESparseResourceAllocation skylineLists =
         resourceSkyline.getSkylineList();
 
     int k;
     for (k = 0; k < 142; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 142; k < 345; k++) {
-      Assert.assertEquals(2,
+      assertEquals(2,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
     for (k = 345; k < 502; k++) {
-      Assert.assertEquals(1,
+      assertEquals(1,
           skylineLists.getCapacityAtTime(k).getMemorySize() / resource
               .getMemorySize());
     }
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public final void testInvalidDateFormat()
       throws ParseException {
-    logParserUtil.stringToUnixTimestamp("2017.07.16 16:37:45");
-  }
+          assertThrows(ParseException.class, () -> {
+              logParserUtil.stringToUnixTimestamp("2017.07.16 16:37:45");
+          });
+      }
 
   @Test public final void testDuplicateJobSubmissionTime()
       throws SkylineStoreException, IOException, ParseException,
@@ -129,7 +136,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "1");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:23"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -140,7 +147,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog2.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "2");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInContainerAlloc()
@@ -151,7 +158,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "3");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(0,
+    assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -164,7 +171,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "4");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(0,
+    assertEquals(0,
         jobSkylineLists.get(recurrenceId).get(0).getSkylineList()
             .getCumulative().size());
   }
@@ -177,7 +184,7 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "5");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(
+    assertEquals(
         logParserUtil.stringToUnixTimestamp("06/21/2017 16:10:13"),
         jobSkylineLists.get(recurrenceId).get(0).getJobSubmissionTime());
   }
@@ -188,7 +195,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog6.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "6");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testRecurrenceIdNotFoundInJobFinish()
@@ -197,7 +204,7 @@ public class TestRmParser {
     final String logFile = "src/test/resources/trace/invalidLog7.txt";
     parseFile(logFile);
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "7");
-    Assert.assertNull(skylineStore.getHistory(recurrenceId));
+    assertNull(skylineStore.getHistory(recurrenceId));
   }
 
   @Test public final void testJobIdNotFoundInResourceSpec()
@@ -208,10 +215,10 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "8");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1024,
+    assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assert.assertEquals(1,
+    assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }
@@ -224,15 +231,16 @@ public class TestRmParser {
     final RecurrenceId recurrenceId = new RecurrenceId("Test", "9");
     final Map<RecurrenceId, List<ResourceSkyline>> jobSkylineLists =
         skylineStore.getHistory(recurrenceId);
-    Assert.assertEquals(1024,
+    assertEquals(1024,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getMemorySize());
-    Assert.assertEquals(1,
+    assertEquals(1,
         jobSkylineLists.get(recurrenceId).get(0).getContainerSpec()
             .getVirtualCores());
   }
 
-  @After public final void cleanUp() {
+  @AfterEach
+  public final void cleanUp() {
     skylineStore = null;
     logParserUtil = null;
   }

--- a/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/AMRunner.java
+++ b/hadoop-tools/hadoop-sls/src/main/java/org/apache/hadoop/yarn/sls/AMRunner.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.yarn.sls.conf.SLSConfiguration;
 import org.apache.hadoop.yarn.sls.scheduler.TaskRunner;
 import org.apache.hadoop.yarn.sls.synthetic.SynthJob;
 import org.apache.hadoop.yarn.sls.synthetic.SynthTraceJobProducer;
-import org.apache.hadoop.util.UTCClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -239,8 +239,8 @@ public class AMRunner {
       if (jobDef.getReservationId() != null) {
         // if we have a ReservationId, delegate reservation creation to
         // AMSim (reservation shape is impl specific)
-        UTCClock clock = new UTCClock();
-        amSim.initReservation(jobDef.getReservationId(), jobDef.getDeadline(), clock.getTime());
+        Clock clock = Clock.systemUTC();
+        amSim.initReservation(jobDef.getReservationId(), jobDef.getDeadline(), clock.millis());
       }
       runner.schedule(amSim);
       maxRuntime = Math.max(maxRuntime, amDef.getJobFinishTime());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
@@ -31,6 +31,7 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -122,7 +123,6 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.util.BoundedAppender;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.TimelineServiceHelper;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
@@ -1133,7 +1133,7 @@ public class ApplicationMaster {
           Long containerStartTime =
               containerStartTimes.get(containerStatus.getContainerId());
           if (containerStartTime == null) {
-            containerStartTime = SystemClock.getInstance().getTime();
+            containerStartTime = Clock.systemUTC().millis();
             containerStartTimes.put(containerStatus.getContainerId(),
                 containerStartTime);
           }
@@ -1338,7 +1338,7 @@ public class ApplicationMaster {
             containerId, container.getNodeId());
       }
       if (applicationMaster.timelineServiceV2Enabled) {
-        long startTime = SystemClock.getInstance().getTime();
+        long startTime = Clock.systemUTC().millis();
         applicationMaster.getContainerStartTimes().put(containerId, startTime);
         applicationMaster.publishContainerStartEventOnTimelineServiceV2(
             container, startTime);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/ServiceScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/ServiceScheduler.java
@@ -84,8 +84,6 @@ import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.ServiceRegistryUtils;
 import org.apache.hadoop.yarn.service.utils.ServiceUtils;
 import org.apache.hadoop.yarn.util.BoundedAppender;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +99,7 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.time.Clock;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -199,7 +198,7 @@ public class ServiceScheduler extends CompositeService {
     super(context.getService().getName());
     this.context = context;
     this.app = context.getService();
-    this.systemClock = SystemClock.getInstance();
+    this.systemClock = Clock.systemUTC();
   }
 
   public void buildInstance(ServiceContext context, Configuration configuration)
@@ -1024,7 +1023,7 @@ public class ServiceScheduler extends CompositeService {
         if (isTimelineServiceEnabled()) {
           // record in ATS
           serviceTimelinePublisher.componentFinished(comp.getComponentSpec(),
-              comp.getComponentSpec().getState(), systemClock.getTime());
+              comp.getComponentSpec().getState(), systemClock.millis());
         }
       } else {
         shouldTerminate = false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/component/instance/ComponentInstance.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/component/instance/ComponentInstance.java
@@ -492,7 +492,7 @@ public class ComponentInstance implements EventHandler<ComponentInstanceEvent>,
 
           compInstance.scheduler.getServiceTimelinePublisher()
               .componentFinished(comp.getComponentSpec(), ComponentState.FAILED,
-                  scheduler.getSystemClock().getTime());
+                  scheduler.getSystemClock().millis());
 
           compInstance.scheduler.getServiceTimelinePublisher()
               .serviceAttemptUnregistered(comp.getContext(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientWithReservation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientWithReservation.java
@@ -50,14 +50,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair
     .allocationfile.AllocationFileQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair
     .allocationfile.AllocationFileWriter;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -190,8 +189,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -203,7 +202,7 @@ public class TestYarnClientWithReservation {
 
       // Submit the reservation with the same reservation id but different
       // reservation definition, and ensure YarnException is thrown.
-      arrival = clock.getTime();
+      arrival = clock.millis();
       ReservationDefinition rDef = sRequest.getReservationDefinition();
       rDef.setArrival(arrival + duration);
       sRequest.setReservationDefinition(rDef);
@@ -231,8 +230,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -243,7 +242,7 @@ public class TestYarnClientWithReservation {
           rDef.getReservationRequests().getReservationResources().get(0);
       ReservationId reservationID = sRequest.getReservationId();
       rr.setNumContainers(5);
-      arrival = clock.getTime();
+      arrival = clock.millis();
       duration = 30000;
       deadline = (long) (arrival + 1.05 * duration);
       rr.setDuration(duration);
@@ -291,8 +290,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -326,8 +325,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -335,7 +334,7 @@ public class TestYarnClientWithReservation {
 
       // List reservations, search by a point in time within the reservation
       // range.
-      arrival = clock.getTime();
+      arrival = clock.millis();
       ReservationId reservationID = sRequest.getReservationId();
       ReservationListRequest request = ReservationListRequest.newInstance(
           ReservationSystemTestUtil.reservationQ, "", arrival + duration / 2,
@@ -384,8 +383,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -427,8 +426,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =
@@ -460,7 +459,7 @@ public class TestYarnClientWithReservation {
       assertNotNull(response);
       assertThat(response.getReservationAllocationState()).isEmpty();
 
-      arrival = clock.getTime();
+      arrival = clock.millis();
       // List reservations, search by end time before the reservation start
       // time.
       request = ReservationListRequest.newInstance(
@@ -499,8 +498,8 @@ public class TestYarnClientWithReservation {
     MiniYARNCluster cluster = setupMiniYARNCluster();
     YarnClient client = setupYarnClient(cluster);
     try {
-      Clock clock = new UTCClock();
-      long arrival = clock.getTime();
+      Clock clock = Clock.systemUTC();
+      long arrival = clock.millis();
       long duration = 60000;
       long deadline = (long) (arrival + 1.05 * duration);
       ReservationSubmissionRequest sRequest =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.event;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -31,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.yarn.metrics.EventTypeMetrics;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +95,7 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
   private Map<Class<? extends Enum>,
       EventTypeMetrics> eventTypeMetricsMap;
 
-  private Clock clock = new MonotonicClock();
+  private Clock clock = MonotonicClock.get();
 
   private ThreadPoolExecutor printEventDetailsExecutor;
 
@@ -153,11 +153,11 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
           if (event != null) {
             if (eventTypeMetricsMap.
                 get(event.getType().getDeclaringClass()) != null) {
-              long startTime = clock.getTime();
+              long startTime = clock.millis();
               dispatch(event);
               eventTypeMetricsMap.get(event.getType().getDeclaringClass())
                   .increment(event.getType(),
-                      clock.getTime() - startTime);
+                      clock.millis() - startTime);
             } else {
               dispatch(event);
             }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/EventDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/EventDispatcher.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.event;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.metrics.EventTypeMetrics;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +29,7 @@ import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 
+import java.time.Clock;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
@@ -57,7 +57,7 @@ public class EventDispatcher<T extends Event> extends
   private static final Marker FATAL =
       MarkerFactory.getMarker("FATAL");
 
-  private Clock clock = new MonotonicClock();
+  private Clock clock = MonotonicClock.get();
 
   private final class EventProcessor implements Runnable {
     @Override
@@ -75,10 +75,10 @@ public class EventDispatcher<T extends Event> extends
 
         try {
           if (metrics != null) {
-            long startTime = clock.getTime();
+            long startTime = clock.millis();
             handler.handle(event);
             metrics.increment(event.getType(),
-                clock.getTime() - startTime);
+                clock.millis() - startTime);
           } else {
             handler.handle(event);
           }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/LogAggregationIndexedFileController.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,8 +85,6 @@ import org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat.LogValue;
 import org.apache.hadoop.yarn.logaggregation.ExtendedLogMetaRequest;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerContext;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.webapp.View.ViewContext;
 import org.apache.hadoop.yarn.webapp.view.HtmlBlock.Block;
@@ -164,7 +163,7 @@ public class LogAggregationIndexedFileController
     this.ugi = userUgi;
     logAggregationSuccessfullyInThisCyCle = false;
     logsMetaInThisCycle = new IndexedPerAggregationLogMeta();
-    logAggregationTimeInThisCycle = this.sysClock.getTime();
+    logAggregationTimeInThisCycle = this.sysClock.millis();
     logsMetaInThisCycle.setUploadTimeStamp(logAggregationTimeInThisCycle);
     logsMetaInThisCycle.setRemoteNodeFile(remoteLogFile.getName());
     try {
@@ -308,7 +307,7 @@ public class LogAggregationIndexedFileController
       indexedLogsMeta.getLogMetas().clear();
       overwriteCheckSum = true;
       aggregatedLogFile = new Path(remoteLogFile.getParent(),
-          remoteLogFile.getName() + "_" + sysClock.getTime());
+          remoteLogFile.getName() + "_" + sysClock.millis());
       fsDataOStream = fc.create(aggregatedLogFile,
           EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE),
           new Options.CreateOpts[] {});
@@ -1351,7 +1350,7 @@ public class LogAggregationIndexedFileController
   @Private
   @VisibleForTesting
   public Clock getSystemClock() {
-    return SystemClock.getInstance();
+    return Clock.systemUTC();
   }
 
   private byte[] createUUID(ApplicationId appId) throws IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/AbstractLivelinessMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/AbstractLivelinessMonitor.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.yarn.util;
 
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +61,7 @@ public abstract class AbstractLivelinessMonitor<O> extends AbstractService {
   }
 
   public AbstractLivelinessMonitor(String name) {
-    this(name, new MonotonicClock());
+    this(name, MonotonicClock.get());
   }
 
   @Override
@@ -101,12 +101,12 @@ public abstract class AbstractLivelinessMonitor<O> extends AbstractService {
   public synchronized void receivedPing(O ob) {
     //only put for the registered objects
     if (running.containsKey(ob)) {
-      running.put(ob, clock.getTime());
+      running.put(ob, clock.millis());
     }
   }
 
   public synchronized void register(O ob) {
-    register(ob, clock.getTime());
+    register(ob, clock.millis());
   }
 
   public synchronized void register(O ob, long expireTime) {
@@ -119,7 +119,7 @@ public abstract class AbstractLivelinessMonitor<O> extends AbstractService {
 
   public synchronized void resetTimer() {
     if (resetTimerOnStart) {
-      long time = clock.getTime();
+      long time = clock.millis();
       for (O ob : running.keySet()) {
         running.put(ob, time);
       }
@@ -139,7 +139,7 @@ public abstract class AbstractLivelinessMonitor<O> extends AbstractService {
           Iterator<Map.Entry<O, Long>> iterator = running.entrySet().iterator();
 
           // avoid calculating current time everytime in loop
-          long currentTime = clock.getTime();
+          long currentTime = clock.millis();
 
           while (iterator.hasNext()) {
             Map.Entry<O, Long> entry = iterator.next();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,8 +53,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.CpuTimeTracker;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.SysInfoLinux;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 /**
@@ -134,7 +133,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
     new HashMap<String, ProcessInfo>();
 
   public ProcfsBasedProcessTree(String pid) {
-    this(pid, PROCFS, SystemClock.getInstance());
+    this(pid, PROCFS, Clock.systemUTC());
   }
 
   @Override
@@ -148,7 +147,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
   }
 
   public ProcfsBasedProcessTree(String pid, String procfsDir) {
-    this(pid, procfsDir, SystemClock.getInstance());
+    this(pid, procfsDir, Clock.systemUTC());
   }
 
   /**
@@ -469,7 +468,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
     BigInteger processTotalJiffies = getTotalProcessJiffies();
     LOG.debug("Process {} jiffies:{}", pid, processTotalJiffies);
     cpuTimeTracker.updateElapsedJiffies(processTotalJiffies,
-        clock.getTime());
+        clock.millis());
     return cpuTimeTracker.getCpuTrackerUsagePercent();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/WindowsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/WindowsBasedProcessTree.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.util;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +31,6 @@ import org.apache.hadoop.util.CpuTimeTracker;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
 import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 @Private
 public class WindowsBasedProcessTree extends ResourceCalculatorProcessTree {
@@ -84,7 +83,7 @@ public class WindowsBasedProcessTree extends ResourceCalculatorProcessTree {
    * @param pid Identifier of the job object.
    */
   public WindowsBasedProcessTree(final String pid) {
-    this(pid, SystemClock.getInstance());
+    this(pid, Clock.systemUTC());
   }
 
   /**
@@ -269,7 +268,7 @@ public class WindowsBasedProcessTree extends ResourceCalculatorProcessTree {
   @Override
   public float getCpuUsagePercent() {
     BigInteger processTotalMs = getTotalProcessMs();
-    cpuTimeTracker.updateElapsedJiffies(processTotalMs, clock.getTime());
+    cpuTimeTracker.updateElapsedJiffies(processTotalMs, clock.millis());
 
     return cpuTimeTracker.getCpuTrackerUsagePercent();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/logaggregation/filecontroller/ifile/TestLogAggregationIndexedFileController.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -64,7 +65,6 @@ import org.apache.hadoop.yarn.logaggregation.LogAggregationUtils;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileController;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerContext;
 import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileControllerFactory;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ControlledClock;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -263,7 +263,7 @@ public class TestLogAggregationIndexedFileController
             + LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX);
     FSDataOutputStream fInput = null;
     try {
-      String nodeName = logPath.getName() + "_" + clock.getTime();
+      String nodeName = logPath.getName() + "_" + clock.millis();
       fInput = FileSystem.create(fs, checksumFile, LOG_FILE_UMASK);
       fInput.writeInt(nodeName.length());
       fInput.write(nodeName.getBytes(
@@ -575,7 +575,7 @@ public class TestLogAggregationIndexedFileController
             + LogAggregationIndexedFileController.CHECK_SUM_FILE_SUFFIX);
     FSDataOutputStream fInput = null;
     try {
-      String nodeName = logPath.getName() + "_" + clock.getTime();
+      String nodeName = logPath.getName() + "_" + clock.millis();
       fInput = FileSystem.create(fs, checksumFile, LOG_FILE_UMASK);
       fInput.writeInt(nodeName.length());
       fInput.write(nodeName.getBytes(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/ControlledClock.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/ControlledClock.java
@@ -17,29 +17,36 @@
 */
 package org.apache.hadoop.yarn.util;
 
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
+import org.apache.hadoop.util.AbstractClock;
+import java.time.Clock;
 
-public class ControlledClock implements Clock {
+public class ControlledClock extends AbstractClock {
+
   private long time = -1;
   private final Clock actualClock;
+
   // Convenience for getting a controlled clock with overridden time
   public ControlledClock() {
-    this(SystemClock.getInstance());
+    this(Clock.systemUTC());
     setTime(0);
   }
+
   public ControlledClock(Clock actualClock) {
     this.actualClock = actualClock;
   }
+
   public synchronized void setTime(long time) {
     this.time = time;
   }
+
   public synchronized void reset() {
     time = -1;
   }
+
   public synchronized void tickSec(int seconds) {
     tickMsec(seconds * 1000L);
   }
+
   public synchronized void tickMsec(long millisec) {
     if (time == -1) {
       throw new IllegalStateException("ControlledClock setTime should be " +
@@ -49,11 +56,11 @@ public class ControlledClock implements Clock {
   }
 
   @Override
-  public synchronized long getTime() {
+  public synchronized long millis() {
     if (time != -1) {
       return time;
     }
-    return actualClock.getTime();
+    return actualClock.millis();
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestProcfsBasedProcessTree.java
@@ -32,8 +32,7 @@ import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
+import java.time.Clock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -583,7 +582,7 @@ public class TestProcfsBasedProcessTree {
       // crank up the process tree class.
       ProcfsBasedProcessTree processTree =
           createProcessTree("100", procfsRootDir.getAbsolutePath(),
-              SystemClock.getInstance());
+              Clock.systemUTC());
       setSmapsInProceTree(processTree, smapEnabled);
 
       // verify virtual memory
@@ -710,7 +709,7 @@ public class TestProcfsBasedProcessTree {
 
       // crank up the process tree class.
       createProcessTree(pid, procfsRootDir.getAbsolutePath(),
-          SystemClock.getInstance());
+          Clock.systemUTC());
 
       // Let us not create stat file for pid 100.
       assertTrue(ProcfsBasedProcessTree.checkPidPgrpidForMatch(pid,
@@ -781,7 +780,7 @@ public class TestProcfsBasedProcessTree {
 
       ProcfsBasedProcessTree processTree =
           createProcessTree("100", procfsRootDir.getAbsolutePath(),
-              SystemClock.getInstance());
+              Clock.systemUTC());
       // build the process tree.
       processTree.updateProcessTree();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestWindowsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestWindowsBasedProcessTree.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.yarn.util;
 
-import org.apache.hadoop.util.Clock;
+import java.time.Clock;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/MemoryFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/MemoryFederationStateStore.java
@@ -128,7 +128,7 @@ public class MemoryFederationStateStore implements FederationStateStore {
       .newInstance(1, 1);
   private byte[] version;
 
-  private final MonotonicClock clock = new MonotonicClock();
+  private final MonotonicClock clock = MonotonicClock.get();
 
   public static final Logger LOG =
       LoggerFactory.getLogger(MemoryFederationStateStore.class);
@@ -159,7 +159,7 @@ public class MemoryFederationStateStore implements FederationStateStore {
   @Override
   public SubClusterRegisterResponse registerSubCluster(SubClusterRegisterRequest request)
       throws YarnException {
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     FederationMembershipStateStoreInputValidator.validate(request);
     SubClusterInfo subClusterInfo = request.getSubClusterInfo();
@@ -176,7 +176,7 @@ public class MemoryFederationStateStore implements FederationStateStore {
             subClusterInfo.getCapability());
 
     membership.put(subClusterInfo.getSubClusterId(), subClusterInfoToSave);
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
 
     FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
     return SubClusterRegisterResponse.newInstance();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/SQLFederationStateStore.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 import java.sql.Blob;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -115,7 +116,6 @@ import org.apache.hadoop.yarn.server.federation.store.sql.RouterStoreTokenHandle
 import org.apache.hadoop.yarn.server.federation.store.sql.RowCountHandler;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -236,7 +236,7 @@ public class SQLFederationStateStore implements FederationStateStore {
   private String url;
   private int maximumPoolSize;
   private HikariDataSource dataSource = null;
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   @VisibleForTesting
   private Connection conn = null;
   private int maxAppsInStateStore;
@@ -338,9 +338,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not add a new subcluster into FederationStateStore
@@ -393,9 +393,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not deregister the subcluster into FederationStateStore
@@ -447,9 +447,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not update the subcluster into FederationStateStore
@@ -506,9 +506,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("capability_OUT", VARCHAR);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.execute();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       String amRMAddress = cstmt.getString("amRMServiceAddress_OUT");
       String clientRMAddress = cstmt.getString("clientRMServiceAddress_OUT");
@@ -564,9 +564,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt = getCallableStatement(CALL_SP_GET_SUBCLUSTERS);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       rs = cstmt.executeQuery();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       while (rs.next()) {
 
@@ -648,9 +648,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       subClusterHome = cstmt.getString("storedHomeSubCluster_OUT");
       SubClusterId subClusterIdHome = SubClusterId.newInstance(subClusterHome);
@@ -732,9 +732,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not update the application into FederationStateStore
@@ -787,9 +787,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("applicationContext_OUT", Types.BLOB);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.execute();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       String homeSubCluster = cstmt.getString("homeSubCluster_OUT");
       if (homeSubCluster != null) {
@@ -854,9 +854,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.setString("homeSubCluster_IN", homeSubClusterIN);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       rs = cstmt.executeQuery();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       while (rs.next() && appsHomeSubClusters.size() <= maxAppsInStateStore) {
 
@@ -900,9 +900,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not delete the application from FederationStateStore
@@ -951,9 +951,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("params_OUT", java.sql.Types.VARBINARY);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check if the output it is a valid policy
       String policyType = cstmt.getString("policyType_OUT");
@@ -1002,9 +1002,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not add a new policy into FederationStateStore
@@ -1046,9 +1046,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt = getCallableStatement(CALL_SP_GET_POLICIES_CONFIGURATIONS);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       rs = cstmt.executeQuery();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       while (rs.next()) {
         // Extract the output for each tuple
@@ -1153,9 +1153,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       callableStatement.registerOutParameter("versionComment_OUT", VARCHAR);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       callableStatement.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Parsing version information.
       String versionComment = callableStatement.getString("versionComment_OUT");
@@ -1207,9 +1207,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       callableStatement.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       callableStatement.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Check the ROWCOUNT value, if it is equal to 0 it means the call
       // did not add a new version into FederationStateStore
@@ -1323,9 +1323,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Get SubClusterHome
       String subClusterHomeIdString = cstmt.getString("storedHomeSubCluster_OUT");
@@ -1411,9 +1411,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("homeSubCluster_OUT", VARCHAR);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.execute();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // Get Result
       String subClusterHomeIdString = cstmt.getString("homeSubCluster_OUT");
@@ -1466,9 +1466,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt = getCallableStatement(CALL_SP_GET_RESERVATIONS_HOME_SUBCLUSTER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       rs = cstmt.executeQuery();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       while (rs.next()) {
         // Extract the output for each tuple
@@ -1529,9 +1529,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       int rowCount = cstmt.getInt("rowCount_OUT");
 
@@ -1598,9 +1598,9 @@ public class SQLFederationStateStore implements FederationStateStore {
       cstmt.registerOutParameter("rowCount_OUT", INTEGER);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       cstmt.executeUpdate();
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       int rowCount = cstmt.getInt("rowCount_OUT");
 
@@ -1669,10 +1669,10 @@ public class SQLFederationStateStore implements FederationStateStore {
           new FederationSQLOutParameter<>("rowCount_OUT", INTEGER, Integer.class);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Integer rowCount = getRowCountByProcedureSQL(CALL_SP_ADD_MASTERKEY, keyId,
           delegationKeyStr, rowCountOUT);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // We hope that 1 record can be written to the database.
       // If the number of records is not 1, it means that the data was written incorrectly.
@@ -1722,12 +1722,12 @@ public class SQLFederationStateStore implements FederationStateStore {
     try {
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       FederationSQLOutParameter<Integer> rowCountOUT =
           new FederationSQLOutParameter<>("rowCount_OUT", INTEGER, Integer.class);
       Integer rowCount = getRowCountByProcedureSQL(CALL_SP_DELETE_MASTERKEY,
           paramKeyId, rowCountOUT);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // if it is equal to 0 it means the call
       // did not delete the reservation from FederationStateStore
@@ -1790,10 +1790,10 @@ public class SQLFederationStateStore implements FederationStateStore {
           new FederationSQLOutParameter<>("masterKey_OUT", VARCHAR, String.class);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RouterMasterKey routerMasterKey = runner.execute(
           conn, CALL_SP_GET_MASTERKEY, new RouterMasterKeyHandler(), paramKeyId, masterKeyOUT);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       LOG.info("Got the information about the specified masterKey = {} according to keyId = {}.",
           routerMasterKey, paramKeyId);
@@ -1917,11 +1917,11 @@ public class SQLFederationStateStore implements FederationStateStore {
         new FederationSQLOutParameter<>("rowCount_OUT", INTEGER, Integer.class);
 
     // Execute the query
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     String procedure = isAdd ? CALL_SP_ADD_DELEGATIONTOKEN : CALL_SP_UPDATE_DELEGATIONTOKEN;
     Integer rowCount = runner.execute(conn, procedure, new RowCountHandler("rowCount_OUT"),
         sequenceNum, tokenIdentifier, tokenInfo, renewDate, rowCountOUT);
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
 
     // Get rowCount
     // In the process of updating the code, rowCount may be 0 or 1;
@@ -1971,10 +1971,10 @@ public class SQLFederationStateStore implements FederationStateStore {
           new FederationSQLOutParameter<>("rowCount_OUT", INTEGER, Integer.class);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Integer rowCount = getRowCountByProcedureSQL(CALL_SP_DELETE_DELEGATIONTOKEN,
           sequenceNum, rowCountOUT);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       // if it is equal to 0 it means the call
       // did not delete the reservation from FederationStateStore
@@ -2032,10 +2032,10 @@ public class SQLFederationStateStore implements FederationStateStore {
           new FederationSQLOutParameter<>("renewDate_OUT", BIGINT, Long.class);
 
       // Execute the query
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RouterStoreToken resultToken = runner.execute(conn, CALL_SP_GET_DELEGATIONTOKEN,
           new RouterStoreTokenHandler(), sequenceNum, tokenIdentOUT, tokenOUT, renewDateOUT);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
 
       FederationStateStoreClientMetrics.succeededStateStoreCall(stopTime - startTime);
       return RouterRMTokenResponse.newInstance(resultToken);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/store/impl/ZookeeperFederationStateStore.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -114,9 +115,7 @@ import org.apache.hadoop.yarn.server.federation.store.utils.FederationRouterRMTo
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.api.records.ReservationId;
 import org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -222,7 +221,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @VisibleForTesting
   public static final String ROUTER_APP_ROOT_HIERARCHIES = "HIERARCHIES";
 
-  private volatile Clock clock = SystemClock.getInstance();
+  private volatile Clock clock = Clock.systemUTC();
 
   protected static final Version CURRENT_VERSION_INFO = Version.newInstance(1, 1);
 
@@ -384,7 +383,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public AddApplicationHomeSubClusterResponse addApplicationHomeSubCluster(
       AddApplicationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationApplicationHomeSubClusterStoreInputValidator.validate(request);
 
     // parse parameters
@@ -415,7 +414,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       ApplicationHomeSubCluster actualAppHomeSubCluster =
           getApplicationHomeSubCluster(requestApplicationId);
       SubClusterId responseSubClusterId = actualAppHomeSubCluster.getHomeSubCluster();
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.addAppHomeSubClusterDuration(start, end);
       return AddApplicationHomeSubClusterResponse.newInstance(responseSubClusterId);
     } catch (Exception e) {
@@ -442,7 +441,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public UpdateApplicationHomeSubClusterResponse updateApplicationHomeSubCluster(
       UpdateApplicationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationApplicationHomeSubClusterStoreInputValidator.validate(request);
     ApplicationHomeSubCluster requestApplicationHomeSubCluster =
         request.getApplicationHomeSubCluster();
@@ -468,7 +467,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     storeOrUpdateApplicationHomeSubCluster(requestApplicationId,
         requestApplicationHomeSubCluster, true);
 
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addUpdateAppHomeSubClusterDuration(start, end);
     return UpdateApplicationHomeSubClusterResponse.newInstance();
   }
@@ -486,7 +485,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public GetApplicationHomeSubClusterResponse getApplicationHomeSubCluster(
       GetApplicationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationApplicationHomeSubClusterStoreInputValidator.validate(request);
     ApplicationId requestApplicationId = request.getApplicationId();
 
@@ -501,7 +500,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     SubClusterId subClusterId = zkStoreApplicationHomeSubCluster.getHomeSubCluster();
     long createTime = zkStoreApplicationHomeSubCluster.getCreateTime();
 
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetAppHomeSubClusterDuration(start, end);
 
     // If the request asks for an ApplicationSubmissionContext to be returned,
@@ -534,14 +533,14 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     }
 
     try {
-      long start = clock.getTime();
+      long start = clock.millis();
       SubClusterId requestSC = request.getSubClusterId();
       List<ApplicationHomeSubCluster> result = loadRouterApplications().stream()
           .sorted(Comparator.comparing(ApplicationHomeSubCluster::getCreateTime).reversed())
           .filter(appHomeSC -> filterHomeSubCluster(requestSC, appHomeSC.getHomeSubCluster()))
           .limit(maxAppsInStateStore)
           .collect(Collectors.toList());
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.addGetAppsHomeSubClusterDuration(start, end);
       LOG.info("filterSubClusterId = {}, appCount = {}.", requestSC, result.size());
       return GetApplicationsHomeSubClusterResponse.newInstance(result);
@@ -567,7 +566,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public DeleteApplicationHomeSubClusterResponse deleteApplicationHomeSubCluster(
       DeleteApplicationHomeSubClusterRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationApplicationHomeSubClusterStoreInputValidator.validate(request);
     ApplicationId appId = request.getApplicationId();
     String appIdRemovePath = getLeafAppIdNodePath(appId.toString(), false);
@@ -602,7 +601,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot delete app: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addDeleteAppHomeSubClusterDuration(start, end);
     return DeleteApplicationHomeSubClusterResponse.newInstance();
   }
@@ -610,7 +609,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public SubClusterRegisterResponse registerSubCluster(
       SubClusterRegisterRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationMembershipStateStoreInputValidator.validate(request);
     SubClusterInfo subClusterInfo = request.getSubClusterInfo();
     SubClusterId subclusterId = subClusterInfo.getSubClusterId();
@@ -625,7 +624,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot register subcluster: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addRegisterSubClusterDuration(start, end);
     return SubClusterRegisterResponse.newInstance();
   }
@@ -633,7 +632,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public SubClusterDeregisterResponse deregisterSubCluster(
       SubClusterDeregisterRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationMembershipStateStoreInputValidator.validate(request);
     SubClusterId subClusterId = request.getSubClusterId();
     SubClusterState state = request.getState();
@@ -647,7 +646,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       subClusterInfo.setState(state);
       putSubclusterInfo(subClusterId, subClusterInfo, true);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addDeregisterSubClusterDuration(start, end);
     return SubClusterDeregisterResponse.newInstance();
   }
@@ -655,7 +654,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public SubClusterHeartbeatResponse subClusterHeartbeat(
       SubClusterHeartbeatRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationMembershipStateStoreInputValidator.validate(request);
     SubClusterId subClusterId = request.getSubClusterId();
 
@@ -672,7 +671,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
     subClusterInfo.setCapability(request.getCapability());
 
     putSubclusterInfo(subClusterId, subClusterInfo, true);
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addSubClusterHeartbeatDuration(start, end);
     return SubClusterHeartbeatResponse.newInstance();
   }
@@ -680,7 +679,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public GetSubClusterInfoResponse getSubCluster(
       GetSubClusterInfoRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationMembershipStateStoreInputValidator.validate(request);
     SubClusterId subClusterId = request.getSubClusterId();
     SubClusterInfo subClusterInfo = null;
@@ -694,7 +693,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot get subcluster: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetSubClusterDuration(start, end);
     return GetSubClusterInfoResponse.newInstance(subClusterInfo);
   }
@@ -702,7 +701,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public GetSubClustersInfoResponse getSubClusters(
       GetSubClustersInfoRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     List<SubClusterInfo> result = new ArrayList<>();
 
     try {
@@ -718,7 +717,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot get subclusters: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetSubClustersDuration(start, end);
     return GetSubClustersInfoResponse.newInstance(result);
   }
@@ -727,7 +726,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public GetSubClusterPolicyConfigurationResponse getPolicyConfiguration(
       GetSubClusterPolicyConfigurationRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationPolicyStoreInputValidator.validate(request);
     String queue = request.getQueue();
     SubClusterPolicyConfiguration policy = null;
@@ -742,7 +741,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       LOG.warn("Policy for queue: {} does not exist.", queue);
       return null;
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetPolicyConfigurationDuration(start, end);
     return GetSubClusterPolicyConfigurationResponse
         .newInstance(policy);
@@ -751,7 +750,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public SetSubClusterPolicyConfigurationResponse setPolicyConfiguration(
       SetSubClusterPolicyConfigurationRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationPolicyStoreInputValidator.validate(request);
     SubClusterPolicyConfiguration policy =
         request.getPolicyConfiguration();
@@ -762,7 +761,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot set policy: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addSetPolicyConfigurationDuration(start, end);
     return SetSubClusterPolicyConfigurationResponse.newInstance();
   }
@@ -770,7 +769,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public GetSubClusterPoliciesConfigurationsResponse getPoliciesConfigurations(
       GetSubClusterPoliciesConfigurationsRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     List<SubClusterPolicyConfiguration> result = new ArrayList<>();
 
     try {
@@ -786,7 +785,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot get policies: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetPoliciesConfigurationsDuration(start, end);
     return GetSubClusterPoliciesConfigurationsResponse.newInstance(result);
   }
@@ -1182,7 +1181,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public AddReservationHomeSubClusterResponse addReservationHomeSubCluster(
       AddReservationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationReservationHomeSubClusterStoreInputValidator.validate(request);
     ReservationHomeSubCluster reservationHomeSubCluster = request.getReservationHomeSubCluster();
     ReservationId reservationId = reservationHomeSubCluster.getReservationId();
@@ -1203,7 +1202,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot check app home subcluster for " + reservationId;
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addReservationHomeSubClusterDuration(start, end);
     return AddReservationHomeSubClusterResponse.newInstance(homeSubCluster);
   }
@@ -1212,7 +1211,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public GetReservationHomeSubClusterResponse getReservationHomeSubCluster(
       GetReservationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationReservationHomeSubClusterStoreInputValidator.validate(request);
     ReservationId reservationId = request.getReservationId();
     SubClusterId homeSubCluster = getReservation(reservationId);
@@ -1224,7 +1223,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
     ReservationHomeSubCluster reservationHomeSubCluster =
         ReservationHomeSubCluster.newInstance(reservationId, homeSubCluster);
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetReservationHomeSubClusterDuration(start, end);
     return GetReservationHomeSubClusterResponse.newInstance(reservationHomeSubCluster);
   }
@@ -1232,7 +1231,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public GetReservationsHomeSubClusterResponse getReservationsHomeSubCluster(
       GetReservationsHomeSubClusterRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     List<ReservationHomeSubCluster> result = new ArrayList<>();
 
     try {
@@ -1247,7 +1246,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot get apps: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addGetReservationsHomeSubClusterDuration(start, end);
     return GetReservationsHomeSubClusterResponse.newInstance(result);
   }
@@ -1255,7 +1254,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   @Override
   public DeleteReservationHomeSubClusterResponse deleteReservationHomeSubCluster(
       DeleteReservationHomeSubClusterRequest request) throws YarnException {
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationReservationHomeSubClusterStoreInputValidator.validate(request);
     ReservationId reservationId = request.getReservationId();
     String reservationZNode = getNodePath(reservationsZNode, reservationId.toString());
@@ -1279,7 +1278,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       String errMsg = "Cannot delete reservation: " + e.getMessage();
       FederationStateStoreUtils.logAndThrowStoreException(LOG, errMsg);
     }
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addDeleteReservationHomeSubClusterDuration(start, end);
     return DeleteReservationHomeSubClusterResponse.newInstance();
   }
@@ -1288,7 +1287,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public UpdateReservationHomeSubClusterResponse updateReservationHomeSubCluster(
       UpdateReservationHomeSubClusterRequest request) throws YarnException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     FederationReservationHomeSubClusterStoreInputValidator.validate(request);
     ReservationHomeSubCluster reservationHomeSubCluster = request.getReservationHomeSubCluster();
     ReservationId reservationId = reservationHomeSubCluster.getReservationId();
@@ -1301,7 +1300,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
     SubClusterId newSubClusterId = reservationHomeSubCluster.getHomeSubCluster();
     putReservation(reservationId, newSubClusterId, true);
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addUpdateReservationHomeSubClusterDuration(start, end);
     return UpdateReservationHomeSubClusterResponse.newInstance();
   }
@@ -1318,7 +1317,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterMasterKeyResponse storeNewMasterKey(RouterMasterKeyRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // For the verification of the request, after passing the verification,
     // the request and the internal objects will not be empty and can be used directly.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1338,7 +1337,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
     // Get the stored masterKey from zk.
     RouterMasterKey masterKeyFromZK = getRouterMasterKeyFromZK(nodeCreatePath);
-    long end = clock.getTime();
+    long end = clock.millis();
     opDurations.addStoreNewMasterKeyDuration(start, end);
     return RouterMasterKeyResponse.newInstance(masterKeyFromZK);
   }
@@ -1355,7 +1354,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterMasterKeyResponse removeStoredMasterKey(RouterMasterKeyRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // For the verification of the request, after passing the verification,
     // the request and the internal objects will not be empty and can be used directly.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1375,7 +1374,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
       // try to remove masterKey.
       zkManager.delete(nodeRemovePath);
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.removeStoredMasterKeyDuration(start, end);
       return RouterMasterKeyResponse.newInstance(masterKey);
     } catch (Exception e) {
@@ -1395,7 +1394,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterMasterKeyResponse getMasterKeyByDelegationKey(RouterMasterKeyRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // For the verification of the request, after passing the verification,
     // the request and the internal objects will not be empty and can be used directly.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1413,7 +1412,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
       // Get the stored masterKey from zk.
       RouterMasterKey routerMasterKey = getRouterMasterKeyFromZK(nodePath);
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.getMasterKeyByDelegationKeyDuration(start, end);
       return RouterMasterKeyResponse.newInstance(routerMasterKey);
     } catch (Exception e) {
@@ -1486,7 +1485,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterRMTokenResponse storeNewToken(RouterRMTokenRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // We verify the RouterRMTokenRequest to ensure that the request is not empty,
     // and that the internal RouterStoreToken is not empty.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1498,7 +1497,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
       // Get the stored delegationToken from ZK and return.
       RouterStoreToken resultStoreToken = getStoreTokenFromZK(request);
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.getStoreNewTokenDuration(start, end);
       return RouterRMTokenResponse.newInstance(resultStoreToken);
     } catch (YarnException | IOException e) {
@@ -1523,7 +1522,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterRMTokenResponse updateStoredToken(RouterRMTokenRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // We verify the RouterRMTokenRequest to ensure that the request is not empty,
     // and that the internal RouterStoreToken is not empty.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1551,7 +1550,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
 
       // Get the stored delegationToken from ZK and return.
       RouterStoreToken resultStoreToken = getStoreTokenFromZK(request);
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.updateStoredTokenDuration(start, end);
       return RouterRMTokenResponse.newInstance(resultStoreToken);
     } catch (YarnException | IOException e) {
@@ -1576,7 +1575,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterRMTokenResponse removeStoredToken(RouterRMTokenRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // We verify the RouterRMTokenRequest to ensure that the request is not empty,
     // and that the internal RouterStoreToken is not empty.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1599,7 +1598,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       }
 
       // return deleted token data.
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.removeStoredTokenDuration(start, end);
       return RouterRMTokenResponse.newInstance(storeToken);
     } catch (YarnException | IOException e) {
@@ -1621,7 +1620,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
   public RouterRMTokenResponse getTokenByRouterStoreToken(RouterRMTokenRequest request)
       throws YarnException, IOException {
 
-    long start = clock.getTime();
+    long start = clock.millis();
     // We verify the RouterRMTokenRequest to ensure that the request is not empty,
     // and that the internal RouterStoreToken is not empty.
     FederationRouterRMTokenInputValidator.validate(request);
@@ -1639,7 +1638,7 @@ public class ZookeeperFederationStateStore implements FederationStateStore {
       // Get the stored delegationToken from ZK and return.
       RouterStoreToken resultStoreToken = getStoreTokenFromZK(request);
       // return deleted token data.
-      long end = clock.getTime();
+      long end = clock.millis();
       opDurations.getTokenByRouterStoreTokenDuration(start, end);
       return RouterRMTokenResponse.newInstance(resultStoreToken);
     } catch (YarnException | IOException e) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/impl/FederationStateStoreBaseTest.java
@@ -104,7 +104,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public abstract class FederationStateStoreBaseTest {
 
-  private static final MonotonicClock CLOCK = new MonotonicClock();
+  private static final MonotonicClock CLOCK = MonotonicClock.get();
   private FederationStateStore stateStore;
   private static final int NUM_APPS_10 = 10;
   private static final int NUM_APPS_20 = 20;
@@ -650,7 +650,7 @@ public abstract class FederationStateStoreBaseTest {
 
     return SubClusterInfo.newInstance(subClusterId, amRMAddress,
         clientRMAddress, rmAdminAddress, webAppAddress, SubClusterState.SC_NEW,
-        CLOCK.getTime(), "capability");
+        CLOCK.millis(), "capability");
   }
 
   private SubClusterPolicyConfiguration createSCPolicyConf(String queueName,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreTestUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreTestUtil.java
@@ -49,7 +49,7 @@ import org.apache.hadoop.util.MonotonicClock;
  */
 public class FederationStateStoreTestUtil {
 
-  private static final MonotonicClock CLOCK = new MonotonicClock();
+  private static final MonotonicClock CLOCK = MonotonicClock.get();
 
   public static final String SC_PREFIX = "SC-";
   public static final String Q_PREFIX = "queue-";
@@ -71,7 +71,7 @@ public class FederationStateStoreTestUtil {
 
     return SubClusterInfo.newInstance(subClusterId, amRMAddress,
         clientRMAddress, rmAdminAddress, webAppAddress,
-        SubClusterState.SC_RUNNING, CLOCK.getTime(), "capability");
+        SubClusterState.SC_RUNNING, CLOCK.millis(), "capability");
   }
 
   public void registerSubCluster(SubClusterId subClusterId)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/AMRMProxyService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/AMRMProxyService.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -77,7 +78,6 @@ import org.apache.hadoop.yarn.server.nodemanager.security.authorize
 import org.apache.hadoop.yarn.server.security.MasterKeyData;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.utils.YarnServerSecurityUtils;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
@@ -101,7 +101,7 @@ public class AMRMProxyService extends CompositeService implements
   private static final String NMSS_USER_KEY = "user";
   private static final String NMSS_AMRMTOKEN_KEY = "amrmtoken";
 
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private Server server;
   private final Context nmContext;
   private final AsyncDispatcher dispatcher;
@@ -220,7 +220,7 @@ public class AMRMProxyService extends CompositeService implements
         .getAppContexts().entrySet()) {
       ApplicationAttemptId attemptId = entry.getKey();
       LOG.info("Recovering app attempt {}.", attemptId);
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
 
       // Try recover for the running application attempt
       try {
@@ -275,7 +275,7 @@ public class AMRMProxyService extends CompositeService implements
         // Create the interceptor pipeline for the AM
         initializePipeline(attemptId, user, amrmToken, localToken,
             entry.getValue(), true, amCred);
-        long endTime = clock.getTime();
+        long endTime = clock.millis();
         this.metrics.succeededRecoverRequests(endTime - startTime);
       } catch (Throwable e) {
         LOG.error("Exception when recovering {}, removing it from NMStateStore and move on.",
@@ -296,7 +296,7 @@ public class AMRMProxyService extends CompositeService implements
       RegisterApplicationMasterRequest request) throws YarnException,
       IOException {
     this.metrics.incrRequestCount();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     try {
       RequestInterceptorChainWrapper pipeline =
           authorizeAndGetInterceptorChain();
@@ -308,7 +308,7 @@ public class AMRMProxyService extends CompositeService implements
       RegisterApplicationMasterResponse response =
           pipeline.getRootInterceptor().registerApplicationMaster(request);
 
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededRegisterAMRequests(endTime - startTime);
       LOG.info("RegisterAM processing finished in {} ms for application {}.",
           endTime - startTime, pipeline.getApplicationAttemptId());
@@ -329,7 +329,7 @@ public class AMRMProxyService extends CompositeService implements
       FinishApplicationMasterRequest request) throws YarnException,
       IOException {
     this.metrics.incrRequestCount();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     try {
       RequestInterceptorChainWrapper pipeline =
           authorizeAndGetInterceptorChain();
@@ -338,7 +338,7 @@ public class AMRMProxyService extends CompositeService implements
       FinishApplicationMasterResponse response =
           pipeline.getRootInterceptor().finishApplicationMaster(request);
 
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededFinishAMRequests(endTime - startTime);
       LOG.info("FinishAM finished with isUnregistered = {} in {} ms for {}.",
           response.getIsUnregistered(), endTime - startTime,
@@ -361,7 +361,7 @@ public class AMRMProxyService extends CompositeService implements
   public AllocateResponse allocate(AllocateRequest request)
       throws YarnException, IOException {
     this.metrics.incrAllocateCount();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     try {
       AMRMTokenIdentifier amrmTokenIdentifier =
           YarnServerSecurityUtils.authorizeRequest();
@@ -372,7 +372,7 @@ public class AMRMProxyService extends CompositeService implements
 
       updateAMRMTokens(amrmTokenIdentifier, pipeline, allocateResponse);
 
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededAllocateRequests(endTime - startTime);
       LOG.info("Allocate processing finished in {} ms for application {}.",
           endTime - startTime, pipeline.getApplicationAttemptId());
@@ -394,7 +394,7 @@ public class AMRMProxyService extends CompositeService implements
   public void processApplicationStartRequest(StartContainerRequest request)
       throws IOException, YarnException {
     this.metrics.incrRequestCount();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     try {
       ContainerTokenIdentifier containerTokenIdentifierForKey =
           BuilderUtils.newContainerTokenIdentifier(request.getContainerToken());
@@ -436,7 +436,7 @@ public class AMRMProxyService extends CompositeService implements
           containerTokenIdentifierForKey.getApplicationSubmitter(), amrmToken,
           localToken, null, false, credentials);
 
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededAppStartRequests(endTime - startTime);
     } catch (Throwable t) {
       this.metrics.incrFailedAppStartRequests();
@@ -556,7 +556,7 @@ public class AMRMProxyService extends CompositeService implements
     RequestInterceptorChainWrapper pipeline =
         this.applPipelineMap.remove(applicationId);
     boolean isStopSuccess = true;
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     if (pipeline == null) {
       LOG.info("No interceptor pipeline for application {},"
@@ -588,7 +588,7 @@ public class AMRMProxyService extends CompositeService implements
     }
 
     if (isStopSuccess) {
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededAppStopRequests(endTime - startTime);
     } else {
       this.metrics.incrFailedAppStopRequests();
@@ -603,7 +603,7 @@ public class AMRMProxyService extends CompositeService implements
         (AMRMProxyApplicationContextImpl) pipeline.getRootInterceptor().getApplicationContext();
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
 
       // check to see if the RM has issued a new AMRMToken & accordingly update
       // the real ARMRMToken in the current context
@@ -651,7 +651,7 @@ public class AMRMProxyService extends CompositeService implements
                       localToken.getService().toString()));
         }
       }
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       this.metrics.succeededUpdateTokenRequests(endTime - startTime);
     } catch (IOException e) {
       LOG.error("Error storing AMRMProxy application context entry for {}.",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -260,7 +260,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
 
   private boolean waitUamRegisterDone;
 
-  private final MonotonicClock clock = new MonotonicClock();
+  private final MonotonicClock clock = MonotonicClock.get();
 
   /*
    * For UAM, keepContainersAcrossApplicationAttempts is always true.
@@ -289,7 +289,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
     this.justRecovered = false;
     this.finishAMCalled = false;
     this.lastSCResponseTime = new ConcurrentHashMap<>();
-    this.lastAMHeartbeatTime = this.clock.getTime();
+    this.lastAMHeartbeatTime = this.clock.millis();
     this.nmTokenMapFromRegisterSecondaryCluster = new ConcurrentHashSet<>();
   }
 
@@ -469,7 +469,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
           nmTokenMapFromRegisterSecondaryCluster.addAll(response.getNMTokensFromPreviousAttempts());
 
           // Set sub-cluster to be timed out initially
-          lastSCResponseTime.put(subClusterId, clock.getTime() - subClusterTimeOut);
+          lastSCResponseTime.put(subClusterId, clock.millis() - subClusterTimeOut);
 
           // Running containers from secondary RMs
           List<Container> previousAttempts = response.getContainersFromPreviousAttempts();
@@ -728,7 +728,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       throws YarnException, IOException {
     Preconditions.checkArgument(this.policyInterpreter != null,
         "Allocate should be called after registerApplicationMaster");
-    this.lastAMHeartbeatTime = this.clock.getTime();
+    this.lastAMHeartbeatTime = this.clock.millis();
 
     if (this.justRecovered) {
       throw new ApplicationMasterNotRegisteredException(
@@ -776,14 +776,14 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       sendRequestsToResourceManagers(requests);
 
       // Wait for the first async response to arrive
-      long startTime = this.clock.getTime();
+      long startTime = this.clock.millis();
       synchronized (this.asyncResponseSink) {
         try {
           this.asyncResponseSink.wait(this.heartbeatMaxWaitTimeMs);
         } catch (InterruptedException e) {
         }
       }
-      long firstResponseTime = this.clock.getTime() - startTime;
+      long firstResponseTime = this.clock.millis() - startTime;
 
       // An extra brief wait for other async heart beats, so that most of their
       // responses can make it back to AM in the same heart beat round trip.
@@ -1087,7 +1087,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
                   amRegistrationRequest);
 
               // Set sub-cluster to be timed out initially
-              lastSCResponseTime.put(subClusterId, clock.getTime() - subClusterTimeOut);
+              lastSCResponseTime.put(subClusterId, clock.millis() - subClusterTimeOut);
 
               if (response != null && response.getContainersFromPreviousAttempts() != null) {
                 cacheAllocatedContainers(response.getContainersFromPreviousAttempts(),
@@ -1289,7 +1289,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       if (!subClusterId.equals(this.homeSubClusterId) && !this.uamPool.hasUAMId(id)) {
         newSubClusters.add(subClusterId);
         // Set sub-cluster to be timed out initially
-        lastSCResponseTime.put(subClusterId, clock.getTime() - subClusterTimeOut);
+        lastSCResponseTime.put(subClusterId, clock.millis() - subClusterTimeOut);
       }
     });
 
@@ -1747,7 +1747,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
         // should not consider the SC as timed out
         continue;
       }
-      long duration = this.clock.getTime() - entry.getValue();
+      long duration = this.clock.millis() - entry.getValue();
       if (duration > this.subClusterTimeOut) {
         if (verbose) {
           LOG.warn("Subcluster {} doesn't have a successful heartbeat for {} seconds for {}",
@@ -1850,7 +1850,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
         asyncResponseSink.notifyAll();
       }
       lastSCResponse.put(subClusterId, response);
-      lastSCResponseTime.put(subClusterId, clock.getTime());
+      lastSCResponseTime.put(subClusterId, clock.millis());
 
       // Notify policy of allocate response
       try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
@@ -169,7 +169,6 @@ import org.apache.hadoop.yarn.server.nodemanager.security.authorize.NMPolicyProv
 import org.apache.hadoop.yarn.server.nodemanager.timelineservice.NMTimelinePublisher;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.utils.YarnServerSecurityUtils;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
 
@@ -179,6 +178,7 @@ import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1170,7 +1170,7 @@ public class ContainerManagerImpl extends CompositeService implements
     Credentials credentials =
         YarnServerSecurityUtils.parseCredentials(launchContext);
 
-    long containerStartTime = SystemClock.getInstance().getTime();
+    long containerStartTime = Clock.systemUTC().millis();
     Container container =
         new ContainerImpl(getConfig(), this.dispatcher,
             launchContext, credentials, metrics, containerTokenIdentifier,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -97,8 +98,6 @@ import org.apache.hadoop.yarn.state.MultipleArcTransition;
 import org.apache.hadoop.yarn.state.SingleArcTransition;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 public class ContainerImpl implements Container {
@@ -179,7 +178,7 @@ public class ContainerImpl implements Container {
   private long containerLocalizationStartTime;
   private long containerLaunchStartTime;
   private ContainerMetrics containerMetrics;
-  private static Clock clock = SystemClock.getInstance();
+  private static Clock clock = Clock.systemUTC();
 
   private ContainerRetryContext containerRetryContext;
   private SlidingWindowRetryPolicy.RetryContext windowRetryContext;
@@ -217,7 +216,7 @@ public class ContainerImpl implements Container {
       NodeManagerMetrics metrics,
       ContainerTokenIdentifier containerTokenIdentifier, Context context) {
     this(conf, dispatcher, launchContext, creds, metrics,
-        containerTokenIdentifier, context, SystemClock.getInstance().getTime());
+        containerTokenIdentifier, context, Clock.systemUTC().millis());
   }
 
   public ContainerImpl(Configuration conf, Dispatcher dispatcher,
@@ -258,7 +257,7 @@ public class ContainerImpl implements Container {
           YarnConfiguration.DEFAULT_NM_CONTAINER_METRICS_UNREGISTER_DELAY_MS);
       containerMetrics = ContainerMetrics
           .forContainer(containerId, flushPeriod, unregisterDelay);
-      containerMetrics.recordStartTime(clock.getTime());
+      containerMetrics.recordStartTime(clock.millis());
     }
 
     // Configure the Retry Context
@@ -1030,7 +1029,7 @@ public class ContainerImpl implements Container {
         launcherEvent = ContainersLauncherEventType.RECOVER_PAUSED_CONTAINER;
       }
 
-      containerLaunchStartTime = clock.getTime();
+      containerLaunchStartTime = clock.millis();
       dispatcher.getEventHandler().handle(
           new ContainersLauncherEvent(this, launcherEvent));
     }
@@ -1077,7 +1076,7 @@ public class ContainerImpl implements Container {
   // resource usage.
   @SuppressWarnings("unchecked") // dispatcher not typed
   private void sendContainerMonitorStartEvent() {
-    long launchDuration = clock.getTime() - containerLaunchStartTime;
+    long launchDuration = clock.millis() - containerLaunchStartTime;
     metrics.addContainerLaunchDuration(launchDuration);
 
     long pmemBytes = getResource().getMemorySize() * 1024 * 1024L;
@@ -1222,7 +1221,7 @@ public class ContainerImpl implements Container {
         }
       }
 
-      container.containerLocalizationStartTime = clock.getTime();
+      container.containerLocalizationStartTime = clock.millis();
       // duration = end - start;
       // record in RequestResourcesTransition: -start
       // add in LocalizedTransition: +end
@@ -1971,7 +1970,7 @@ public class ContainerImpl implements Container {
           container.containerTokenIdentifier.getResource());
       if (container.containerMetrics != null) {
         container.containerMetrics
-            .recordFinishTimeAndExitCode(clock.getTime(), container.exitCode);
+            .recordFinishTimeAndExitCode(clock.millis(), container.exitCode);
         container.containerMetrics.finished(false);
       }
       container.sendFinishedEvents();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/SlidingWindowRetryPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/SlidingWindowRetryPolicy.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.ContainerRetryContext;
 import org.apache.hadoop.yarn.api.records.ContainerRetryPolicy;
-import org.apache.hadoop.util.Clock;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -65,7 +65,7 @@ public class SlidingWindowRetryPolicy {
         retryContext.containerRetryContext;
     if (containerRC.getFailuresValidityInterval() > 0) {
       int validFailuresCount = 0;
-      long currentTime = clock.getTime();
+      long currentTime = clock.millis();
       for (int i = retryContext.restartTimes.size() - 1; i >= 0; i--) {
         long restartTime = retryContext.restartTimes.get(i);
         if (currentTime - restartTime
@@ -93,7 +93,7 @@ public class SlidingWindowRetryPolicy {
     if (retryContext.containerRetryContext.getFailuresValidityInterval() > 0) {
       ContainerRetryContext containerRC = retryContext.containerRetryContext;
       Iterator<Long> iterator = retryContext.getRestartTimes().iterator();
-      long currentTime = clock.getTime();
+      long currentTime = clock.millis();
 
       while (iterator.hasNext()) {
         long restartTime = iterator.next();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsHandler.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileged.PrivilegedOperationExecutor;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +41,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +97,7 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
     this.parsedMtab = new HashMap<>();
     this.rwLock = new ReentrantReadWriteLock();
     this.privilegedOperationExecutor = privilegedOperationExecutor;
-    this.clock = SystemClock.getInstance();
+    this.clock = Clock.systemUTC();
     mtabFile = mtab;
     init();
   }
@@ -480,7 +479,7 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
 
     LOG.debug("deleteCGroup: {}", cGroupPath);
 
-    long start = clock.getTime();
+    long start = clock.millis();
 
     do {
       try {
@@ -491,7 +490,7 @@ public abstract class AbstractCGroupsHandler implements CGroupsHandler {
       } catch (InterruptedException ex) {
         // NOP
       }
-    } while (!deleted && (clock.getTime() - start) < deleteCGroupTimeout);
+    } while (!deleted && (clock.millis() - start) < deleteCGroupTimeout);
 
     if (!deleted) {
       LOG.warn(String.format("Unable to delete  %s, tried to delete for %d ms",

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsResourceCalculator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/AbstractCGroupsResourceCalculator.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,9 +38,7 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.CpuTimeTracker;
 import org.apache.hadoop.util.SysInfoLinux;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ResourceCalculatorProcessTree;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Common code base for the CGroupsResourceCalculator implementations.
@@ -48,7 +47,7 @@ public abstract class AbstractCGroupsResourceCalculator extends ResourceCalculat
   private static final Logger LOG =
       LoggerFactory.getLogger(AbstractCGroupsResourceCalculator.class);
   private final String pid;
-  private final Clock clock = SystemClock.getInstance();
+  private final Clock clock = Clock.systemUTC();
   private final Map<String, String> stats = new ConcurrentHashMap<>();
 
   private long jiffyLengthMs = SysInfoLinux.JIFFY_LENGTH_IN_MILLIS;
@@ -130,7 +129,7 @@ public abstract class AbstractCGroupsResourceCalculator extends ResourceCalculat
       }
     }
     LOG.debug("After updateProcessTree the {} pid has stats {}", pid, stats);
-    cpuTimeTracker.updateElapsedJiffies(BigInteger.valueOf(getTotalJiffies()), clock.getTime());
+    cpuTimeTracker.updateElapsedJiffies(BigInteger.valueOf(getTotalJiffies()), clock.millis());
   }
 
   private void addSingleLineToStat(Path file, String line) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupElasticMemoryController.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupElasticMemoryController.java
@@ -28,13 +28,13 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.nodemanager.Context;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -58,7 +58,7 @@ import static org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.r
 public class CGroupElasticMemoryController extends Thread {
   protected static final Logger LOG = LoggerFactory
       .getLogger(CGroupElasticMemoryController.class);
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private String yarnCGroupPath;
   private String oomListenerPath;
   private Runnable oomHandler;
@@ -335,7 +335,7 @@ public class CGroupElasticMemoryController extends Thread {
   private void resolveOOM(ExecutorService executor)
       throws InterruptedException, java.util.concurrent.ExecutionException {
     // Just log, when we are still in OOM after a couple of seconds
-    final long start = clock.getTime();
+    final long start = clock.millis();
     Future<Boolean> watchdog =
         executor.submit(() -> watchAndLogOOMState(start));
     // Kill something to resolve the issue
@@ -363,7 +363,7 @@ public class CGroupElasticMemoryController extends Thread {
       long end = start;
       // Throw an error, if we are still in OOM after 5 seconds
       while(end - start < timeoutMS) {
-        end = clock.getTime();
+        end = clock.millis();
         String underOOM = cgroups.getCGroupParam(
             CGroupsHandler.CGroupController.MEMORY,
             "",
@@ -390,7 +390,7 @@ public class CGroupElasticMemoryController extends Thread {
       LOG.warn("Exception running logging thread", e);
     }
     LOG.warn(String.format("OOM was not resolved in %d ms",
-        clock.getTime() - start));
+        clock.millis() - start));
     stopListening();
     return false;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/util/CgroupsLCEResourcesHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/util/CgroupsLCEResourcesHandler.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,9 +57,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.privileg
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsCpuResourceHandlerImpl;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.CGroupsHandler;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.linux.resources.ResourceHandlerModule;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.ResourceCalculatorPlugin;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * Resource handler that lets you setup cgroups
@@ -99,7 +98,7 @@ public class CgroupsLCEResourcesHandler implements LCEResourcesHandler {
 
   public CgroupsLCEResourcesHandler() {
     this.controllerPaths = new HashMap<String, String>();
-    clock = SystemClock.getInstance();
+    clock = Clock.systemUTC();
   }
 
   @Override
@@ -297,7 +296,7 @@ public class CgroupsLCEResourcesHandler implements LCEResourcesHandler {
     boolean deleted = false;
 
     LOG.debug("deleteCgroup: {}", cgroupPath);
-    long start = clock.getTime();
+    long start = clock.millis();
     do {
       try {
         deleted = checkAndDeleteCgroup(new File(cgroupPath));
@@ -307,7 +306,7 @@ public class CgroupsLCEResourcesHandler implements LCEResourcesHandler {
       } catch (InterruptedException ex) {
         // NOP
       }
-    } while (!deleted && (clock.getTime() - start) < deleteCgroupTimeout);
+    } while (!deleted && (clock.millis() - start) < deleteCgroupTimeout);
 
     if (!deleted) {
       LOG.warn("Unable to delete cgroup at: " + cgroupPath +

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.security.AccessControlException;
 import java.text.MessageFormat;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -193,9 +194,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.ReservationsACLsMa
 import org.apache.hadoop.yarn.server.resourcemanager.security.authorize.RMPolicyProvider;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.hadoop.util.UTCClock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
@@ -248,7 +247,7 @@ public class ClientRMService extends AbstractService implements
       QueueACLsManager queueACLsManager,
       RMDelegationTokenSecretManager rmDTSecretManager) {
     this(rmContext, scheduler, rmAppManager, applicationACLsManager,
-        queueACLsManager, rmDTSecretManager, new UTCClock());
+        queueACLsManager, rmDTSecretManager, Clock.systemUTC());
   }
 
   public ClientRMService(RMContext rmContext, YarnScheduler scheduler,
@@ -1544,7 +1543,7 @@ public class ClientRMService extends AbstractService implements
 
   private void refreshScheduler(String planName,
       ReservationDefinition contract, String reservationId) {
-    if ((contract.getArrival() - clock.getTime()) < reservationSystem
+    if ((contract.getArrival() - clock.millis()) < reservationSystem
         .getPlanFollowerTimeStep()) {
       LOG.debug("Reservation {} is within threshold so attempting to"
           + " create synchronously.", reservationId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DecommissioningNodesWatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/DecommissioningNodesWatcher.java
@@ -99,7 +99,7 @@ public class DecommissioningNodesWatcher {
     public DecommissioningNodeContext(NodeId nodeId, int timeoutSec) {
       this.nodeId = nodeId;
       this.appIds = new ArrayList<>();
-      this.decommissioningStartTime = mclock.getTime();
+      this.decommissioningStartTime = mclock.millis();
       this.timeoutMs = 1000L * timeoutSec;
     }
 
@@ -118,7 +118,7 @@ public class DecommissioningNodesWatcher {
   public DecommissioningNodesWatcher(RMContext rmContext) {
     this.rmContext = rmContext;
     pollTimer = new Timer(true);
-    mclock = new MonotonicClock();
+    mclock = MonotonicClock.get();
   }
 
   public void init(Configuration conf) {
@@ -136,7 +136,7 @@ public class DecommissioningNodesWatcher {
    */
   public synchronized void update(RMNode rmNode, NodeStatus remoteNodeStatus) {
     DecommissioningNodeContext context = decomNodes.get(rmNode.getNodeID());
-    long now = mclock.getTime();
+    long now = mclock.millis();
     if (rmNode.getState() == NodeState.DECOMMISSIONED) {
       if (context == null) {
         return;
@@ -239,7 +239,7 @@ public class DecommissioningNodesWatcher {
       return DecommissioningNodeStatus.DECOMMISSIONED;
     }
 
-    long waitTime = mclock.getTime() - context.decommissioningStartTime;
+    long waitTime = mclock.millis() - context.decommissioningStartTime;
     if (context.numActiveContainers > 0) {
       return (context.timeoutMs < 0 || waitTime < context.timeoutMs)?
           DecommissioningNodeStatus.WAIT_CONTAINER :
@@ -270,7 +270,7 @@ public class DecommissioningNodesWatcher {
 
     public void run() {
       logDecommissioningNodesStatus();
-      long now = mclock.getTime();
+      long now = mclock.millis();
       Set<NodeId> staleNodes = new HashSet<NodeId>();
 
       for (Iterator<Map.Entry<NodeId, DecommissioningNodeContext>> it =
@@ -342,7 +342,7 @@ public class DecommissioningNodesWatcher {
       return -1;
     }
 
-    long now = mclock.getTime();
+    long now = mclock.millis();
     long timeout = context.decommissioningStartTime + context.timeoutMs - now;
     return Math.max(0, (int)(timeout / 1000));
   }
@@ -351,7 +351,7 @@ public class DecommissioningNodesWatcher {
     if (!LOG.isDebugEnabled() || decomNodes.size() == 0) {
       return;
     }
-    long now = mclock.getTime();
+    long now = mclock.millis();
     for (DecommissioningNodeContext d : decomNodes.values()) {
       StringBuilder sb = new StringBuilder();
       DecommissioningNodeStatus s = checkDecommissioningStatus(d.nodeId);
@@ -376,7 +376,7 @@ public class DecommissioningNodesWatcher {
               (rmApp.getApplicationType() == null)?
                   "" : rmApp.getApplicationType(),
               100.0 * rmApp.getProgress(),
-              (mclock.getTime() - rmApp.getStartTime()) / 1000));
+              (mclock.millis() - rmApp.getStartTime()) / 1000));
         }
       }
       LOG.debug("Decommissioning node: " + sb.toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NodesListManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -60,8 +61,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeDecommissionin
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEventType;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeImpl;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
@@ -108,7 +107,7 @@ public class NodesListManager extends CompositeService implements
       resolver = new DirectResolver();
     } else {
       resolver =
-          new CachedResolver(SystemClock.getInstance(), nodeIpCacheTimeout);
+          new CachedResolver(Clock.systemUTC(), nodeIpCacheTimeout);
       addIfService(resolver);
     }
 
@@ -569,7 +568,7 @@ public class NodesListManager extends CompositeService implements
 
     @VisibleForTesting
     public void addToCache(String hostName, String ip) {
-      cache.put(hostName, new CacheEntry(ip, clock.getTime()));
+      cache.put(hostName, new CacheEntry(ip, clock.millis()));
     }
 
     public void removeFromCache(String hostName) {
@@ -599,7 +598,7 @@ public class NodesListManager extends CompositeService implements
     private class ExpireChecker extends TimerTask {
       @Override
       public void run() {
-        long currentTime = clock.getTime();
+        long currentTime = clock.millis();
         Iterator<Map.Entry<String, CacheEntry>> iterator =
             cache.entrySet().iterator();
         while (iterator.hasNext()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMActiveServiceContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMActiveServiceContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager;
 
+import java.time.Clock;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -58,8 +59,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.ProxyCAManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.resourcemanager.volume.csi.VolumeManager;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * The RMActiveServiceContext is the class that maintains <b>Active</b> service
@@ -108,7 +107,7 @@ public class RMActiveServiceContext {
   private NodeAttributesManager nodeAttributesManager;
   private RMDelegatedNodeLabelsUpdater rmDelegatedNodeLabelsUpdater;
   private long epoch;
-  private Clock systemClock = SystemClock.getInstance();
+  private Clock systemClock = Clock.systemUTC();
   private long schedulerRecoveryStartTime = 0;
   private long schedulerRecoveryWaitTime = 0;
   private boolean printLog = true;
@@ -482,7 +481,7 @@ public class RMActiveServiceContext {
   @Private
   @Unstable
   public void setSchedulerRecoveryStartAndWaitTime(long waitTime) {
-    this.schedulerRecoveryStartTime = systemClock.getTime();
+    this.schedulerRecoveryStartTime = systemClock.millis();
     this.schedulerRecoveryWaitTime = waitTime;
   }
 
@@ -493,7 +492,7 @@ public class RMActiveServiceContext {
       return isSchedulerReady;
     }
     isSchedulerReady =
-        (systemClock.getTime() - schedulerRecoveryStartTime) > schedulerRecoveryWaitTime;
+        (systemClock.millis() - schedulerRecoveryStartTime) > schedulerRecoveryWaitTime;
     if (!isSchedulerReady && printLog) {
       LOG.info("Skip allocating containers. Scheduler is waiting for recovery.");
       printLog = false;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Clock;
 import java.util.concurrent.ConcurrentMap;
 
 import org.slf4j.Logger;
@@ -64,7 +65,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenS
 import org.apache.hadoop.yarn.server.resourcemanager.timelineservice.RMTimelineCollectorManager;
 import org.apache.hadoop.yarn.server.resourcemanager.volume.csi.VolumeManager;
 import org.apache.hadoop.yarn.server.webproxy.ProxyUriUtils;
-import org.apache.hadoop.util.Clock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMServerUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -77,8 +78,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.YarnScheduler;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.slf4j.Logger;
@@ -104,7 +103,7 @@ public class RMServerUtils {
   protected static final RecordFactory RECORD_FACTORY =
       RecordFactoryProvider.getRecordFactory(null);
 
-  private static Clock clock = SystemClock.getInstance();
+  private static Clock clock = Clock.systemUTC();
 
   public static List<RMNode> queryRMNodes(RMContext context,
       EnumSet<NodeState> acceptedStates) {
@@ -566,7 +565,7 @@ public class RMServerUtils {
   public static Map<ApplicationTimeoutType, Long> validateISO8601AndConvertToLocalTimeEpoch(
       Map<ApplicationTimeoutType, String> timeoutsInISO8601)
       throws YarnException {
-    long currentTimeMillis = clock.getTime();
+    long currentTimeMillis = clock.millis();
     Map<ApplicationTimeoutType, Long> newApplicationTimeout =
         new HashMap<ApplicationTimeoutType, Long>();
     if (timeoutsInISO8601 != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationClientMethod.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationClientMethod.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.yarn.server.resourcemanager.federation;
 
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
-import org.apache.hadoop.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.time.Clock;
 import java.util.Arrays;
 
 /**
@@ -104,11 +104,11 @@ public class FederationClientMethod<R> {
    */
   protected R invoke() throws YarnException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Method method = FederationStateStore.class.getMethod(methodName, types);
       R result = clazz.cast(method.invoke(stateStoreClient, params));
 
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       FederationStateStoreServiceMetrics.succeededStateStoreServiceCall(
           methodName, stopTime - startTime);
       return result;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/federation/FederationStateStoreService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.federation;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -89,7 +90,6 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
@@ -116,7 +116,7 @@ public class FederationStateStoreService extends AbstractService
   private long heartbeatInterval;
   private long heartbeatInitialDelay;
   private RMContext rmContext;
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private FederationStateStoreServiceMetrics metrics;
   private String cleanUpThreadNamePrefix = "FederationStateStoreService-Clean-Thread";
   private int cleanUpRetryCountNum;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/ProportionalCapacityPreemptionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/ProportionalCapacityPreemptionPolicy.java
@@ -46,13 +46,12 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueueCap
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.preemption.PreemptableQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.ContainerPreemptEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEventType;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -143,7 +142,7 @@ public class ProportionalCapacityPreemptionPolicy
   private Set<ContainerId> killableContainers;
 
   public ProportionalCapacityPreemptionPolicy() {
-    clock = SystemClock.getInstance();
+    clock = Clock.systemUTC();
     allPartitions = Collections.emptySet();
     leafQueueNames = Collections.emptySet();
     preemptableQueues = Collections.emptyMap();
@@ -334,14 +333,14 @@ public class ProportionalCapacityPreemptionPolicy
   public synchronized void editSchedule() {
     updateConfigIfNeeded();
 
-    long startTs = clock.getTime();
+    long startTs = clock.millis();
 
     CSQueue root = scheduler.getRootQueue();
     Resource clusterResources = Resources.clone(scheduler.getClusterResource());
     containerBasedPreemptOrKill(root, clusterResources);
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Total time used=" + (clock.getTime() - startTs) + " ms.");
+      LOG.debug("Total time used=" + (clock.millis() - startTs) + " ms.");
     }
   }
 
@@ -504,7 +503,7 @@ public class ProportionalCapacityPreemptionPolicy
         LOG.debug(MessageFormat
             .format("Trying to use {0} to select preemption candidates",
                 selector.getClass().getName()));
-        startTime = clock.getTime();
+        startTime = clock.millis();
       }
       Map<ApplicationAttemptId, Set<RMContainer>> curCandidates =
           selector.selectCandidates(toPreempt, clusterResources,
@@ -514,7 +513,7 @@ public class ProportionalCapacityPreemptionPolicy
       if (LOG.isDebugEnabled()) {
         LOG.debug(MessageFormat
             .format("{0} uses {1} millisecond to run",
-                selector.getClass().getName(), clock.getTime() - startTime));
+                selector.getClass().getName(), clock.millis() - startTime));
         int totalSelected = 0;
         int curSelected = 0;
         for (Set<RMContainer> set : toPreempt.values()) {
@@ -547,7 +546,7 @@ public class ProportionalCapacityPreemptionPolicy
     // containers. The bottom line is, we shouldn't preempt a queue which is already
     // below its guaranteed resource.
 
-    long currentTime = clock.getTime();
+    long currentTime = clock.millis();
 
     pcsMap = toPreemptPerSelector;
 
@@ -661,7 +660,7 @@ public class ProportionalCapacityPreemptionPolicy
   // plotting)
   private void logToCSV(List<String> leafQueueNames){
     Collections.sort(leafQueueNames);
-    String queueState = " QUEUESTATE: " + clock.getTime();
+    String queueState = " QUEUESTATE: " + clock.millis();
     StringBuilder sb = new StringBuilder();
     sb.append(queueState);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/ReservationInvariantsChecker.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/invariants/ReservationInvariantsChecker.java
@@ -18,11 +18,11 @@
 package org.apache.hadoop.yarn.server.resourcemanager.monitor.invariants;
 
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.Plan;
-import org.apache.hadoop.util.UTCClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Collection;
 
 /**
@@ -33,7 +33,7 @@ public class ReservationInvariantsChecker extends InvariantsChecker {
   private static final Logger LOG =
       LoggerFactory.getLogger(ReservationInvariantsChecker.class);
 
-  private UTCClock clock = new UTCClock();
+  private Clock clock = Clock.systemUTC();
 
   @Override
   public void editSchedule() {
@@ -43,7 +43,7 @@ public class ReservationInvariantsChecker extends InvariantsChecker {
     try {
       for (Plan plan : plans) {
         long currReservations =
-            plan.getReservationsAtTime(clock.getTime()).size();
+            plan.getReservationsAtTime(clock.millis()).size();
         long numberReservationQueues = getContext().getScheduler()
             .getQueueInfo(plan.getQueueName(), true, false).getChildQueues()
             .size();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/ZKRMStateStore.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.yarn.server.resourcemanager.recovery;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.curator.framework.CuratorFramework;
@@ -72,6 +70,7 @@ import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -236,7 +235,7 @@ public class ZKRMStateStore extends RMStateStore {
   /** Manager for the ZooKeeper connection. */
   private ZKCuratorManager zkManager;
 
-  private volatile Clock clock = SystemClock.getInstance();
+  private volatile Clock clock = Clock.systemUTC();
   @VisibleForTesting
   protected ZKRMStateStoreOpDurations opDurations;
 
@@ -526,7 +525,7 @@ public class ZKRMStateStore extends RMStateStore {
 
   @Override
   public synchronized RMState loadState() throws Exception {
-    long start = clock.getTime();
+    long start = clock.millis();
     RMState rmState = new RMState();
     // recover DelegationTokenSecretManager
     loadRMDTSecretManagerState(rmState);
@@ -538,7 +537,7 @@ public class ZKRMStateStore extends RMStateStore {
     loadReservationSystemState(rmState);
     // recover ProxyCAManager state
     loadProxyCAManagerState(rmState);
-    opDurations.addLoadStateCallDuration(clock.getTime() - start);
+    opDurations.addLoadStateCallDuration(clock.millis() - start);
     return rmState;
   }
 
@@ -844,7 +843,7 @@ public class ZKRMStateStore extends RMStateStore {
   @Override
   public synchronized void storeApplicationStateInternal(ApplicationId appId,
       ApplicationStateData appStateDataPB) throws Exception {
-    long start = clock.getTime();
+    long start = clock.millis();
     String nodeCreatePath = getLeafAppIdNodePath(appId.toString(), true);
 
     LOG.debug("Storing info for app: {} at: {}", appId, nodeCreatePath);
@@ -861,14 +860,14 @@ public class ZKRMStateStore extends RMStateStore {
           + " exceeds the maximum allowed size for application data. "
           + "See yarn.resourcemanager.zk-max-znode-size.bytes.");
     }
-    opDurations.addStoreApplicationStateCallDuration(clock.getTime() - start);
+    opDurations.addStoreApplicationStateCallDuration(clock.millis() - start);
   }
 
   @Override
   protected synchronized void updateApplicationStateInternal(
       ApplicationId appId, ApplicationStateData appStateDataPB)
       throws Exception {
-    long start = clock.getTime();
+    long start = clock.millis();
     String nodeUpdatePath = getLeafAppIdNodePath(appId.toString(), false);
     boolean pathExists = true;
     // Look for paths based on other split indices if path as per split index
@@ -905,7 +904,7 @@ public class ZKRMStateStore extends RMStateStore {
       LOG.debug("Path {} for {} didn't exist. Creating a new znode to update"
           + " the application state.", nodeUpdatePath, appId);
     }
-    opDurations.addUpdateApplicationStateCallDuration(clock.getTime() - start);
+    opDurations.addUpdateApplicationStateCallDuration(clock.millis() - start);
   }
 
   /*
@@ -990,10 +989,10 @@ public class ZKRMStateStore extends RMStateStore {
   @Override
   protected synchronized void removeApplicationStateInternal(
       ApplicationStateData appState) throws Exception {
-    long start = clock.getTime();
+    long start = clock.millis();
     removeApp(appState.getApplicationSubmissionContext().
         getApplicationId().toString(), true, appState.attempts.keySet());
-    opDurations.addRemoveApplicationStateCallDuration(clock.getTime() - start);
+    opDurations.addRemoveApplicationStateCallDuration(clock.millis() - start);
   }
 
   private void removeApp(String removeAppId) throws Exception {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/AbstractReservationSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/AbstractReservationSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -54,8 +55,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedule
 import org.apache.hadoop.yarn.server.resourcemanager.security.CapacityReservationsACLsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.FairReservationsACLsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.security.ReservationsACLsManager;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +80,7 @@ public abstract class AbstractReservationSystem extends AbstractService
 
   private boolean initialized = false;
 
-  private final Clock clock = new UTCClock();
+  private final Clock clock = Clock.systemUTC();
 
   private AtomicLong resCounter = new AtomicLong();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/AbstractSchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/AbstractSchedulerPlanFollower.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,7 +36,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Queue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.YarnScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.QueueEntitlement;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.slf4j.Logger;
@@ -76,7 +76,7 @@ public abstract class AbstractSchedulerPlanFollower implements PlanFollower {
     LOG.debug("Running plan follower edit policy for plan: {}", planQueueName);
     // align with plan step
     long step = plan.getStep();
-    long now = clock.getTime();
+    long now = clock.millis();
     if (now % step != 0) {
       now += step - (now % step);
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/CapacitySchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/CapacitySchedulerPlanFollower.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
 
@@ -34,7 +35,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.PlanQueu
 
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity
     .ReservationQueue;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/FairSchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/FairSchedulerPlanFollower.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,7 +30,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSLeafQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSParentQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
-import org.apache.hadoop.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/InMemoryPlan.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/InMemoryPlan.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,8 +42,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.exceptions.Plan
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.planning.Planner;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.planning.ReservationAgent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.slf4j.Logger;
@@ -115,7 +114,7 @@ public class InMemoryPlan implements Plan {
       long maxPeriodicity, RMContext rmContext) {
     this(queueMetrics, policy, agent, totalCapacity, step, resCalc, minAlloc,
         maxAlloc, queueName, replanner, getMoveOnExpiry, maxPeriodicity,
-        rmContext, new UTCClock());
+        rmContext, Clock.systemUTC());
   }
 
   @SuppressWarnings("checkstyle:parameternumber")
@@ -347,7 +346,7 @@ public class InMemoryPlan implements Plan {
       if (!isRecovering) {
         policy.validate(this, inMemReservation);
         // we record here the time in which the allocation has been accepted
-        reservation.setAcceptanceTimestamp(clock.getTime());
+        reservation.setAcceptanceTimestamp(clock.millis());
         if (rmStateStore != null) {
           rmStateStore.storeNewReservation(
               ReservationSystemUtil.buildStateProto(inMemReservation),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/PlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/PlanFollower.java
@@ -17,10 +17,10 @@
  *******************************************************************************/
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.Collection;
 
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
-import org.apache.hadoop.util.Clock;
 
 /**
  * A PlanFollower is a component that runs on a timer, and synchronizes the

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/ReservationInputValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/ReservationInputValidator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation;
 
+import java.time.Clock;
 import java.util.List;
 
 import org.apache.hadoop.yarn.api.protocolrecords.ReservationDeleteRequest;
@@ -35,7 +36,6 @@ import org.apache.hadoop.yarn.ipc.RPCUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.RMAuditLogger;
 import org.apache.hadoop.yarn.server.resourcemanager.RMAuditLogger.AuditConstants;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.Queue;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 public class ReservationInputValidator {
@@ -84,7 +84,7 @@ public class ReservationInputValidator {
           "validate reservation input definition", "ClientRMService", message);
       throw RPCUtil.getRemoteException(message);
     }
-    if (contract.getDeadline() <= clock.getTime()) {
+    if (contract.getDeadline() <= clock.millis()) {
       message = "The specified deadline: " + contract.getDeadline()
           + " is the past. Please try again with deadline in the future.";
       RMAuditLogger.logFailure("UNKNOWN", auditConstant,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/planning/SimpleCapacityReplanner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/planning/SimpleCapacityReplanner.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.reservation.planning;
 
+import java.time.Clock;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -32,8 +33,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.Plan;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationAllocation;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationSchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.exceptions.PlanningException;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
@@ -62,7 +61,7 @@ public class SimpleCapacityReplanner implements Planner {
   private long lengthOfCheckZone;
 
   public SimpleCapacityReplanner() {
-    this(new UTCClock());
+    this(Clock.systemUTC());
   }
 
   @VisibleForTesting
@@ -87,7 +86,7 @@ public class SimpleCapacityReplanner implements Planner {
 
     ResourceCalculator resCalc = plan.getResourceCalculator();
     Resource totCap = plan.getTotalCapacity();
-    long now = clock.getTime();
+    long now = clock.millis();
 
     // loop on all moment in time from now to the end of the check Zone
     // or the end of the planned sessions whichever comes first

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.rmapp;
 
 import java.net.InetAddress;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -106,8 +107,6 @@ import org.apache.hadoop.yarn.state.MultipleArcTransition;
 import org.apache.hadoop.yarn.state.SingleArcTransition;
 import org.apache.hadoop.yarn.state.StateMachine;
 import org.apache.hadoop.yarn.state.StateMachineFactory;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.Times;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
@@ -435,7 +434,7 @@ public class RMAppImpl implements RMApp, Recoverable {
       long submitTime, String applicationType, Set<String> applicationTags,
       List<ResourceRequest> amReqs, ApplicationPlacementContext
       placementContext, long startTime) {
-    this.systemClock = SystemClock.getInstance();
+    this.systemClock = Clock.systemUTC();
 
     this.applicationId = applicationId;
     this.name = StringInterner.weakIntern(name);
@@ -452,7 +451,7 @@ public class RMAppImpl implements RMApp, Recoverable {
     this.masterService = masterService;
     this.submitTime = submitTime;
     if (startTime <= 0) {
-      this.startTime = this.systemClock.getTime();
+      this.startTime = this.systemClock.millis();
     } else {
       this.startTime = startTime;
     }
@@ -806,7 +805,7 @@ public class RMAppImpl implements RMApp, Recoverable {
           timeout.setRemainingTime(0);
         } else {
           timeout.setRemainingTime(
-              Math.max((timeoutInMillis - systemClock.getTime()) / 1000, 0));
+              Math.max((timeoutInMillis - systemClock.millis()) / 1000, 0));
         }
       }
       report.setApplicationTimeouts(
@@ -1046,7 +1045,7 @@ public class RMAppImpl implements RMApp, Recoverable {
 
     public void transition(RMAppImpl app, RMAppEvent event) {
       app.rmContext.getSystemMetricsPublisher().appStateUpdated(
-          app, stateToATS, app.systemClock.getTime());
+          app, stateToATS, app.systemClock.millis());
     };
   }
 
@@ -1144,7 +1143,7 @@ public class RMAppImpl implements RMApp, Recoverable {
         app.rmContext.getRMAppLifetimeMonitor().registerApp(app.applicationId,
             timeout.getKey(), timeout.getValue());
         if (LOG.isDebugEnabled()) {
-          long remainingTime = timeout.getValue() - app.systemClock.getTime();
+          long remainingTime = timeout.getValue() - app.systemClock.millis();
           LOG.debug("Application " + app.applicationId
               + " is registered for timeout monitor, type=" + timeout.getKey()
               + " remaining timeout=" + (remainingTime > 0 ?
@@ -1308,7 +1307,7 @@ public class RMAppImpl implements RMApp, Recoverable {
       RMAppState stateToBeStored) {
     rememberTargetTransitions(event, transitionToDo, targetFinalState);
     this.stateBeforeFinalSaving = getState();
-    this.storedFinishTime = this.systemClock.getTime();
+    this.storedFinishTime = this.systemClock.millis();
 
     LOG.info("Updating application " + this.applicationId
         + " with final state: " + this.targetedFinalState);
@@ -1536,11 +1535,11 @@ public class RMAppImpl implements RMApp, Recoverable {
 
     private void handleAppFinished(RMAppImpl app) {
       app.logAggregation
-          .recordLogAggregationStartTime(app.systemClock.getTime());
+          .recordLogAggregationStartTime(app.systemClock.millis());
       // record finish time
       app.finishTime = app.storedFinishTime;
       if (app.finishTime == 0) {
-        app.finishTime = app.systemClock.getTime();
+        app.finishTime = app.systemClock.millis();
       }
 
       //record finish in history and metrics
@@ -1638,7 +1637,7 @@ public class RMAppImpl implements RMApp, Recoverable {
         ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(
             app.getApplicationId(), app.firstAttemptIdInStateStore);
         RMAppAttempt rmAppAttempt = app.getRMAppAttempt(attemptId);
-        long endTime = app.systemClock.getTime();
+        long endTime = app.systemClock.millis();
         if (rmAppAttempt.getFinishTime() < (endTime
             - app.attemptFailuresValidityInterval)) {
           app.firstAttemptIdInStateStore++;
@@ -1836,7 +1835,7 @@ public class RMAppImpl implements RMApp, Recoverable {
     String appViewACLs = submissionContext.getAMContainerSpec()
         .getApplicationACLs().get(ApplicationAccessType.VIEW_APP);
     rmContext.getSystemMetricsPublisher().appACLsUpdated(
-        this, appViewACLs, systemClock.getTime());
+        this, appViewACLs, systemClock.millis());
   }
 
   @Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppLogAggregation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppLogAggregation.java
@@ -94,7 +94,7 @@ public class RMAppLogAggregation {
     this.readLock.lock();
     try {
       if (!isLogAggregationFinished() && RMAppImpl.isAppInFinalState(rmApp) &&
-          rmApp.getSystemClock().getTime() > this.logAggregationStartTime
+          rmApp.getSystemClock().millis() > this.logAggregationStartTime
               + this.logAggregationStatusTimeout) {
         for (Map.Entry<NodeId, LogAggregationReport> output :
             logAggregationStatus.entrySet()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/AMLivelinessMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/AMLivelinessMonitor.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.Event;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.AbstractLivelinessMonitor;
-import org.apache.hadoop.util.Clock;
+
+import java.time.Clock;
 
 import java.util.concurrent.TimeUnit;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/monitor/RMAppLifetimeMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/monitor/RMAppLifetimeMonitor.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.rmapp.monitor;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -33,7 +34,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppEventType;
 import org.apache.hadoop.yarn.util.AbstractLivelinessMonitor;
-import org.apache.hadoop.util.SystemClock;
 
 /**
  * This service will monitor the applications against the lifetime value given.
@@ -48,7 +48,7 @@ public class RMAppLifetimeMonitor
   private RMContext rmContext;
 
   public RMAppLifetimeMonitor(RMContext rmContext) {
-    super(RMAppLifetimeMonitor.class.getName(), SystemClock.getInstance());
+    super(RMAppLifetimeMonitor.class.getName(), Clock.systemUTC());
     this.rmContext = rmContext;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -109,8 +110,6 @@ import org.apache.hadoop.yarn.server.scheduler.OpportunisticContainerContext;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.utils.Lock;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.Resources;
@@ -202,7 +201,7 @@ public abstract class AbstractYarnScheduler
    */
   public AbstractYarnScheduler(String name) {
     super(name);
-    clock = SystemClock.getInstance();
+    clock = Clock.systemUTC();
     ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     readLock = lock.readLock();
     writeLock = lock.writeLock();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
@@ -17,6 +17,7 @@
 */
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -86,7 +87,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.policy.Schedulabl
 import org.apache.hadoop.yarn.server.scheduler.OpportunisticContainerContext;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.state.InvalidStateTransitionException;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
@@ -245,7 +245,7 @@ public class SchedulerApplicationAttempt implements SchedulableEntity {
     ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     readLock = lock.readLock();
     writeLock = lock.writeLock();
-    startTime = SystemClock.getInstance().getTime();
+    startTime = Clock.systemUTC().millis();
   }
 
   public void setOpportunisticContainerContext(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/ActivitiesManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/ActivitiesManager.java
@@ -41,10 +41,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplicat
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ActivitiesInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppActivitiesInfo;
-import org.apache.hadoop.util.SystemClock;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
+import java.time.Clock;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -250,7 +250,7 @@ public class ActivitiesManager extends AbstractService {
 
   public void turnOnAppActivitiesRecording(ApplicationId applicationId,
       double maxTime) {
-    long startTS = SystemClock.getInstance().getTime();
+    long startTS = Clock.systemUTC().millis();
     long endTS = startTS + (long) (maxTime * 1000);
     recordingAppActivitiesUntilSpecifiedTime.put(applicationId, endTS);
   }
@@ -301,7 +301,7 @@ public class ActivitiesManager extends AbstractService {
         while (!stopped && !Thread.currentThread().isInterrupted()) {
           Iterator<Map.Entry<NodeId, List<NodeAllocation>>> ite =
               completedNodeAllocations.entrySet().iterator();
-          long curTS = SystemClock.getInstance().getTime();
+          long curTS = Clock.systemUTC().millis();
           while (ite.hasNext()) {
             Map.Entry<NodeId, List<NodeAllocation>> nodeAllocation = ite.next();
             List<NodeAllocation> allocations = nodeAllocation.getValue();
@@ -454,7 +454,7 @@ public class ActivitiesManager extends AbstractService {
   void finishAppAllocationRecording(ApplicationId applicationId,
       ContainerId containerId, ActivityState appState, String diagnostic) {
     if (shouldRecordThisApp(applicationId)) {
-      long currTS = SystemClock.getInstance().getTime();
+      long currTS = Clock.systemUTC().millis();
       AppAllocation appAllocation = appsAllocation.get().remove(applicationId);
       appAllocation.updateAppContainerStateAndTime(containerId, appState,
           currTS, diagnostic);
@@ -485,7 +485,7 @@ public class ActivitiesManager extends AbstractService {
 
   void finishNodeUpdateRecording(NodeId nodeID, String partition) {
     List<NodeAllocation> value = recordingNodesAllocation.get().get(nodeID);
-    long timestamp = SystemClock.getInstance().getTime();
+    long timestamp = Clock.systemUTC().millis();
 
     if (value != null) {
       if (value.size() > 0) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -81,7 +82,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.policy.IteratorSe
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.policy.OrderingPolicy;
 import org.apache.hadoop.yarn.server.utils.Lock;
 import org.apache.hadoop.yarn.server.utils.Lock.NoLock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 import org.apache.hadoop.classification.VisibleForTesting;
@@ -1104,7 +1104,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
 
         if (null != application) {
           ActivitiesLogger.APP.startAppAllocationRecording(activitiesManager,
-              node, SystemClock.getInstance().getTime(), application);
+              node, Clock.systemUTC().millis(), application);
           CSAssignment assignment = application.assignContainers(
               clusterResource, candidates, currentResourceLimits,
               schedulingMode, reservedContainer);
@@ -1213,7 +1213,7 @@ public class AbstractLeafQueue extends AbstractCSQueue {
       FiCaSchedulerApp application = assignmentIterator.next();
 
       ActivitiesLogger.APP.startAppAllocationRecording(activitiesManager,
-          node, SystemClock.getInstance().getTime(), application);
+          node, Clock.systemUTC().millis(), application);
 
       // Check queue max-capacity limit
       Resource appReserved = application.getCurrentReservation();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueDeletionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedQueueDeletionPolicy.java
@@ -24,11 +24,11 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.monitor.SchedulingEditPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AutoCreatedQueueDeletionEvent;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Clock;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -109,13 +109,13 @@ public class AutoCreatedQueueDeletionPolicy implements SchedulingEditPolicy {
 
   @Override
   public void editSchedule() {
-    long startTs = clock.getTime();
+    long startTs = clock.millis();
 
     prepareForAutoDeletion();
     triggerAutoDeletionForExpiredQueues();
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Total time used=" + (clock.getTime() - startTs) + " ms.");
+      LOG.debug("Total time used=" + (clock.millis() - startTs) + " ms.");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerContext.java
@@ -31,8 +31,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.preempti
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
+
+import java.time.Clock;
 
 /**
  * Read-only interface to {@link CapacityScheduler} context.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueConfigurationAutoRefreshPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueConfigurationAutoRefreshPolicy.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.monitor.SchedulingEditPolic
 import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 
 import java.io.IOException;
+import java.time.Clock;
 
 
 /**
@@ -72,7 +72,7 @@ public class QueueConfigurationAutoRefreshPolicy
    * Instantiated by CapacitySchedulerConfiguration.
    */
   public QueueConfigurationAutoRefreshPolicy() {
-    clock = new MonotonicClock();
+    clock = MonotonicClock.get();
   }
 
   @Override
@@ -104,7 +104,7 @@ public class QueueConfigurationAutoRefreshPolicy
 
   @Override
   public void editSchedule() {
-    long startTs = clock.getTime();
+    long startTs = clock.millis();
 
     try {
 
@@ -128,21 +128,21 @@ public class QueueConfigurationAutoRefreshPolicy
       lastModified =
           fs.getFileStatus(allocCsFile).getModificationTime();
 
-      long time = clock.getTime();
+      long time = clock.millis();
 
       if (lastModified > lastReloadAttempt &&
           time > lastReloadAttempt + monitoringInterval) {
         try {
           rmContext.getRMAdminService().refreshQueues();
           LOG.info("Queue auto refresh completed successfully");
-          lastReloadAttempt = clock.getTime();
+          lastReloadAttempt = clock.millis();
         } catch (IOException | YarnException e) {
           LOG.error("Can't refresh queue: " + e);
           if (!lastReloadAttemptFailed) {
             LOG.error("Failed to reload capacity scheduler config file - " +
                 "will use existing conf. Message: {}", e.getMessage());
           }
-          lastReloadAttempt = clock.getTime();
+          lastReloadAttempt = clock.millis();
           lastReloadAttemptFailed = true;
         }
 
@@ -160,7 +160,7 @@ public class QueueConfigurationAutoRefreshPolicy
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Total time used=" + (clock.getTime() - startTs) + " ms.");
+      LOG.debug("Total time used=" + (clock.millis() - startTs) + " ms.");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueManagementDynamicEditPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueManagementDynamicEditPolicy.java
@@ -33,10 +33,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler
 
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event
     .QueueManagementChangeEvent;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -69,7 +68,7 @@ public class QueueManagementDynamicEditPolicy implements SchedulingEditPolicy {
    * Instantiated by CapacitySchedulerConfiguration
    */
   public QueueManagementDynamicEditPolicy() {
-    clock = SystemClock.getInstance();
+    clock = Clock.systemUTC();
   }
 
   @SuppressWarnings("unchecked")
@@ -144,13 +143,13 @@ public class QueueManagementDynamicEditPolicy implements SchedulingEditPolicy {
 
   @Override
   public void editSchedule() {
-    long startTs = clock.getTime();
+    long startTs = clock.millis();
 
     initQueues();
     manageAutoCreatedLeafQueues();
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Total time used=" + (clock.getTime() - startTs) + " ms.");
+      LOG.debug("Total time used=" + (clock.millis() - startTs) + " ms.");
     }
   }
 
@@ -189,7 +188,7 @@ public class QueueManagementDynamicEditPolicy implements SchedulingEditPolicy {
           parentQueue.getAutoCreatedQueueManagementPolicy();
       long startTime = 0;
       try {
-        startTime = clock.getTime();
+        startTime = clock.millis();
 
         queueManagementChanges = policyClazz.computeQueueManagementChanges();
 
@@ -204,7 +203,7 @@ public class QueueManagementDynamicEditPolicy implements SchedulingEditPolicy {
 
         if (LOG.isDebugEnabled()) {
           LOG.debug("{} uses {} millisecond" + " to run",
-              policyClazz.getClass().getName(), clock.getTime() - startTime);
+              policyClazz.getClass().getName(), clock.millis() - startTime);
           if (queueManagementChanges.size() > 0) {
             LOG.debug(" Updated queue management changes for parent queue" + " "
                     + "{}: [{}]", parentQueue.getQueuePath(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/queuemanagement/GuaranteedOrZeroCapacityOverTimePolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/queuemanagement/GuaranteedOrZeroCapacityOverTimePolicy.java
@@ -35,11 +35,11 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.ManagedP
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueueCapacities;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueueManagementChange;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -85,7 +85,7 @@ public class GuaranteedOrZeroCapacityOverTimePolicy
 
   private LeafQueueState leafQueueState = new LeafQueueState();
 
-  private Clock clock = new MonotonicClock();
+  private Clock clock = MonotonicClock.get();
 
   private class LeafQueueState {
 
@@ -170,13 +170,13 @@ public class GuaranteedOrZeroCapacityOverTimePolicy
 
     private boolean activate() {
       boolean ret = isActive.compareAndSet(false, true);
-      mostRecentActivationTime = clock.getTime();
+      mostRecentActivationTime = clock.millis();
       return ret;
     }
 
     private boolean deactivate() {
       boolean ret = isActive.compareAndSet(true, false);
-      mostRecentDeactivationTime = clock.getTime();
+      mostRecentDeactivationTime = clock.millis();
       return ret;
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/AllocationFileLoaderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/AllocationFileLoaderService.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,8 +48,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocation.AllocationFileParser;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocation.AllocationFileQueueParser;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocation.QueueProperties;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.SystemClock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +101,7 @@ public class AllocationFileLoaderService extends AbstractService {
   private volatile boolean running = true;
 
   public AllocationFileLoaderService(FairScheduler scheduler) {
-    this(SystemClock.getInstance(), scheduler);
+    this(Clock.systemUTC(), scheduler);
   }
 
   private List<Permission> defaultPermissions;
@@ -124,7 +123,7 @@ public class AllocationFileLoaderService extends AbstractService {
             synchronized (this) {
               reloadListener.onCheck();
             }
-            long time = clock.getTime();
+            long time = clock.millis();
             long lastModified =
                 fs.getFileStatus(allocFile).getModificationTime();
             if (lastModified > lastSuccessfulReload &&
@@ -275,7 +274,7 @@ public class AllocationFileLoaderService extends AbstractService {
     AllocationConfiguration info = new AllocationConfiguration(queueProperties,
         allocationFileParser, globalReservationQueueConfig);
 
-    lastSuccessfulReload = clock.getTime();
+    lastSuccessfulReload = clock.millis();
     lastReloadAttemptFailed = false;
 
     reloadListener.onReload(info);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSAppAttempt.java
@@ -122,7 +122,7 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
     super(applicationAttemptId, user, queue, activeUsersManager, rmContext);
 
     this.scheduler = scheduler;
-    this.startTime = scheduler.getClock().getTime();
+    this.startTime = scheduler.getClock().millis();
     this.lastTimeAtFairShare = this.startTime;
     this.appPriority = Priority.newInstance(1);
     this.enableAMPreemption = scheduler.getConf()
@@ -994,7 +994,7 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
           allowedLocality = getAllowedLocalityLevelByTime(schedulerKey,
               scheduler.getNodeLocalityDelayMs(),
               scheduler.getRackLocalityDelayMs(),
-              scheduler.getClock().getTime());
+              scheduler.getClock().millis());
         } else {
           allowedLocality = getAllowedLocalityLevel(schedulerKey,
               scheduler.getNumClusterNodes(),
@@ -1159,7 +1159,7 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
    * @return freshly computed fairshare starvation
    */
   Resource fairShareStarvation() {
-    long now = scheduler.getClock().getTime();
+    long now = scheduler.getClock().millis();
     Resource threshold = Resources.multiply(
         getFairShare(), getQueue().getFairSharePreemptionThreshold());
     Resource fairDemand = Resources.componentwiseMin(threshold, demand);
@@ -1272,14 +1272,14 @@ public class FSAppAttempt extends SchedulerApplicationAttempt
    */
   void preemptionTriggered(long delayBeforeNextStarvationCheck) {
     nextStarvationCheck =
-        scheduler.getClock().getTime() + delayBeforeNextStarvationCheck;
+        scheduler.getClock().millis() + delayBeforeNextStarvationCheck;
   }
 
   /**
    * Whether this app's starvation should be considered.
    */
   boolean shouldCheckForStarvation() {
-    return scheduler.getClock().getTime() >= nextStarvationCheck;
+    return scheduler.getClock().millis() >= nextStarvationCheck;
   }
 
   /* Schedulable methods implementation */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FSLeafQueue.java
@@ -81,7 +81,7 @@ public class FSLeafQueue extends FSQueue {
       FSParentQueue parent) {
     super(name, scheduler, parent);
     this.context = scheduler.getContext();
-    this.lastTimeAtMinShare = scheduler.getClock().getTime();
+    this.lastTimeAtMinShare = scheduler.getClock().millis();
     activeUsersManager = new ActiveUsersManager(getMetrics());
     amResourceUsage = Resource.newInstance(0, 0);
     getMetrics().setAMResourceUsage(amResourceUsage);
@@ -599,7 +599,7 @@ public class FSLeafQueue extends FSQueue {
     Resources.subtractFromNonNegative(starvation, getResourceUsage());
 
     boolean starved = !Resources.isNone(starvation);
-    long now = scheduler.getClock().getTime();
+    long now = scheduler.getClock().millis();
 
     if (!starved) {
       // Record that the queue is not starved

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/FairScheduler.java
@@ -357,7 +357,7 @@ public class FairScheduler extends
   @Override
   public void update() {
     // Storing start time for fsOpDurations
-    long start = getClock().getTime();
+    long start = getClock().millis();
     FSQueue rootQueue = queueMgr.getRootQueue();
 
     // Update demands and fairshares
@@ -392,7 +392,7 @@ public class FairScheduler extends
     } finally {
       readLock.unlock();
     }
-    fsOpDurations.addUpdateThreadRunDuration(getClock().getTime() - start);
+    fsOpDurations.addUpdateThreadRunDuration(getClock().millis() - start);
   }
 
   public RMContainerTokenSecretManager
@@ -928,7 +928,7 @@ public class FairScheduler extends
     // TODO, normalize SchedulingRequest
 
     // Record container allocation start time
-    application.recordContainerRequestTime(getClock().getTime());
+    application.recordContainerRequestTime(getClock().millis());
 
     // Release containers
     releaseContainers(release, application);
@@ -977,7 +977,7 @@ public class FairScheduler extends
         application.pullNewlyAllocatedContainers();
     // Record container allocation time
     if (!(newlyAllocatedContainers.isEmpty())) {
-      application.recordContainerAllocationTime(getClock().getTime());
+      application.recordContainerAllocationTime(getClock().millis());
     }
 
     Resource headroom = application.getHeadroom();
@@ -1026,13 +1026,13 @@ public class FairScheduler extends
   protected void nodeUpdate(RMNode nm) {
     writeLock.lock();
     try {
-      long start = getClock().getTime();
+      long start = getClock().millis();
       super.nodeUpdate(nm);
 
       FSSchedulerNode fsNode = getFSSchedulerNode(nm.getNodeID());
       attemptScheduling(fsNode);
 
-      long duration = getClock().getTime() - start;
+      long duration = getClock().millis() - start;
       fsOpDurations.addNodeUpdateDuration(duration);
     } finally {
       writeLock.unlock();
@@ -1041,7 +1041,7 @@ public class FairScheduler extends
 
   @Deprecated
   void continuousSchedulingAttempt() throws InterruptedException {
-    long start = getClock().getTime();
+    long start = getClock().millis();
     TreeSet<FSSchedulerNode> nodeIdSet;
     // Hold a lock to prevent node changes as much as possible.
     readLock.lock();
@@ -1071,7 +1071,7 @@ public class FairScheduler extends
       }
     }
 
-    long duration = getClock().getTime() - start;
+    long duration = getClock().millis() - start;
     fsOpDurations.addContinuousSchedulingRunDuration(duration);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AppActivitiesInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/AppActivitiesInfo.java
@@ -24,11 +24,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.activities.AppAllocation;
-import org.apache.hadoop.util.SystemClock;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -54,7 +54,7 @@ public class AppActivitiesInfo {
   public AppActivitiesInfo(String errorMessage, String applicationId) {
     this.diagnostic = errorMessage;
     this.applicationId = applicationId;
-    setTime(SystemClock.getInstance().getTime());
+    setTime(Clock.systemUTC().millis());
   }
 
   public AppActivitiesInfo(List<AppAllocation> appAllocations,
@@ -65,7 +65,7 @@ public class AppActivitiesInfo {
 
     if (appAllocations == null) {
       diagnostic = "waiting for display";
-      setTime(SystemClock.getInstance().getTime());
+      setTime(Clock.systemUTC().millis());
     } else {
       for (int i = appAllocations.size() - 1; i > -1; i--) {
         AppAllocation appAllocation = appAllocations.get(i);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestClientRMService.java
@@ -50,6 +50,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -186,8 +187,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.timelineservice.RMTimelineC
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
@@ -1804,8 +1803,8 @@ public class TestClientRMService {
   public void testCreateReservation() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -1821,7 +1820,7 @@ public class TestClientRMService {
 
     // Submit the reservation with the same reservation id but different
     // reservation definition, and ensure YarnException is thrown.
-    arrival = clock.getTime();
+    arrival = clock.millis();
     ReservationDefinition rDef = sRequest.getReservationDefinition();
     rDef.setArrival(arrival + duration);
     sRequest.setReservationDefinition(rDef);
@@ -1839,8 +1838,8 @@ public class TestClientRMService {
   public void testUpdateReservation() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -1851,7 +1850,7 @@ public class TestClientRMService {
         rDef.getReservationRequests().getReservationResources().get(0);
     ReservationId reservationID = sRequest.getReservationId();
     rr.setNumContainers(5);
-    arrival = clock.getTime();
+    arrival = clock.millis();
     duration = 30000;
     deadline = (long) (arrival + 1.05 * duration);
     rr.setDuration(duration);
@@ -1873,8 +1872,8 @@ public class TestClientRMService {
   public void testListReservationsByReservationId() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -1902,8 +1901,8 @@ public class TestClientRMService {
   public void testListReservationsByTimeInterval() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -1911,7 +1910,7 @@ public class TestClientRMService {
 
     // List reservations, search by a point in time within the reservation
     // range.
-    arrival = clock.getTime();
+    arrival = clock.millis();
     ReservationId reservationID = sRequest.getReservationId();
     ReservationListRequest request = ReservationListRequest.newInstance(
         ReservationSystemTestUtil.reservationQ, "", arrival + duration / 2,
@@ -1959,8 +1958,8 @@ public class TestClientRMService {
   public void testListReservationsByInvalidTimeInterval() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -2001,8 +2000,8 @@ public class TestClientRMService {
   public void testListReservationsByTimeIntervalContainingNoReservations() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =
@@ -2043,7 +2042,7 @@ public class TestClientRMService {
     assertNotNull(response);
     assertThat(response.getReservationAllocationState()).isEmpty();
 
-    arrival = clock.getTime();
+    arrival = clock.millis();
     // List reservations, search by end time before the reservation start
     // time.
     request = ReservationListRequest.newInstance(
@@ -2081,8 +2080,8 @@ public class TestClientRMService {
   public void testReservationDelete() {
     resourceManager = setupResourceManager();
     ClientRMService clientService = resourceManager.getClientRMService();
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + 1.05 * duration);
     ReservationSubmissionRequest sRequest =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestReservationSystemWithRMHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestReservationSystemWithRMHA.java
@@ -37,11 +37,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationSyst
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.Map;
 
 public class TestReservationSystemWithRMHA extends RMHATestBase {
@@ -208,8 +207,8 @@ public class TestReservationSystemWithRMHA extends RMHATestBase {
 
   private ReservationSubmissionRequest createReservationSubmissionRequest(
       ReservationId reservationId) {
-    Clock clock = new UTCClock();
-    long arrival = clock.getTime();
+    Clock clock = Clock.systemUTC();
+    long arrival = clock.millis();
     long duration = 60000;
     long deadline = (long) (arrival + duration + 1500);
     return ReservationSystemTestUtil.createSimpleReservationRequest(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaS
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.ContainerPreemptEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEventType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.policy.OrderingPolicy;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
@@ -68,6 +67,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Deque;
@@ -299,17 +299,17 @@ public class TestProportionalCapacityPreemptionPolicy {
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
 
     // ensure all pending rsrc from A get preempted from other queues
-    when(mClock.getTime()).thenReturn(0L);
+    when(mClock.millis()).thenReturn(0L);
     policy.editSchedule();
     verify(mDisp, times(10)).handle(argThat(new IsPreemptionRequestFor(appC)));
 
     // requests reiterated
-    when(mClock.getTime()).thenReturn(killTime / 2);
+    when(mClock.millis()).thenReturn(killTime / 2);
     policy.editSchedule();
     verify(mDisp, times(10)).handle(argThat(new IsPreemptionRequestFor(appC)));
 
     // kill req sent
-    when(mClock.getTime()).thenReturn(killTime + 1);
+    when(mClock.millis()).thenReturn(killTime + 1);
     policy.editSchedule();
     verify(mDisp, times(20)).handle(evtCaptor.capture());
     List<ContainerPreemptEvent> events = evtCaptor.getAllValues();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/mockframework/ProportionalCapacityPreemptionPolicyMockFramework.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/mockframework/ProportionalCapacityPreemptionPolicyMockFramework.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.preempti
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.ContainerPreemptEvent;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
@@ -54,6 +53,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatcher;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacitySchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestCapacitySchedulerPlanFollower.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -48,7 +49,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueuePat
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.TestUtils;
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSecretManager;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestFairSchedulerPlanFollower.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestFairSchedulerPlanFollower.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -50,7 +51,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedule
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerTestBase;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
-import org.apache.hadoop.util.Clock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestInMemoryPlan.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestInMemoryPlan.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,8 +48,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.exceptions.Plan
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.planning.Planner;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.planning.ReservationAgent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
@@ -88,7 +87,7 @@ public class TestInMemoryPlan {
     policy = new NoOverCommitPolicy();
     replanner = mock(Planner.class);
 
-    when(clock.getTime()).thenReturn(1L);
+    when(clock.millis()).thenReturn(1L);
 
     context = ReservationSystemTestUtil.createMockRMContext();
   }
@@ -132,7 +131,7 @@ public class TestInMemoryPlan {
       maxPeriodicity = 100;
       Plan plan = new InMemoryPlan(queueMetrics, policy, agent, totalCapacity, 1L,
           resCalc, minAlloc, maxAlloc, planName, replanner, true, maxPeriodicity,
-          context, new UTCClock());
+          context, Clock.systemUTC());
 
       // we expect the plan to complaint as the range 330-150 > 50
       RLESparseResourceAllocation availableBefore =
@@ -146,7 +145,7 @@ public class TestInMemoryPlan {
     maxPeriodicity = 100;
     Plan plan = new InMemoryPlan(queueMetrics, policy, agent, totalCapacity, 1L,
         resCalc, minAlloc, maxAlloc, planName, replanner, true, maxPeriodicity,
-        context, new UTCClock());
+        context, Clock.systemUTC());
 
     ReservationId reservationID =
         ReservationSystemTestUtil.getNewReservationId();
@@ -530,12 +529,12 @@ public class TestInMemoryPlan {
     }
 
     // Now archive completed reservations
-    when(clock.getTime()).thenReturn(106L);
+    when(clock.millis()).thenReturn(106L);
     when(sharingPolicy.getValidWindow()).thenReturn(1L);
     try {
       // will only remove 2nd reservation as only that has fallen out of the
       // archival window
-      plan.archiveCompletedReservations(clock.getTime());
+      plan.archiveCompletedReservations(clock.millis());
     } catch (PlanningException e) {
       fail(e.getMessage());
     }
@@ -543,11 +542,11 @@ public class TestInMemoryPlan {
     assertNull(plan.getReservationById(reservationID2));
     checkAllocation(plan, alloc1, start, 0);
 
-    when(clock.getTime()).thenReturn(107L);
+    when(clock.millis()).thenReturn(107L);
     try {
       // will remove 1st reservation also as it has fallen out of the archival
       // window
-      plan.archiveCompletedReservations(clock.getTime());
+      plan.archiveCompletedReservations(clock.millis());
     } catch (PlanningException e) {
       fail(e.getMessage());
     }
@@ -934,7 +933,7 @@ public class TestInMemoryPlan {
     maxPeriodicity = period * periodMultiplier;
     Plan plan = new InMemoryPlan(queueMetrics, policy, agent, totalCapacity, 1L,
         resCalc, minAlloc, maxAlloc, planName, replanner, true, maxPeriodicity,
-        context, new UTCClock());
+        context, Clock.systemUTC());
 
     ReservationId reservationID = submitReservation(plan, reservationStart,
         reservationEnd, period);
@@ -955,7 +954,7 @@ public class TestInMemoryPlan {
     maxPeriodicity = period * periodMultiplier;
     Plan plan = new InMemoryPlan(queueMetrics, policy, agent, totalCapacity, 1L,
         resCalc, minAlloc, maxAlloc, planName, replanner, true, maxPeriodicity,
-        context, new UTCClock());
+        context, Clock.systemUTC());
     submitReservation(plan, reservationStart, reservationEnd, period);
 
     for (int i = 0; i < cycles; i++) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestReservationInputValidator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestReservationInputValidator.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.text.MessageFormat;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +52,6 @@ import org.apache.hadoop.yarn.api.records.impl.pb.ReservationDefinitionPBImpl;
 import org.apache.hadoop.yarn.api.records.impl.pb.ReservationRequestsPBImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +79,7 @@ public class TestReservationInputValidator {
     rSystem = mock(ReservationSystem.class);
     plans.put(PLAN_NAME, plan);
     rrValidator = new ReservationInputValidator(clock);
-    when(clock.getTime()).thenReturn(1L);
+    when(clock.millis()).thenReturn(1L);
     ResourceCalculator rCalc = new DefaultResourceCalculator();
     Resource resource = Resource.newInstance(10240, 10);
     when(plan.getResourceCalculator()).thenReturn(rCalc);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestSchedulerPlanFollowerBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/TestSchedulerPlanFollowerBase.java
@@ -41,9 +41,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAddedSch
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAttemptAddedSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAttemptRemovedSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
+
+import java.time.Clock;
 
 public abstract class TestSchedulerPlanFollowerBase {
   final static int GB = 1024;
@@ -98,7 +99,7 @@ public abstract class TestSchedulerPlanFollowerBase {
 
     AbstractSchedulerPlanFollower planFollower = createPlanFollower();
 
-    when(mClock.getTime()).thenReturn(0L);
+    when(mClock.millis()).thenReturn(0L);
     planFollower.run();
 
     Queue q = getReservationQueue(r1.toString());
@@ -132,7 +133,7 @@ public abstract class TestSchedulerPlanFollowerBase {
     assertReservationQueueDoesNotExist(r2);
     assertReservationQueueDoesNotExist(r3);
 
-    when(mClock.getTime()).thenReturn(3L);
+    when(mClock.millis()).thenReturn(3L);
     planFollower.run();
 
     assertEquals(0, getNumberOfApplications(defQ));
@@ -141,7 +142,7 @@ public abstract class TestSchedulerPlanFollowerBase {
     assertReservationQueueExists(r2, 0.1, 0.1);
     assertReservationQueueDoesNotExist(r3);
 
-    when(mClock.getTime()).thenReturn(10L);
+    when(mClock.millis()).thenReturn(10L);
     planFollower.run();
 
     q = getReservationQueue(r1.toString());
@@ -161,7 +162,7 @@ public abstract class TestSchedulerPlanFollowerBase {
     assertReservationQueueDoesNotExist(r2);
     assertReservationQueueExists(r3, 0, 1.0);
 
-    when(mClock.getTime()).thenReturn(11L);
+    when(mClock.millis()).thenReturn(11L);
     planFollower.run();
 
     if (isMove) {
@@ -175,14 +176,14 @@ public abstract class TestSchedulerPlanFollowerBase {
     assertReservationQueueDoesNotExist(r2);
     assertReservationQueueExists(r3, 0.1, 0.1);
 
-    when(mClock.getTime()).thenReturn(12L);
+    when(mClock.millis()).thenReturn(12L);
     planFollower.run();
 
     assertReservationQueueDoesNotExist(r1);
     assertReservationQueueDoesNotExist(r2);
     assertReservationQueueExists(r3, 0.2, 0.2);
 
-    when(mClock.getTime()).thenReturn(16L);
+    when(mClock.millis()).thenReturn(16L);
     planFollower.run();
 
     assertReservationQueueDoesNotExist(r1);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/planning/TestSimpleCapacityReplanner.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/planning/TestSimpleCapacityReplanner.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -45,7 +46,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.SharingPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.reservation.exceptions.PlanningException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.QueuePath;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.jupiter.api.Test;
@@ -69,7 +69,7 @@ public class TestSimpleCapacityReplanner {
 
     QueueMetrics queueMetrics = mock(QueueMetrics.class);
 
-    when(clock.getTime()).thenReturn(0L);
+    when(clock.millis()).thenReturn(0L);
     SimpleCapacityReplanner enf = new SimpleCapacityReplanner(clock);
 
     RMContext context = ReservationSystemTestUtil.createMockRMContext();
@@ -97,25 +97,25 @@ public class TestSimpleCapacityReplanner {
         new InMemoryReservationAllocation(r1, rDef, "u3",
         "dedicated", 0, 0 + f5.length, generateAllocation(0, f5), res,
         minAlloc), false), plan.toString());
-    when(clock.getTime()).thenReturn(1L);
+    when(clock.millis()).thenReturn(1L);
     ReservationId r2 = ReservationId.newInstance(ts, 2);
     assertTrue(plan.addReservation(
         new InMemoryReservationAllocation(r2, rDef, "u4",
         "dedicated", 0, 0 + f5.length, generateAllocation(0, f5), res,
         minAlloc), false), plan.toString());
-    when(clock.getTime()).thenReturn(2L);
+    when(clock.millis()).thenReturn(2L);
     ReservationId r3 = ReservationId.newInstance(ts, 3);
     assertTrue(plan.addReservation(
         new InMemoryReservationAllocation(r3, rDef, "u5",
         "dedicated", 0, 0 + f5.length, generateAllocation(0, f5), res,
         minAlloc), false), plan.toString());
-    when(clock.getTime()).thenReturn(3L);
+    when(clock.millis()).thenReturn(3L);
     ReservationId r4 = ReservationId.newInstance(ts, 4);
     assertTrue(plan.addReservation(
         new InMemoryReservationAllocation(r4, rDef, "u6",
         "dedicated", 0, 0 + f5.length, generateAllocation(0, f5), res,
         minAlloc), false), plan.toString());
-    when(clock.getTime()).thenReturn(4L);
+    when(clock.millis()).thenReturn(4L);
     ReservationId r5 = ReservationId.newInstance(ts, 5);
     assertTrue(plan.addReservation(new InMemoryReservationAllocation(r5, rDef, "u7",
         "dedicated", 0, 0 + f5.length, generateAllocation(0, f5), res,
@@ -127,7 +127,7 @@ public class TestSimpleCapacityReplanner {
         new InMemoryReservationAllocation(r6, rDef, "u3",
         "dedicated", 10, 10 + f6.length, generateAllocation(10, f6), res,
         minAlloc), false), plan.toString());
-    when(clock.getTime()).thenReturn(6L);
+    when(clock.millis()).thenReturn(6L);
     ReservationId r7 = ReservationId.newInstance(ts, 7);
     assertTrue(plan.addReservation(
         new InMemoryReservationAllocation(r7, rDef, "u4",
@@ -137,7 +137,7 @@ public class TestSimpleCapacityReplanner {
     // remove some of the resources (requires replanning)
     plan.setTotalCapacity(Resource.newInstance(70 * 1024, 70));
 
-    when(clock.getTime()).thenReturn(0L);
+    when(clock.millis()).thenReturn(0L);
 
     // run the replanner
     enf.plan(plan, null);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/TestActivitiesManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/activities/TestActivitiesManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.activities;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaS
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWSConsts;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.AppActivitiesInfo;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
-import org.apache.hadoop.yarn.util.SystemClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -83,6 +83,8 @@ public class TestActivitiesManager {
 
   private final static int NUM_THREADS = 5;
 
+  private Clock clock;
+
   private RMContext rmContext;
 
   private TestingActivitiesManager activitiesManager;
@@ -95,6 +97,7 @@ public class TestActivitiesManager {
 
   @BeforeEach
   public void setup() {
+    clock = Clock.systemUTC();
     rmContext = mock(RMContext.class);
     Configuration conf = new Configuration();
     when(rmContext.getYarnConfiguration()).thenReturn(conf);
@@ -234,7 +237,7 @@ public class TestActivitiesManager {
       Callable<Void> task = () -> {
         ActivitiesLogger.APP.startAppAllocationRecording(activitiesManager,
             (FiCaSchedulerNode) nodes.get(0),
-            SystemClock.getInstance().getTime(), randomApp);
+            clock.millis(), randomApp);
         for (SchedulerNode node : nodes) {
           ActivitiesLogger.APP
               .recordAppActivityWithoutAllocation(activitiesManager, node,
@@ -286,7 +289,7 @@ public class TestActivitiesManager {
     for (int i = 0; i < numActivities; i++) {
       ActivitiesLogger.APP
           .startAppAllocationRecording(newActivitiesManager, node,
-              SystemClock.getInstance().getTime(), app);
+              clock.millis(), app);
       ActivitiesLogger.APP
           .recordAppActivityWithoutAllocation(newActivitiesManager, node, app,
               new SchedulerRequestKey(Priority.newInstance(0), 0, null),
@@ -324,7 +327,7 @@ public class TestActivitiesManager {
     int testingTimes = 10;
     for (int ano = 0; ano < numActivities; ano++) {
       ActivitiesLogger.APP.startAppAllocationRecording(activitiesManager, node,
-          SystemClock.getInstance().getTime(), app);
+          clock.millis(), app);
       for (int i = 0; i < numNodes; i++) {
         NodeId nodeId = NodeId.newInstance("host" + i, 0);
         activitiesManager
@@ -467,9 +470,9 @@ public class TestActivitiesManager {
       Supplier<Void> supplier, int testingTimes) {
     long totalTime = 0;
     for (int i = 0; i < testingTimes; i++) {
-      long startTime = System.currentTimeMillis();
+      long startTime = clock.millis();
       supplier.get();
-      totalTime += System.currentTimeMillis() - startTime;
+      totalTime += clock.millis() - startTime;
     }
     System.out.println("#" + testingName + ", testing times : " + testingTimes
         + ", total cost time : " + totalTime + " ms, average cost time : "

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerPreemptionTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerPreemptionTestBase.java
@@ -32,8 +32,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainer;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode;
-import org.apache.hadoop.yarn.util.Clock;
 import org.junit.jupiter.api.BeforeEach;
+
+import java.time.Clock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -75,7 +76,7 @@ public class CapacitySchedulerPreemptionTestBase {
     mgr = new NullRMNodeLabelsManager();
     mgr.init(this.conf);
     clock = mock(Clock.class);
-    when(clock.getTime()).thenReturn(0L);
+    when(clock.millis()).thenReturn(0L);
   }
 
   SchedulingEditPolicy getSchedulingEditPolicy(MockRM rm) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCSMaxRunningAppsEnforcer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCSMaxRunningAppsEnforcer.java
@@ -130,7 +130,7 @@ public class TestCSMaxRunningAppsEnforcer {
         rmContext, Priority.newInstance(0), false,
         activitiesManager) {
 
-      private final long startTime = clock.getTime();
+      private final long startTime = clock.millis();
 
       @Override
       public long getStartTime() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestQueueConfigurationAutoRefreshPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestQueueConfigurationAutoRefreshPolicy.java
@@ -264,7 +264,7 @@ public class TestQueueConfigurationAutoRefreshPolicy  {
     assertTrue(maxAppsAfter != maxAppsBefore);
 
     // Trigger interval for refresh.
-    GenericTestUtils.waitFor(() -> (policy.getClock().getTime() -
+    GenericTestUtils.waitFor(() -> (policy.getClock().millis() -
             policy.getLastReloadAttempt()) / 1000 > 1,
         500, 3000);
 
@@ -289,7 +289,7 @@ public class TestQueueConfigurationAutoRefreshPolicy  {
         getMaximumSystemApplications(), 3000);
 
     // Trigger interval for refresh.
-    GenericTestUtils.waitFor(() -> (policy.getClock().getTime() -
+    GenericTestUtils.waitFor(() -> (policy.getClock().millis() -
           policy.getLastReloadAttempt()) / 1000 > 1,
         500, 3000);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestAllocationFileLoaderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestAllocationFileLoaderService.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocationfi
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.policies.DominantResourceFairnessPolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.policies.FairSharePolicy;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.CustomResourceTypesConfigurationProvider;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +55,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,7 +88,7 @@ public class TestAllocationFileLoaderService {
 
   @BeforeEach
   public void setup() {
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     PlacementManager placementManager = new PlacementManager();
     FairSchedulerConfiguration fsConf = new FairSchedulerConfiguration();
     RMContext rmContext = mock(RMContext.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSAppAttempt.java
@@ -154,37 +154,37 @@ public class TestFSAppAttempt extends FairSchedulerTestBase {
     // Default level should be node-local
     assertEquals(NodeType.NODE_LOCAL,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
 
     // after 4 seconds should remain node local
     clock.tickSec(4);
     assertEquals(NodeType.NODE_LOCAL,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
 
     // after 6 seconds should switch to rack local
     clock.tickSec(2);
     assertEquals(NodeType.RACK_LOCAL,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
 
     // manually set back to node local
     schedulerApp.resetAllowedLocalityLevel(prio, NodeType.NODE_LOCAL);
-    schedulerApp.resetSchedulingOpportunities(prio, clock.getTime());
+    schedulerApp.resetSchedulingOpportunities(prio, clock.millis());
     assertEquals(NodeType.NODE_LOCAL,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
 
     // Now escalate again to rack-local, then to off-switch
     clock.tickSec(6);
     assertEquals(NodeType.RACK_LOCAL,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
 
     clock.tickSec(7);
     assertEquals(NodeType.OFF_SWITCH,
             schedulerApp.getAllowedLocalityLevelByTime(prio,
-                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.getTime()));
+                    nodeLocalityDelayMs, rackLocalityDelayMs, clock.millis()));
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFSParentQueue.java
@@ -20,10 +20,11 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair;
 
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementManager;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -37,7 +38,7 @@ public class TestFSParentQueue {
   public void setUp() {
     FairSchedulerConfiguration conf = new FairSchedulerConfiguration();
     RMContext rmContext = mock(RMContext.class);
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     PlacementManager placementManager = new PlacementManager();
     FairScheduler scheduler = mock(FairScheduler.class);
     when(scheduler.getRMContext()).thenReturn(rmContext);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairScheduler.java
@@ -5314,7 +5314,7 @@ public class TestFairScheduler extends FairSchedulerTestBase {
         + " MaxAMShare: 0.5,"
         + " MaxAMResource: <memory:0, vCores:0>,"
         + " AMResourceUsage: <memory:0, vCores:0>,"
-        + " LastTimeAtMinShare: " + clock.getTime()
+        + " LastTimeAtMinShare: " + clock.millis()
         + "}";
 
     assertEquals(childQueueString, child1.dumpState(),

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerPreemption.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestFairSchedulerPreemption.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocationfile.AllocationFileQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.allocationfile.AllocationFileWriter;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -41,6 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -195,7 +195,7 @@ public class TestFairSchedulerPreemption extends FairSchedulerTestBase {
     scheduler = (FairScheduler) resourceManager.getResourceScheduler();
     // YARN-6249, FSLeafQueue#lastTimeAtMinShare is initialized to the time in
     // the real world, so we should keep the clock up with it.
-    clock.setTime(SystemClock.getInstance().getTime());
+    clock.setTime(Clock.systemUTC().millis());
     scheduler.setClock(clock);
     resourceManager.start();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueueManager.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.Set;
 
@@ -35,7 +36,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ActiveUsersManager;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +57,7 @@ public class TestQueueManager {
     FairSchedulerConfiguration conf = new FairSchedulerConfiguration();
     RMContext rmContext = mock(RMContext.class);
     when(rmContext.getQueuePlacementManager()).thenReturn(placementManager);
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
 
     scheduler = mock(FairScheduler.class);
     when(scheduler.getConf()).thenReturn(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueuePlacementPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/TestQueuePlacementPolicy.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -47,7 +48,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.placement.FSPlacementRule;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementManager;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.PlacementRule;
 import org.apache.hadoop.yarn.server.resourcemanager.placement.UserPlacementRule;
-import org.apache.hadoop.util.SystemClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -78,7 +78,7 @@ public class TestQueuePlacementPolicy {
 
   @BeforeEach
   public void initTest() {
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     RMContext rmContext = mock(RMContext.class);
     placementManager = new PlacementManager();
     scheduler = mock(FairScheduler.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/policy/MockSchedulableEntity.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/policy/MockSchedulableEntity.java
@@ -21,8 +21,9 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.policy;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceUsage;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager;
+
+import java.time.Clock;
 
 
 public class MockSchedulableEntity implements SchedulableEntity {
@@ -41,7 +42,7 @@ public class MockSchedulableEntity implements SchedulableEntity {
     this.serial = serial;
     this.priority = Priority.newInstance(priority);
     this.isRecovering = isRecovering;
-    this.startTime = SystemClock.getInstance().getTime();
+    this.startTime = Clock.systemUTC().millis();
   }
 
   public void setId(String id) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/TestRMWebServicesReservation.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import java.security.Principal;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -71,8 +72,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationDeleteRequestInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationSubmissionRequestInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.webapp.dao.ReservationUpdateRequestInfo;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 
 import org.apache.hadoop.yarn.webapp.JerseyTestBase;
@@ -99,7 +98,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
   private static MockRM rm;
 
   private static final int MINIMUM_RESOURCE_DURATION = 100000;
-  private static final Clock clock = new UTCClock();
+  private static final Clock clock = Clock.systemUTC();
   private static final int MAXIMUM_PERIOD = 86400000;
   private static final int DEFAULT_RECURRENCE = MAXIMUM_PERIOD / 10;
   private static final String TEST_DIR = new File(System.getProperty(
@@ -358,7 +357,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     setupCluster(100);
 
     ReservationId rid = getReservationIdTestHelper(1);
-    long currentTimestamp = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long currentTimestamp = clock.millis() + MINIMUM_RESOURCE_DURATION;
     Response response = reservationSubmissionTestHelper(
         "reservation/submit", MediaType.APPLICATION_JSON, currentTimestamp, "",
         rid);
@@ -390,7 +389,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     setupCluster(100);
 
     ReservationId rid = getReservationIdTestHelper(1);
-    long currentTimestamp = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long currentTimestamp = clock.millis() + MINIMUM_RESOURCE_DURATION;
     Response response =
         reservationSubmissionTestHelper("reservation/submit", MediaType.APPLICATION_JSON,
         currentTimestamp, "res1", rid);
@@ -457,7 +456,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -501,7 +500,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -550,7 +549,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -593,7 +592,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -647,7 +646,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -700,7 +699,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     rm.start();
     setupCluster(100);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
@@ -750,7 +749,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id1 = getReservationIdTestHelper(1);
     ReservationId id2 = getReservationIdTestHelper(2);
 
-    long time = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long time = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     reservationSubmissionTestHelper("reservation/submit",
             MediaType.APPLICATION_JSON, time, "res_1", id1);
@@ -794,9 +793,9 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id2 = getReservationIdTestHelper(2);
 
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_2", id2);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_2", id2);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("queue", DEFAULT_QUEUE);
@@ -828,9 +827,9 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id2 = getReservationIdTestHelper(2);
 
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_2", id2);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_2", id2);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH);
 
@@ -851,9 +850,9 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id2 = getReservationIdTestHelper(2);
 
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_2", id2);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_2", id2);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("queue", DEFAULT_QUEUE + "_invalid");
@@ -875,11 +874,11 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id2 = getReservationIdTestHelper(2);
 
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_2", id2);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_2", id2);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("include-resource-allocations", "true")
@@ -918,7 +917,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id1 = getReservationIdTestHelper(1);
 
     reservationSubmissionTestHelper("reservation/submit",
-        MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+        MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("queue", DEFAULT_QUEUE);
@@ -942,7 +941,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
     ReservationId id1 = getReservationIdTestHelper(1);
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("include-resource-allocations", "true")
@@ -981,7 +980,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
     ReservationId id1 = getReservationIdTestHelper(1);
 
     reservationSubmissionTestHelper("reservation/submit",
-            MediaType.APPLICATION_JSON, clock.getTime(), "res_1", id1);
+            MediaType.APPLICATION_JSON, clock.millis(), "res_1", id1);
 
     WebTarget target = constructWebResource(LIST_RESERVATION_PATH)
             .queryParam("include-resource-allocations", "false")
@@ -1058,7 +1057,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
     if (!this.isAuthenticationEnabled()) {
       assertResponseStatusCode(Response.Status.UNAUTHORIZED, response.getStatusInfo());
-      return ReservationId.newInstance(clock.getTime(), fallbackReservationId);
+      return ReservationId.newInstance(clock.millis(), fallbackReservationId);
     }
 
     System.out.println("RESPONSE:" + response);
@@ -1081,7 +1080,7 @@ public class TestRMWebServicesReservation extends JerseyTestBase {
 
   private Response reservationSubmissionTestHelper(String path,
       String media, ReservationId reservationId) throws Exception {
-    long arrival = clock.getTime() + MINIMUM_RESOURCE_DURATION;
+    long arrival = clock.millis() + MINIMUM_RESOURCE_DURATION;
 
     return reservationSubmissionTestHelper(path, media, arrival, "res_1",
       reservationId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/TestFairSchedulerQueueInfo.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSQueue;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.QueueManager;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +44,7 @@ public class TestFairSchedulerQueueInfo {
     FairSchedulerConfiguration fsConf = new FairSchedulerConfiguration();
     RMContext rmContext = mock(RMContext.class);
     PlacementManager placementManager = new PlacementManager();
-    SystemClock clock = SystemClock.getInstance();
+    Clock clock = Clock.systemUTC();
     FairScheduler scheduler = mock(FairScheduler.class);
     when(scheduler.getConf()).thenReturn(fsConf);
     when(scheduler.getConfig()).thenReturn(fsConf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFact
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -140,7 +141,6 @@ import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade
 import org.apache.hadoop.yarn.server.router.RouterAuditLogger;
 import org.apache.hadoop.yarn.server.router.RouterMetrics;
 import org.apache.hadoop.yarn.server.router.RouterServerUtil;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.apache.hadoop.yarn.util.Records;
 import org.slf4j.Logger;
@@ -205,7 +205,7 @@ public class FederationClientInterceptor
   private RouterPolicyFacade policyFacade;
   private RouterMetrics routerMetrics;
   private ThreadPoolExecutor executorService;
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private boolean returnPartialReport;
   private long submitIntervalTime;
   private boolean allowPartialResult;
@@ -344,7 +344,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(errMsg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     Map<SubClusterId, SubClusterInfo> subClustersActive =
         federationFacade.getSubClusters(true);
 
@@ -360,7 +360,7 @@ public class FederationClientInterceptor
           runWithRetries(actualRetryNums, submitIntervalTime);
 
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededAppsCreated(stopTime - startTime);
         return response;
       }
@@ -497,7 +497,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(errMsg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ApplicationId applicationId =
         request.getApplicationSubmissionContext().getApplicationId();
     List<SubClusterId> blacklist = new ArrayList<>();
@@ -518,7 +518,7 @@ public class FederationClientInterceptor
           runWithRetries(actualRetryNums, submitIntervalTime);
 
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededAppsSubmitted(stopTime - startTime);
         return response;
       }
@@ -640,7 +640,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     ApplicationId applicationId = request.getApplicationId();
     SubClusterId subClusterId = null;
@@ -690,7 +690,7 @@ public class FederationClientInterceptor
           applicationId, subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededAppsKilled(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), FORCE_KILL_APP,
         TARGET_CLIENT_RM_SERVICE, applicationId);
@@ -725,7 +725,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(errMsg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
 
     try {
@@ -760,7 +760,7 @@ public class FederationClientInterceptor
           + "the application {} to SubCluster {}.",
           request.getApplicationId(), subClusterId.getId());
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededAppsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_APP_REPORT,
         TARGET_CLIENT_RM_SERVICE, request.getApplicationId());
@@ -796,7 +796,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getApplications",
         new Class[] {GetApplicationsRequest.class}, new Object[] {request});
     Collection<GetApplicationsResponse> applications = null;
@@ -809,7 +809,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededMultipleAppsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_APPLICATIONS,
         TARGET_CLIENT_RM_SERVICE);
@@ -827,7 +827,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getClusterMetrics",
         new Class[] {GetClusterMetricsRequest.class}, new Object[] {request});
     Collection<GetClusterMetricsResponse> clusterMetrics = null;
@@ -840,7 +840,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetClusterMetricsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CLUSTERMETRICS,
         TARGET_CLIENT_RM_SERVICE);
@@ -979,13 +979,13 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getClusterNodes",
         new Class[]{GetClusterNodesRequest.class}, new Object[]{request});
     try {
       Collection<GetClusterNodesResponse> clusterNodes =
           invokeConcurrent(remoteMethod, GetClusterNodesResponse.class);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededGetClusterNodesRetrieved(stopTime - startTime);
       RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CLUSTERNODES,
           TARGET_CLIENT_RM_SERVICE);
@@ -1027,7 +1027,7 @@ public class FederationClientInterceptor
     }
     String rSubCluster = request.getSubClusterId();
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getQueueInfo",
         new Class[]{GetQueueInfoRequest.class}, new Object[]{request});
     Collection<GetQueueInfoResponse> queues = null;
@@ -1044,7 +1044,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetQueueInfoRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_QUEUEINFO, TARGET_CLIENT_RM_SERVICE);
     // Merge the GetQueueInfoResponse
@@ -1061,7 +1061,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getQueueUserAcls",
         new Class[] {GetQueueUserAclsInfoRequest.class}, new Object[] {request});
     Collection<GetQueueUserAclsInfoResponse> queueUserAcls = null;
@@ -1074,7 +1074,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetQueueUserAclsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_QUEUE_USER_ACLS,
         TARGET_CLIENT_RM_SERVICE);
@@ -1095,7 +1095,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
 
     ApplicationId applicationId = request.getApplicationId();
@@ -1127,7 +1127,7 @@ public class FederationClientInterceptor
            request.getApplicationId(), request.getTargetQueue(), subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     RouterAuditLogger.logSuccess(user.getShortUserName(), MOVE_APPLICATION_ACROSS_QUEUES,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
     routerMetrics.succeededMoveApplicationAcrossQueuesRetrieved(stopTime - startTime);
@@ -1146,7 +1146,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(errMsg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     Map<SubClusterId, SubClusterInfo> subClustersActive = federationFacade.getSubClusters(true);
 
     for (int i = 0; i < numSubmitRetries; ++i) {
@@ -1156,7 +1156,7 @@ public class FederationClientInterceptor
       try {
         GetNewReservationResponse response = clientRMProxy.getNewReservation(request);
         if (response != null) {
-          long stopTime = clock.getTime();
+          long stopTime = clock.millis();
           routerMetrics.succeededGetNewReservationRetrieved(stopTime - startTime);
           RouterAuditLogger.logSuccess(user.getShortUserName(), GET_NEW_RESERVATION,
               TARGET_CLIENT_RM_SERVICE);
@@ -1192,7 +1192,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ReservationId reservationId = request.getReservationId();
 
     for (int i = 0; i < numSubmitRetries; i++) {
@@ -1224,7 +1224,7 @@ public class FederationClientInterceptor
         ReservationSubmissionResponse response = clientRMProxy.submitReservation(request);
         if (response != null) {
           LOG.info("Reservation {} submitted on subCluster {}.", reservationId, subClusterId);
-          long stopTime = clock.getTime();
+          long stopTime = clock.millis();
           routerMetrics.succeededSubmitReservationRetrieved(stopTime - startTime);
           RouterAuditLogger.logSuccess(user.getShortUserName(), SUBMIT_RESERVATION,
               TARGET_CLIENT_RM_SERVICE);
@@ -1252,7 +1252,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("listReservations",
         new Class[] {ReservationListRequest.class}, new Object[] {request});
     Collection<ReservationListResponse> listResponses = null;
@@ -1265,7 +1265,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededListReservationsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), LIST_RESERVATIONS,
         TARGET_CLIENT_RM_SERVICE);
@@ -1286,7 +1286,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ReservationId reservationId = request.getReservationId();
     SubClusterId subClusterId = getReservationHomeSubCluster(reservationId);
 
@@ -1294,7 +1294,7 @@ public class FederationClientInterceptor
       ApplicationClientProtocol client = getClientRMProxyForSubCluster(subClusterId);
       ReservationUpdateResponse response = client.updateReservation(request);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededUpdateReservationRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(user.getShortUserName(), UPDATE_RESERVATION,
             TARGET_CLIENT_RM_SERVICE);
@@ -1326,7 +1326,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ReservationId reservationId = request.getReservationId();
     SubClusterId subClusterId = getReservationHomeSubCluster(reservationId);
 
@@ -1335,7 +1335,7 @@ public class FederationClientInterceptor
       ReservationDeleteResponse response = client.deleteReservation(request);
       if (response != null) {
         federationFacade.deleteReservationHomeSubCluster(reservationId);
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededDeleteReservationRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(user.getShortUserName(), DELETE_RESERVATION,
             TARGET_CLIENT_RM_SERVICE);
@@ -1366,7 +1366,7 @@ public class FederationClientInterceptor
       RouterAuditLogger.logFailure(user.getShortUserName(), GET_NODETOLABELS, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, msg);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getNodeToLabels",
         new Class[] {GetNodesToLabelsRequest.class}, new Object[] {request});
     Collection<GetNodesToLabelsResponse> clusterNodes = null;
@@ -1379,7 +1379,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetNodeToLabelsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_NODETOLABELS,
         TARGET_CLIENT_RM_SERVICE);
@@ -1397,7 +1397,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getLabelsToNodes",
          new Class[] {GetLabelsToNodesRequest.class}, new Object[] {request});
     Collection<GetLabelsToNodesResponse> labelNodes = null;
@@ -1410,7 +1410,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetLabelsToNodesRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_LABELSTONODES,
         TARGET_CLIENT_RM_SERVICE);
@@ -1428,7 +1428,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getClusterNodeLabels",
          new Class[] {GetClusterNodeLabelsRequest.class}, new Object[] {request});
     Collection<GetClusterNodeLabelsResponse> nodeLabels = null;
@@ -1441,7 +1441,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetClusterNodeLabelsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CLUSTERNODELABELS,
         TARGET_CLIENT_RM_SERVICE);
@@ -1480,7 +1480,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
     ApplicationId applicationId = request.getApplicationAttemptId().getApplicationId();
     try {
@@ -1517,7 +1517,7 @@ public class FederationClientInterceptor
           request.getApplicationAttemptId(), subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededAppAttemptReportRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_APPLICATION_ATTEMPT_REPORT,
         TARGET_CLIENT_RM_SERVICE);
@@ -1535,7 +1535,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ApplicationId applicationId = request.getApplicationId();
     SubClusterId subClusterId = null;
     try {
@@ -1567,7 +1567,7 @@ public class FederationClientInterceptor
            subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_APPLICATION_ATTEMPTS,
         TARGET_CLIENT_RM_SERVICE, applicationId);
     routerMetrics.succeededAppAttemptsRetrieved(stopTime - startTime);
@@ -1585,7 +1585,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ApplicationId applicationId = request.getContainerId().
         getApplicationAttemptId().getApplicationId();
     SubClusterId subClusterId = null;
@@ -1616,7 +1616,7 @@ public class FederationClientInterceptor
            subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CONTAINERREPORT,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
     routerMetrics.succeededGetContainerReportRetrieved(stopTime - startTime);
@@ -1634,7 +1634,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ApplicationId applicationId = request.getApplicationAttemptId().getApplicationId();
     SubClusterId subClusterId = null;
     try {
@@ -1667,7 +1667,7 @@ public class FederationClientInterceptor
           subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CONTAINERS,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
     routerMetrics.succeededGetContainersRetrieved(stopTime - startTime);
@@ -1696,7 +1696,7 @@ public class FederationClientInterceptor
         throw new IOException(msg);
       }
 
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
       Text owner = new Text(ugi.getUserName());
       Text realUser = null;
@@ -1714,7 +1714,7 @@ public class FederationClientInterceptor
               realRMDToken.getKind().toString(),
               realRMDToken.getPassword(), realRMDToken.getService().toString());
 
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededGetDelegationTokenRetrieved((stopTime - startTime));
       RouterAuditLogger.logSuccess(user.getShortUserName(), GET_DELEGATIONTOKEN,
           TARGET_CLIENT_RM_SERVICE);
@@ -1740,7 +1740,7 @@ public class FederationClientInterceptor
         throw new IOException(msg);
       }
 
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       org.apache.hadoop.yarn.api.records.Token protoToken = request.getDelegationToken();
       Token<RMDelegationTokenIdentifier> token = new Token<>(
           protoToken.getIdentifier().array(), protoToken.getPassword().array(),
@@ -1750,7 +1750,7 @@ public class FederationClientInterceptor
       RenewDelegationTokenResponse renewResponse =
           Records.newRecord(RenewDelegationTokenResponse.class);
       renewResponse.setNextExpirationTime(nextExpTime);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededRenewDelegationTokenRetrieved((stopTime - startTime));
       RouterAuditLogger.logSuccess(user.getShortUserName(), RENEW_DELEGATIONTOKEN,
           TARGET_CLIENT_RM_SERVICE);
@@ -1776,14 +1776,14 @@ public class FederationClientInterceptor
         throw new IOException(msg);
       }
 
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       org.apache.hadoop.yarn.api.records.Token protoToken = request.getDelegationToken();
       Token<RMDelegationTokenIdentifier> token = new Token<>(
           protoToken.getIdentifier().array(), protoToken.getPassword().array(),
           new Text(protoToken.getKind()), new Text(protoToken.getService()));
       String currentUser = UserGroupInformation.getCurrentUser().getUserName();
       this.getTokenSecretManager().cancelToken(token, currentUser);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededCancelDelegationTokenRetrieved((stopTime - startTime));
       RouterAuditLogger.logSuccess(user.getShortUserName(), CANCEL_DELEGATIONTOKEN,
           TARGET_CLIENT_RM_SERVICE);
@@ -1808,7 +1808,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
     ApplicationAttemptId applicationAttemptId = request.getApplicationAttemptId();
     ApplicationId applicationId = applicationAttemptId.getApplicationId();
@@ -1844,7 +1844,7 @@ public class FederationClientInterceptor
           request.getApplicationAttemptId(), subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededFailAppAttemptRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), FAIL_APPLICATIONATTEMPT,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
@@ -1865,7 +1865,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
     ApplicationId applicationId = request.getApplicationId();
 
@@ -1899,7 +1899,7 @@ public class FederationClientInterceptor
            applicationId, subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededUpdateAppPriorityRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), UPDATE_APPLICATIONPRIORITY,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
@@ -1918,7 +1918,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
     ApplicationId applicationId =
         request.getContainerId().getApplicationAttemptId().getApplicationId();
@@ -1949,7 +1949,7 @@ public class FederationClientInterceptor
           "the applicationId {} to SubCluster {}.", applicationId, subClusterId);
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededSignalToContainerRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), SIGNAL_TOCONTAINER,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
@@ -1970,7 +1970,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException(msg, null);
     }
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     SubClusterId subClusterId = null;
     ApplicationId applicationId = request.getApplicationId();
     try {
@@ -2002,7 +2002,7 @@ public class FederationClientInterceptor
           applicationId, subClusterId.getId());
     }
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededUpdateAppTimeoutsRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), UPDATE_APPLICATIONTIMEOUTS,
         TARGET_CLIENT_RM_SERVICE, applicationId, subClusterId);
@@ -2019,7 +2019,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getResourceProfiles",
         new Class[] {GetAllResourceProfilesRequest.class}, new Object[] {request});
     Collection<GetAllResourceProfilesResponse> resourceProfiles = null;
@@ -2033,7 +2033,7 @@ public class FederationClientInterceptor
       RouterServerUtil.logAndThrowException("Unable to get resource profiles due to exception.",
           ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetResourceProfilesRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_RESOURCEPROFILES,
         TARGET_CLIENT_RM_SERVICE);
@@ -2050,7 +2050,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getResourceProfile",
         new Class[] {GetResourceProfileRequest.class}, new Object[] {request});
     Collection<GetResourceProfileResponse> resourceProfile = null;
@@ -2063,7 +2063,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetResourceProfileRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_RESOURCEPROFILE,
         TARGET_CLIENT_RM_SERVICE);
@@ -2080,7 +2080,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getResourceTypeInfo",
         new Class[] {GetAllResourceTypeInfoRequest.class}, new Object[] {request});
     Collection<GetAllResourceTypeInfoResponse> listResourceTypeInfo;
@@ -2094,7 +2094,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       throw ex;
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetResourceTypeInfoRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_RESOURCETYPEINFO,
         TARGET_CLIENT_RM_SERVICE);
@@ -2118,7 +2118,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getAttributesToNodes",
         new Class[] {GetAttributesToNodesRequest.class}, new Object[] {request});
     Collection<GetAttributesToNodesResponse> attributesToNodesResponses = null;
@@ -2132,7 +2132,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetAttributesToNodesRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_ATTRIBUTESTONODES,
         TARGET_CLIENT_RM_SERVICE);
@@ -2149,7 +2149,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getClusterNodeAttributes",
         new Class[] {GetClusterNodeAttributesRequest.class}, new Object[] {request});
     Collection<GetClusterNodeAttributesResponse> clusterNodeAttributesResponses = null;
@@ -2163,7 +2163,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetClusterNodeAttributesRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_CLUSTERNODEATTRIBUTES,
         TARGET_CLIENT_RM_SERVICE);
@@ -2180,7 +2180,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, null);
     }
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     ClientMethod remoteMethod = new ClientMethod("getNodesToAttributes",
         new Class[] {GetNodesToAttributesRequest.class}, new Object[] {request});
     Collection<GetNodesToAttributesResponse> nodesToAttributesResponses = null;
@@ -2194,7 +2194,7 @@ public class FederationClientInterceptor
           TARGET_CLIENT_RM_SERVICE, msg);
       RouterServerUtil.logAndThrowException(msg, ex);
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetNodesToAttributesRetrieved(stopTime - startTime);
     RouterAuditLogger.logSuccess(user.getShortUserName(), GET_NODESTOATTRIBUTES,
         TARGET_CLIENT_RM_SERVICE);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/rmadmin/FederationRMAdminInterceptor.java
@@ -92,13 +92,13 @@ import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.router.RouterMetrics;
 import org.apache.hadoop.yarn.server.router.RouterServerUtil;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -132,7 +132,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
   private Map<SubClusterId, ResourceManagerAdministrationProtocol> adminRMProxies;
   private FederationStateStoreFacade federationFacade;
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private RouterMetrics routerMetrics;
   private ThreadPoolExecutor executorService;
   private Configuration conf;
@@ -238,7 +238,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshQueues of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
            new Class[] {RefreshQueuesRequest.class}, new Object[] {request});
 
@@ -250,7 +250,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
       // it means that the call has been successful,
       // and the RefreshQueuesResponse method can be reconstructed and returned.
       if (CollectionUtils.isNotEmpty(refreshQueueResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshQueuesRetrieved(stopTime - startTime);
         return RefreshQueuesResponse.newInstance();
       }
@@ -295,7 +295,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshNodes of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[] {RefreshNodesRequest.class}, new Object[] {request});
 
@@ -304,7 +304,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           remoteMethod.invokeConcurrent(this, RefreshNodesResponse.class, subClusterId);
 
       if (CollectionUtils.isNotEmpty(refreshNodesResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshNodesRetrieved(stopTime - startTime);
         return RefreshNodesResponse.newInstance();
       }
@@ -352,7 +352,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshSuperUserGroupsConfiguration of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[] {RefreshSuperUserGroupsConfigurationRequest.class}, new Object[] {request});
 
@@ -362,7 +362,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           subClusterId);
 
       if (CollectionUtils.isNotEmpty(refreshSuperUserGroupsConfResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshSuperUserGroupsConfRetrieved(stopTime - startTime);
         return RefreshSuperUserGroupsConfigurationResponse.newInstance();
       }
@@ -409,7 +409,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshUserToGroupsMappings of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[] {RefreshUserToGroupsMappingsRequest.class}, new Object[] {request});
 
@@ -419,7 +419,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           subClusterId);
 
       if (CollectionUtils.isNotEmpty(refreshUserToGroupsMappingsResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshUserToGroupsMappingsRetrieved(stopTime - startTime);
         return RefreshUserToGroupsMappingsResponse.newInstance();
       }
@@ -445,14 +445,14 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshAdminAcls of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[] {RefreshAdminAclsRequest.class}, new Object[] {request});
       String subClusterId = request.getSubClusterId();
       Collection<RefreshAdminAclsResponse> refreshAdminAclsResps =
           remoteMethod.invokeConcurrent(this, RefreshAdminAclsResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(refreshAdminAclsResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshAdminAclsRetrieved(stopTime - startTime);
         return RefreshAdminAclsResponse.newInstance();
       }
@@ -478,14 +478,14 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // call refreshAdminAcls of activeSubClusters.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{RefreshServiceAclsRequest.class}, new Object[]{request});
       String subClusterId = request.getSubClusterId();
       Collection<RefreshServiceAclsResponse> refreshServiceAclsResps =
           remoteMethod.invokeConcurrent(this, RefreshServiceAclsResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(refreshServiceAclsResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshServiceAclsRetrieved(stopTime - startTime);
         return RefreshServiceAclsResponse.newInstance();
       }
@@ -516,13 +516,13 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{UpdateNodeResourceRequest.class}, new Object[]{request});
       Collection<UpdateNodeResourceResponse> updateNodeResourceResps =
           remoteMethod.invokeConcurrent(this, UpdateNodeResourceResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(updateNodeResourceResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededUpdateNodeResourceRetrieved(stopTime - startTime);
         return UpdateNodeResourceResponse.newInstance();
       }
@@ -553,13 +553,13 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{RefreshNodesResourcesRequest.class}, new Object[]{request});
       Collection<RefreshNodesResourcesResponse> refreshNodesResourcesResps =
           remoteMethod.invokeConcurrent(this, RefreshNodesResourcesResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(refreshNodesResourcesResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshNodesResourcesRetrieved(stopTime - startTime);
         return RefreshNodesResourcesResponse.newInstance();
       }
@@ -589,13 +589,13 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{AddToClusterNodeLabelsRequest.class}, new Object[]{request});
       Collection<AddToClusterNodeLabelsResponse> addToClusterNodeLabelsResps =
           remoteMethod.invokeConcurrent(this, AddToClusterNodeLabelsResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(addToClusterNodeLabelsResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededAddToClusterNodeLabelsRetrieved(stopTime - startTime);
         return AddToClusterNodeLabelsResponse.newInstance();
       }
@@ -627,14 +627,14 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{RemoveFromClusterNodeLabelsRequest.class}, new Object[]{request});
       Collection<RemoveFromClusterNodeLabelsResponse> refreshNodesResourcesResps =
           remoteMethod.invokeConcurrent(this, RemoveFromClusterNodeLabelsResponse.class,
           subClusterId);
       if (CollectionUtils.isNotEmpty(refreshNodesResourcesResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRemoveFromClusterNodeLabelsRetrieved(stopTime - startTime);
         return RemoveFromClusterNodeLabelsResponse.newInstance();
       }
@@ -664,13 +664,13 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{ReplaceLabelsOnNodeRequest.class}, new Object[]{request});
       Collection<ReplaceLabelsOnNodeResponse> replaceLabelsOnNodeResps =
           remoteMethod.invokeConcurrent(this, ReplaceLabelsOnNodeResponse.class, subClusterId);
       if (CollectionUtils.isNotEmpty(replaceLabelsOnNodeResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRemoveFromClusterNodeLabelsRetrieved(stopTime - startTime);
         return ReplaceLabelsOnNodeResponse.newInstance();
       }
@@ -702,7 +702,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{CheckForDecommissioningNodesRequest.class}, new Object[]{request});
 
@@ -716,7 +716,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
             responses.stream().collect(Collectors.toList());
         if (!collects.isEmpty() && collects.size() == 1) {
           CheckForDecommissioningNodesResponse response = collects.get(0);
-          long stopTime = clock.getTime();
+          long stopTime = clock.millis();
           routerMetrics.succeededCheckForDecommissioningNodesRetrieved((stopTime - startTime));
           Set<NodeId> nodes = response.getDecommissioningNodes();
           return CheckForDecommissioningNodesResponse.newInstance(nodes);
@@ -750,14 +750,14 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{RefreshClusterMaxPriorityRequest.class}, new Object[]{request});
       Collection<RefreshClusterMaxPriorityResponse> refreshClusterMaxPriorityResps =
           remoteMethod.invokeConcurrent(this, RefreshClusterMaxPriorityResponse.class,
           subClusterId);
       if (CollectionUtils.isNotEmpty(refreshClusterMaxPriorityResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededRefreshClusterMaxPriorityRetrieved(stopTime - startTime);
         return RefreshClusterMaxPriorityResponse.newInstance();
       }
@@ -787,14 +787,14 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{NodesToAttributesMappingRequest.class}, new Object[]{request});
       Collection<NodesToAttributesMappingResponse> mapAttributesToNodesResps =
           remoteMethod.invokeConcurrent(this, NodesToAttributesMappingResponse.class,
           subClusterId);
       if (CollectionUtils.isNotEmpty(mapAttributesToNodesResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededMapAttributesToNodesRetrieved(stopTime - startTime);
         return NodesToAttributesMappingResponse.newInstance();
       }
@@ -817,13 +817,13 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       RMAdminProtocolMethod remoteMethod = new RMAdminProtocolMethod(
           new Class[]{String.class}, new Object[]{user});
       Collection<String[]> getGroupsForUserResps =
           remoteMethod.invokeConcurrent(this, String[].class, null);
       if (CollectionUtils.isNotEmpty(getGroupsForUserResps)) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         Set<String> groups = new HashSet<>();
         for (String[] groupArr : getGroupsForUserResps) {
           if (groupArr != null && groupArr.length > 0) {
@@ -878,7 +878,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       List<DeregisterSubClusters> deregisterSubClusterList = new ArrayList<>();
       String reqSubClusterId = request.getSubClusterId();
       if (StringUtils.isNotBlank(reqSubClusterId)) {
@@ -895,7 +895,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           deregisterSubClusterList.add(deregisterSubClusters);
         }
       }
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededDeregisterSubClusterRetrieved(stopTime - startTime);
       return DeregisterSubClusterResponse.newInstance(deregisterSubClusterList);
     } catch (Exception e) {
@@ -956,7 +956,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     FederationQueueWeight.checkHeadRoomAlphaValid(headRoomAlpha);
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
 
       // Step2, parse amRMPolicyWeights.
       Map<SubClusterIdInfo, Float> amRMPolicyWeights = getSubClusterWeightMap(amRmWeight);
@@ -977,7 +977,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
           SubClusterPolicyConfiguration.newInstance(queue, policyManagerClassName,
           weightedPolicyInfo.toByteBuffer());
       federationFacade.setPolicyConfiguration(policyConfiguration);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededSaveFederationQueuePolicyRetrieved(stopTime - startTime);
       return SaveFederationQueuePolicyResponse.newInstance("save policy success.");
     } catch (Exception e) {
@@ -1016,11 +1016,11 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       for (FederationQueueWeight federationQueueWeight : federationQueueWeights) {
         saveFederationQueuePolicy(federationQueueWeight);
       }
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededBatchSaveFederationQueuePoliciesRetrieved(stopTime - startTime);
       return BatchSaveFederationQueuePoliciesResponse.newInstance("batch save policies success.");
     } catch (Exception e) {
@@ -1068,7 +1068,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
     try {
       QueryFederationQueuePoliciesResponse response;
 
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       String queue = request.getQueue();
       List<String> queues = request.getQueues();
       int currentPage = request.getCurrentPage();
@@ -1094,7 +1094,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
         // If we don't have any filtering criteria, we should also support paginating the results.
         response = filterPoliciesConfigurations(policiesConfigurations, pageSize, currentPage);
       }
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededListFederationQueuePoliciesRetrieved(stopTime - startTime);
       if (response == null) {
         response = QueryFederationQueuePoliciesResponse.newInstance();
@@ -1130,10 +1130,10 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // Try calling deleteApplicationHomeSubCluster to delete the application.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       ApplicationId applicationId = ApplicationId.fromString(application);
       federationFacade.deleteApplicationHomeSubCluster(applicationId);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededDeleteFederationApplicationFailedRetrieved(stopTime - startTime);
       return DeleteFederationApplicationResponse.newInstance(
           "applicationId = " + applicationId + " delete success.");
@@ -1170,7 +1170,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // Step2. Get FederationSubCluster data.
     List<FederationSubCluster> federationSubClusters = new ArrayList<>();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     for (Map.Entry<SubClusterId, SubClusterInfo> subCluster : subClusters.entrySet()) {
       SubClusterId subClusterId = subCluster.getKey();
       try {
@@ -1185,7 +1185,7 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
         LOG.error("getSubClusters SubClusterId = [%s] error.", subClusterId, e);
       }
     }
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededGetFederationSubClustersRetrieved(stopTime - startTime);
 
     // Step3. Return results.
@@ -1219,9 +1219,9 @@ public class FederationRMAdminInterceptor extends AbstractRMAdminRequestIntercep
 
     // Try calling deleteApplicationHomeSubCluster to delete the application.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       federationFacade.deletePolicyConfigurations(queues);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededDeleteFederationPoliciesByQueuesRetrieved(stopTime - startTime);
       return DeleteFederationQueuePoliciesResponse.newInstance(
          "queues = " + StringUtils.join(queues, ",") + " delete success.");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -142,7 +143,6 @@ import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
 import org.apache.hadoop.yarn.util.LRUCacheHashMap;
 import org.apache.hadoop.yarn.webapp.dao.ConfInfo;
 import org.apache.hadoop.yarn.webapp.dao.SchedConfUpdateInfo;
-import org.apache.hadoop.util.Clock;
 import org.apache.hadoop.util.MonotonicClock;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
@@ -214,7 +214,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   private FederationStateStoreFacade federationFacade;
   private RouterPolicyFacade policyFacade;
   private RouterMetrics routerMetrics;
-  private final Clock clock = new MonotonicClock();
+  private final Clock clock = MonotonicClock.get();
   private boolean returnPartialReport;
   private boolean appInfosCacheEnabled;
   private int appInfosCacheCount;
@@ -384,7 +384,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public Response createNewApplication(HttpServletRequest hsr)
       throws AuthorizationException, IOException, InterruptedException {
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     try {
       Map<SubClusterId, SubClusterInfo> subClustersActive =
@@ -400,7 +400,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       // If the response is not empty and the status is SC_OK,
       // this request can be returned directly.
       if (response != null && response.getStatus() == HttpServletResponse.SC_OK) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededAppsCreated(stopTime - startTime);
         return response;
       }
@@ -539,7 +539,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public Response submitApplication(ApplicationSubmissionContextInfo newApp, HttpServletRequest hsr)
       throws AuthorizationException, IOException, InterruptedException {
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     // We verify the parameters to ensure that newApp is not empty and
     // that the format of applicationId is correct.
@@ -570,7 +570,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           invokeSubmitApplication(newApp, blackList, hsr, retryCount)).
           runWithRetries(actualRetryNums, submitIntervalTime);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededAppsSubmitted(stopTime - startTime);
         return response;
       }
@@ -680,7 +680,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public AppInfo getApp(HttpServletRequest hsr, String appId, Set<String> unselectedFields) {
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
 
       // Get SubClusterInfo according to applicationId
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
@@ -689,7 +689,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         return null;
       }
       AppInfo response = interceptor.getApp(hsr, appId, unselectedFields);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededAppsRetrieved(stopTime - startTime);
       return response;
     } catch (YarnException e) {
@@ -722,7 +722,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public Response updateAppState(AppState targetState, HttpServletRequest hsr, String appId)
       throws AuthorizationException, YarnException, InterruptedException, IOException {
 
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     ApplicationId applicationId;
     try {
@@ -753,7 +753,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         subClusterInfo.getRMWebServiceAddress()).updateAppState(targetState,
             hsr, appId);
 
-    long stopTime = clock.getTime();
+    long stopTime = clock.millis();
     routerMetrics.succeededAppsRetrieved(stopTime - startTime);
 
     return response;
@@ -797,7 +797,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     AppsInfo apps = new AppsInfo();
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
 
     // HttpServletRequest does not work with ExecutorCompletionService.
     // Create a duplicate hsr.
@@ -824,7 +824,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     appsInfos.forEach(appsInfo -> {
       if (appsInfo != null) {
         apps.addAll(appsInfo.getApps());
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededMultipleAppsRetrieved(stopTime - startTime);
       }
     });
@@ -1330,7 +1330,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
     // Step2. Call dumpSchedulerLogs of each subcluster.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{String.class, HttpServletRequest.class};
@@ -1344,7 +1344,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         stringBuilder.append("subClusterId")
             .append(subClusterId).append(" : ").append(msg).append("; ");
       });
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), DUMP_SCHEDULERLOGS,
           TARGET_WEB_SERVICE);
       routerMetrics.succeededDumpSchedulerLogsRetrieved(stopTime - startTime);
@@ -1391,12 +1391,12 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       // Query SubClusterInfo according to id,
       // if the nodeId cannot get SubClusterInfo, an exception will be thrown directly.
       // Call the corresponding subCluster to get ActivitiesInfo.
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByNodeId(nodeId);
       final HttpServletRequest hsrCopy = clone(hsr);
       ActivitiesInfo activitiesInfo = interceptor.getActivities(hsrCopy, nodeId, groupBy);
       if (activitiesInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_ACTIVITIES,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetActivitiesLatencyRetrieved(stopTime - startTime);
@@ -1442,7 +1442,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           subClustersActive, remoteMethod, BulkActivitiesInfo.class);
 
       // Step3. Generate Federation objects and set subCluster information.
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       FederationBulkActivitiesInfo fedBulkActivitiesInfo = new FederationBulkActivitiesInfo();
       appStatisticsMap.forEach((subClusterInfo, bulkActivitiesInfo) -> {
         SubClusterId subClusterId = subClusterInfo.getSubClusterId();
@@ -1451,7 +1451,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       });
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_BULKACTIVITIES,
           TARGET_WEB_SERVICE);
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       routerMetrics.succeededGetBulkActivitiesRetrieved(stopTime - startTime);
       return fedBulkActivitiesInfo;
     } catch (IllegalArgumentException e) {
@@ -1493,13 +1493,13 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       Set<String> actions, boolean summarize) {
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       final HttpServletRequest hsrCopy = clone(hsr);
       AppActivitiesInfo appActivitiesInfo = interceptor.getAppActivities(hsrCopy, appId, time,
           requestPriorities, allocationRequestIds, groupBy, limit, actions, summarize);
       if (appActivitiesInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetAppActivitiesRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_APPACTIVITIES,
             TARGET_WEB_SERVICE);
@@ -1528,7 +1528,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public ApplicationStatisticsInfo getAppStatistics(HttpServletRequest hsr,
       Set<String> stateQueries, Set<String> typeQueries) {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{HttpServletRequest.class, Set.class, Set.class};
@@ -1539,7 +1539,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       ApplicationStatisticsInfo applicationStatisticsInfo  =
           RouterWebServiceUtil.mergeApplicationStatisticsInfo(appStatisticsMap.values());
       if (applicationStatisticsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetAppStatisticsRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_APPSTATISTICS,
             TARGET_WEB_SERVICE);
@@ -1577,7 +1577,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public NodeToLabelsInfo getNodeToLabels(HttpServletRequest hsr)
       throws IOException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{HttpServletRequest.class};
@@ -1588,7 +1588,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       NodeToLabelsInfo nodeToLabelsInfo =
           RouterWebServiceUtil.mergeNodeToLabels(nodeToLabelsInfoMap);
       if (nodeToLabelsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetNodeToLabelsRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_NODETOLABELS,
             TARGET_WEB_SERVICE);
@@ -1614,7 +1614,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   @Override
   public NodeLabelsInfo getRMNodeLabels(HttpServletRequest hsr) throws IOException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{HttpServletRequest.class};
@@ -1625,7 +1625,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       NodeLabelsInfo nodeToLabelsInfo =
           RouterWebServiceUtil.mergeNodeLabelsInfo(nodeToLabelsInfoMap);
       if (nodeToLabelsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetRMNodeLabelsRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_RMNODELABELS,
             TARGET_WEB_SERVICE);
@@ -1652,7 +1652,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public LabelsToNodesInfo getLabelsToNodes(Set<String> labels)
       throws IOException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       Class[] argsClasses = new Class[]{Set.class};
       Object[] args = new Object[]{labels};
@@ -1672,7 +1672,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       });
       LabelsToNodesInfo labelsToNodesInfo = new LabelsToNodesInfo(labelToNodesMap);
       if (labelsToNodesInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_LABELSTONODES,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetLabelsToNodesRetrieved(stopTime - startTime);
@@ -1747,7 +1747,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       });
 
       // Step4. Traverse the subCluster and call the replaceLabelsOnNodes interface.
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       final HttpServletRequest hsrCopy = clone(hsr);
       StringBuilder builder = new StringBuilder();
       subClusterToNodeToLabelsEntryList.forEach((subClusterInfo, nodeToLabelsEntryList) -> {
@@ -1762,7 +1762,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           builder.append("subCluster-").append(subClusterId.getId()).append(":Failed,");
         }
       });
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), REPLACE_LABELSONNODES,
           TARGET_WEB_SERVICE);
       routerMetrics.succeededReplaceLabelsOnNodesRetrieved(stopTime - startTime);
@@ -1810,14 +1810,14 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     try {
       // Step2. We find the subCluster according to the nodeId,
       // and then call the replaceLabelsOnNode of the subCluster.
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       SubClusterInfo subClusterInfo = getNodeSubcluster(nodeId);
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByNodeId(nodeId);
       final HttpServletRequest hsrCopy = clone(hsr);
       interceptor.replaceLabelsOnNode(newNodeLabelsName, hsrCopy, nodeId);
 
       // Step3. Return the response result.
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), REPLACE_LABELSONNODE,
           TARGET_WEB_SERVICE);
       routerMetrics.succeededReplaceLabelsOnNodeRetrieved(stopTime - startTime);
@@ -1835,7 +1835,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public NodeLabelsInfo getClusterNodeLabels(HttpServletRequest hsr)
       throws IOException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{HttpServletRequest.class};
@@ -1847,7 +1847,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       nodeToLabelsInfoMap.values().forEach(item -> hashSets.addAll(item.getNodeLabels()));
       NodeLabelsInfo nodeLabelsInfo = new NodeLabelsInfo(hashSets);
       if (nodeLabelsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetClusterNodeLabelsRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_CLUSTER_NODELABELS,
             TARGET_WEB_SERVICE);
@@ -1900,7 +1900,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActives = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{NodeLabelsInfo.class, HttpServletRequest.class};
@@ -1912,7 +1912,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       // SubCluster-0:SUCCESS,SubCluster-1:SUCCESS
       responseInfoMap.forEach((subClusterInfo, response) ->
           buildAppendMsg(subClusterInfo, buffer, response));
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), ADD_TO_CLUSTER_NODELABELS,
           TARGET_WEB_SERVICE);
       routerMetrics.succeededAddToClusterNodeLabelsRetrieved((stopTime - startTime));
@@ -1957,7 +1957,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActives = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{Set.class, HttpServletRequest.class};
@@ -1970,7 +1970,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       // SubCluster-0:SUCCESS,SubCluster-1:SUCCESS
       responseInfoMap.forEach((subClusterInfo, response) ->
           buildAppendMsg(subClusterInfo, buffer, response));
-      long stopTime = clock.getTime();
+      long stopTime = clock.millis();
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), REMOVE_FROM_CLUSTERNODELABELS,
           TARGET_WEB_SERVICE);
       routerMetrics.succeededRemoveFromClusterNodeLabelsRetrieved(stopTime - startTime);
@@ -2014,7 +2014,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public NodeLabelsInfo getLabelsOnNode(HttpServletRequest hsr, String nodeId)
       throws IOException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
       Class[] argsClasses = new Class[]{HttpServletRequest.class, String.class};
@@ -2026,7 +2026,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       nodeToLabelsInfoMap.values().forEach(item -> hashSets.addAll(item.getNodeLabels()));
       NodeLabelsInfo nodeLabelsInfo = new NodeLabelsInfo(hashSets);
       if (nodeLabelsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetLabelsToNodesRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_LABELS_ON_NODE,
             TARGET_WEB_SERVICE);
@@ -2056,11 +2056,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       throws AuthorizationException {
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       AppPriority appPriority = interceptor.getAppPriority(hsr, appId);
       if (appPriority != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetAppPriorityRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_APP_PRIORITY,
             TARGET_WEB_SERVICE);
@@ -2097,11 +2097,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       Response response = interceptor.updateApplicationPriority(targetPriority, hsr, appId);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededUpdateAppPriorityRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), UPDATE_APPLICATIONPRIORITY,
             TARGET_WEB_SERVICE);
@@ -2130,11 +2130,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       throws AuthorizationException {
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       AppQueue queue = interceptor.getAppQueue(hsr, appId);
       if (queue != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededGetAppQueueRetrieved((stopTime - startTime));
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_QUEUEINFO,
             TARGET_WEB_SERVICE);
@@ -2170,11 +2170,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       Response response = interceptor.updateAppQueue(targetQueue, hsr, appId);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         routerMetrics.succeededUpdateAppQueueRetrieved(stopTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), UPDATE_APP_QUEUE,
             TARGET_WEB_SERVICE);
@@ -2421,7 +2421,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   @Override
   public Response createNewReservation(HttpServletRequest hsr)
       throws AuthorizationException, IOException, InterruptedException {
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     try {
       Map<SubClusterId, SubClusterInfo> subClustersActive =
           federationFacade.getSubClusters(true);
@@ -2434,7 +2434,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       // If the response is not empty and the status is SC_OK,
       // this request can be returned directly.
       if (response != null && response.getStatus() == HttpServletResponse.SC_OK) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_NEW_RESERVATION,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetNewReservationRetrieved(stopTime - startTime);
@@ -2488,7 +2488,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   @Override
   public Response submitReservation(ReservationSubmissionRequestInfo resContext,
       HttpServletRequest hsr) throws AuthorizationException, IOException, InterruptedException {
-    long startTime = clock.getTime();
+    long startTime = clock.millis();
     if (resContext == null || resContext.getReservationId() == null
         || resContext.getReservationDefinition() == null || resContext.getQueue() == null) {
       routerMetrics.incrSubmitReservationFailedRetrieved();
@@ -2518,7 +2518,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           invokeSubmitReservation(resContext, blackList, hsr, retryCount)).
           runWithRetries(actualRetryNums, submitIntervalTime);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), SUBMIT_RESERVATION,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededSubmitReservationRetrieved(stopTime - startTime);
@@ -2723,7 +2723,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime1 = clock.getTime();
+      long startTime1 = clock.millis();
       SubClusterInfo subClusterInfo = getHomeSubClusterInfoByReservationId(reservationId);
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorForSubCluster(
           subClusterInfo.getSubClusterId(), subClusterInfo.getRMWebServiceAddress());
@@ -2731,7 +2731,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       Response response = interceptor.listReservation(queue, reservationId, startTime, endTime,
           includeResourceAllocations, hsrCopy);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), LIST_RESERVATIONS,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededListReservationRetrieved(stopTime - startTime1);
@@ -2762,11 +2762,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       AppTimeoutInfo appTimeoutInfo = interceptor.getAppTimeout(hsr, appId, type);
       if (appTimeoutInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_APP_TIMEOUT,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetAppTimeoutRetrieved((stopTime - startTime));
@@ -2795,11 +2795,11 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       throws AuthorizationException {
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       AppTimeoutsInfo appTimeoutsInfo = interceptor.getAppTimeouts(hsr, appId);
       if (appTimeoutsInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_APP_TIMEOUTS,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetAppTimeoutsRetrieved((stopTime - startTime));
@@ -2841,7 +2841,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorByAppId(appId);
       Response response = interceptor.updateApplicationTimeout(appTimeout, hsr, appId);
       if (response != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), UPDATE_APPLICATIONTIMEOUTS,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededUpdateAppTimeoutsRetrieved((stopTime - startTime));
@@ -3028,7 +3028,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
     }
 
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       ContainersInfo containersInfo = new ContainersInfo();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       Class[] argsClasses = new Class[]{
@@ -3042,7 +3042,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
             containersInfo.addAll(containers.getContainers()));
       }
       if (containersInfo != null) {
-        long stopTime = clock.getTime();
+        long stopTime = clock.millis();
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_CONTAINERS,
             TARGET_WEB_SERVICE);
         routerMetrics.succeededGetContainersRetrieved(stopTime - startTime);
@@ -3164,13 +3164,13 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
     // Get the subClusterInfo , then update the scheduler configuration.
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       SubClusterInfo subClusterInfo = getActiveSubCluster(pSubClusterId);
       DefaultRequestInterceptorREST interceptor = getOrCreateInterceptorForSubCluster(
           subClusterInfo.getSubClusterId(), subClusterInfo.getRMWebServiceAddress());
       Response response = interceptor.updateSchedulerConfiguration(mutationInfo, hsr);
       if (response != null) {
-        long endTime = clock.getTime();
+        long endTime = clock.millis();
         routerMetrics.succeededUpdateSchedulerConfigurationRetrieved(endTime - startTime);
         RouterAuditLogger.logSuccess(getUser().getShortUserName(), UPDATE_SCHEDULER_CONFIGURATION,
             TARGET_WEB_SERVICE);
@@ -3210,7 +3210,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
   public Response getSchedulerConfiguration(HttpServletRequest hsr)
       throws AuthorizationException {
     try {
-      long startTime = clock.getTime();
+      long startTime = clock.millis();
       FederationConfInfo federationConfInfo = new FederationConfInfo();
       Collection<SubClusterInfo> subClustersActive = federationFacade.getActiveSubClusters();
       final HttpServletRequest hsrCopy = clone(hsr);
@@ -3233,7 +3233,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
           federationConfInfo.getList().add(fedConfInfo);
         }
       });
-      long endTime = clock.getTime();
+      long endTime = clock.millis();
       routerMetrics.succeededGetSchedulerConfigurationRetrieved(endTime - startTime);
       RouterAuditLogger.logSuccess(getUser().getShortUserName(), GET_SCHEDULER_CONFIGURATION,
           TARGET_WEB_SERVICE);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/BaseRouterClientRMTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -97,8 +98,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.reservation.ReservationSyst
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
-import org.apache.hadoop.util.Clock;
-import org.apache.hadoop.util.UTCClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.junit.After;
 import org.junit.Assert;
@@ -353,8 +352,8 @@ public abstract class BaseRouterClientRMTest {
         .doAs(new PrivilegedExceptionAction<ReservationSubmissionResponse>() {
           @Override
           public ReservationSubmissionResponse run() throws Exception {
-            Clock clock = new UTCClock();
-            long arrival = clock.getTime();
+            Clock clock = Clock.systemUTC();
+            long arrival = clock.millis();
             long duration = 60000;
             long deadline = (long) (arrival + 1.05 * duration);
             ReservationSubmissionRequest req = ReservationSystemTestUtil
@@ -374,8 +373,8 @@ public abstract class BaseRouterClientRMTest {
         .doAs(new PrivilegedExceptionAction<ReservationUpdateResponse>() {
           @Override
           public ReservationUpdateResponse run() throws Exception {
-            Clock clock = new UTCClock();
-            long arrival = clock.getTime();
+            Clock clock = Clock.systemUTC();
+            long arrival = clock.millis();
             long duration = 60000;
             long deadline = (long) (arrival + 1.05 * duration);
             ReservationDefinition rDef =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/MockDefaultRequestInterceptorREST.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.router.webapp;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.security.Principal;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.Map;
@@ -155,7 +156,6 @@ import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainerInfo;
 import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
-import org.apache.hadoop.util.SystemClock;
 import org.apache.hadoop.yarn.util.resource.Resources;
 import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.ForbiddenException;
@@ -865,7 +865,7 @@ public class MockDefaultRequestInterceptorREST
     int numActivities = 10;
     for (int i = 0; i < numActivities; i++) {
       ActivitiesLogger.APP.startAppAllocationRecording(newActivitiesManager, node,
-          SystemClock.getInstance().getTime(), app);
+          Clock.systemUTC().millis(), app);
       ActivitiesLogger.APP.recordAppActivityWithoutAllocation(newActivitiesManager, node, app,
           new SchedulerRequestKey(Priority.newInstance(0), 0, null),
           ActivityDiagnosticConstant.NODE_IS_BLACKLISTED, ActivityState.REJECTED,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/webapp/TestFederationInterceptorREST.java
@@ -690,7 +690,7 @@ public class TestFederationInterceptorREST extends BaseRouterWebServicesTest {
 
     SubClusterInfo subClusterInfo = SubClusterInfo.newInstance(subClusterId,
             amRMAddress, clientRMAddress, rmAdminAddress, webAppAddress,
-            SubClusterState.SC_RUNNING, new MonotonicClock().getTime(),
+            SubClusterState.SC_RUNNING, MonotonicClock.get().millis(),
             "capability");
     stateStore.registerSubCluster(
             SubClusterRegisterRequest.newInstance(subClusterInfo));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineReaderHBaseDown.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/src/test/java/org/apache/hadoop/yarn/server/timelineservice/storage/TestTimelineReaderHBaseDown.java
@@ -40,6 +40,7 @@ import static org.apache.hadoop.yarn.server.timelineservice.storage.HBaseStorage
 import static org.apache.hadoop.yarn.server.timelineservice.storage.HBaseStorageMonitor.MONITOR_FILTERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestTimelineReaderHBaseDown {
 
@@ -58,6 +59,13 @@ public class TestTimelineReaderHBaseDown {
       HBaseTimelineReaderImpl htr = getHBaseTimelineReaderImpl(server);
       server.start();
       checkQuery(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -101,6 +109,13 @@ public class TestTimelineReaderHBaseDown {
       // start server and check that it detects hbase is down
       server.start();
       waitForHBaseDown(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -129,6 +144,13 @@ public class TestTimelineReaderHBaseDown {
       // start server and check that it detects hbase is down
       server.start();
       waitForHBaseDown(htr);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }
@@ -167,6 +189,13 @@ public class TestTimelineReaderHBaseDown {
           return false;
         }
       }, 1000, 150000);
+    } catch (Exception e) {
+      // TODO catch InaccessibleObjectException directly once Java 8 support is dropped
+      if (e.getClass().getSimpleName().equals("InaccessibleObjectException")) {
+        assumeTrue(false, "Could not start HBase because of HBASE-29234");
+      } else {
+        throw e;
+      }
     } finally {
       util.shutdownMiniCluster();
     }


### PR DESCRIPTION
### Description of PR

Closes HADOOP-19525

### How was this patch tested?

Ran all existing tests.

### For code changes:

- [V] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

