### PR TITLE
HADOOP-19435. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-fs2img.

### DIFF
--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
@@ -90,12 +90,12 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.NodeBase;
+import org.apache.hadoop.test.TestName;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,14 +108,20 @@ import static org.apache.hadoop.hdfs.MiniDFSCluster.HDFS_MINIDFS_BASEDIR;
 import static org.apache.hadoop.hdfs.server.common.Util.fileAsURI;
 import static org.apache.hadoop.hdfs.server.common.blockaliasmap.impl.TextFileRegionAliasMap.fileNameFromBlockPoolID;
 import static org.apache.hadoop.net.NodeBase.PATH_SEPARATOR_STR;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration tests for the Provided implementation.
  */
 public class ITestProvidedImplementation {
 
-  @Rule public TestName name = new TestName();
+  @RegisterExtension
+  private TestName name = new TestName();
+
   public static final Logger LOG =
       LoggerFactory.getLogger(ITestProvidedImplementation.class);
 

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
@@ -578,8 +578,8 @@ public class ITestProvidedImplementation {
   private void checkUniqueness(DatanodeInfo[] locations) {
     Set<String> set = new HashSet<>();
     for (DatanodeInfo info: locations) {
-      assertFalse(
-         set.contains(info.getDatanodeUuid()), "All locations should be unique");
+      assertFalse(set.contains(info.getDatanodeUuid()),
+          "All locations should be unique");
       set.add(info.getDatanodeUuid());
     }
   }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/ITestProvidedImplementation.java
@@ -90,10 +90,11 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.NodeBase;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +108,7 @@ import static org.apache.hadoop.hdfs.MiniDFSCluster.HDFS_MINIDFS_BASEDIR;
 import static org.apache.hadoop.hdfs.server.common.Util.fileAsURI;
 import static org.apache.hadoop.hdfs.server.common.blockaliasmap.impl.TextFileRegionAliasMap.fileNameFromBlockPoolID;
 import static org.apache.hadoop.net.NodeBase.PATH_SEPARATOR_STR;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for the Provided implementation.
@@ -136,7 +137,7 @@ public class ITestProvidedImplementation {
   private Configuration conf;
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setSeed() throws Exception {
     if (fBASE.exists() && !FileUtil.fullyDelete(fBASE)) {
       throw new IOException("Could not fully delete " + fBASE);
@@ -196,7 +197,7 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     try {
       if (cluster != null) {
@@ -312,7 +313,8 @@ public class ITestProvidedImplementation {
     return nnDirs;
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testLoadImage() throws Exception {
     final long seed = r.nextLong();
     LOG.info("providedPath: " + providedPath);
@@ -338,7 +340,8 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testProvidedReporting() throws Exception {
     conf.setClass(ImageWriter.Options.UGI_CLASS,
         SingleUGIResolver.class, UGIResolver.class);
@@ -417,7 +420,8 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @Test(timeout=500000)
+  @Test
+  @Timeout(value = 500)
   public void testDefaultReplication() throws Exception {
     int targetReplication = 2;
     conf.setInt(FixedBlockMultiReplicaResolver.REPLICATION, targetReplication);
@@ -529,7 +533,8 @@ public class ITestProvidedImplementation {
     return fs.getFileBlockLocations(path, 0, fileLen);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testClusterWithEmptyImage() throws IOException {
     // start a cluster with 2 datanodes without any provided storage
     startCluster(nnDirPath, 2, null,
@@ -567,8 +572,8 @@ public class ITestProvidedImplementation {
   private void checkUniqueness(DatanodeInfo[] locations) {
     Set<String> set = new HashSet<>();
     for (DatanodeInfo info: locations) {
-      assertFalse("All locations should be unique",
-          set.contains(info.getDatanodeUuid()));
+      assertFalse(
+         set.contains(info.getDatanodeUuid()), "All locations should be unique");
       set.add(info.getDatanodeUuid());
     }
   }
@@ -577,7 +582,8 @@ public class ITestProvidedImplementation {
    * Tests setting replication of provided files.
    * @throws Exception
    */
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50)
   public void testSetReplicationForProvidedFiles() throws Exception {
     createImage(new FSTreeWalk(providedPath, conf), nnDirPath,
         FixedBlockResolver.class);
@@ -618,7 +624,8 @@ public class ITestProvidedImplementation {
         defaultReplication);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testProvidedDatanodeFailures() throws Exception {
     createImage(new FSTreeWalk(providedPath, conf), nnDirPath,
             FixedBlockResolver.class);
@@ -689,7 +696,8 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testTransientDeadDatanodes() throws Exception {
     createImage(new FSTreeWalk(providedPath, conf), nnDirPath,
             FixedBlockResolver.class);
@@ -727,7 +735,8 @@ public class ITestProvidedImplementation {
     return providedStorageMap.getProvidedStorageInfo();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testNamenodeRestart() throws Exception {
     createImage(new FSTreeWalk(providedPath, conf), nnDirPath,
         FixedBlockResolver.class);
@@ -768,7 +777,8 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSetClusterID() throws Exception {
     String clusterID = "PROVIDED-CLUSTER";
     createImage(new FSTreeWalk(providedPath, conf), nnDirPath,
@@ -783,7 +793,8 @@ public class ITestProvidedImplementation {
     assertEquals(clusterID, nn.getNamesystem().getClusterId());
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testNumberOfProvidedLocations() throws Exception {
     // set default replication to 4
     conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY, 4);
@@ -814,7 +825,8 @@ public class ITestProvidedImplementation {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testNumberOfProvidedLocationsManyBlocks() throws Exception {
     // increase number of blocks per file to at least 10 blocks per file
     conf.setLong(FixedBlockResolver.BLOCKSIZE, baseFileLen/10);

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -23,17 +23,18 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Validate FSTreeWalk specific behavior.
@@ -84,37 +85,41 @@ public class TestFSTreeWalk {
    * Verify ACL enabled TreeWalk iterator throws an error if the external file
    * system does not support ACLs.
    */
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testACLNotSupported() throws Exception {
-    Configuration conf = new Configuration();
-    conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
+      Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+          Configuration conf = new Configuration();
+          conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
+          FileSystem fs = mock(FileSystem.class);
+          when(fs.getAclStatus(any())).thenThrow(new UnsupportedOperationException());
+          Path root = mock(Path.class);
+          when(root.getFileSystem(conf)).thenReturn(fs);
+          FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
+          when(fs.getFileStatus(root)).thenReturn(rootFileStatus);
+          FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
+          TreeWalk.TreeIterator iter = fsTreeWalk.iterator();
+          fail("Unexpected successful creation of iter: " + iter);
+      });
+  
 
-    FileSystem fs = mock(FileSystem.class);
-    when(fs.getAclStatus(any())).thenThrow(new UnsupportedOperationException());
-    Path root = mock(Path.class);
-    when(root.getFileSystem(conf)).thenReturn(fs);
-    FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
-    when(fs.getFileStatus(root)).thenReturn(rootFileStatus);
-
-    FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
-    TreeWalk.TreeIterator iter = fsTreeWalk.iterator();
-    fail("Unexpected successful creation of iter: " + iter);
-  }
+}
 
   /**
    * Verify creation of INode for ACL enabled TreePath throws an error.
    */
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testToINodeACLNotSupported() throws Exception {
-    BlockResolver blockResolver = new FixedBlockResolver();
-    Path root = new Path("/");
-    FileStatus rootFileStatus = new FileStatus(0, false, 0, 0, 1, root);
+      Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+          BlockResolver blockResolver = new FixedBlockResolver();
+          Path root = new Path("/");
+          FileStatus rootFileStatus = new FileStatus(0, false, 0, 0, 1, root);
+          AclStatus acls = mock(AclStatus.class);
+          TreePath treePath = new TreePath(rootFileStatus, 1, null, null, acls);
+          UGIResolver ugiResolver = mock(UGIResolver.class);
+          when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1L);
+          treePath.toINode(ugiResolver, blockResolver, null);
+      });
+  
 
-    AclStatus acls = mock(AclStatus.class);
-    TreePath treePath = new TreePath(rootFileStatus, 1, null, null, acls);
-
-    UGIResolver ugiResolver = mock(UGIResolver.class);
-    when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1L);
-    treePath.toINode(ugiResolver, blockResolver, null);
-  }
+}
 }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -84,39 +84,35 @@ public class TestFSTreeWalk {
    */
   @Test
   public void testACLNotSupported() throws Exception {
-      assertThrows(UnsupportedOperationException.class, () -> {
-          Configuration conf = new Configuration();
-          conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
-          FileSystem fs = mock(FileSystem.class);
-          when(fs.getAclStatus(any())).thenThrow(new UnsupportedOperationException());
-          Path root = mock(Path.class);
-          when(root.getFileSystem(conf)).thenReturn(fs);
-          FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
-          when(fs.getFileStatus(root)).thenReturn(rootFileStatus);
-          FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
-          TreeWalk.TreeIterator iter = fsTreeWalk.iterator();
-          fail("Unexpected successful creation of iter: " + iter);
-      });
-  
-
-}
+    assertThrows(UnsupportedOperationException.class, () -> {
+      Configuration conf = new Configuration();
+      conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
+      FileSystem fs = mock(FileSystem.class);
+      when(fs.getAclStatus(any())).thenThrow(new UnsupportedOperationException());
+      Path root = mock(Path.class);
+      when(root.getFileSystem(conf)).thenReturn(fs);
+      FileStatus rootFileStatus = new FileStatus(0, true, 0, 0, 1, root);
+      when(fs.getFileStatus(root)).thenReturn(rootFileStatus);
+      FSTreeWalk fsTreeWalk = new FSTreeWalk(root, conf);
+      TreeWalk.TreeIterator iter = fsTreeWalk.iterator();
+      fail("Unexpected successful creation of iter: " + iter);
+    });
+  }
 
   /**
    * Verify creation of INode for ACL enabled TreePath throws an error.
    */
   @Test
   public void testToINodeACLNotSupported() throws Exception {
-      assertThrows(UnsupportedOperationException.class, () -> {
-          BlockResolver blockResolver = new FixedBlockResolver();
-          Path root = new Path("/");
-          FileStatus rootFileStatus = new FileStatus(0, false, 0, 0, 1, root);
-          AclStatus acls = mock(AclStatus.class);
-          TreePath treePath = new TreePath(rootFileStatus, 1, null, null, acls);
-          UGIResolver ugiResolver = mock(UGIResolver.class);
-          when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1L);
-          treePath.toINode(ugiResolver, blockResolver, null);
-      });
-  
-
-}
+    assertThrows(UnsupportedOperationException.class, () -> {
+      BlockResolver blockResolver = new FixedBlockResolver();
+      Path root = new Path("/");
+      FileStatus rootFileStatus = new FileStatus(0, false, 0, 0, 1, root);
+      AclStatus acls = mock(AclStatus.class);
+      TreePath treePath = new TreePath(rootFileStatus, 1, null, null, acls);
+      UGIResolver ugiResolver = mock(UGIResolver.class);
+      when(ugiResolver.getPermissionsProto(null, acls)).thenReturn(1L);
+      treePath.toINode(ugiResolver, blockResolver, null);
+    });
+  }
 }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSTreeWalk.java
@@ -28,13 +28,10 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Validate FSTreeWalk specific behavior.
@@ -87,7 +84,7 @@ public class TestFSTreeWalk {
    */
   @Test
   public void testACLNotSupported() throws Exception {
-      Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+      assertThrows(UnsupportedOperationException.class, () -> {
           Configuration conf = new Configuration();
           conf.setBoolean(DFSConfigKeys.DFS_PROVIDED_ACLS_IMPORT_ENABLED, true);
           FileSystem fs = mock(FileSystem.class);
@@ -109,7 +106,7 @@ public class TestFSTreeWalk {
    */
   @Test
   public void testToINodeACLNotSupported() throws Exception {
-      Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+      assertThrows(UnsupportedOperationException.class, () -> {
           BlockResolver blockResolver = new FixedBlockResolver();
           Path root = new Path("/");
           FileStatus rootFileStatus = new FileStatus(0, false, 0, 0, 1, root);

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFixedBlockResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFixedBlockResolver.java
@@ -25,18 +25,22 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.BlockProto;
 
+import org.apache.hadoop.test.TestName;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestName;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validate fixed-size block partitioning.
  */
 public class TestFixedBlockResolver {
 
-  @Rule public TestName name = new TestName();
+  @RegisterExtension
+  private TestName name = new TestName();
 
   private final FixedBlockResolver blockId = new FixedBlockResolver();
 

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFixedBlockResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFixedBlockResolver.java
@@ -25,11 +25,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos.BlockProto;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Validate fixed-size block partitioning.
@@ -40,7 +40,7 @@ public class TestFixedBlockResolver {
 
   private final FixedBlockResolver blockId = new FixedBlockResolver();
 
-  @Before
+  @BeforeEach
   public void setup() {
     Configuration conf = new Configuration(false);
     conf.setLong(FixedBlockResolver.BLOCKSIZE, 512L * (1L << 20));

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestRandomTreeWalk {
 
   @RegisterExtension
-  public TestName name = new TestName();
+  private TestName name = new TestName();
 
   private Random r = new Random();
 

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
@@ -26,11 +26,11 @@ import java.util.Set;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Validate randomly generated hierarchies, including fork() support in
@@ -42,7 +42,7 @@ public class TestRandomTreeWalk {
 
   private Random r = new Random();
 
-  @Before
+  @BeforeEach
   public void setSeed() {
     long seed = r.nextLong();
     r.setSeed(seed);

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestRandomTreeWalk.java
@@ -25,12 +25,13 @@ import java.util.Set;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-
+import org.apache.hadoop.test.TestName;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestName;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validate randomly generated hierarchies, including fork() support in
@@ -38,7 +39,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class TestRandomTreeWalk {
 
-  @Rule public TestName name = new TestName();
+  @RegisterExtension
+  public TestName name = new TestName();
 
   private Random r = new Random();
 

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
@@ -31,18 +31,20 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import org.apache.hadoop.test.TestName;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestName;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Validate resolver assigning all paths to a single owner/group.
  */
 public class TestSingleUGIResolver {
 
-  @Rule public TestName name = new TestName();
+  @RegisterExtension
+  private TestName name = new TestName();
 
   private static final int TESTUID = 10101;
   private static final int TESTGID = 10102;

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
@@ -129,35 +129,35 @@ public class TestSingleUGIResolver {
 
   @Test
   public void testInvalidUid() {
-      assertThrows(IllegalArgumentException.class, () -> {
-          Configuration conf = ugi.getConf();
-          conf.setInt(SingleUGIResolver.UID, (1 << 24) + 1);
-          ugi.setConf(conf);
-          ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
-      });
+    assertThrows(IllegalArgumentException.class, () -> {
+      Configuration conf = ugi.getConf();
+      conf.setInt(SingleUGIResolver.UID, (1 << 24) + 1);
+      ugi.setConf(conf);
+      ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short) 0777)));
+    });
   }
 
   @Test
   public void testInvalidGid() {
-      assertThrows(IllegalArgumentException.class, () -> {
-          Configuration conf = ugi.getConf();
-          conf.setInt(SingleUGIResolver.GID, (1 << 24) + 1);
-          ugi.setConf(conf);
-          ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
-      });
+    assertThrows(IllegalArgumentException.class, () -> {
+      Configuration conf = ugi.getConf();
+      conf.setInt(SingleUGIResolver.GID, (1 << 24) + 1);
+      ugi.setConf(conf);
+      ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short) 0777)));
+    });
   }
 
   @Test
   public void testDuplicateIds() {
-      assertThrows(IllegalStateException.class, () -> {
-          Configuration conf = new Configuration(false);
-          conf.setInt(SingleUGIResolver.UID, 4344);
-          conf.setInt(SingleUGIResolver.GID, 4344);
-          conf.set(SingleUGIResolver.USER, TESTUSER);
-          conf.set(SingleUGIResolver.GROUP, TESTGROUP);
-          ugi.setConf(conf);
-          ugi.ugiMap();
-      });
+    assertThrows(IllegalStateException.class, () -> {
+      Configuration conf = new Configuration(false);
+      conf.setInt(SingleUGIResolver.UID, 4344);
+      conf.setInt(SingleUGIResolver.GID, 4344);
+      conf.set(SingleUGIResolver.USER, TESTUSER);
+      conf.set(SingleUGIResolver.GROUP, TESTGROUP);
+      ugi.setConf(conf);
+      ugi.ugiMap();
+    });
   }
 
   static void match(long encoded, FsPermission p) {
@@ -184,5 +184,4 @@ public class TestSingleUGIResolver {
           group,                   /* String group,            */
           p);                      /* Path path                */
   }
-
 }

--- a/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
+++ b/hadoop-tools/hadoop-fs2img/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSingleUGIResolver.java
@@ -31,11 +31,11 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Validate resolver assigning all paths to a single owner/group.
@@ -51,7 +51,7 @@ public class TestSingleUGIResolver {
 
   private SingleUGIResolver ugi = new SingleUGIResolver();
 
-  @Before
+  @BeforeEach
   public void setup() {
     Configuration conf = new Configuration(false);
     conf.setInt(SingleUGIResolver.UID, TESTUID);
@@ -125,31 +125,37 @@ public class TestSingleUGIResolver {
     match(perm, p1);
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInvalidUid() {
-    Configuration conf = ugi.getConf();
-    conf.setInt(SingleUGIResolver.UID, (1 << 24) + 1);
-    ugi.setConf(conf);
-    ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
+      assertThrows(IllegalArgumentException.class, () -> {
+          Configuration conf = ugi.getConf();
+          conf.setInt(SingleUGIResolver.UID, (1 << 24) + 1);
+          ugi.setConf(conf);
+          ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
+      });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInvalidGid() {
-    Configuration conf = ugi.getConf();
-    conf.setInt(SingleUGIResolver.GID, (1 << 24) + 1);
-    ugi.setConf(conf);
-    ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
+      assertThrows(IllegalArgumentException.class, () -> {
+          Configuration conf = ugi.getConf();
+          conf.setInt(SingleUGIResolver.GID, (1 << 24) + 1);
+          ugi.setConf(conf);
+          ugi.resolve(file(TESTUSER, TESTGROUP, new FsPermission((short)0777)));
+      });
   }
 
-  @Test(expected=IllegalStateException.class)
+  @Test
   public void testDuplicateIds() {
-    Configuration conf = new Configuration(false);
-    conf.setInt(SingleUGIResolver.UID, 4344);
-    conf.setInt(SingleUGIResolver.GID, 4344);
-    conf.set(SingleUGIResolver.USER, TESTUSER);
-    conf.set(SingleUGIResolver.GROUP, TESTGROUP);
-    ugi.setConf(conf);
-    ugi.ugiMap();
+      assertThrows(IllegalStateException.class, () -> {
+          Configuration conf = new Configuration(false);
+          conf.setInt(SingleUGIResolver.UID, 4344);
+          conf.setInt(SingleUGIResolver.GID, 4344);
+          conf.set(SingleUGIResolver.USER, TESTUSER);
+          conf.set(SingleUGIResolver.GROUP, TESTGROUP);
+          ugi.setConf(conf);
+          ugi.ugiMap();
+      });
   }
 
   static void match(long encoded, FsPermission p) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19435. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-fs2img.

### How was this patch tested?

mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

