### PR TITLE
HADOOP-19541. Make HadoopArchives support human-friendly units about blocksize and partsize.

### DIFF
--- a/hadoop-tools/hadoop-archives/src/main/java/org/apache/hadoop/tools/HadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/main/java/org/apache/hadoop/tools/HadoopArchives.java
@@ -469,8 +469,8 @@ public class HadoopArchives implements Tool {
     int numFiles = 0;
     long totalSize = 0;
     FileSystem fs = parentPath.getFileSystem(conf);
-    this.blockSize = conf.getLong(HAR_BLOCKSIZE_LABEL, blockSize);
-    this.partSize = conf.getLong(HAR_PARTSIZE_LABEL, partSize);
+    this.blockSize = conf.getLongBytes(HAR_BLOCKSIZE_LABEL, blockSize);
+    this.partSize = conf.getLongBytes(HAR_PARTSIZE_LABEL, partSize);
     conf.setLong(HAR_BLOCKSIZE_LABEL, blockSize);
     conf.setLong(HAR_PARTSIZE_LABEL, partSize);
     conf.set(DST_HAR_LABEL, archiveName);

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -804,5 +804,66 @@ public class TestHadoopArchives {
       localFs.delete(tmpPath, true);      
     }
   }
-  
+
+  @Test
+  public void testBlockSize() throws Exception {
+    conf.set(HadoopArchives.HAR_BLOCKSIZE_LABEL, "1m");
+
+    final String inputPathStr = inputPath.toUri().getPath();
+    System.out.println("inputPathStr = " + inputPathStr);
+
+    final String harName = "foo.har";
+    final String[] args =
+        { "-archiveName", harName, "-p", inputPathStr, "*",
+            archivePath.toString() };
+    System.setProperty(HadoopArchives.TEST_HADOOP_ARCHIVES_JAR_PATH,
+        HADOOP_ARCHIVES_JAR);
+    final HadoopArchives har = new HadoopArchives(conf);
+    assertEquals(0, ToolRunner.run(har, args));
+
+    RemoteIterator<LocatedFileStatus> listFiles =
+        fs.listFiles(new Path(archivePath.toString() + "/" + harName), false);
+    while (listFiles.hasNext()) {
+      LocatedFileStatus next = listFiles.next();
+      if (next.getPath().toString().startsWith("part-")) {
+        // compare blockSize
+        Assert.assertEquals(1 * 1024 * 1024, next.getBlockSize());
+      }
+    }
+  }
+
+  @Test
+  public void testPartfileSize() throws Exception {
+    conf.set(HadoopArchives.HAR_PARTSIZE_LABEL, "2m");
+
+    final Path sub1 = new Path(inputPath, "dir1");
+    fs.mkdirs(sub1);
+    for (int i = 0; i < 10; i++) {
+      createFile(sub1, fs, new byte[1 * 1024 * 1024], sub1.getName(), "file" + i);
+    }
+    final String inputPathStr = sub1.toUri().getPath();
+    System.out.println("inputPathStr = " + inputPathStr);
+
+    final String harName = "foo.har";
+    final String[] args =
+        { "-archiveName", harName, "-p", inputPathStr, "*",
+            archivePath.toString() };
+    System.setProperty(HadoopArchives.TEST_HADOOP_ARCHIVES_JAR_PATH,
+        HADOOP_ARCHIVES_JAR);
+    final HadoopArchives har = new HadoopArchives(conf);
+    assertEquals(0, ToolRunner.run(har, args));
+
+    RemoteIterator<LocatedFileStatus> listFiles =
+        fs.listFiles(new Path(archivePath.toString() + "/" + harName), false);
+    int i = 0;
+    while (listFiles.hasNext()) {
+      LocatedFileStatus next = listFiles.next();
+      if (next.getPath().toString().startsWith("part-")) {
+        // compare partfileSize
+        assertEquals(2 * 1024 * 1024, next.getLen());
+        i++;
+      }
+    }
+    assertEquals(5, i);
+  }
 }

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -810,8 +810,6 @@ public class TestHadoopArchives {
     conf.set(HadoopArchives.HAR_BLOCKSIZE_LABEL, "1m");
 
     final String inputPathStr = inputPath.toUri().getPath();
-    System.out.println("inputPathStr = " + inputPathStr);
-
     final String harName = "foo.har";
     final String[] args =
         { "-archiveName", harName, "-p", inputPathStr, "*",

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -841,12 +841,12 @@ public class TestHadoopArchives {
     for (int i = 0; i < 10; i++) {
       createFile(sub1, fs, new byte[1 * 1024 * 1024], sub1.getName(), "file" + i);
     }
-    final String inputPathStr = sub1.toUri().getPath();
+    final String inputPathStr = inputPath.toUri().getPath();
     System.out.println("inputPathStr = " + inputPathStr);
 
     final String harName = "foo.har";
     final String[] args =
-        { "-archiveName", harName, "-p", inputPathStr, "*",
+        { "-archiveName", harName, "-p", inputPathStr, "dir1",
             archivePath.toString() };
     System.setProperty(HadoopArchives.TEST_HADOOP_ARCHIVES_JAR_PATH,
         HADOOP_ARCHIVES_JAR);

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -825,7 +825,7 @@ public class TestHadoopArchives {
       LocatedFileStatus next = listFiles.next();
       if (next.getPath().toString().matches(".*/part-\\d+$")) {
         // compare blockSize
-        Assert.assertEquals(1 * 1024 * 1024, next.getBlockSize());
+        assertEquals(1 * 1024 * 1024, next.getBlockSize());
       }
     }
   }

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -831,39 +831,4 @@ public class TestHadoopArchives {
       }
     }
   }
-
-  @Test
-  public void testPartfileSize() throws Exception {
-    conf.set(HadoopArchives.HAR_PARTSIZE_LABEL, "2m");
-
-    final Path sub1 = new Path(inputPath, "dir1");
-    fs.mkdirs(sub1);
-    for (int i = 0; i < 10; i++) {
-      createFile(sub1, fs, new byte[1 * 1024 * 1024], sub1.getName(), "file" + i);
-    }
-    final String inputPathStr = inputPath.toUri().getPath();
-    System.out.println("inputPathStr = " + inputPathStr);
-
-    final String harName = "foo.har";
-    final String[] args =
-        { "-archiveName", harName, "-p", inputPathStr, "dir1",
-            archivePath.toString() };
-    System.setProperty(HadoopArchives.TEST_HADOOP_ARCHIVES_JAR_PATH,
-        HADOOP_ARCHIVES_JAR);
-    final HadoopArchives har = new HadoopArchives(conf);
-    assertEquals(0, ToolRunner.run(har, args));
-
-    RemoteIterator<LocatedFileStatus> listFiles =
-        fs.listFiles(new Path(archivePath.toString() + "/" + harName), false);
-    int i = 0;
-    while (listFiles.hasNext()) {
-      LocatedFileStatus next = listFiles.next();
-      if (next.getPath().toString().matches(".*/part-\\d+$")) {
-        // compare partfileSize
-        assertEquals(2 * 1024 * 1024, next.getLen());
-        i++;
-      }
-    }
-    assertEquals(5, i);
-  }
 }

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -825,7 +825,7 @@ public class TestHadoopArchives {
         fs.listFiles(new Path(archivePath.toString() + "/" + harName), false);
     while (listFiles.hasNext()) {
       LocatedFileStatus next = listFiles.next();
-      if (next.getPath().toString().startsWith("part-")) {
+      if (next.getPath().toString().matches(".*/part-\\d+$")) {
         // compare blockSize
         Assert.assertEquals(1 * 1024 * 1024, next.getBlockSize());
       }
@@ -858,7 +858,7 @@ public class TestHadoopArchives {
     int i = 0;
     while (listFiles.hasNext()) {
       LocatedFileStatus next = listFiles.next();
-      if (next.getPath().toString().startsWith("part-")) {
+      if (next.getPath().toString().matches(".*/part-\\d+$")) {
         // compare partfileSize
         assertEquals(2 * 1024 * 1024, next.getLen());
         i++;


### PR DESCRIPTION
You can use the following suffix (case insensitive): k(kilo), m(mega), g(giga), t(tera), p(peta), e(exa) to specify the size (such as 128k, 512m, 1g, etc.), Or provide complete size in bytes (such as 134217728 for 128 MB).