### PR TITLE
HADOOP-19527. Skip AAL tests if encryption is set.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -22,7 +22,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionSet;
 
 /**
  * S3A contract tests for vectored reads with the Analytics stream. The analytics stream does
@@ -44,6 +48,19 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     enableAnalyticsAccelerator(conf);
+
+    // If encryption is set, some AAL tests will fail. This is because AAL caches the head request response, and uses
+    // the eTag when making a GET request. When using encryption, the eTag is no longer a hash of the object content,
+    // and is not always the same when the same object is created multiple times. This test creates the file
+    // vectored_file.txt before running each test, which will have a different eTag when using encryption, leading to
+    // preconditioned failures. This issue is tracked in:
+    // https://github.com/awslabs/analytics-accelerator-s3/issues/218
+    try {
+      skipIfEncryptionSet(conf);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
     conf.set("fs.contract.vector-io-early-eof-check", "false");
     return conf;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -26,10 +26,12 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSSES3;
 
 /**
- * S3A contract tests for vectored reads with the Analytics stream. The analytics stream does
- * not explicitly implement the vectoredRead() method, or currently do and vectored-read specific
- * optimisations (such as range coalescing). However, this test ensures that the base implementation
- * of readVectored {@link org.apache.hadoop.fs.PositionedReadable} still works.
+ * S3A contract tests for vectored reads with the Analytics stream.
+ * The analytics stream does not explicitly implement the vectoredRead() method,
+ * or currently do and vectored-read specific optimisations
+ * (such as range coalescing). However, this test ensures that the base
+ * implementation of readVectored {@link org.apache.hadoop.fs.PositionedReadable}
+ * still works.
  */
 public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContractVectoredReadTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -47,11 +47,14 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     enableAnalyticsAccelerator(conf);
-    // If encryption is set, some AAL tests will fail. This is because AAL caches the head request response, and uses
-    // the eTag when making a GET request. When using encryption, the eTag is no longer a hash of the object content,
-    // and is not always the same when the same object is created multiple times. This test creates the file
-    // vectored_file.txt before running each test, which will have a different eTag when using encryption, leading to
-    // preconditioned failures. This issue is tracked in:
+    // If encryption is set, some AAL tests will fail.
+    // This is because AAL caches the head request response, and uses
+    // the eTag when making a GET request. When using encryption, the eTag is
+    // no longer a hash of the object content, and is not always the same when
+    // the same object is created multiple times. This test creates the file
+    // vectored_file.txt before running each test, which will have a
+    // different eTag when using encryption, leading to preconditioned failures.
+    // This issue is tracked in:
     // https://github.com/awslabs/analytics-accelerator-s3/issues/218
     skipForAnyEncryptionExceptSSES3(conf);
     conf.set("fs.contract.vector-io-early-eof-check", "false");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -22,11 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionSet;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSSES3;
 
 /**
  * S3A contract tests for vectored reads with the Analytics stream. The analytics stream does
@@ -48,19 +45,13 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
     enableAnalyticsAccelerator(conf);
-
     // If encryption is set, some AAL tests will fail. This is because AAL caches the head request response, and uses
     // the eTag when making a GET request. When using encryption, the eTag is no longer a hash of the object content,
     // and is not always the same when the same object is created multiple times. This test creates the file
     // vectored_file.txt before running each test, which will have a different eTag when using encryption, leading to
     // preconditioned failures. This issue is tracked in:
     // https://github.com/awslabs/analytics-accelerator-s3/issues/218
-    try {
-      skipIfEncryptionSet(conf);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-
+    skipForAnyEncryptionExceptSSES3(conf);
     conf.set("fs.contract.vector-io-early-eof-check", "false");
     return conf;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -69,6 +69,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
   @Before
   public void setUp() throws Exception {
     super.setup();
+    skipIfClientSideEncryption();
     externalTestFile = getExternalData(getConfiguration());
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1711,7 +1711,8 @@ public final class S3ATestUtils {
   }
 
   /**
-   * Skip a test if encryption algorithm is not empty, or if it is set to anything other than AES256.
+   * Skip a test if encryption algorithm is not empty, or if it is set to
+   * anything other than AES256.
    *
    * @param configuration configuration
    */
@@ -1721,7 +1722,8 @@ public final class S3ATestUtils {
       final EncryptionSecrets secrets = buildEncryptionSecrets(bucket, configuration);
       S3AEncryptionMethods s3AEncryptionMethods = secrets.getEncryptionMethod();
 
-      if (s3AEncryptionMethods.getMethod().equals(SSE_S3.getMethod()) || s3AEncryptionMethods.getMethod().isEmpty()) {
+      if (s3AEncryptionMethods.getMethod().equals(SSE_S3.getMethod())
+              || s3AEncryptionMethods.getMethod().isEmpty()) {
         return;
       }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -105,6 +105,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.impl.FlagSet.createFlagSet;
+import static org.apache.hadoop.fs.s3a.S3AEncryptionMethods.SSE_S3;
 import static org.apache.hadoop.fs.s3a.impl.streams.InputStreamType.Analytics;
 import static org.apache.hadoop.fs.s3a.impl.streams.InputStreamType.Prefetch;
 import static org.apache.hadoop.fs.s3a.impl.CallableSupplier.submit;
@@ -1707,6 +1708,24 @@ public final class S3ATestUtils {
           + Arrays.stream(s3AEncryptionMethods).map(S3AEncryptionMethods::getMethod)
           .collect(Collectors.toList()) + " in " + secrets);
     }
+  }
+
+  /**
+   * Skip a test if encryption algorithm is not empty, or if it is set to anything other than AES256.
+   *
+   * @param configuration configuration
+   * @throws IOException  if the secret lookup fails.
+   */
+  public static void skipIfEncryptionSet(Configuration configuration) throws IOException {
+    String bucket = getTestBucketName(configuration);
+    final EncryptionSecrets secrets = buildEncryptionSecrets(bucket, configuration);
+    S3AEncryptionMethods s3AEncryptionMethods = secrets.getEncryptionMethod();
+
+    if (s3AEncryptionMethods.getMethod().equals(SSE_S3.getMethod()) || s3AEncryptionMethods.getMethod().isEmpty()) {
+      return;
+    }
+
+    skip("Encryption method is set to " + s3AEncryptionMethods.getMethod());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -1714,18 +1714,22 @@ public final class S3ATestUtils {
    * Skip a test if encryption algorithm is not empty, or if it is set to anything other than AES256.
    *
    * @param configuration configuration
-   * @throws IOException  if the secret lookup fails.
    */
-  public static void skipIfEncryptionSet(Configuration configuration) throws IOException {
+  public static void skipForAnyEncryptionExceptSSES3(Configuration configuration) {
     String bucket = getTestBucketName(configuration);
-    final EncryptionSecrets secrets = buildEncryptionSecrets(bucket, configuration);
-    S3AEncryptionMethods s3AEncryptionMethods = secrets.getEncryptionMethod();
+    try {
+      final EncryptionSecrets secrets = buildEncryptionSecrets(bucket, configuration);
+      S3AEncryptionMethods s3AEncryptionMethods = secrets.getEncryptionMethod();
 
-    if (s3AEncryptionMethods.getMethod().equals(SSE_S3.getMethod()) || s3AEncryptionMethods.getMethod().isEmpty()) {
-      return;
+      if (s3AEncryptionMethods.getMethod().equals(SSE_S3.getMethod()) || s3AEncryptionMethods.getMethod().isEmpty()) {
+        return;
+      }
+
+      skip("Encryption method is set to " + s3AEncryptionMethods.getMethod());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
 
-    skip("Encryption method is set to " + s3AEncryptionMethods.getMethod());
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When encryption is set to anything other than AES256, eTag behaviour changes, which leads to some test failures. See https://issues.apache.org/jira/browse/HADOOP-19527 for more details.

Also skip AAL tests if CSE is enabled as that is not supported currently.

### How was this patch tested?

Ran both `ITestS3AContractAnalyticsStreamVectoredRead` and `ITestS3AAnalyticsAcceleratorStreamReading` with different encryption configurations. 

Tests pass when nothing is set or if `fs.s3a.encryption.algorithm` is set to AES256. 
ITestS3AContractAnalyticsStreamVectoredRead is skipped when encryption is set to SSE-KMS (or anything else)
ITestS3AAnalyticsAcceleratorStreamReading is skipped when encryption is set to CSE-KMS.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

