### PR TITLE
HADOOP-19423. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-archives.

### DIFF
--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -303,7 +303,7 @@ public class TestHadoopArchives {
     System.setErr(out);
     final String results;
     try {
-      assertEquals(0, shell.run(new String[] { "-lsr", dir }));
+      assertEquals(0, shell.run(new String[]{"-lsr", dir}));
       results = bytes.toString();
     } finally {
       IOUtils.closeStream(out);

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -47,14 +47,15 @@ import org.apache.hadoop.util.JarFinder;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.slf4j.LoggerFactory.getLogger;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * test {@link HadoopArchives}
@@ -155,7 +156,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assertions.assertEquals(originalPaths, harPaths);
+    assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -173,7 +174,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assertions.assertEquals(originalPaths, harPaths);
+    assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -194,10 +195,10 @@ public class TestHadoopArchives {
     createFile(archivePath, fs, harName);
     final String[] args = { "-archiveName", harName, "-p", inputPathStr, "*",
         archivePath.toString() };
-    Assertions.assertEquals(-1, ToolRunner.run(har, args));
+    assertEquals(-1, ToolRunner.run(har, args));
     String output = byteStream.toString();
     final Path outputPath = new Path(archivePath, harName);
-    Assertions.assertTrue(output.indexOf("Archive path: " + outputPath.toString()
+    assertTrue(output.indexOf("Archive path: " + outputPath.toString()
         + " already exists") != -1);
 
     byteStream.reset();
@@ -207,9 +208,9 @@ public class TestHadoopArchives {
     final Path archivePath2 = new Path(archivePath, "sub1");
     final String[] args2 = { "-archiveName", harName, "-p", inputPathStr, "*",
         archivePath2.toString() };
-    Assertions.assertEquals(-1, ToolRunner.run(har, args2));
+    assertEquals(-1, ToolRunner.run(har, args2));
     output = byteStream.toString();
-    Assertions.assertTrue(output.indexOf("Destination " + archivePath2.toString()
+    assertTrue(output.indexOf("Destination " + archivePath2.toString()
         + " should be a directory but is a file") != -1);
 
     System.setErr(stderr);
@@ -239,7 +240,7 @@ public class TestHadoopArchives {
 
     // compare results
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assertions.assertEquals(originalPaths, harPaths);
+    assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -258,7 +259,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assertions.assertEquals(originalPaths, harPaths);
+    assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -283,7 +284,7 @@ public class TestHadoopArchives {
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr,
         fullHarPathStr + "/" + glob);
-    Assertions.assertEquals(originalPaths, harPaths);
+    assertEquals(originalPaths, harPaths);
   }
 
   private static List<String> lsr(final FsShell shell, String rootDir) throws Exception {
@@ -302,7 +303,7 @@ public class TestHadoopArchives {
     System.setErr(out);
     final String results;
     try {
-      Assertions.assertEquals(0, shell.run(new String[] { "-lsr", dir }));
+      assertEquals(0, shell.run(new String[] { "-lsr", dir }));
       results = bytes.toString();
     } finally {
       IOUtils.closeStream(out);

--- a/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
+++ b/hadoop-tools/hadoop-archives/src/test/java/org/apache/hadoop/tools/TestHadoopArchives.java
@@ -46,14 +46,14 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.JarFinder;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration;
-import org.junit.After;
-import org.junit.Assert;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**
@@ -104,7 +104,7 @@ public class TestHadoopArchives {
     return sb.toString();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.set(CapacitySchedulerConfiguration.PREFIX
@@ -133,7 +133,7 @@ public class TestHadoopArchives {
     fileList.add(createFile(inputPath, fs, "c"));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (dfscluster != null) {
       dfscluster.shutdown();
@@ -155,7 +155,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assert.assertEquals(originalPaths, harPaths);
+    Assertions.assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -173,7 +173,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assert.assertEquals(originalPaths, harPaths);
+    Assertions.assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -194,10 +194,10 @@ public class TestHadoopArchives {
     createFile(archivePath, fs, harName);
     final String[] args = { "-archiveName", harName, "-p", inputPathStr, "*",
         archivePath.toString() };
-    Assert.assertEquals(-1, ToolRunner.run(har, args));
+    Assertions.assertEquals(-1, ToolRunner.run(har, args));
     String output = byteStream.toString();
     final Path outputPath = new Path(archivePath, harName);
-    Assert.assertTrue(output.indexOf("Archive path: " + outputPath.toString()
+    Assertions.assertTrue(output.indexOf("Archive path: " + outputPath.toString()
         + " already exists") != -1);
 
     byteStream.reset();
@@ -207,9 +207,9 @@ public class TestHadoopArchives {
     final Path archivePath2 = new Path(archivePath, "sub1");
     final String[] args2 = { "-archiveName", harName, "-p", inputPathStr, "*",
         archivePath2.toString() };
-    Assert.assertEquals(-1, ToolRunner.run(har, args2));
+    Assertions.assertEquals(-1, ToolRunner.run(har, args2));
     output = byteStream.toString();
-    Assert.assertTrue(output.indexOf("Destination " + archivePath2.toString()
+    Assertions.assertTrue(output.indexOf("Destination " + archivePath2.toString()
         + " should be a directory but is a file") != -1);
 
     System.setErr(stderr);
@@ -239,7 +239,7 @@ public class TestHadoopArchives {
 
     // compare results
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assert.assertEquals(originalPaths, harPaths);
+    Assertions.assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -258,7 +258,7 @@ public class TestHadoopArchives {
 
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr);
-    Assert.assertEquals(originalPaths, harPaths);
+    Assertions.assertEquals(originalPaths, harPaths);
   }
 
   @Test
@@ -283,7 +283,7 @@ public class TestHadoopArchives {
     // compare results:
     final List<String> harPaths = lsr(shell, fullHarPathStr,
         fullHarPathStr + "/" + glob);
-    Assert.assertEquals(originalPaths, harPaths);
+    Assertions.assertEquals(originalPaths, harPaths);
   }
 
   private static List<String> lsr(final FsShell shell, String rootDir) throws Exception {
@@ -302,7 +302,7 @@ public class TestHadoopArchives {
     System.setErr(out);
     final String results;
     try {
-      Assert.assertEquals(0, shell.run(new String[] { "-lsr", dir }));
+      Assertions.assertEquals(0, shell.run(new String[] { "-lsr", dir }));
       results = bytes.toString();
     } finally {
       IOUtils.closeStream(out);
@@ -605,7 +605,7 @@ public class TestHadoopArchives {
   private static void expectSeekIOE(FSDataInputStream fsdis, long seekPos, String message) {
     try {
       fsdis.seek(seekPos);
-      assertTrue(message + " (Position = " + fsdis.getPos() + ")", false);
+      assertTrue(false, message + " (Position = " + fsdis.getPos() + ")");
     } catch (IOException ioe) {
       // okay
     }
@@ -764,7 +764,7 @@ public class TestHadoopArchives {
     while (listFiles.hasNext()) {
       LocatedFileStatus next = listFiles.next();
       if (!next.getPath().toString().endsWith("_SUCCESS")) {
-        assertEquals(next.getPath().toString(), 2, next.getReplication());
+        assertEquals(2, next.getReplication(), next.getPath().toString());
       }
     }
     return fullHarPathStr;


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19423. Upgrade JUnit from 4 to 5 in hadoop-archives.

### How was this patch tested?

mvn clean test & Junit test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

