### PR TITLE
HADOOP-19543. [ABFS][FnsOverBlob] Remove Duplicates from Blob Endpoint Listing Across Iterations

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -45,6 +45,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -76,6 +77,8 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidUriAuthorityExc
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidUriException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TrileanConversionException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode;
+import org.apache.hadoop.fs.azurebfs.contracts.services.BlobListResultEntrySchema;
+import org.apache.hadoop.fs.azurebfs.services.AbfsBlobClient;
 import org.apache.hadoop.fs.azurebfs.services.ListResponseData;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
 import org.apache.hadoop.fs.azurebfs.extensions.EncryptionContextProvider;
@@ -1273,6 +1276,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       }
     }
 
+    TreeMap<String, VersionedFileStatus> nameToEntryMap = new TreeMap<>();
     do {
       try (AbfsPerfInfo perfInfo = startTracking("listStatus", "listPath")) {
         ListResponseData listResponseData = listingClient.listPath(relativePath,
@@ -1281,9 +1285,17 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         AbfsRestOperation op = listResponseData.getOp();
         perfInfo.registerResult(op.getResult());
         continuation = listResponseData.getContinuationToken();
-        List<FileStatus> fileStatusListInCurrItr = listResponseData.getFileStatusList();
+        List<VersionedFileStatus> fileStatusListInCurrItr = listResponseData.getFileStatusList();
         if (fileStatusListInCurrItr != null && !fileStatusListInCurrItr.isEmpty()) {
-          fileStatuses.addAll(fileStatusListInCurrItr);
+          if (listingClient instanceof AbfsBlobClient) {
+            /* Blob Endpoint can return duplicate entries for non-empty explicit
+             * directories. Such entries can come across multiple iterations of
+             * list call and hence need to be filtered here.
+             */
+            filterDuplicateEntriesForBlobClient(nameToEntryMap, fileStatusListInCurrItr, fileStatuses);
+          } else {
+            fileStatuses.addAll(fileStatusListInCurrItr);
+          }
         }
         perfInfo.registerSuccess(true);
         countAggregate++;
@@ -1297,6 +1309,29 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     } while (shouldContinue);
 
     return continuation;
+  }
+
+  private void filterDuplicateEntriesForBlobClient(
+      TreeMap<String, VersionedFileStatus> nameToEntryMap,
+      List<VersionedFileStatus> fileStatusListInCurrItr,
+      List<FileStatus> fileStatuses) {
+    for (VersionedFileStatus fileStatus : fileStatusListInCurrItr) {
+      String entryName = fileStatus.getPath().getName();
+      if (StringUtils.isNotEmpty(fileStatus.getEtag())) {
+        // This is a blob entry. It is either a file or a marker blob.
+        // In both cases we will add this.
+        nameToEntryMap.put(entryName, fileStatus);
+        fileStatuses.add(fileStatus);
+      } else {
+        // This is a BlobPrefix entry.
+        // It is a directory with file inside
+        // This might have already been added as a marker blob.
+        if (!nameToEntryMap.containsKey(entryName)) {
+          nameToEntryMap.put(entryName, fileStatus);
+          fileStatuses.add(fileStatus);
+        }
+      }
+    }
   }
 
   // generate continuation token for xns account

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -77,7 +77,6 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidUriAuthorityExc
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidUriException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TrileanConversionException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode;
-import org.apache.hadoop.fs.azurebfs.contracts.services.BlobListResultEntrySchema;
 import org.apache.hadoop.fs.azurebfs.services.AbfsBlobClient;
 import org.apache.hadoop.fs.azurebfs.services.ListResponseData;
 import org.apache.hadoop.fs.azurebfs.enums.Trilean;
@@ -1311,6 +1310,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return continuation;
   }
 
+  /**
+   * This is to handle duplicate listing entries returned by Blob Endpoint for
+   * implicit paths that also has a marker file created for them.
+   * This will retain the entry corresponding to the marker file
+   * and remove the BlobPrefix entry corresponding to implicit directory.
+   * @param nameToEntryMap to keep track of paths already added to the list.
+   * @param fileStatusListInCurrItr the list of file statuses returned in the current iteration.
+   * @param fileStatuses the final list of file statuses to be returned.
+   */
   private void filterDuplicateEntriesForBlobClient(
       TreeMap<String, VersionedFileStatus> nameToEntryMap,
       List<VersionedFileStatus> fileStatusListInCurrItr,
@@ -1319,7 +1327,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       String entryName = fileStatus.getPath().getName();
       if (StringUtils.isNotEmpty(fileStatus.getEtag())) {
         // This is a blob entry. It is either a file or a marker blob.
-        // In both cases we will add this.
+        // In both cases, we will add this.
         nameToEntryMap.put(entryName, fileStatus);
         fileStatuses.add(fileStatus);
       } else {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1300,6 +1300,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
     if (listingClient instanceof AbfsBlobClient) {
       fileStatuses.addAll(ListUtils.getUniqueListResult(fileStatusList));
+      LOG.debug("ListBlob API returned a total of {} elements including duplicates."
+          + "Number of unique Elements are {}", fileStatusList.size(), fileStatuses.size());
     } else {
       fileStatuses.addAll(fileStatusList);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1330,14 +1330,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         // In both cases, we will add this.
         nameToEntryMap.put(entryName, fileStatus);
         fileStatuses.add(fileStatus);
-      } else {
+      } else if (!nameToEntryMap.containsKey(entryName)) {
         // This is a BlobPrefix entry.
         // It is a directory with file inside
         // This might have already been added as a marker blob.
-        if (!nameToEntryMap.containsKey(entryName)) {
-          nameToEntryMap.put(entryName, fileStatus);
-          fileStatuses.add(fileStatus);
-        }
+        nameToEntryMap.put(entryName, fileStatus);
+        fileStatuses.add(fileStatus);
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -40,13 +40,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -120,6 +118,7 @@ import org.apache.hadoop.fs.azurebfs.utils.Base64;
 import org.apache.hadoop.fs.azurebfs.utils.CRC64;
 import org.apache.hadoop.fs.azurebfs.utils.DateTimeUtils;
 import org.apache.hadoop.fs.azurebfs.utils.EncryptionType;
+import org.apache.hadoop.fs.azurebfs.utils.ListUtils;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.azurebfs.utils.UriUtils;
 import org.apache.hadoop.fs.impl.BackReference;
@@ -1300,53 +1299,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     } while (shouldContinue);
 
     if (listingClient instanceof AbfsBlobClient) {
-      fileStatuses.addAll(removeDuplicates(fileStatusList));
+      fileStatuses.addAll(ListUtils.getUniqueListResult(fileStatusList));
     } else {
       fileStatuses.addAll(fileStatusList);
     }
 
     return continuation;
-  }
-
-  /**
-   * This is to handle duplicate listing entries returned by Blob Endpoint for
-   * implicit paths that also has a marker file created for them.
-   * This will retain the entry corresponding to the marker file
-   * and remove the BlobPrefix entry corresponding to implicit directory.
-   * @param fileStatusList the list of file statuses to be rectified.
-   */
-  private List<FileStatus> removeDuplicates(List<FileStatus> fileStatusList) {
-    if (fileStatusList.isEmpty()) {
-      return fileStatusList;
-    }
-    List<FileStatus> rectifiedFileStatusList = new ArrayList<>();
-    Iterator<FileStatus> iterator = fileStatusList.iterator();
-    FileStatus curr = iterator.next();
-    TreeMap<String, FileStatus> nameToEntryMap = new TreeMap<>();
-    String prefix = curr.getPath().getName();
-    nameToEntryMap.put(prefix, curr);
-    rectifiedFileStatusList.add(curr);
-    while (iterator.hasNext()) {
-      FileStatus next = iterator.next();
-      if (next.getPath().getName().startsWith(prefix)) {
-        /*
-         * This is either a duplicate entry or a duplicate entry might follow.
-         * Keep adding unique entries to map and final list
-         */
-        if (!nameToEntryMap.containsKey(next.getPath().getName())) {
-          nameToEntryMap.put(next.getPath().getName(), next);
-          rectifiedFileStatusList.add(next);
-        }
-      } else {
-        // The prefix pattern breaks here.
-        prefix = next.getPath().getName();
-        nameToEntryMap = new TreeMap<>();
-        nameToEntryMap.put(prefix, next);
-        rectifiedFileStatusList.add(next);
-      }
-    }
-
-    return rectifiedFileStatusList;
   }
 
   // generate continuation token for xns account

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -40,6 +40,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1274,8 +1275,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             : generateContinuationTokenForNonXns(relativePath, startFrom);
       }
     }
-
-    TreeMap<String, VersionedFileStatus> nameToEntryMap = new TreeMap<>();
+    List<FileStatus> fileStatusList = new ArrayList<>();
     do {
       try (AbfsPerfInfo perfInfo = startTracking("listStatus", "listPath")) {
         ListResponseData listResponseData = listingClient.listPath(relativePath,
@@ -1286,15 +1286,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         continuation = listResponseData.getContinuationToken();
         List<VersionedFileStatus> fileStatusListInCurrItr = listResponseData.getFileStatusList();
         if (fileStatusListInCurrItr != null && !fileStatusListInCurrItr.isEmpty()) {
-          if (listingClient instanceof AbfsBlobClient) {
-            /* Blob Endpoint can return duplicate entries for non-empty explicit
-             * directories. Such entries can come across multiple iterations of
-             * list call and hence need to be filtered here.
-             */
-            filterDuplicateEntriesForBlobClient(nameToEntryMap, fileStatusListInCurrItr, fileStatuses);
-          } else {
-            fileStatuses.addAll(fileStatusListInCurrItr);
-          }
+          fileStatusList.addAll(fileStatusListInCurrItr);
         }
         perfInfo.registerSuccess(true);
         countAggregate++;
@@ -1307,6 +1299,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       }
     } while (shouldContinue);
 
+    if (listingClient instanceof AbfsBlobClient) {
+      fileStatuses.addAll(removeDuplicates(fileStatusList));
+    } else {
+      fileStatuses.addAll(fileStatusList);
+    }
+
     return continuation;
   }
 
@@ -1315,29 +1313,40 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * implicit paths that also has a marker file created for them.
    * This will retain the entry corresponding to the marker file
    * and remove the BlobPrefix entry corresponding to implicit directory.
-   * @param nameToEntryMap to keep track of paths already added to the list.
-   * @param fileStatusListInCurrItr the list of file statuses returned in the current iteration.
-   * @param fileStatuses the final list of file statuses to be returned.
+   * @param fileStatusList the list of file statuses to be rectified.
    */
-  private void filterDuplicateEntriesForBlobClient(
-      TreeMap<String, VersionedFileStatus> nameToEntryMap,
-      List<VersionedFileStatus> fileStatusListInCurrItr,
-      List<FileStatus> fileStatuses) {
-    for (VersionedFileStatus fileStatus : fileStatusListInCurrItr) {
-      String entryName = fileStatus.getPath().getName();
-      if (StringUtils.isNotEmpty(fileStatus.getEtag())) {
-        // This is a blob entry. It is either a file or a marker blob.
-        // In both cases, we will add this.
-        nameToEntryMap.put(entryName, fileStatus);
-        fileStatuses.add(fileStatus);
-      } else if (!nameToEntryMap.containsKey(entryName)) {
-        // This is a BlobPrefix entry.
-        // It is a directory with file inside
-        // This might have already been added as a marker blob.
-        nameToEntryMap.put(entryName, fileStatus);
-        fileStatuses.add(fileStatus);
+  private List<FileStatus> removeDuplicates(List<FileStatus> fileStatusList) {
+    if (fileStatusList.isEmpty()) {
+      return fileStatusList;
+    }
+    List<FileStatus> rectifiedFileStatusList = new ArrayList<>();
+    Iterator<FileStatus> iterator = fileStatusList.iterator();
+    FileStatus curr = iterator.next();
+    TreeMap<String, FileStatus> nameToEntryMap = new TreeMap<>();
+    String prefix = curr.getPath().getName();
+    nameToEntryMap.put(prefix, curr);
+    rectifiedFileStatusList.add(curr);
+    while (iterator.hasNext()) {
+      FileStatus next = iterator.next();
+      if (next.getPath().getName().startsWith(prefix)) {
+        /*
+         * This is either a duplicate entry or a duplicate entry might follow.
+         * Keep adding unique entries to map and final list
+         */
+        if (!nameToEntryMap.containsKey(next.getPath().getName())) {
+          nameToEntryMap.put(next.getPath().getName(), next);
+          rectifiedFileStatusList.add(next);
+        }
+      } else {
+        // The prefix pattern breaks here.
+        prefix = next.getPath().getName();
+        nameToEntryMap = new TreeMap<>();
+        nameToEntryMap.put(prefix, next);
+        rectifiedFileStatusList.add(next);
       }
     }
+
+    return rectifiedFileStatusList;
   }
 
   // generate continuation token for xns account

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -402,7 +402,7 @@ public class AbfsBlobClient extends AbfsClient {
       AbfsRestOperation pathStatus = this.getPathStatus(relativePath, tracingContext, null, false);
       BlobListResultSchema listResultSchema = getListResultSchemaFromPathStatus(relativePath, pathStatus);
       LOG.debug("ListBlob attempted on a file path. Returning file status.");
-      List<FileStatus> fileStatusList = new ArrayList<>();
+      List<VersionedFileStatus> fileStatusList = new ArrayList<>();
       for (BlobListResultEntrySchema entry : listResultSchema.paths()) {
         fileStatusList.add(getVersionedFileStatusFromEntry(entry, uri));
       }
@@ -1617,7 +1617,7 @@ public class AbfsBlobClient extends AbfsClient {
         LOG.debug("ListBlobs listed {} blobs with {} as continuation token",
             listResultSchema.paths().size(),
             listResultSchema.getNextMarker());
-        return filterDuplicateEntriesAndRenamePendingFiles(listResultSchema, uri);
+        return filterRenamePendingFiles(listResultSchema, uri);
       } catch (SAXException | IOException ex) {
         throw new AbfsDriverException(ERR_BLOB_LIST_PARSING, ex);
       }
@@ -1927,29 +1927,16 @@ public class AbfsBlobClient extends AbfsClient {
    * @throws IOException if path conversion fails.
    */
   @VisibleForTesting
-  public ListResponseData filterDuplicateEntriesAndRenamePendingFiles(
+  public ListResponseData filterRenamePendingFiles(
       BlobListResultSchema listResultSchema, URI uri) throws IOException {
-    List<FileStatus> fileStatuses = new ArrayList<>();
+    List<VersionedFileStatus> fileStatuses = new ArrayList<>();
     Map<Path, Integer> renamePendingJsonPaths = new HashMap<>();
-    TreeMap<String, BlobListResultEntrySchema> nameToEntryMap = new TreeMap<>();
 
     for (BlobListResultEntrySchema entry : listResultSchema.paths()) {
-      if (StringUtils.isNotEmpty(entry.eTag())) {
-        // This is a blob entry. It is either a file or a marker blob.
-        // In both cases we will add this.
-        if (isRenamePendingJsonPathEntry(entry)) {
-          renamePendingJsonPaths.put(entry.path(), entry.contentLength().intValue());
-        } else {
-          nameToEntryMap.put(entry.name(), entry);
-          fileStatuses.add(getVersionedFileStatusFromEntry(entry, uri));
-        }
+      if (isRenamePendingJsonPathEntry(entry)) {
+        renamePendingJsonPaths.put(entry.path(), entry.contentLength().intValue());
       } else {
-        // This is a BlobPrefix entry. It is a directory with file inside
-        // This might have already been added as a marker blob.
-        if (!nameToEntryMap.containsKey(entry.name())) {
-          nameToEntryMap.put(entry.name(), entry);
-          fileStatuses.add(getVersionedFileStatusFromEntry(entry, uri));
-        }
+        fileStatuses.add(getVersionedFileStatusFromEntry(entry, uri));
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -1917,10 +1917,7 @@ public class AbfsBlobClient extends AbfsClient {
   });
 
   /**
-   * This is to handle duplicate listing entries returned by Blob Endpoint for
-   * implicit paths that also has a marker file created for them.
-   * This will retain entry corresponding to marker file and remove the BlobPrefix entry.
-   * This will also filter out all the rename pending json files in listing output.
+   * This will filter out all the rename pending json files in listing output.
    * @param listResultSchema List of entries returned by Blob Endpoint.
    * @param uri URI to be used for path conversion.
    * @return List of entries after removing duplicates.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -42,7 +42,6 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.UUID;
 
 import org.w3c.dom.Document;
@@ -52,7 +51,6 @@ import org.xml.sax.SAXException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.Path;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
@@ -1353,7 +1353,7 @@ public class AbfsDfsClient extends AbfsClient {
         LOG.debug("ListPath listed {} paths with {} as continuation token",
             listResultSchema.paths().size(),
             getContinuationFromResponse(result));
-        List<FileStatus> fileStatuses = new ArrayList<>();
+        List<VersionedFileStatus> fileStatuses = new ArrayList<>();
         for (DfsListResultEntrySchema entry : listResultSchema.paths()) {
           fileStatuses.add(getVersionedFileStatusFromEntry(entry, uri));
         }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileAlreadyExistsException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.Path;
  */
 public class ListResponseData {
 
-  private List<FileStatus> fileStatusList;
+  private List<VersionedFileStatus> fileStatusList;
   private Map<Path, Integer> renamePendingJsonPaths;
   private AbfsRestOperation executedRestOperation;
   private String continuationToken;
@@ -40,7 +40,7 @@ public class ListResponseData {
    * Returns the list of FileStatus objects.
    * @return the list of FileStatus objects
    */
-  public List<FileStatus> getFileStatusList() {
+  public List<VersionedFileStatus> getFileStatusList() {
     return fileStatusList;
   }
 
@@ -48,7 +48,7 @@ public class ListResponseData {
    * Sets the list of FileStatus objects.
    * @param fileStatusList the list of FileStatus objects
    */
-  public void setFileStatusList(final List<FileStatus> fileStatusList) {
+  public void setFileStatusList(final List<VersionedFileStatus> fileStatusList) {
     this.fileStatusList = fileStatusList;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
@@ -21,12 +21,11 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 /**
  * This class is used to hold the response data for list operations.
- * It contains a list of FileStatus objects, a map of rename pending JSON paths,
+ * It contains a list of VersionedFileStatus objects, a map of rename pending JSON paths,
  * continuation token and the executed REST operation.
  */
 public class ListResponseData {
@@ -37,16 +36,16 @@ public class ListResponseData {
   private String continuationToken;
 
   /**
-   * Returns the list of FileStatus objects.
-   * @return the list of FileStatus objects
+   * Returns the list of VersionedFileStatus objects.
+   * @return the list of VersionedFileStatus objects
    */
   public List<VersionedFileStatus> getFileStatusList() {
     return fileStatusList;
   }
 
   /**
-   * Sets the list of FileStatus objects.
-   * @param fileStatusList the list of FileStatus objects
+   * Sets the list of VersionedFileStatus objects.
+   * @param fileStatusList the list of VersionedFileStatus objects
    */
   public void setFileStatusList(final List<VersionedFileStatus> fileStatusList) {
     this.fileStatusList = fileStatusList;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
@@ -29,6 +29,10 @@ import org.apache.hadoop.fs.FileStatus;
  */
 public class ListUtils {
 
+  private ListUtils() {
+    // Private constructor to prevent instantiation
+  }
+
   /**
    * Utility method to remove duplicates from a list of FileStatus.
    * ListBlob API of blob endpoint can return duplicate entries.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.FileStatus;
 /**
  * Utility class for List operations.
  */
-public class ListUtils {
+public final class ListUtils {
 
   private ListUtils() {
     // Private constructor to prevent instantiation

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
@@ -19,51 +19,47 @@
 package org.apache.hadoop.fs.azurebfs.utils;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
 
 import org.apache.hadoop.fs.FileStatus;
 
+/**
+ * Utility class for List operations.
+ */
 public class ListUtils {
 
+  /**
+   * Utility method to remove duplicates from a list of FileStatus.
+   * ListBlob API of blob endpoint can return duplicate entries.
+   * @param originalList prone to have duplicates
+   * @return rectified list with no duplicates.
+   */
   public static List<FileStatus> getUniqueListResult(List<FileStatus> originalList) {
     if (originalList == null || originalList.isEmpty()) {
       return originalList;
     }
+
     TreeMap<String, FileStatus> nameToEntryMap = new TreeMap<>();
-    String prefix;
-    Iterator<FileStatus> iterator = originalList.iterator();
+    String prefix = null;
     List<FileStatus> rectifiedFileStatusList = new ArrayList<>();
 
-    FileStatus curr = iterator.next();
-    prefix = curr.getPath().getName();
-    addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, curr);
+    for (FileStatus current : originalList) {
+      String fileName = current.getPath().getName();
 
-    while (iterator.hasNext()) {
-      FileStatus next = iterator.next();
-      if (next.getPath().getName().startsWith(prefix)) {
-        /*
-         * This is either a duplicate entry or a duplicate entry might follow.
-         * Keep adding unique entries to map and final list
-         */
-        if (!nameToEntryMap.containsKey(next.getPath().getName())) {
-          addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, next);
-        }
-      } else {
-        // The prefix pattern breaks here.
-        prefix = next.getPath().getName();
-        nameToEntryMap = new TreeMap<>();
-        addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, next);
+      if (prefix == null || !fileName.startsWith(prefix)) {
+        // Prefix pattern breaks here. Reset Map and prefix.
+        prefix = fileName;
+        nameToEntryMap.clear();
+      }
+
+      // Add the current entry if it is not already added.
+      if (!nameToEntryMap.containsKey(fileName)) {
+        nameToEntryMap.put(fileName, current);
+        rectifiedFileStatusList.add(current);
       }
     }
 
     return rectifiedFileStatusList;
-  }
-
-  private static void addToUniqueResult(TreeMap<String, FileStatus> nameToEntryMap,
-      List<FileStatus> rectifiedFileStatusList, FileStatus fileStatus) {
-    nameToEntryMap.put(fileStatus.getPath().getName(), fileStatus);
-    rectifiedFileStatusList.add(fileStatus);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeMap;
+
+import org.apache.hadoop.fs.FileStatus;
+
+public class ListUtils {
+
+  public static List<FileStatus> getUniqueListResult(List<FileStatus> originalList) {
+    if (originalList == null || originalList.isEmpty()) {
+      return originalList;
+    }
+    TreeMap<String, FileStatus> nameToEntryMap = new TreeMap<>();
+    String prefix;
+    Iterator<FileStatus> iterator = originalList.iterator();
+    List<FileStatus> rectifiedFileStatusList = new ArrayList<>();
+
+    FileStatus curr = iterator.next();
+    prefix = curr.getPath().getName();
+    addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, curr);
+
+    while (iterator.hasNext()) {
+      FileStatus next = iterator.next();
+      if (next.getPath().getName().startsWith(prefix)) {
+        /*
+         * This is either a duplicate entry or a duplicate entry might follow.
+         * Keep adding unique entries to map and final list
+         */
+        if (!nameToEntryMap.containsKey(next.getPath().getName())) {
+          addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, next);
+        }
+      } else {
+        // The prefix pattern breaks here.
+        prefix = next.getPath().getName();
+        nameToEntryMap = new TreeMap<>();
+        addToUniqueResult(nameToEntryMap, rectifiedFileStatusList, next);
+      }
+    }
+
+    return rectifiedFileStatusList;
+  }
+
+  private static void addToUniqueResult(TreeMap<String, FileStatus> nameToEntryMap,
+      List<FileStatus> rectifiedFileStatusList, FileStatus fileStatus) {
+    nameToEntryMap.put(fileStatus.getPath().getName(), fileStatus);
+    rectifiedFileStatusList.add(fileStatus);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -532,6 +532,13 @@ public class ITestAzureBlobFileSystemListStatus extends
         .describedAs("Listing Size Not as expected").hasSize(1);
   }
 
+  /**
+   * Test to verify that listStatus returns the correct file status
+   * after removing duplicates across multiple iterations of list blobs.
+   * Also verifies that in case of non-empty explicit dir,
+   * entry corresponding to marker blob is returned.
+   * @throws Exception if test fails.
+   */
   @Test
   public void testDuplicateEntriesAcrossListBlobIterations() throws Exception {
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
@@ -542,16 +549,46 @@ public class ITestAzureBlobFileSystemListStatus extends
     Mockito.doReturn(store).when(fs).getAbfsStore();
     Mockito.doReturn(client).when(store).getClient();
 
-    // Create a non-empty explicit directory under root
+    // Path 1: Create a non-empty explicit directory under root.
     Path dir = new Path("/a");
     Path fileInsideDir = new Path("/a/file");
     createAzCopyFolder(dir);
     fs.create(fileInsideDir);
 
+    // Path 2: Create an empty explicit directory under root.
+    Path emptyDir = new Path("/b");
+    fs.mkdirs(emptyDir);
+
+    // Path 3: Create a file under root.
+    Path file1 = new Path("/c");
+    fs.create(file1);
+
+    // Path 4: Create an implicit directory under root.
+    Path implicitDir = new Path("/d");
+    createAzCopyFolder(implicitDir);
+
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
+
+    // Assert that client.listPath was called 5 times for each entry.
+    Mockito.verify(client, Mockito.times(5))
+        .listPath(eq(ROOT_PATH), eq(false), eq(1), any(), any(), any());
+
+    // Assert that after duplicate removal, 4 entries are returned.
     Assertions.assertThat(fileStatuses.length)
-        .describedAs("List size is not expected").isEqualTo(1);
+        .describedAs("List size is not expected").isEqualTo(4);
     assertExplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(dir));
+    assertExplicitDirectoryFileStatus(fileStatuses[1], fs.makeQualified(emptyDir));
+    assertFilePathFileStatus(fileStatuses[2], fs.makeQualified(file1));
+    assertImplicitDirectoryFileStatus(fileStatuses[3], fs.makeQualified(implicitDir));
+
+    // Assert that there are no duplicates in the returned file statuses.
+    for (int i = 0; i < fileStatuses.length; i++) {
+      for (int j = i + 1; j < fileStatuses.length; j++) {
+        Assertions.assertThat(fileStatuses[i].getPath())
+            .describedAs("Duplicate entries found")
+            .isNotEqualTo(fileStatuses[j].getPath());
+      }
+    }
   }
 
   private void assertFilePathFileStatus(final FileStatus fileStatus,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -586,16 +586,19 @@ public class ITestAzureBlobFileSystemListStatus extends
     // Create Path 9 and 10
     fs.create(new Path("/e/file4"));
 
+    int totalNoOfPaths = 11;
+    int noOfUniquePaths = 7;
+
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
 
     // Assert that client.listPath was called 11 times.
     // This will assert server returned 11 entries in total.
-    Mockito.verify(client, Mockito.times(11))
+    Mockito.verify(client, Mockito.times(totalNoOfPaths))
         .listPath(eq(ROOT_PATH), eq(false), eq(1), any(), any(), any());
 
     // Assert that after duplicate removal, only 7 unique entries are returned.
     Assertions.assertThat(fileStatuses.length)
-        .describedAs("List size is not expected").isEqualTo(7);
+        .describedAs("List size is not expected").isEqualTo(noOfUniquePaths);
 
     // Assert that for duplicates, entry corresponding to marker blob is returned.
     assertImplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(new Path("/A")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -24,7 +24,9 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -605,12 +607,11 @@ public class ITestAzureBlobFileSystemListStatus extends
     assertExplicitDirectoryFileStatus(fileStatuses[6], fs.makeQualified(new Path("/e")));
 
     // Assert that there are no duplicates in the returned file statuses.
-    for (int i = 0; i < fileStatuses.length; i++) {
-      for (int j = i + 1; j < fileStatuses.length; j++) {
-        Assertions.assertThat(fileStatuses[i].getPath())
-            .describedAs("Duplicate entries found")
-            .isNotEqualTo(fileStatuses[j].getPath());
-      }
+    Set<Path> uniquePaths = new HashSet<>();
+    for (FileStatus fileStatus : fileStatuses) {
+      Assertions.assertThat(uniquePaths.add(fileStatus.getPath()))
+          .describedAs("Duplicate entries found")
+          .isTrue();
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -92,6 +92,8 @@ public class ITestAzureBlobFileSystemListStatus extends
     AbstractAbfsIntegrationTest {
   private static final int TEST_FILES_NUMBER = 6000;
   public static final String TEST_CONTINUATION_TOKEN = "continuation";
+  private static final int TOTAL_NUMBER_OF_PATHS = 11;
+  private static final int NUMBER_OF_UNIQUE_PATHS = 7;
 
   public ITestAzureBlobFileSystemListStatus() throws Exception {
     super();
@@ -585,9 +587,6 @@ public class ITestAzureBlobFileSystemListStatus extends
 
     // Create Path 9 and 10
     fs.create(new Path("/e/file4"));
-
-    final int TOTAL_NUMBER_OF_PATHS = 11;
-    final int NUMBER_OF_UNIQUE_PATHS = 7;
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -549,37 +549,53 @@ public class ITestAzureBlobFileSystemListStatus extends
     Mockito.doReturn(store).when(fs).getAbfsStore();
     Mockito.doReturn(client).when(store).getClient();
 
-    // Path 1: Create a non-empty explicit directory under root.
-    Path dir = new Path("/a");
-    Path fileInsideDir = new Path("/a/file");
-    createAzCopyFolder(dir);
-    fs.create(fileInsideDir);
+    /*
+     * Following entries will be created inside the root path.
+     * 1. /a - marker file for explicit directory
+     * 2. /a/file1 - normal file inside explicit directory
+     * 3. /b - normal file inside root
+     * 4. /c - marker file for explicit directory
+     * 5. /c.bak - marker file for explicit directory
+     * 6. /c.bak/file2 - normal file inside explicit directory
+     * 7. /c/file3 - normal file inside explicit directory
+     * 8. /d - implicit directory
+     * 9. /e - marker file for explicit directory
+     * 10. /e/file4 - normal file inside explicit directory
+     */
 
-    // Path 2: Create an empty explicit directory under root.
-    Path emptyDir = new Path("/b");
-    fs.mkdirs(emptyDir);
+    // Create Path 1 and 2.
+    fs.create(new Path("/a/file1"));
 
-    // Path 3: Create a file under root.
-    Path file1 = new Path("/c");
-    fs.create(file1);
+    // Create Path 3
+    fs.create(new Path("/b"));
 
-    // Path 4: Create an implicit directory under root.
-    Path implicitDir = new Path("/d");
-    createAzCopyFolder(implicitDir);
+    // Create Path 4 and 7
+    fs.create(new Path("/c/file3"));
+
+    // Create Path 5 and 6
+    fs.create(new Path("/c.bak/file2"));
+
+    // Create Path 8
+    createAzCopyFolder(new Path("/d"));
+
+    // Create Path 9 and 10
+    fs.create(new Path("/e/file4"));
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
 
     // Assert that client.listPath was called 5 times for each entry.
-    Mockito.verify(client, Mockito.times(5))
+    Mockito.verify(client, Mockito.times(10))
         .listPath(eq(ROOT_PATH), eq(false), eq(1), any(), any(), any());
 
     // Assert that after duplicate removal, 4 entries are returned.
     Assertions.assertThat(fileStatuses.length)
-        .describedAs("List size is not expected").isEqualTo(4);
-    assertExplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(dir));
-    assertExplicitDirectoryFileStatus(fileStatuses[1], fs.makeQualified(emptyDir));
-    assertFilePathFileStatus(fileStatuses[2], fs.makeQualified(file1));
-    assertImplicitDirectoryFileStatus(fileStatuses[3], fs.makeQualified(implicitDir));
+        .describedAs("List size is not expected").isEqualTo(6);
+    assertExplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(new Path("/a")));
+    assertFilePathFileStatus(fileStatuses[1], fs.makeQualified(new Path("/b")));
+    assertExplicitDirectoryFileStatus(fileStatuses[2], fs.makeQualified(new Path("/c")));
+    assertExplicitDirectoryFileStatus(fileStatuses[3], fs.makeQualified(new Path("/c.bak")));
+    assertImplicitDirectoryFileStatus(fileStatuses[4], fs.makeQualified(new Path("/d")));
+    assertExplicitDirectoryFileStatus(fileStatuses[5], fs.makeQualified(new Path("/e")));
 
     // Assert that there are no duplicates in the returned file statuses.
     for (int i = 0; i < fileStatuses.length; i++) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -551,6 +551,7 @@ public class ITestAzureBlobFileSystemListStatus extends
 
     /*
      * Following entries will be created inside the root path.
+     * 0. /A - implicit directory without any marker blob
      * 1. /a - marker file for explicit directory
      * 2. /a/file1 - normal file inside explicit directory
      * 3. /b - normal file inside root
@@ -562,6 +563,8 @@ public class ITestAzureBlobFileSystemListStatus extends
      * 9. /e - marker file for explicit directory
      * 10. /e/file4 - normal file inside explicit directory
      */
+    // Create Path 0
+    createAzCopyFolder(new Path("/A"));
 
     // Create Path 1 and 2.
     fs.create(new Path("/a/file1"));
@@ -583,19 +586,23 @@ public class ITestAzureBlobFileSystemListStatus extends
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
 
-    // Assert that client.listPath was called 5 times for each entry.
-    Mockito.verify(client, Mockito.times(10))
+    // Assert that client.listPath was called 11 times.
+    // This will assert server returned 11 entries in total.
+    Mockito.verify(client, Mockito.times(11))
         .listPath(eq(ROOT_PATH), eq(false), eq(1), any(), any(), any());
 
-    // Assert that after duplicate removal, 4 entries are returned.
+    // Assert that after duplicate removal, only 7 unique entries are returned.
     Assertions.assertThat(fileStatuses.length)
-        .describedAs("List size is not expected").isEqualTo(6);
-    assertExplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(new Path("/a")));
-    assertFilePathFileStatus(fileStatuses[1], fs.makeQualified(new Path("/b")));
-    assertExplicitDirectoryFileStatus(fileStatuses[2], fs.makeQualified(new Path("/c")));
-    assertExplicitDirectoryFileStatus(fileStatuses[3], fs.makeQualified(new Path("/c.bak")));
-    assertImplicitDirectoryFileStatus(fileStatuses[4], fs.makeQualified(new Path("/d")));
-    assertExplicitDirectoryFileStatus(fileStatuses[5], fs.makeQualified(new Path("/e")));
+        .describedAs("List size is not expected").isEqualTo(7);
+
+    // Assert that for duplicates, entry corresponding to marker blob is returned.
+    assertImplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(new Path("/A")));
+    assertExplicitDirectoryFileStatus(fileStatuses[1], fs.makeQualified(new Path("/a")));
+    assertFilePathFileStatus(fileStatuses[2], fs.makeQualified(new Path("/b")));
+    assertExplicitDirectoryFileStatus(fileStatuses[3], fs.makeQualified(new Path("/c")));
+    assertExplicitDirectoryFileStatus(fileStatuses[4], fs.makeQualified(new Path("/c.bak")));
+    assertImplicitDirectoryFileStatus(fileStatuses[5], fs.makeQualified(new Path("/d")));
+    assertExplicitDirectoryFileStatus(fileStatuses[6], fs.makeQualified(new Path("/e")));
 
     // Assert that there are no duplicates in the returned file statuses.
     for (int i = 0; i < fileStatuses.length; i++) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -586,19 +586,19 @@ public class ITestAzureBlobFileSystemListStatus extends
     // Create Path 9 and 10
     fs.create(new Path("/e/file4"));
 
-    int totalNoOfPaths = 11;
-    int noOfUniquePaths = 7;
+    final int TOTAL_NUMBER_OF_PATHS = 11;
+    final int NUMBER_OF_UNIQUE_PATHS = 7;
 
     FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
 
     // Assert that client.listPath was called 11 times.
     // This will assert server returned 11 entries in total.
-    Mockito.verify(client, Mockito.times(totalNoOfPaths))
+    Mockito.verify(client, Mockito.times(TOTAL_NUMBER_OF_PATHS))
         .listPath(eq(ROOT_PATH), eq(false), eq(1), any(), any(), any());
 
     // Assert that after duplicate removal, only 7 unique entries are returned.
     Assertions.assertThat(fileStatuses.length)
-        .describedAs("List size is not expected").isEqualTo(noOfUniquePaths);
+        .describedAs("List size is not expected").isEqualTo(NUMBER_OF_UNIQUE_PATHS);
 
     // Assert that for duplicates, entry corresponding to marker blob is returned.
     assertImplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(new Path("/A")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -613,7 +613,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     Set<Path> uniquePaths = new HashSet<>();
     for (FileStatus fileStatus : fileStatuses) {
       Assertions.assertThat(uniquePaths.add(fileStatus.getPath()))
-          .describedAs("Duplicate entries found")
+          .describedAs("Duplicate Entries found")
           .isTrue();
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -197,7 +197,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
     Mockito.doReturn(spiedClient).when(spiedStore).getClient();
 
-    Mockito.doThrow(new SocketException(CONNECTION_RESET_MESSAGE)).when(spiedClient).filterDuplicateEntriesAndRenamePendingFiles(any(), any());
+    Mockito.doThrow(new SocketException(CONNECTION_RESET_MESSAGE)).when(spiedClient).filterRenamePendingFiles(any(), any());
     List<FileStatus> fileStatuses = new ArrayList<>();
     AbfsDriverException ex = intercept(AbfsDriverException.class,
       () -> {
@@ -530,6 +530,28 @@ public class ITestAzureBlobFileSystemListStatus extends
         .describedAs("Continuation Token Should Not be null").isNotNull();
     Assertions.assertThat(listResponseData.getFileStatusList())
         .describedAs("Listing Size Not as expected").hasSize(1);
+  }
+
+  @Test
+  public void testDuplicateEntriesAcrossListBlobIterations() throws Exception {
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    store.getAbfsConfiguration().setListMaxResults(1);
+    AbfsClient client = Mockito.spy(store.getClient());
+
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    Mockito.doReturn(client).when(store).getClient();
+
+    // Create a non-empty explicit directory under root
+    Path dir = new Path("/a");
+    Path fileInsideDir = new Path("/a/file");
+    createAzCopyFolder(dir);
+    fs.create(fileInsideDir);
+
+    FileStatus[] fileStatuses = fs.listStatus(new Path(ROOT_PATH));
+    Assertions.assertThat(fileStatuses.length)
+        .describedAs("List size is not expected").isEqualTo(1);
+    assertExplicitDirectoryFileStatus(fileStatuses[0], fs.makeQualified(dir));
   }
 
   private void assertFilePathFileStatus(final FileStatus fileStatus,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.utils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+public class TestListUtils {
+
+  @Test
+  public void testRemoveDuplicates() {
+    List<FileStatus> originalList = new ArrayList<>();
+    validateList(originalList, 0);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/A")));
+    validateList(originalList, 1);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/A")));
+    originalList.add(getFileStatusObject(new Path("/A")));
+    validateList( originalList, 1);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1.bak2")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1.bak2")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1")));
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc.bak1")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    validateList( originalList, 5);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1_bak2")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1_bak2")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc_bak1")));
+    validateList( originalList, 5);
+  }
+
+  private void validateList(List<FileStatus> originalList, int expectedSize) {
+    List<FileStatus> uniqueList = ListUtils.getUniqueListResult(originalList);
+    Assertions.assertThat(uniqueList)
+        .describedAs("List Size is not as expected after duplicate removal")
+        .hasSize(expectedSize);
+  }
+
+  private FileStatus getFileStatusObject(Path path) {
+    FileStatus status = new FileStatus();
+    status.setPath(path);
+    return status;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
@@ -27,8 +27,14 @@ import org.junit.Test;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
+/**
+ * Test class for ListUtils.
+ */
 public class TestListUtils {
 
+  /**
+   * Test method to check the removal of duplicates from a list of FileStatus.
+   */
   @Test
   public void testRemoveDuplicates() {
     List<FileStatus> originalList = new ArrayList<>();
@@ -79,6 +85,11 @@ public class TestListUtils {
     validateList(originalList, 2);
   }
 
+  /**
+   * Validate the size of the list after removing duplicates.
+   * @param originalList list having duplicates
+   * @param expectedSize number of unique entries expected
+   */
   private void validateList(List<FileStatus> originalList, int expectedSize) {
     List<FileStatus> uniqueList = ListUtils.getUniqueListResult(originalList);
     Assertions.assertThat(uniqueList)
@@ -86,6 +97,11 @@ public class TestListUtils {
         .hasSize(expectedSize);
   }
 
+  /**
+   * Create a FileStatus object with the given path.
+   * @param path path to be set in the FileStatus object
+   * @return FileStatus object with the given path
+   */
   private FileStatus getFileStatusObject(Path path) {
     FileStatus status = new FileStatus();
     status.setPath(path);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
@@ -18,11 +18,8 @@
 
 package org.apache.hadoop.fs.azurebfs.utils;
 
-import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -44,7 +41,7 @@ public class TestListUtils {
     originalList = new ArrayList<>();
     originalList.add(getFileStatusObject(new Path("/A")));
     originalList.add(getFileStatusObject(new Path("/A")));
-    validateList( originalList, 1);
+    validateList(originalList, 1);
 
     originalList = new ArrayList<>();
     originalList.add(getFileStatusObject(new Path("/a")));
@@ -56,7 +53,7 @@ public class TestListUtils {
     originalList.add(getFileStatusObject(new Path("/abc")));
     originalList.add(getFileStatusObject(new Path("/abc.bak1")));
     originalList.add(getFileStatusObject(new Path("/abc")));
-    validateList( originalList, 5);
+    validateList(originalList, 5);
 
     originalList = new ArrayList<>();
     originalList.add(getFileStatusObject(new Path("/a")));
@@ -68,7 +65,18 @@ public class TestListUtils {
     originalList.add(getFileStatusObject(new Path("/abc")));
     originalList.add(getFileStatusObject(new Path("/abc")));
     originalList.add(getFileStatusObject(new Path("/abc_bak1")));
-    validateList( originalList, 5);
+    validateList(originalList, 5);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    validateList(originalList, 2);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    validateList(originalList, 2);
   }
 
   private void validateList(List<FileStatus> originalList, int expectedSize) {


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19543
On FNS-Blob, the List Blobs API is known to return duplicate entries for non-empty explicit directories. One entry corresponds to the directory itself, and another corresponds to the marker blob that the driver internally creates and maintains to mark that path as a directory. We already know about this behaviour, and it was handled to remove such duplicate entries from the set of entries that were returned as part of current list iterations.

Due to a possible partition split, if such duplicate entries happen to be returned in separate iterations, there is no handling on this, and the caller might get back the result with duplicate entries, as happened in this case. The logic to remove duplicates was designed before the realization of the partition split.

This PR fixes this bug

### How was this patch tested?
A new test for the failing scenario was added and existing test suite was ran to validate changes across all combinations.