### PR TITLE
YARN-9511. Refactoring TestAuxServices to eliminate flakyness

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/AuxServices.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/AuxServices.java
@@ -516,7 +516,8 @@ public class AuxServices extends AbstractService
     loadServices(services, getConfig(), true);
   }
 
-  private boolean checkManifestPermissions(FileStatus status) throws
+  @VisibleForTesting
+  boolean checkManifestPermissions(FileStatus status) throws
       IOException {
     if ((status.getPermission().toShort() & 0022) != 0) {
       LOG.error("Manifest file and parents must not be writable by group or " +
@@ -528,7 +529,7 @@ public class AuxServices extends AbstractService
     if (parent == null) {
       return true;
     }
-    return checkManifestPermissions(manifestFS.getFileStatus(parent));
+    return checkManifestPermissions(getManifestFS().getFileStatus(parent));
   }
 
   private boolean checkManifestOwnerAndPermissions(FileStatus status) throws
@@ -962,6 +963,10 @@ public class AuxServices extends AbstractService
   protected static void setSystemClasses(AuxServiceRecord service, String
       systemClasses) {
     service.getConfiguration().setProperty(SYSTEM_CLASSES, systemClasses);
+  }
+
+  protected FileSystem getManifestFS() {
+    return manifestFS;
   }
 
   /**


### PR DESCRIPTION
Change-Id: I98a827325d646cc1b8c84f01c27e46fe9b3b7d12

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When we initialize auxiliary services, permission checking iterates through the parents of the manifest file until it reaches the system root, and checks if any of the parents are writable to user group or others. Without mocking this the success of the initialization would heavily depend on the environment where the test is running.

As a solution I mocked AuxServices.checkManifestPermissions method in the test cases where we are assuming that the file system permissions are correct.

### How was this patch tested?
Unit tests

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

