### PR TITLE
HADOOP-19427. [JDK17]  Upgrade JUnit from 4 to 5 in hadoop-compat-bench.

### DIFF
--- a/hadoop-tools/hadoop-compat-bench/pom.xml
+++ b/hadoop-tools/hadoop-compat-bench/pom.xml
@@ -69,6 +69,31 @@
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatDefaultSuites.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatDefaultSuites.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.fs.compat.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.hadoop.fs.compat.HdfsCompatTool;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatMiniCluster;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestCommand;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestHdfsCompatDefaultSuites {
@@ -35,7 +36,7 @@ public class TestHdfsCompatDefaultSuites {
       HdfsCompatCommand cmd = new HdfsCompatTestCommand(uri, "ALL", conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assertions.assertEquals(0, report.getFailedCase().size());
+      assertEquals(0, report.getFailedCase().size());
       new HdfsCompatTool(conf).printReport(report, System.out);
     } finally {
       cluster.shutdown();
@@ -52,7 +53,7 @@ public class TestHdfsCompatDefaultSuites {
       HdfsCompatCommand cmd = new HdfsCompatTestCommand(uri, "TPCDS", conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assertions.assertEquals(0, report.getFailedCase().size());
+      assertEquals(0, report.getFailedCase().size());
       new HdfsCompatTool(conf).printReport(report, System.out);
     } finally {
       cluster.shutdown();

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatDefaultSuites.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatDefaultSuites.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.fs.compat.HdfsCompatTool;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatMiniCluster;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestCommand;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestHdfsCompatDefaultSuites {
   @Test
@@ -35,7 +35,7 @@ public class TestHdfsCompatDefaultSuites {
       HdfsCompatCommand cmd = new HdfsCompatTestCommand(uri, "ALL", conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assert.assertEquals(0, report.getFailedCase().size());
+      Assertions.assertEquals(0, report.getFailedCase().size());
       new HdfsCompatTool(conf).printReport(report, System.out);
     } finally {
       cluster.shutdown();
@@ -52,7 +52,7 @@ public class TestHdfsCompatDefaultSuites {
       HdfsCompatCommand cmd = new HdfsCompatTestCommand(uri, "TPCDS", conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assert.assertEquals(0, report.getFailedCase().size());
+      Assertions.assertEquals(0, report.getFailedCase().size());
       new HdfsCompatTool(conf).printReport(report, System.out);
     } finally {
       cluster.shutdown();

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatFsCommand.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatFsCommand.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.fs.compat.cases.HdfsCompatAclTestCases;
 import org.apache.hadoop.fs.compat.cases.HdfsCompatMkdirTestCases;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -47,8 +47,8 @@ public class TestHdfsCompatFsCommand {
       HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assert.assertEquals(7, report.getPassedCase().size());
-      Assert.assertEquals(0, report.getFailedCase().size());
+      Assertions.assertEquals(7, report.getPassedCase().size());
+      Assertions.assertEquals(0, report.getFailedCase().size());
       show(conf, report);
     } finally {
       if (cluster != null) {
@@ -65,8 +65,8 @@ public class TestHdfsCompatFsCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assert.assertEquals(1, report.getPassedCase().size());
-    Assert.assertEquals(6, report.getFailedCase().size());
+    Assertions.assertEquals(1, report.getPassedCase().size());
+    Assertions.assertEquals(6, report.getFailedCase().size());
     show(conf, report);
     cleanup(cmd, conf);
   }
@@ -79,8 +79,8 @@ public class TestHdfsCompatFsCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assert.assertEquals(0, report.getPassedCase().size());
-    Assert.assertEquals(6, report.getFailedCase().size());
+    Assertions.assertEquals(0, report.getPassedCase().size());
+    Assertions.assertEquals(6, report.getFailedCase().size());
     show(conf, report);
     cleanup(cmd, conf);
   }

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatFsCommand.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatFsCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.compat.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.fs.compat.HdfsCompatTool;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatMiniCluster;
@@ -25,7 +26,6 @@ import org.apache.hadoop.fs.compat.cases.HdfsCompatAclTestCases;
 import org.apache.hadoop.fs.compat.cases.HdfsCompatMkdirTestCases;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -47,8 +47,8 @@ public class TestHdfsCompatFsCommand {
       HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
       cmd.initialize();
       HdfsCompatReport report = cmd.apply();
-      Assertions.assertEquals(7, report.getPassedCase().size());
-      Assertions.assertEquals(0, report.getFailedCase().size());
+      assertEquals(7, report.getPassedCase().size());
+      assertEquals(0, report.getFailedCase().size());
       show(conf, report);
     } finally {
       if (cluster != null) {
@@ -65,8 +65,8 @@ public class TestHdfsCompatFsCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assertions.assertEquals(1, report.getPassedCase().size());
-    Assertions.assertEquals(6, report.getFailedCase().size());
+    assertEquals(1, report.getPassedCase().size());
+    assertEquals(6, report.getFailedCase().size());
     show(conf, report);
     cleanup(cmd, conf);
   }
@@ -79,8 +79,8 @@ public class TestHdfsCompatFsCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, suite, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assertions.assertEquals(0, report.getPassedCase().size());
-    Assertions.assertEquals(6, report.getFailedCase().size());
+    assertEquals(0, report.getPassedCase().size());
+    assertEquals(6, report.getFailedCase().size());
     show(conf, report);
     cleanup(cmd, conf);
   }

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
@@ -20,9 +20,9 @@ package org.apache.hadoop.fs.compat.common;
 
 import org.apache.hadoop.fs.compat.cases.HdfsCompatBasics;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;
@@ -30,13 +30,13 @@ import java.util.Set;
 
 public class TestHdfsCompatInterfaceCoverage {
   @Test
-  @Ignore
+  @Disabled
   public void testFsCompatibility() {
     Set<String> publicMethods = getPublicInterfaces(FileSystem.class);
     Set<String> targets = getTargets(HdfsCompatBasics.class);
     for (String publicMethod : publicMethods) {
-      Assert.assertTrue("Method not tested: " + publicMethod,
-          targets.contains(publicMethod));
+      Assertions.assertTrue(
+         targets.contains(publicMethod), "Method not tested: " + publicMethod);
     }
   }
 

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.fs.compat.common;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.fs.compat.cases.HdfsCompatBasics;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 
@@ -35,7 +35,7 @@ public class TestHdfsCompatInterfaceCoverage {
     Set<String> publicMethods = getPublicInterfaces(FileSystem.class);
     Set<String> targets = getTargets(HdfsCompatBasics.class);
     for (String publicMethod : publicMethods) {
-      Assertions.assertTrue(
+      assertTrue(
          targets.contains(publicMethod), "Method not tested: " + publicMethod);
     }
   }

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatInterfaceCoverage.java
@@ -35,8 +35,8 @@ public class TestHdfsCompatInterfaceCoverage {
     Set<String> publicMethods = getPublicInterfaces(FileSystem.class);
     Set<String> targets = getTargets(HdfsCompatBasics.class);
     for (String publicMethod : publicMethods) {
-      assertTrue(
-         targets.contains(publicMethod), "Method not tested: " + publicMethod);
+      assertTrue(targets.contains(publicMethod),
+          "Method not tested: " + publicMethod);
     }
   }
 

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatShellCommand.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatShellCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.compat.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.compat.HdfsCompatTool;
@@ -25,7 +26,6 @@ import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestCommand;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestShellScope;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,8 +55,8 @@ public class TestHdfsCompatShellCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assertions.assertEquals(3, report.getPassedCase().size());
-    Assertions.assertEquals(0, report.getFailedCase().size());
+    assertEquals(3, report.getPassedCase().size());
+    assertEquals(0, report.getFailedCase().size());
     show(conf, report);
   }
 
@@ -67,8 +67,8 @@ public class TestHdfsCompatShellCommand {
     HdfsCompatCommand cmd = new TestSkipCommand(uri, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assertions.assertEquals(2, report.getPassedCase().size());
-    Assertions.assertEquals(0, report.getFailedCase().size());
+    assertEquals(2, report.getPassedCase().size());
+    assertEquals(0, report.getFailedCase().size());
     show(conf, report);
   }
 

--- a/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatShellCommand.java
+++ b/hadoop-tools/hadoop-compat-bench/src/test/java/org/apache/hadoop/fs/compat/common/TestHdfsCompatShellCommand.java
@@ -24,10 +24,10 @@ import org.apache.hadoop.fs.compat.hdfs.HdfsCompatMiniCluster;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestCommand;
 import org.apache.hadoop.fs.compat.hdfs.HdfsCompatTestShellScope;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,13 +36,13 @@ import java.nio.file.Files;
 public class TestHdfsCompatShellCommand {
   private HdfsCompatMiniCluster cluster;
 
-  @Before
+  @BeforeEach
   public void runCluster() throws IOException {
     this.cluster = new HdfsCompatMiniCluster();
     this.cluster.start();
   }
 
-  @After
+  @AfterEach
   public void shutdownCluster() {
     this.cluster.shutdown();
     this.cluster = null;
@@ -55,8 +55,8 @@ public class TestHdfsCompatShellCommand {
     HdfsCompatCommand cmd = new TestCommand(uri, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assert.assertEquals(3, report.getPassedCase().size());
-    Assert.assertEquals(0, report.getFailedCase().size());
+    Assertions.assertEquals(3, report.getPassedCase().size());
+    Assertions.assertEquals(0, report.getFailedCase().size());
     show(conf, report);
   }
 
@@ -67,8 +67,8 @@ public class TestHdfsCompatShellCommand {
     HdfsCompatCommand cmd = new TestSkipCommand(uri, conf);
     cmd.initialize();
     HdfsCompatReport report = cmd.apply();
-    Assert.assertEquals(2, report.getPassedCase().size());
-    Assert.assertEquals(0, report.getFailedCase().size());
+    Assertions.assertEquals(2, report.getPassedCase().size());
+    Assertions.assertEquals(0, report.getFailedCase().size());
     show(conf, report);
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19427.  [JDK17] Upgrade JUnit from 4 to 5 in hadoop-compat-bench.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

