### PR TITLE
YARN-11810. Fix SQL script in SQLServer/FederationStateStoreTables.sql

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/bin/FederationStateStore/SQLServer/FederationStateStoreTables.sql
+++ b/hadoop-yarn-project/hadoop-yarn/bin/FederationStateStore/SQLServer/FederationStateStoreTables.sql
@@ -220,68 +220,6 @@ ELSE
 GO
 
 IF NOT EXISTS ( SELECT * FROM [FederationStateStore].sys.tables
-    WHERE name = 'masterKeys'
-    AND schema_id = SCHEMA_ID('dbo'))
-    BEGIN
-        PRINT 'Table masterKeys does not exist, create it...'
-
-        SET ANSI_NULLS ON
-
-        SET QUOTED_IDENTIFIER ON
-
-        SET ANSI_PADDING ON
-
-        CREATE TABLE [dbo].[masterKeys](
-            keyId BIGINT NOT NULL,
-            masterKey VARCHAR(1024) NOT NULL,
-            CONSTRAINT [pk_keyId] PRIMARY KEY
-            (
-                [keyId]
-            )
-        )
-
-        SET ANSI_PADDING OFF
-
-        PRINT 'Table masterKeys created.'
-    END
-ELSE
-    PRINT 'Table masterKeys exists, no operation required...'
-    GO
-GO
-
-IF NOT EXISTS ( SELECT * FROM [FederationStateStore].sys.tables
-    WHERE name = 'delegationTokens'
-    AND schema_id = SCHEMA_ID('dbo'))
-    BEGIN
-        PRINT 'Table delegationTokens does not exist, create it...'
-
-        SET ANSI_NULLS ON
-
-        SET QUOTED_IDENTIFIER ON
-
-        SET ANSI_PADDING ON
-
-        CREATE TABLE [dbo].[delegationTokens](
-            sequenceNum BIGINT NOT NULL,
-            tokenIdent VARCHAR(1024) NOT NULL,
-            token VARCHAR(1024) NOT NULL,
-            renewDate BIGINT NOT NULL,
-            CONSTRAINT [pk_sequenceNum] PRIMARY KEY
-            (
-                [sequenceNum]
-            )
-        )
-
-        SET ANSI_PADDING OFF
-
-        PRINT 'Table delegationTokens created.'
-    END
-ELSE
-    PRINT 'Table delegationTokens exists, no operation required...'
-    GO
-GO
-
-IF NOT EXISTS ( SELECT * FROM [FederationStateStore].sys.tables
     WHERE name = 'sequenceTable'
     AND schema_id = SCHEMA_ID('dbo'))
     BEGIN
@@ -295,7 +233,7 @@ IF NOT EXISTS ( SELECT * FROM [FederationStateStore].sys.tables
 
         CREATE TABLE [dbo].[sequenceTable](
             sequenceName VARCHAR(255) NOT NULL,
-            nextVal bigint NOT NULL
+            nextVal bigint NOT NULL,
             CONSTRAINT [pk_sequenceName] PRIMARY KEY
             (
                 [sequenceName]
@@ -325,7 +263,7 @@ IF NOT EXISTS ( SELECT * FROM [FederationStateStore].sys.tables
 
         CREATE TABLE [dbo].[versions](
             fedVersion VARBINARY(1024) NOT NULL,
-            versionComment VARCHAR(255) NOT NULL
+            versionComment VARCHAR(255) NOT NULL,
             CONSTRAINT [pk_fedVersion] PRIMARY KEY
             (
                 [fedVersion]


### PR DESCRIPTION
Change-Id: I5b2a4f6436b1d55984f0420321a62b6d0b4b087b

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The SQLServer/FederationStateStoreTables.sql script contains duplicated create statements and SQL syntax errors which makes TestFederationSQLServerScriptAccuracy#checkSqlServerScriptAccuracy unit test fail. Details can be found in [YARN-11810](https://issues.apache.org/jira/browse/YARN-11810).

### How was this patch tested?
Unit tests

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

