### PR TITLE
HADOOP-19432. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-dynamometer-workload.

### DIFF
--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/TestWorkloadGenerator.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/TestWorkloadGenerator.java
@@ -40,16 +40,16 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.authorize.ImpersonationProvider;
 import org.jline.utils.Log;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /** Tests for {@link WorkloadDriver} and related classes. */
@@ -61,7 +61,7 @@ public class TestWorkloadGenerator {
   private MiniDFSCluster miniCluster;
   private FileSystem dfs;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new Configuration();
     conf.setClass(HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS,
@@ -74,7 +74,7 @@ public class TestWorkloadGenerator {
     dfs.setOwner(new Path("/tmp"), "hdfs", "hdfs");
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (miniCluster != null) {
       miniCluster.shutdown();
@@ -135,7 +135,7 @@ public class TestWorkloadGenerator {
     Job workloadJob = WorkloadDriver.getJobForSubmission(conf,
         dfs.getUri().toString(), workloadStartTime, AuditReplayMapper.class);
     boolean success = workloadJob.waitForCompletion(true);
-    assertTrue("workload job should succeed", success);
+    assertTrue(success, "workload job should succeed");
     Counters counters = workloadJob.getCounters();
     assertEquals(6,
         counters.findCounter(AuditReplayMapper.REPLAYCOUNTERS.TOTALCOMMANDS)

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/audit/TestAuditLogDirectParser.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-workload/src/test/java/org/apache/hadoop/tools/dynamometer/workloadgenerator/audit/TestAuditLogDirectParser.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.tools.dynamometer.workloadgenerator.audit;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link AuditLogDirectParser}. */
 public class TestAuditLogDirectParser {
@@ -32,7 +32,7 @@ public class TestAuditLogDirectParser {
   private AuditLogDirectParser parser;
   private Long sequence = 1L;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     parser = new AuditLogDirectParser();
     Configuration conf = new Configuration();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19432. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-dynamometer-workload.

### How was this patch tested?

Junit test & mvn clean test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

