### PR TITLE
HADOOP-19429. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-dynamometer-infra.

### DIFF
--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
 import org.junit.jupiter.api.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,8 +188,7 @@ public class TestDynamometerInfra {
     // Set up the Hadoop binary to be used as the system-level Hadoop install
     hadoopUnpackedDir = new File(testBaseDir,
         HADOOP_BIN_UNPACKED_DIR_PREFIX + UUID.randomUUID());
-    assertTrue(
-       hadoopUnpackedDir.mkdirs(), "Failed to make temporary directory");
+    assertTrue(hadoopUnpackedDir.mkdirs(), "Failed to make temporary directory");
     Shell.ShellCommandExecutor shexec = new Shell.ShellCommandExecutor(
         new String[] {"tar", "xzf", hadoopTarballPath.getAbsolutePath(), "-C",
             hadoopUnpackedDir.getAbsolutePath()});

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
@@ -71,7 +71,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsMana
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynamometerInfra.java
@@ -71,22 +71,16 @@ import org.apache.hadoop.yarn.server.resourcemanager.nodelabels.RMNodeLabelsMana
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.apache.hadoop.yarn.util.resource.DominantResourceCalculator;
 import org.apache.hadoop.yarn.util.resource.ResourceCalculator;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.tools.dynamometer.DynoInfraUtils.fetchHadoopTarball;
 import static org.apache.hadoop.hdfs.MiniDFSCluster.PROP_TEST_BUILD_DATA;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Start a Dynamometer cluster in a MiniYARNCluster. Ensure that the NameNode is
@@ -112,7 +106,7 @@ import static org.junit.Assert.fail;
  * property to point directly to a Hadoop tarball which is present locally and
  * no download will occur.
  */
-@Ignore
+@Disabled
 public class TestDynamometerInfra {
 
   private static final Logger LOG =
@@ -153,19 +147,19 @@ public class TestDynamometerInfra {
 
   private ApplicationId infraAppId;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     PlatformAssumptions.assumeNotWindows("Dynamometer will not run on Windows");
-    Assume.assumeThat("JAVA_HOME must be set properly",
-        System.getenv("JAVA_HOME"), notNullValue());
+    assumeTrue(System.getenv("JAVA_HOME") != null,
+        "JAVA_HOME must be set properly");
     try {
       Shell.ShellCommandExecutor tarCheck = new Shell.ShellCommandExecutor(
           new String[]{"bash", "-c", "command -v tar"});
       tarCheck.execute();
-      Assume.assumeTrue("tar command is not available",
-          tarCheck.getExitCode() == 0);
+      assumeTrue(tarCheck.getExitCode() == 0,
+          "tar command is not available");
     } catch (IOException ioe) {
-      Assume.assumeNoException("Unable to execute a shell command", ioe);
+      assumeTrue(false, "Unexpected exception occurred: " + ioe.getMessage());
     }
 
     conf = new Configuration();
@@ -193,8 +187,8 @@ public class TestDynamometerInfra {
     // Set up the Hadoop binary to be used as the system-level Hadoop install
     hadoopUnpackedDir = new File(testBaseDir,
         HADOOP_BIN_UNPACKED_DIR_PREFIX + UUID.randomUUID());
-    assertTrue("Failed to make temporary directory",
-        hadoopUnpackedDir.mkdirs());
+    assertTrue(
+       hadoopUnpackedDir.mkdirs(), "Failed to make temporary directory");
     Shell.ShellCommandExecutor shexec = new Shell.ShellCommandExecutor(
         new String[] {"tar", "xzf", hadoopTarballPath.getAbsolutePath(), "-C",
             hadoopUnpackedDir.getAbsolutePath()});
@@ -280,7 +274,7 @@ public class TestDynamometerInfra {
     nodeLabelManager.addLabelsToNode(nodeLabels);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardownClass() throws Exception {
     if (miniDFSCluster != null) {
       miniDFSCluster.shutdown(true);
@@ -303,7 +297,7 @@ public class TestDynamometerInfra {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (infraAppId != null && yarnClient != null) {
       yarnClient.killApplication(infraAppId);
@@ -311,7 +305,8 @@ public class TestDynamometerInfra {
     infraAppId = null;
   }
 
-  @Test(timeout = 15 * 60 * 1000)
+  @Test
+  @Timeout(15 * 60)
   public void testNameNodeInYARN() throws Exception {
     Configuration localConf = new Configuration(yarnConf);
     localConf.setLong(AuditLogDirectParser.AUDIT_START_TIMESTAMP_KEY, 60000);
@@ -458,7 +453,7 @@ public class TestDynamometerInfra {
 
   private Client createAndStartClient(Configuration localConf) {
     final Client client = new Client(JarFinder.getJar(ApplicationMaster.class),
-        JarFinder.getJar(Assert.class));
+        JarFinder.getJar(Assertions.class));
     client.setConf(localConf);
     Thread appThread = new Thread(() -> {
       try {

--- a/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynoInfraUtils.java
+++ b/hadoop-tools/hadoop-dynamometer/hadoop-dynamometer-infra/src/test/java/org/apache/hadoop/tools/dynamometer/TestDynoInfraUtils.java
@@ -18,12 +18,12 @@
 package org.apache.hadoop.tools.dynamometer;
 
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /** Tests for {@link DynoInfraUtils}. */


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19429. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-dynamometer-infra.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

