### PR TITLE
YARN-11808. RM memory leak due to Opportunistic container request cancellation at App level.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.yarn.server.scheduler;
 
 import org.apache.hadoop.yarn.api.records.Priority;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -32,7 +32,9 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.ArrayList;
 
-
+/**
+ * Test cases for OpportunisticContainerContext.
+ */
 public class TestOpportunisticContainerContext {
 
     @Spy
@@ -50,11 +52,11 @@ public class TestOpportunisticContainerContext {
         outstandingOpReqs = new TreeMap<>();
     }
 
-    /*
-     Resource Request - {
-        Location = ANY
-        No of container != 0
-     }
+    /**
+     *  Resource Request - {
+     *         Location = ANY
+     *         No of container != 0
+     *      }
      */
     @Test
     public void testAddToOutstandingReqsWithANYRequest() {
@@ -65,11 +67,11 @@ public class TestOpportunisticContainerContext {
         Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
     }
 
-    /*
-     Resource Request - {
-        Location != ANY
-        No of Container = 0
-     }
+    /**
+     *  Resource Request - {
+     *         Location != ANY
+     *         No of container = 0
+     *      }
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainer() {
@@ -84,11 +86,11 @@ public class TestOpportunisticContainerContext {
                 getOutstandingOpReqs().size(), 1);
     }
 
-    /*
-     Resource Request - [
-        {Location != ANY, No of Container = 0}
-        {Location = ANY, No of Container = 0}
-     ]
+    /**
+     *  Resource Request - [
+     *         {Location != ANY, No of Container = 0}
+     *         {Location = ANY, No of Container = 0}
+     *      ]
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
@@ -106,11 +108,11 @@ public class TestOpportunisticContainerContext {
                 getOutstandingOpReqs().size(), 1);
     }
 
-    /*
-     Resource Request - [
-        {Location != ANY, No of Container = 0}
-        {Location = ANY, No of Container != 0}
-     ]
+    /**
+     *  Resource Request - [
+     *         {Location != ANY, No of Container = 0}
+     *         {Location = ANY, No of Container != 0}
+     *      ]
      */
     @Test
     public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
@@ -128,12 +130,12 @@ public class TestOpportunisticContainerContext {
                 getOutstandingOpReqs().size(), 1);
     }
 
-    /*
-     Resource Request - {
-        Location != ANY
-        No of container = 0
-        Capability = NULL
-     }
+    /**
+     *  Resource Request - {
+     *         Location != ANY
+     *         No of container = 0
+     *         Capability = NULL
+     *      }
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
@@ -148,12 +150,12 @@ public class TestOpportunisticContainerContext {
                 getOutstandingOpReqs().size(), 1);
     }
 
-    /*
-     Resource Request - {
-        Location != ANY
-        No of container = 0
-        Req map is NULL
-     }
+    /**
+     *  Resource Request - {
+     *         Location != ANY
+     *         No of container = 0
+     *         Req map is NULL
+     *      }
      */
     @Test
     public void testAddToOutstandingReqsWithEmptyReqMap() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -1,0 +1,182 @@
+package org.apache.hadoop.yarn.server.scheduler;
+
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.ArrayList;
+
+
+public class TestOpportunisticContainerContext {
+
+    @Spy
+    OpportunisticContainerContext opportunisticContainerContext;
+
+    Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>
+            reqMap = new HashMap<>();
+
+    TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
+            outstandingOpReqs;
+
+    @Before
+    public void SetUp() {
+        opportunisticContainerContext = Mockito.spy(new OpportunisticContainerContext());
+        outstandingOpReqs = new TreeMap<>();
+    }
+
+    /*
+     Resource Request - {
+        Location = ANY
+        No of container != 0
+     }
+     */
+    @Test
+    public void testAddToOutstandingReqsWithANYRequest() {
+        ResourceRequest request = getResourceRequest(ResourceRequest.ANY, 1);
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(request);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    }
+
+    /*
+     Resource Request - {
+        Location != ANY
+        No of Container = 0
+     }
+     */
+    @Test
+    public void testAddToOutstandingReqsWithZeroContainer() {
+        ResourceRequest request = getResourceRequest("resource", 0);
+        createOutstandingOpReqs(request, getResource());
+        Mockito.doReturn(outstandingOpReqs)
+                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(request);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.
+                getOutstandingOpReqs().size(), 1);
+    }
+
+    /*
+     Resource Request - [
+        {Location != ANY, No of Container = 0}
+        {Location = ANY, No of Container = 0}
+     ]
+     */
+    @Test
+    public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
+        ResourceRequest req1 = getResourceRequest("resource", 0);
+        ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 0);
+        createOutstandingOpReqs(req1, getResource());
+        createOutstandingOpReqs(req2, getResource());
+        Mockito.doReturn(outstandingOpReqs)
+                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(req1);
+        resourceRequestList.add(req2);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.
+                getOutstandingOpReqs().size(), 1);
+    }
+
+    /*
+     Resource Request - [
+        {Location != ANY, No of Container = 0}
+        {Location = ANY, No of Container != 0}
+     ]
+     */
+    @Test
+    public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
+        ResourceRequest req1 = getResourceRequest("resource", 0);
+        ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 1);
+        createOutstandingOpReqs(req1, getResource());
+        createOutstandingOpReqs(req2, getResource());
+        Mockito.doReturn(outstandingOpReqs)
+                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(req1);
+        resourceRequestList.add(req2);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.
+                getOutstandingOpReqs().size(), 1);
+    }
+
+    /*
+     Resource Request - {
+        Location != ANY
+        No of container = 0
+        Capability = NULL
+     }
+     */
+    @Test
+    public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
+        ResourceRequest request = getResourceRequestWithoutCapability();
+        createOutstandingOpReqs(request, getResource());
+        Mockito.doReturn(outstandingOpReqs)
+                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(request);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.
+                getOutstandingOpReqs().size(), 1);
+    }
+
+    /*
+     Resource Request - {
+        Location != ANY
+        No of container = 0
+        Req map is NULL
+     }
+     */
+    @Test
+    public void testAddToOutstandingReqsWithEmptyReqMap() {
+        ResourceRequest request = getResourceRequest("resource", 0);
+        Mockito.doReturn(new TreeMap<>())
+                .when(opportunisticContainerContext).getContainerIdGenerator();
+        List<ResourceRequest> resourceRequestList = new ArrayList<>();
+        resourceRequestList.add(request);
+        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+        Assert.assertEquals(opportunisticContainerContext.
+                getOutstandingOpReqs().size(), 0);
+    }
+
+    private void createOutstandingOpReqs(ResourceRequest req, Resource resource) {
+        SchedulerRequestKey schedulerRequestKey = SchedulerRequestKey.create(req);
+        reqMap.put(resource,
+                new OpportunisticContainerAllocator.EnrichedResourceRequest(req));
+        outstandingOpReqs.put(schedulerRequestKey, reqMap);
+    }
+
+    private ResourceRequest getResourceRequest(String resourceName, int numContainer) {
+        return ResourceRequest.newBuilder()
+                .resourceName(resourceName)
+                .numContainers(numContainer)
+                .allocationRequestId(1)
+                .priority(Priority.newInstance(1))
+                .capability(getResource())
+                .build();
+    }
+
+    private ResourceRequest getResourceRequestWithoutCapability() {
+        return ResourceRequest.newBuilder()
+                .resourceName("resource")
+                .numContainers(0)
+                .allocationRequestId(1)
+                .priority(Priority.newInstance(1))
+                .build();
+    }
+
+    private Resource getResource() {
+        return Resource.newInstance(1024, 2);
+    }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -38,25 +38,23 @@ import java.util.ArrayList;
 public class TestOpportunisticContainerContext {
 
     @Spy
-    OpportunisticContainerContext opportunisticContainerContext;
-
-    Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>
-            reqMap = new HashMap<>();
-
-    TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
-            outstandingOpReqs;
+    private OpportunisticContainerContext opportunisticContainerContext;
+    private Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest> reqMap =
+        new HashMap<>();
+    private TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
+        outstandingOpReqs;
 
     @Before
-    public void SetUp() {
+    public void setUp() {
         opportunisticContainerContext = Mockito.spy(new OpportunisticContainerContext());
         outstandingOpReqs = new TreeMap<>();
     }
 
     /**
-     *  Resource Request - {
-     *         Location = ANY
-     *         No of container != 0
-     *      }
+     * Resource Request - {
+     * Location = ANY
+     * No of container != 0
+     * }
      */
     @Test
     public void testAddToOutstandingReqsWithANYRequest() {
@@ -68,29 +66,28 @@ public class TestOpportunisticContainerContext {
     }
 
     /**
-     *  Resource Request - {
-     *         Location != ANY
-     *         No of container = 0
-     *      }
+     * Resource Request - {
+     * Location != ANY
+     * No of container = 0
+     * }
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainer() {
         ResourceRequest request = getResourceRequest("resource", 0);
         createOutstandingOpReqs(request, getResource());
-        Mockito.doReturn(outstandingOpReqs)
-                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.
-                getOutstandingOpReqs().size(), 1);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
     }
 
     /**
-     *  Resource Request - [
-     *         {Location != ANY, No of Container = 0}
-     *         {Location = ANY, No of Container = 0}
-     *      ]
+     * Resource Request - [
+     * {Location != ANY, No of Container = 0}
+     * {Location = ANY, No of Container = 0}
+     * ]
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
@@ -98,21 +95,20 @@ public class TestOpportunisticContainerContext {
         ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 0);
         createOutstandingOpReqs(req1, getResource());
         createOutstandingOpReqs(req2, getResource());
-        Mockito.doReturn(outstandingOpReqs)
-                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(req1);
         resourceRequestList.add(req2);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.
-                getOutstandingOpReqs().size(), 1);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
     }
 
     /**
-     *  Resource Request - [
-     *         {Location != ANY, No of Container = 0}
-     *         {Location = ANY, No of Container != 0}
-     *      ]
+     * Resource Request - [
+     * {Location != ANY, No of Container = 0}
+     * {Location = ANY, No of Container != 0}
+     * ]
      */
     @Test
     public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
@@ -120,79 +116,67 @@ public class TestOpportunisticContainerContext {
         ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 1);
         createOutstandingOpReqs(req1, getResource());
         createOutstandingOpReqs(req2, getResource());
-        Mockito.doReturn(outstandingOpReqs)
-                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(req1);
         resourceRequestList.add(req2);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.
-                getOutstandingOpReqs().size(), 1);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
     }
 
     /**
-     *  Resource Request - {
-     *         Location != ANY
-     *         No of container = 0
-     *         Capability = NULL
-     *      }
+     * Resource Request - {
+     * Location != ANY
+     * No of container = 0
+     * Capability = NULL
+     * }
      */
     @Test
     public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
         ResourceRequest request = getResourceRequestWithoutCapability();
         createOutstandingOpReqs(request, getResource());
-        Mockito.doReturn(outstandingOpReqs)
-                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.
-                getOutstandingOpReqs().size(), 1);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
     }
 
     /**
-     *  Resource Request - {
-     *         Location != ANY
-     *         No of container = 0
-     *         Req map is NULL
-     *      }
+     * Resource Request - {
+     * Location != ANY
+     * No of container = 0
+     * Req map is NULL
+     * }
      */
     @Test
     public void testAddToOutstandingReqsWithEmptyReqMap() {
         ResourceRequest request = getResourceRequest("resource", 0);
-        Mockito.doReturn(new TreeMap<>())
-                .when(opportunisticContainerContext).getOutstandingOpReqs();
+        Mockito.doReturn(new TreeMap<>()).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.
-                getOutstandingOpReqs().size(), 0);
+        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 0);
     }
 
     private void createOutstandingOpReqs(ResourceRequest req, Resource resource) {
         SchedulerRequestKey schedulerRequestKey = SchedulerRequestKey.create(req);
-        reqMap.put(resource,
-                new OpportunisticContainerAllocator.EnrichedResourceRequest(req));
+        reqMap.put(resource, new OpportunisticContainerAllocator.EnrichedResourceRequest(req));
         outstandingOpReqs.put(schedulerRequestKey, reqMap);
     }
 
     private ResourceRequest getResourceRequest(String resourceName, int numContainer) {
-        return ResourceRequest.newBuilder()
-                .resourceName(resourceName)
-                .numContainers(numContainer)
-                .allocationRequestId(1)
-                .priority(Priority.newInstance(1))
-                .capability(getResource())
-                .build();
+        return ResourceRequest.newBuilder().resourceName(resourceName).numContainers(numContainer)
+            .allocationRequestId(1).priority(Priority.newInstance(1)).capability(getResource())
+            .build();
     }
 
     private ResourceRequest getResourceRequestWithoutCapability() {
-        return ResourceRequest.newBuilder()
-                .resourceName("resource")
-                .numContainers(0)
-                .allocationRequestId(1)
-                .priority(Priority.newInstance(1))
-                .build();
+        return ResourceRequest.newBuilder().resourceName("resource").numContainers(0)
+            .allocationRequestId(1).priority(Priority.newInstance(1)).build();
     }
 
     private Resource getResource() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -142,7 +142,7 @@ public class TestOpportunisticContainerContext {
     public void testAddToOutstandingReqsWithEmptyReqMap() {
         ResourceRequest request = getResourceRequest("resource", 0);
         Mockito.doReturn(new TreeMap<>())
-                .when(opportunisticContainerContext).getContainerIdGenerator();
+                .when(opportunisticContainerContext).getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -40,9 +40,9 @@ public class TestOpportunisticContainerContext {
     @Spy
     private OpportunisticContainerContext opportunisticContainerContext;
     private Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest> reqMap =
-        new HashMap<>();
+            new HashMap<>();
     private TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
-        outstandingOpReqs;
+            outstandingOpReqs;
 
     @Before
     public void setUp() {
@@ -76,7 +76,7 @@ public class TestOpportunisticContainerContext {
         ResourceRequest request = getResourceRequest("resource", 0);
         createOutstandingOpReqs(request, getResource());
         Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-            .getOutstandingOpReqs();
+                .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
@@ -96,7 +96,7 @@ public class TestOpportunisticContainerContext {
         createOutstandingOpReqs(req1, getResource());
         createOutstandingOpReqs(req2, getResource());
         Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-            .getOutstandingOpReqs();
+                .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(req1);
         resourceRequestList.add(req2);
@@ -117,7 +117,7 @@ public class TestOpportunisticContainerContext {
         createOutstandingOpReqs(req1, getResource());
         createOutstandingOpReqs(req2, getResource());
         Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-            .getOutstandingOpReqs();
+                .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(req1);
         resourceRequestList.add(req2);
@@ -137,7 +137,7 @@ public class TestOpportunisticContainerContext {
         ResourceRequest request = getResourceRequestWithoutCapability();
         createOutstandingOpReqs(request, getResource());
         Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-            .getOutstandingOpReqs();
+                .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
@@ -155,7 +155,7 @@ public class TestOpportunisticContainerContext {
     public void testAddToOutstandingReqsWithEmptyReqMap() {
         ResourceRequest request = getResourceRequest("resource", 0);
         Mockito.doReturn(new TreeMap<>()).when(opportunisticContainerContext)
-            .getOutstandingOpReqs();
+                .getOutstandingOpReqs();
         List<ResourceRequest> resourceRequestList = new ArrayList<>();
         resourceRequestList.add(request);
         opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
@@ -170,13 +170,13 @@ public class TestOpportunisticContainerContext {
 
     private ResourceRequest getResourceRequest(String resourceName, int numContainer) {
         return ResourceRequest.newBuilder().resourceName(resourceName).numContainers(numContainer)
-            .allocationRequestId(1).priority(Priority.newInstance(1)).capability(getResource())
-            .build();
+                .allocationRequestId(1).priority(Priority.newInstance(1)).capability(getResource())
+                .build();
     }
 
     private ResourceRequest getResourceRequestWithoutCapability() {
         return ResourceRequest.newBuilder().resourceName("resource").numContainers(0)
-            .allocationRequestId(1).priority(Priority.newInstance(1)).build();
+                .allocationRequestId(1).priority(Priority.newInstance(1)).build();
     }
 
     private Resource getResource() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.scheduler;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -42,8 +42,8 @@ public class TestOpportunisticContainerContext {
   private OpportunisticContainerContext opportunisticContainerContext;
   private Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest> reqMap =
           new HashMap<>();
-  private TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
-          outstandingOpReqs;
+  private TreeMap<SchedulerRequestKey,
+          Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>> outstandingOpReqs;
 
   @Before
   public void setUp() {
@@ -55,7 +55,7 @@ public class TestOpportunisticContainerContext {
    * Resource Request - {
    * Location = ANY
    * No of container != 0
-   * }
+   * }.
    */
   @Test
   public void testAddToOutstandingReqsWithANYRequest() {
@@ -70,7 +70,7 @@ public class TestOpportunisticContainerContext {
    * Resource Request - {
    * Location != ANY
    * No of container = 0
-   * }
+   * }.
    */
   @Test
   public void testAddToOutstandingReqsWithZeroContainer() {
@@ -88,7 +88,7 @@ public class TestOpportunisticContainerContext {
    * Resource Request - [
    * {Location != ANY, No of Container = 0}
    * {Location = ANY, No of Container = 0}
-   * ]
+   * ].
    */
   @Test
   public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
@@ -109,7 +109,7 @@ public class TestOpportunisticContainerContext {
    * Resource Request - [
    * {Location != ANY, No of Container = 0}
    * {Location = ANY, No of Container != 0}
-   * ]
+   * ].
    */
   @Test
   public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
@@ -131,7 +131,7 @@ public class TestOpportunisticContainerContext {
    * Location != ANY
    * No of container = 0
    * Capability = NULL
-   * }
+   * }.
    */
   @Test
   public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
@@ -150,7 +150,7 @@ public class TestOpportunisticContainerContext {
    * Location != ANY
    * No of container = 0
    * Req map is NULL
-   * }
+   * }.
    */
   @Test
   public void testAddToOutstandingReqsWithEmptyReqMap() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -38,149 +38,149 @@ import java.util.ArrayList;
  */
 public class TestOpportunisticContainerContext {
 
-    @Spy
-    private OpportunisticContainerContext opportunisticContainerContext;
-    private Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest> reqMap =
-            new HashMap<>();
-    private TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
-            outstandingOpReqs;
+  @Spy
+  private OpportunisticContainerContext opportunisticContainerContext;
+  private Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest> reqMap =
+          new HashMap<>();
+  private TreeMap<SchedulerRequestKey, Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>>
+          outstandingOpReqs;
 
-    @Before
-    public void setUp() {
-        opportunisticContainerContext = Mockito.spy(new OpportunisticContainerContext());
-        outstandingOpReqs = new TreeMap<>();
-    }
+  @Before
+  public void setUp() {
+    opportunisticContainerContext = Mockito.spy(new OpportunisticContainerContext());
+    outstandingOpReqs = new TreeMap<>();
+  }
 
-    /**
-     * Resource Request - {
-     * Location = ANY
-     * No of container != 0
-     * }
-     */
-    @Test
-    public void testAddToOutstandingReqsWithANYRequest() {
-        ResourceRequest request = getResourceRequest(ResourceRequest.ANY, 1);
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(request);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
-    }
+  /**
+   * Resource Request - {
+   * Location = ANY
+   * No of container != 0
+   * }
+   */
+  @Test
+  public void testAddToOutstandingReqsWithANYRequest() {
+    ResourceRequest request = getResourceRequest(ResourceRequest.ANY, 1);
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(request);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+  }
 
-    /**
-     * Resource Request - {
-     * Location != ANY
-     * No of container = 0
-     * }
-     */
-    @Test
-    public void testAddToOutstandingReqsWithZeroContainer() {
-        ResourceRequest request = getResourceRequest("resource", 0);
-        createOutstandingOpReqs(request, getResource());
-        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-                .getOutstandingOpReqs();
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(request);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
-    }
+  /**
+   * Resource Request - {
+   * Location != ANY
+   * No of container = 0
+   * }
+   */
+  @Test
+  public void testAddToOutstandingReqsWithZeroContainer() {
+    ResourceRequest request = getResourceRequest("resource", 0);
+    createOutstandingOpReqs(request, getResource());
+    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(request);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+  }
 
-    /**
-     * Resource Request - [
-     * {Location != ANY, No of Container = 0}
-     * {Location = ANY, No of Container = 0}
-     * ]
-     */
-    @Test
-    public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
-        ResourceRequest req1 = getResourceRequest("resource", 0);
-        ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 0);
-        createOutstandingOpReqs(req1, getResource());
-        createOutstandingOpReqs(req2, getResource());
-        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-                .getOutstandingOpReqs();
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(req1);
-        resourceRequestList.add(req2);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
-    }
+  /**
+   * Resource Request - [
+   * {Location != ANY, No of Container = 0}
+   * {Location = ANY, No of Container = 0}
+   * ]
+   */
+  @Test
+  public void testAddToOutstandingReqsWithZeroContainerAndMultipleSchedulerKey() {
+    ResourceRequest req1 = getResourceRequest("resource", 0);
+    ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 0);
+    createOutstandingOpReqs(req1, getResource());
+    createOutstandingOpReqs(req2, getResource());
+    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(req1);
+    resourceRequestList.add(req2);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+  }
 
-    /**
-     * Resource Request - [
-     * {Location != ANY, No of Container = 0}
-     * {Location = ANY, No of Container != 0}
-     * ]
-     */
-    @Test
-    public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
-        ResourceRequest req1 = getResourceRequest("resource", 0);
-        ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 1);
-        createOutstandingOpReqs(req1, getResource());
-        createOutstandingOpReqs(req2, getResource());
-        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-                .getOutstandingOpReqs();
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(req1);
-        resourceRequestList.add(req2);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
-    }
+  /**
+   * Resource Request - [
+   * {Location != ANY, No of Container = 0}
+   * {Location = ANY, No of Container != 0}
+   * ]
+   */
+  @Test
+  public void testAddToOutstandingReqsWithMultipleSchedulerKey() {
+    ResourceRequest req1 = getResourceRequest("resource", 0);
+    ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 1);
+    createOutstandingOpReqs(req1, getResource());
+    createOutstandingOpReqs(req2, getResource());
+    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(req1);
+    resourceRequestList.add(req2);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+  }
 
-    /**
-     * Resource Request - {
-     * Location != ANY
-     * No of container = 0
-     * Capability = NULL
-     * }
-     */
-    @Test
-    public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
-        ResourceRequest request = getResourceRequestWithoutCapability();
-        createOutstandingOpReqs(request, getResource());
-        Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
-                .getOutstandingOpReqs();
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(request);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
-    }
+  /**
+   * Resource Request - {
+   * Location != ANY
+   * No of container = 0
+   * Capability = NULL
+   * }
+   */
+  @Test
+  public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
+    ResourceRequest request = getResourceRequestWithoutCapability();
+    createOutstandingOpReqs(request, getResource());
+    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(request);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+  }
 
-    /**
-     * Resource Request - {
-     * Location != ANY
-     * No of container = 0
-     * Req map is NULL
-     * }
-     */
-    @Test
-    public void testAddToOutstandingReqsWithEmptyReqMap() {
-        ResourceRequest request = getResourceRequest("resource", 0);
-        Mockito.doReturn(new TreeMap<>()).when(opportunisticContainerContext)
-                .getOutstandingOpReqs();
-        List<ResourceRequest> resourceRequestList = new ArrayList<>();
-        resourceRequestList.add(request);
-        opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-        Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 0);
-    }
+  /**
+   * Resource Request - {
+   * Location != ANY
+   * No of container = 0
+   * Req map is NULL
+   * }
+   */
+  @Test
+  public void testAddToOutstandingReqsWithEmptyReqMap() {
+    ResourceRequest request = getResourceRequest("resource", 0);
+    Mockito.doReturn(new TreeMap<>()).when(opportunisticContainerContext)
+            .getOutstandingOpReqs();
+    List<ResourceRequest> resourceRequestList = new ArrayList<>();
+    resourceRequestList.add(request);
+    opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
+    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 0);
+  }
 
-    private void createOutstandingOpReqs(ResourceRequest req, Resource resource) {
-        SchedulerRequestKey schedulerRequestKey = SchedulerRequestKey.create(req);
-        reqMap.put(resource, new OpportunisticContainerAllocator.EnrichedResourceRequest(req));
-        outstandingOpReqs.put(schedulerRequestKey, reqMap);
-    }
+  private void createOutstandingOpReqs(ResourceRequest req, Resource resource) {
+    SchedulerRequestKey schedulerRequestKey = SchedulerRequestKey.create(req);
+    reqMap.put(resource, new OpportunisticContainerAllocator.EnrichedResourceRequest(req));
+    outstandingOpReqs.put(schedulerRequestKey, reqMap);
+  }
 
-    private ResourceRequest getResourceRequest(String resourceName, int numContainer) {
-        return ResourceRequest.newBuilder().resourceName(resourceName).numContainers(numContainer)
-                .allocationRequestId(1).priority(Priority.newInstance(1)).capability(getResource())
-                .build();
-    }
+  private ResourceRequest getResourceRequest(String resourceName, int numContainer) {
+    return ResourceRequest.newBuilder().resourceName(resourceName).numContainers(numContainer)
+            .allocationRequestId(1).priority(Priority.newInstance(1)).capability(getResource())
+            .build();
+  }
 
-    private ResourceRequest getResourceRequestWithoutCapability() {
-        return ResourceRequest.newBuilder().resourceName("resource").numContainers(0)
-                .allocationRequestId(1).priority(Priority.newInstance(1)).build();
-    }
+  private ResourceRequest getResourceRequestWithoutCapability() {
+    return ResourceRequest.newBuilder().resourceName("resource").numContainers(0)
+            .allocationRequestId(1).priority(Priority.newInstance(1)).build();
+  }
 
-    private Resource getResource() {
-        return Resource.newInstance(1024, 2);
-    }
+  private Resource getResource() {
+    return Resource.newInstance(1024, 2);
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [Y ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

