### PR TITLE
HDFS-17770. TestRouterRpcSingleNS#testSaveNamespace should leave safemode after finishing.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcSingleNS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpcSingleNS.java
@@ -205,7 +205,9 @@ public class TestRouterRpcSingleNS {
     cluster.getCluster().getFileSystem()
         .setSafeMode(SafeModeAction.ENTER);
     Boolean saveNamespace = routerProtocol.saveNamespace(0, 0);
-
     assertTrue(saveNamespace);
+    // Leave safe mode after saving the namespace.
+    cluster.getCluster().getFileSystem()
+        .setSafeMode(SafeModeAction.LEAVE);
   }
 }


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17770.

We should leave safemode after finishing, or we may get safemode exceptions when execute other unit tests in TestRouterRpcSingleNS.

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/a04caa08-8011-420c-bcdf-949be378242b" />
