### PR TITLE
HADOOP-19434. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-federation-balance.

### DIFF
--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
@@ -33,9 +33,8 @@ import org.apache.hadoop.tools.fedbalance.procedure.BalanceProcedure.RetryExcept
 import org.apache.hadoop.tools.fedbalance.procedure.BalanceProcedureScheduler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -46,15 +45,14 @@ import java.io.DataInputStream;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.test.GenericTestUtils.getMethodName;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.CURRENT_SNAPSHOT_NAME;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.LAST_SNAPSHOT_NAME;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /**
  * Test DistCpProcedure.
  */
+@Timeout(180)
 public class TestDistCpProcedure {
   private static MiniDFSCluster cluster;
   private static Configuration conf;
@@ -76,11 +75,6 @@ public class TestDistCpProcedure {
           new FileEntry(SRCDAT + "/b", true),
           new FileEntry(SRCDAT + "/b/c", false)};
   private static String nnUri;
-
-  @Rule
-  // There are multiple unit tests with different timeouts that fail multiple times because of
-  // DataStreamer#waitAndQueuePacket, so we set a larger global timeout.
-  public Timeout globalTimeout = new Timeout(180000, TimeUnit.MILLISECONDS);
 
   @BeforeAll
   public static void beforeClass() throws IOException {

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestDistCpProcedure.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.tools.fedbalance.procedure.BalanceJob;
 import org.apache.hadoop.tools.fedbalance.procedure.BalanceProcedure.RetryException;
 import org.apache.hadoop.tools.fedbalance.procedure.BalanceProcedureScheduler;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
@@ -48,17 +48,17 @@ import java.net.URI;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.test.GenericTestUtils.getMethodName;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.CURRENT_SNAPSHOT_NAME;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.LAST_SNAPSHOT_NAME;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test DistCpProcedure.
@@ -82,7 +82,7 @@ public class TestDistCpProcedure {
   // DataStreamer#waitAndQueuePacket, so we set a larger global timeout.
   public Timeout globalTimeout = new Timeout(180000, TimeUnit.MILLISECONDS);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     DistCpProcedure.enableForTest();
     conf = new Configuration();
@@ -98,7 +98,7 @@ public class TestDistCpProcedure {
     nnUri = FileSystem.getDefaultUri(conf).toString();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     DistCpProcedure.disableForTest();
     if (cluster != null) {

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestFedBalance.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.tools.fedbalance;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.WORK_THREAD_NUM;
 

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestTrashProcedure.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/TestTrashProcedure.java
@@ -21,9 +21,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutput;
@@ -34,9 +34,9 @@ import java.io.IOException;
 
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.TrashOption;
 import static org.apache.hadoop.test.GenericTestUtils.getMethodName;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test TrashProcedure.
@@ -47,7 +47,7 @@ public class TestTrashProcedure {
   private static MiniDFSCluster cluster;
   private static String nnUri;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
@@ -55,7 +55,7 @@ public class TestTrashProcedure {
     nnUri = FileSystem.getDefaultUri(conf).toString();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/procedure/TestBalanceProcedureScheduler.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/procedure/TestBalanceProcedureScheduler.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.ByteArrayOutputStream;
@@ -53,6 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test BalanceProcedureScheduler.
@@ -156,10 +159,10 @@ public class TestBalanceProcedureScheduler {
     scheduler.init(true);
     try {
       // Mock bad procedure.
-      BalanceProcedure badProcedure = Mockito.mock(BalanceProcedure.class);
-      Mockito.doThrow(new IOException("Job failed exception."))
+      BalanceProcedure badProcedure = mock(BalanceProcedure.class);
+      doThrow(new IOException("Job failed exception."))
           .when(badProcedure).execute();
-      Mockito.doReturn("bad-procedure").when(badProcedure).name();
+      doReturn("bad-procedure").when(badProcedure).name();
 
       BalanceJob.Builder builder = new BalanceJob.Builder<>();
       builder.nextProcedure(badProcedure);
@@ -390,9 +393,9 @@ public class TestBalanceProcedureScheduler {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
 
-    BalanceJournal journal = Mockito.mock(BalanceJournal.class);
+    BalanceJournal journal = mock(BalanceJournal.class);
     AtomicInteger count = new AtomicInteger(0);
-    Mockito.doAnswer(invocation -> {
+    doAnswer(invocation -> {
       if (count.incrementAndGet() == 1) {
         throw new IOException("Mock clear failure");
       }

--- a/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/procedure/TestBalanceProcedureScheduler.java
+++ b/hadoop-tools/hadoop-federation-balance/src/test/java/org/apache/hadoop/tools/fedbalance/procedure/TestBalanceProcedureScheduler.java
@@ -26,9 +26,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -46,11 +47,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.SCHEDULER_JOURNAL_URI;
 import static org.apache.hadoop.tools.fedbalance.FedBalanceConfigs.WORK_THREAD_NUM;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_KEY;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -63,7 +64,7 @@ public class TestBalanceProcedureScheduler {
   private static DistributedFileSystem fs;
   private static final int DEFAULT_BLOCK_SIZE = 512;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     CONF.setBoolean(DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_ALWAYS_USE_KEY,
         true);
@@ -84,7 +85,7 @@ public class TestBalanceProcedureScheduler {
     fs.mkdirs(new Path(workPath));
   }
 
-  @AfterClass
+  @AfterAll
   public static void close() {
     if (cluster != null) {
       cluster.shutdown();
@@ -94,7 +95,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test the scheduler could be shutdown correctly.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testShutdownScheduler() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -115,7 +117,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test a successful job.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSuccessfulJob() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -146,7 +149,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test a job fails and the error can be got.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFailedJob() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -174,7 +178,8 @@ public class TestBalanceProcedureScheduler {
    * the last unfinished procedure, which is the first procedure without
    * journal.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetJobAfterRecover() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -238,7 +243,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test RetryException is handled correctly.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRetry() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -265,7 +271,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test schedule an empty job.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testEmptyJob() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -281,7 +288,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test serialization and deserialization of Job.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testJobSerializeAndDeserialize() throws Exception {
     BalanceJob.Builder builder = new BalanceJob.Builder<RecordProcedure>();
     for (int i = 0; i < 5; i++) {
@@ -305,7 +313,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test scheduler crashes and recovers.
    */
-  @Test(timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testSchedulerDownAndRecoverJob() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -347,7 +356,8 @@ public class TestBalanceProcedureScheduler {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRecoverJobFromJournal() throws Exception {
     BalanceJournal journal =
         ReflectionUtils.newInstance(BalanceJournalInfoHDFS.class, CONF);
@@ -374,7 +384,8 @@ public class TestBalanceProcedureScheduler {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testClearJournalFail() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);
@@ -404,7 +415,8 @@ public class TestBalanceProcedureScheduler {
   /**
    * Test the job will be recovered if writing journal fails.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testJobRecoveryWhenWriteJournalFail() throws Exception {
     BalanceProcedureScheduler scheduler = new BalanceProcedureScheduler(CONF);
     scheduler.init(true);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19434. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-federation-balance.

### How was this patch tested?

mvn clean test & Junit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

