### PR TITLE
HADOOP-19259. Upgrade to jackson 2.14.3 (#7428)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -218,12 +218,12 @@ com.aliyun:aliyun-java-sdk-sts:3.0.0
 com.aliyun.oss:aliyun-sdk-oss:3.13.2
 com.cedarsoftware:java-util:1.9.0
 com.cedarsoftware:json-io:2.5.1
-com.fasterxml.jackson.core:jackson-annotations:2.12.7
-com.fasterxml.jackson.core:jackson-core:2.12.7
-com.fasterxml.jackson.core:jackson-databind:2.12.7.1
-com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.12.7
-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.7
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.7
+com.fasterxml.jackson.core:jackson-annotations:2.14.3
+com.fasterxml.jackson.core:jackson-core:2.14.3
+com.fasterxml.jackson.core:jackson-databind:2.14.3
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.14.3
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.14.3
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.14.3
 com.fasterxml.uuid:java-uuid-generator:3.1.4
 com.fasterxml.woodstox:woodstox-core:5.4.0
 com.github.davidmoten:rxjava-extras:0.8.0.17
@@ -508,8 +508,7 @@ javax.cache:cache-api:1.1.1
 javax.servlet:javax.servlet-api:3.1.0
 javax.servlet.jsp:jsp-api:2.1
 javax.websocket:javax.websocket-api:1.0
-javax.ws.rs:jsr311-api:1.1.1
-javax.xml.bind:jaxb-api:2.2.11
+javax.xml.bind:jaxb-api:2.3.1
 
 
 Eclipse Public License 1.0

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.net;
 
 import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -846,6 +845,6 @@ public class TestNetUtils {
   }
 
   private void assertNullCause(Exception e) {
-    assertNull(e.getCause(), "Expected exception to have null cause");
+    assertNull("Expected exception to have null cause", e.getCause());
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestNetUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.net;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -793,9 +795,57 @@ public class TestNetUtils {
         .bindToLocalAddress(NetUtils.getLocalInetAddress("127.0.0.1"), true));
   }
 
+  public static class WrappedIOException extends IOException {
+    public WrappedIOException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+  }
+
+  private static class PrivateIOException extends IOException {
+    PrivateIOException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+  }
+
+  @Test
+  public void testAddNodeNameToIOException() {
+    IOException e0 = new IOException("test123");
+    assertNullCause(e0);
+    IOException new0 = NetUtils.addNodeNameToIOException(e0, "node123");
+    assertNullCause(new0);
+    assertEquals("node123: test123", new0.getMessage());
+
+    IOException e1 = new IOException("test456", new IllegalStateException("deliberate"));
+    IOException new1 = NetUtils.addNodeNameToIOException(e1, "node456");
+    assertSame(e1.getCause(), new1.getCause());
+    assertEquals("node456: test456", new1.getMessage());
+
+    ZipException e2 = new ZipException("test789");
+    assertNullCause(e2);
+    IOException new2 = NetUtils.addNodeNameToIOException(e2, "node789");
+    assertNullCause(new2);
+    assertEquals("node789: test789", new2.getMessage());
+
+    WrappedIOException e3 = new WrappedIOException("test987",
+        new IllegalStateException("deliberate"));
+    IOException new3 = NetUtils.addNodeNameToIOException(e3, "node987");
+    assertSame(e3.getCause(), new3.getCause());
+    assertEquals("node987: test987", new3.getMessage());
+
+    // addNodeNameToIOException will return the original exception if the class is not accessible
+    PrivateIOException e4 = new PrivateIOException("test654",
+        new IllegalStateException("deliberate"));
+    IOException new4 = NetUtils.addNodeNameToIOException(e4, "node654");
+    assertSame(e4, new4);
+  }
+
   private <T> void assertBetterArrayEquals(T[] expect, T[]got) {
     String expectStr = StringUtils.join(expect, ", ");
     String gotStr = StringUtils.join(got, ", ");
     assertEquals(expectStr, gotStr);
+  }
+
+  private void assertNullCause(Exception e) {
+    assertNull(e.getCause(), "Expected exception to have null cause");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -31,7 +31,6 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -845,16 +844,7 @@ public class WebHdfsFileSystem extends FileSystem
           if (node == null) {
             node = url.getAuthority();
           }
-          try {
-            IOException newIoe = ioe.getClass().getConstructor(String.class)
-                .newInstance(node + ": " + ioe.getMessage());
-            newIoe.initCause(ioe.getCause());
-            newIoe.setStackTrace(ioe.getStackTrace());
-            ioe = newIoe;
-          } catch (NoSuchMethodException | SecurityException 
-                   | InstantiationException | IllegalAccessException
-                   | IllegalArgumentException | InvocationTargetException e) {
-          }
+          ioe = NetUtils.addNodeNameToIOException(ioe, node);
           shouldRetry(ioe, retry);
         }
       }

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -69,8 +69,8 @@
     <jersey.version>1.19.4</jersey.version>
 
     <!-- jackson versions -->
-    <jackson2.version>2.12.7</jackson2.version>
-    <jackson2.databind.version>2.12.7.1</jackson2.databind.version>
+    <jackson2.version>2.14.3</jackson2.version>
+    <jackson2.databind.version>2.14.3</jackson2.databind.version>
 
     <!-- httpcomponents versions -->
     <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
This upgrades Jackson to 2.14.3

as a side effect this changes two javax dependencies

-removes javax.ws.rs:jsr311-api:1.1.1
-adds javax.xml.bind:jaxb-api:2.3.1

Contributed by PJ Fanning

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

