### PR TITLE
HDFS-17772. Fix JournaledEditsCache int overflow while the maximum capacity to be Integer MAX_VALUE.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournaledEditsCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournaledEditsCache.java
@@ -79,7 +79,7 @@ class JournaledEditsCache {
   private static final long INVALID_TXN_ID = -1;
 
   /** The capacity, in bytes, of this cache. */
-  private final int capacity;
+  private final long capacity;
 
   /**
    * Read/write lock pair wrapped in AutoCloseable; these refer to the same
@@ -117,7 +117,7 @@ class JournaledEditsCache {
    */
   private long initialTxnId;
   /** The current total size of all buffers in this cache. */
-  private int totalSize;
+  private long totalSize;
 
   // ** End lock-protected fields **
 
@@ -128,8 +128,8 @@ class JournaledEditsCache {
         String.format("Cache config %s is set at %f, it should be a positive float value, " +
             "less than 1.0. The recommended value is less than 0.9.",
             DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY, fraction));
-    capacity = conf.getInt(DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_KEY,
-        (int) (Runtime.getRuntime().maxMemory() * fraction));
+    capacity = conf.getLong(DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_KEY,
+        (long) (Runtime.getRuntime().maxMemory() * fraction));
     if (capacity > 0.9 * Runtime.getRuntime().maxMemory()) {
       Journal.LOG.warn(String.format("Cache capacity is set at %d bytes but " +
           "maximum JVM memory is only %d bytes. It is recommended that you " +
@@ -424,7 +424,7 @@ class JournaledEditsCache {
   }
 
   @VisibleForTesting
-  int getCapacity() {
+  long getCapacity() {
     return capacity;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournaledEditsCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournaledEditsCache.java
@@ -226,7 +226,7 @@ public class TestJournaledEditsCache {
     // Assert the default configs.
     Configuration config = new Configuration();
     cache = new JournaledEditsCache(config);
-    assertEquals((int) (Runtime.getRuntime().maxMemory() * 0.5f), cache.getCapacity());
+    assertEquals((long) (Runtime.getRuntime().maxMemory() * 0.5f), cache.getCapacity());
 
     // Set dfs.journalnode.edit-cache-size.bytes.
     Configuration config1 = new Configuration();
@@ -239,7 +239,7 @@ public class TestJournaledEditsCache {
     Configuration config2 = new Configuration();
     config2.setFloat(DFSConfigKeys.DFS_JOURNALNODE_EDIT_CACHE_SIZE_FRACTION_KEY, 0.1f);
     cache = new JournaledEditsCache(config2);
-    assertEquals((int) (Runtime.getRuntime().maxMemory() * 0.1f), cache.getCapacity());
+    assertEquals((long) (Runtime.getRuntime().maxMemory() * 0.1f), cache.getCapacity());
   }
 
   private void storeEdits(int startTxn, int endTxn) throws Exception {


### PR DESCRIPTION
JIRA: [HDFS-17772](https://issues.apache.org/jira/browse/HDFS-17772).

### Description of PR
When we use the RBF SBN READ in the production environment, we found the following issue.

HDFS-16550 provides the parameter `dfs.journalnode.edit-cache-size.fraction` to control cache size based on journalnode memory ratio, but there is an issue of int overflow:

When using the `dfs.journalnode.edit-cache-size.fraction` parameter to control cache capacity, during the initialization of the `capacity` in `org.apache.hadoop.hdfs.qjournal.server.JournaledEditsCache#JournaledEditsCache`, **a long-to-int overflow issue occurs**. For instance, when the heap memory is configured as 32GB (where `Runtime.getRuntime().maxMemory()` returns 30,542,397,440 bytes), the overflow results in the `capacity` being truncated to `Integer.MAX_VALUE` (2,147,483,647). 

This renders the parameter setting ineffective, as the intended proportional cache capacity cannot be achieved. To resolve this, the `capacity` should be declared as a `long` type, and the `totalSize` variable should also be converted to a `long` type to prevent overflow in scenarios where `capacity` exceeds 2,147,483,647, ensuring both variables can accurately represent large values without integer limitations.

1. The error situation is as follows: 
    The dfs.Journalnode.edit-cache-size.fraction parameter uses the default value of 0.5f. I configured the heap memory size of Journalnode to 30,542,397,440 bytes, and expected it to be 15,271,198,720 bytes, but the capacity size is always Integer.MAX_VALUE=2,147,483,647 bytes
`2025-04-15 14:14:03,970 INFO  server.Journal (JournaledEditsCache.java:<init>(144)) - Enabling the journaled edits cache with a capacity of bytes: 2147483647`

2. The repaired result is as follows，meet expectation:
`2025-04-15 16:04:44,840 INFO  server.Journal (JournaledEditsCache.java:<init>(144)) - Enabling the journaled edits cache with a capacity of bytes: 15271198720`

### How was this patch tested?
Since Runtime.getRuntime().maxMemory() cannot be adjusted in unit tests, it is not easy to write unit tests, but code changes are no problem for existing unit tests.

