### PR TITLE
HADOOP-19419. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-registry.

### DIFF
--- a/hadoop-common-project/hadoop-registry/pom.xml
+++ b/hadoop-common-project/hadoop-registry/pom.xml
@@ -146,6 +146,32 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractRegistryTest.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractRegistryTest.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.registry.client.types.yarn.PersistencePolicies;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 
 import org.apache.hadoop.registry.server.services.RegistryAdminService;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ public class AbstractRegistryTest extends AbstractZKRegistryTest {
   protected RegistryAdminService registry;
   protected RegistryOperations operations;
 
-  @Before
+  @BeforeEach
   public void setupRegistry() throws IOException {
     registry = new RegistryAdminService("yarnRegistry");
     operations = registry;

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractZKRegistryTest.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractZKRegistryTest.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.registry.conf.RegistryConfiguration;
 import org.apache.hadoop.registry.server.services.AddingCompositeService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperServiceKeys;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
@@ -61,7 +61,7 @@ public class AbstractZKRegistryTest extends RegistryTestHelper {
     servicesToTeardown.addService(svc);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardownServices() throws IOException {
     describe(LOG, "teardown of static services");
     servicesToTeardown.close();
@@ -70,7 +70,7 @@ public class AbstractZKRegistryTest extends RegistryTestHelper {
   protected static MicroZookeeperService zookeeper;
 
 
-  @BeforeClass
+  @BeforeAll
   public static void createZKServer() throws Exception {
     File zkDir = new File("target/zookeeper");
     FileUtils.deleteDirectory(zkDir);
@@ -86,7 +86,7 @@ public class AbstractZKRegistryTest extends RegistryTestHelper {
   /**
    * give our thread a name
    */
-  @Before
+  @BeforeEach
   public void nameThread() {
     Thread.currentThread().setName("JUnit");
   }

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractZKRegistryTest.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/AbstractZKRegistryTest.java
@@ -29,15 +29,14 @@ import org.apache.hadoop.registry.server.services.MicroZookeeperServiceKeys;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 
+@Timeout(10)
 public class AbstractZKRegistryTest extends RegistryTestHelper {
   private static final Logger LOG =
       LoggerFactory.getLogger(AbstractZKRegistryTest.class);
@@ -50,12 +49,6 @@ public class AbstractZKRegistryTest extends RegistryTestHelper {
     servicesToTeardown.init(new Configuration());
     servicesToTeardown.start();
   }
-
-  @Rule
-  public final Timeout testTimeout = new Timeout(10000);
-
-  @Rule
-  public TestName methodName = new TestName();
 
   protected static void addToTeardown(Service svc) {
     servicesToTeardown.addService(svc);

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/RegistryTestHelper.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/RegistryTestHelper.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.YarnRegistryAttributes;
 import org.apache.hadoop.registry.secure.AbstractSecureRegistryTest;
 import org.apache.zookeeper.common.PathUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ import static org.apache.hadoop.registry.client.binding.RegistryTypeUtils.*;
  * The methods can be imported statically —or the class used as a base
  * class for tests.
  */
-public class RegistryTestHelper extends Assert {
+public class RegistryTestHelper extends Assertions {
   public static final String SC_HADOOP = "org-apache-hadoop";
   public static final String USER = "devteam/";
   public static final String NAME = "hdfs";
@@ -109,7 +109,7 @@ public class RegistryTestHelper extends Assert {
    */
   public static void logLoginDetails(String name,
       LoginContext loginContext) {
-    assertNotNull("Null login context", loginContext);
+    assertNotNull(loginContext, "Null login context");
     Subject subject = loginContext.getSubject();
     LOG.info("Logged in as {}:\n {}", name, subject);
   }
@@ -135,7 +135,7 @@ public class RegistryTestHelper extends Assert {
    * @param record instance to check
    */
   public static void validateEntry(ServiceRecord record) {
-    assertNotNull("null service record", record);
+    assertNotNull(record, "null service record");
     List<Endpoint> endpoints = record.external;
     assertEquals(2, endpoints.size());
 
@@ -150,8 +150,8 @@ public class RegistryTestHelper extends Assert {
     assertTrue(addr.contains(":8020"));
 
     Endpoint nnipc = findEndpoint(record, NNIPC, false, 1,2);
-    assertEquals("wrong protocol in " + nnipc, ProtocolTypes.PROTOCOL_THRIFT,
-        nnipc.protocolType);
+    assertEquals(ProtocolTypes.PROTOCOL_THRIFT
+,         nnipc.protocolType, "wrong protocol in " + nnipc);
 
     Endpoint ipc2 = findEndpoint(record, IPC2, false, 1,2);
     assertNotNull(ipc2);
@@ -184,26 +184,26 @@ public class RegistryTestHelper extends Assert {
    * @param resolved the one that resolved.
    */
   public static void assertMatches(ServiceRecord source, ServiceRecord resolved) {
-    assertNotNull("Null source record ", source);
-    assertNotNull("Null resolved record ", resolved);
+    assertNotNull(source, "Null source record ");
+    assertNotNull(resolved, "Null resolved record ");
     assertEquals(source.description, resolved.description);
 
     Map<String, String> srcAttrs = source.attributes();
     Map<String, String> resolvedAttrs = resolved.attributes();
     String sourceAsString = source.toString();
     String resolvedAsString = resolved.toString();
-    assertEquals("Wrong count of attrs in \n" + sourceAsString
-                 + "\nfrom\n" + resolvedAsString,
-        srcAttrs.size(),
-        resolvedAttrs.size());
+    assertEquals(
+       srcAttrs.size()
+,         resolvedAttrs.size(), "Wrong count of attrs in \n" + sourceAsString
+                 + "\nfrom\n" + resolvedAsString);
     for (Map.Entry<String, String> entry : srcAttrs.entrySet()) {
       String attr = entry.getKey();
-      assertEquals("attribute "+ attr, entry.getValue(), resolved.get(attr));
+      assertEquals(entry.getValue(), resolved.get(attr), "attribute "+ attr);
     }
-    assertEquals("wrong external endpoint count",
-        source.external.size(), resolved.external.size());
-    assertEquals("wrong external endpoint count",
-        source.internal.size(), resolved.internal.size());
+    assertEquals(
+       source.external.size(), resolved.external.size(), "wrong external endpoint count");
+    assertEquals(
+       source.internal.size(), resolved.internal.size(), "wrong external endpoint count");
   }
 
   /**
@@ -220,10 +220,10 @@ public class RegistryTestHelper extends Assert {
     Endpoint epr = external ? record.getExternalEndpoint(api)
                             : record.getInternalEndpoint(api);
     if (epr != null) {
-      assertEquals("wrong # of addresses",
-          addressElements, epr.addresses.size());
-      assertEquals("wrong # of elements in an address tuple",
-          addressTupleSize, epr.addresses.get(0).size());
+      assertEquals(
+         addressElements, epr.addresses.size(), "wrong # of addresses");
+      assertEquals(
+         addressTupleSize, epr.addresses.get(0).size(), "wrong # of elements in an address tuple");
       return epr;
     }
     List<Endpoint> endpoints = external ? record.external : record.internal;

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/RegistryTestHelper.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/RegistryTestHelper.java
@@ -150,8 +150,8 @@ public class RegistryTestHelper extends Assertions {
     assertTrue(addr.contains(":8020"));
 
     Endpoint nnipc = findEndpoint(record, NNIPC, false, 1,2);
-    assertEquals(ProtocolTypes.PROTOCOL_THRIFT
-,         nnipc.protocolType, "wrong protocol in " + nnipc);
+    assertEquals(ProtocolTypes.PROTOCOL_THRIFT,
+        nnipc.protocolType, "wrong protocol in " + nnipc);
 
     Endpoint ipc2 = findEndpoint(record, IPC2, false, 1,2);
     assertNotNull(ipc2);
@@ -192,18 +192,17 @@ public class RegistryTestHelper extends Assertions {
     Map<String, String> resolvedAttrs = resolved.attributes();
     String sourceAsString = source.toString();
     String resolvedAsString = resolved.toString();
-    assertEquals(
-       srcAttrs.size()
-,         resolvedAttrs.size(), "Wrong count of attrs in \n" + sourceAsString
-                 + "\nfrom\n" + resolvedAsString);
+    assertEquals(srcAttrs.size(),
+        resolvedAttrs.size(), "Wrong count of attrs in \n" + sourceAsString
+        + "\nfrom\n" + resolvedAsString);
     for (Map.Entry<String, String> entry : srcAttrs.entrySet()) {
       String attr = entry.getKey();
       assertEquals(entry.getValue(), resolved.get(attr), "attribute "+ attr);
     }
-    assertEquals(
-       source.external.size(), resolved.external.size(), "wrong external endpoint count");
-    assertEquals(
-       source.internal.size(), resolved.internal.size(), "wrong external endpoint count");
+    assertEquals(source.external.size(), resolved.external.size(),
+        "wrong external endpoint count");
+    assertEquals(source.internal.size(), resolved.internal.size(),
+        "wrong external endpoint count");
   }
 
   /**
@@ -220,10 +219,10 @@ public class RegistryTestHelper extends Assertions {
     Endpoint epr = external ? record.getExternalEndpoint(api)
                             : record.getInternalEndpoint(api);
     if (epr != null) {
-      assertEquals(
-         addressElements, epr.addresses.size(), "wrong # of addresses");
-      assertEquals(
-         addressTupleSize, epr.addresses.get(0).size(), "wrong # of elements in an address tuple");
+      assertEquals(addressElements, epr.addresses.size(),
+          "wrong # of addresses");
+      assertEquals(addressTupleSize, epr.addresses.get(0).size(),
+          "wrong # of elements in an address tuple");
       return epr;
     }
     List<Endpoint> endpoints = external ? record.external : record.internal;

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/cli/TestRegistryCli.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/cli/TestRegistryCli.java
@@ -22,9 +22,9 @@ import java.io.PrintStream;
 
 import org.apache.hadoop.registry.AbstractRegistryTest;
 import org.apache.hadoop.registry.operations.TestRegistryOperations;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,7 @@ public class TestRegistryCli extends AbstractRegistryTest {
   private PrintStream sysErr;
   private RegistryCli cli;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     sysOutStream = new ByteArrayOutputStream();
     sysOut = new PrintStream(sysOutStream);
@@ -48,7 +48,7 @@ public class TestRegistryCli extends AbstractRegistryTest {
     cli = new RegistryCli(operations, createRegistryConfiguration(), sysOut, sysErr);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cli.close();
   }

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
@@ -24,25 +24,18 @@ import org.apache.hadoop.registry.client.exceptions.NoRecordException;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.PersistencePolicies;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Test record marshalling
  */
+@Timeout(10)
 public class TestMarshalling extends RegistryTestHelper {
   private static final Logger
       LOG = LoggerFactory.getLogger(TestMarshalling.class);
-
-  @Rule
-  public final Timeout testTimeout = new Timeout(10000);
-  @Rule
-  public TestName methodName = new TestName();
 
   private static RegistryUtils.ServiceRecordMarshal marshal;
 
@@ -68,65 +61,65 @@ public class TestMarshalling extends RegistryTestHelper {
 
   @Test
   public void testUnmarshallNoData() throws Throwable {
-      Assertions.assertThrows(NoRecordException.class, () -> {
-          marshal.fromBytes("src", new byte[]{});
-      });
+    assertThrows(NoRecordException.class, () -> {
+      marshal.fromBytes("src", new byte[]{});
+    });
   }
 
   @Test
   public void testUnmarshallNotEnoughData() throws Throwable {
-      Assertions.assertThrows(NoRecordException.class, () -> {
-          marshal.fromBytes("src", new byte[]{'{','}'}, ServiceRecord.RECORD_TYPE);
-      });
-  // this is nominally JSON -but without the service record header
+    // this is nominally JSON -but without the service record header
+    assertThrows(NoRecordException.class, () -> {
+      marshal.fromBytes("src", new byte[]{'{','}'}, ServiceRecord.RECORD_TYPE);
+    });
 }
 
   @Test
   public void testUnmarshallNoBody() throws Throwable {
-      Assertions.assertThrows(InvalidRecordException.class, () -> {
-          byte[] bytes = "this is not valid JSON at all and should fail".getBytes();
-          marshal.fromBytes("src", bytes);
-      });
+    assertThrows(InvalidRecordException.class, () -> {
+      byte[] bytes = "this is not valid JSON at all and should fail".getBytes();
+      marshal.fromBytes("src", bytes);
+    });
   }
 
   @Test
   public void testUnmarshallWrongType() throws Throwable {
-      Assertions.assertThrows(InvalidRecordException.class, () -> {
-          byte[] bytes = "{'type':''}".getBytes();
-          ServiceRecord serviceRecord = marshal.fromBytes("marshalling", bytes);
-          RegistryTypeUtils.validateServiceRecord("validating", serviceRecord);
-      });
+    assertThrows(InvalidRecordException.class, () -> {
+      byte[] bytes = "{'type':''}".getBytes();
+      ServiceRecord serviceRecord = marshal.fromBytes("marshalling", bytes);
+      RegistryTypeUtils.validateServiceRecord("validating", serviceRecord);
+    });
   }
 
   @Test
   public void testUnmarshallWrongLongType() throws Throwable {
-      Assertions.assertThrows(NoRecordException.class, () -> {
-          ServiceRecord record = new ServiceRecord();
-          record.type = "ThisRecordHasALongButNonMatchingType";
-          byte[] bytes = marshal.toBytes(record);
-          ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
+    assertThrows(NoRecordException.class, () -> {
+      ServiceRecord record = new ServiceRecord();
+      record.type = "ThisRecordHasALongButNonMatchingType";
+      byte[] bytes = marshal.toBytes(record);
+      ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
         bytes, ServiceRecord.RECORD_TYPE);
-      });
+    });
   }
 
   @Test
   public void testUnmarshallNoType() throws Throwable {
-      Assertions.assertThrows(NoRecordException.class, () -> {
-          ServiceRecord record = new ServiceRecord();
-          record.type = "NoRecord";
-          byte[] bytes = marshal.toBytes(record);
-          ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
+    assertThrows(NoRecordException.class, () -> {
+      ServiceRecord record = new ServiceRecord();
+      record.type = "NoRecord";
+      byte[] bytes = marshal.toBytes(record);
+      ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
         bytes, ServiceRecord.RECORD_TYPE);
-      });
+    });
   }
 
   @Test
   public void testRecordValidationWrongType() throws Throwable {
-      Assertions.assertThrows(InvalidRecordException.class, () -> {
-          ServiceRecord record = new ServiceRecord();
-          record.type = "NotAServiceRecordType";
-          RegistryTypeUtils.validateServiceRecord("validating", record);
-      });
+    assertThrows(InvalidRecordException.class, () -> {
+      ServiceRecord record = new ServiceRecord();
+      record.type = "NotAServiceRecordType";
+      RegistryTypeUtils.validateServiceRecord("validating", record);
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
@@ -70,9 +70,9 @@ public class TestMarshalling extends RegistryTestHelper {
   public void testUnmarshallNotEnoughData() throws Throwable {
     // this is nominally JSON -but without the service record header
     assertThrows(NoRecordException.class, () -> {
-      marshal.fromBytes("src", new byte[]{'{','}'}, ServiceRecord.RECORD_TYPE);
+      marshal.fromBytes("src", new byte[]{'{', '}'}, ServiceRecord.RECORD_TYPE);
     });
-}
+  }
 
   @Test
   public void testUnmarshallNoBody() throws Throwable {
@@ -98,7 +98,7 @@ public class TestMarshalling extends RegistryTestHelper {
       record.type = "ThisRecordHasALongButNonMatchingType";
       byte[] bytes = marshal.toBytes(record);
       ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
-        bytes, ServiceRecord.RECORD_TYPE);
+          bytes, ServiceRecord.RECORD_TYPE);
     });
   }
 
@@ -109,7 +109,7 @@ public class TestMarshalling extends RegistryTestHelper {
       record.type = "NoRecord";
       byte[] bytes = marshal.toBytes(record);
       ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
-        bytes, ServiceRecord.RECORD_TYPE);
+          bytes, ServiceRecord.RECORD_TYPE);
     });
   }
 

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestMarshalling.java
@@ -23,13 +23,14 @@ import org.apache.hadoop.registry.client.exceptions.InvalidRecordException;
 import org.apache.hadoop.registry.client.exceptions.NoRecordException;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.PersistencePolicies;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Test record marshalling
@@ -45,7 +46,7 @@ public class TestMarshalling extends RegistryTestHelper {
 
   private static RegistryUtils.ServiceRecordMarshal marshal;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     marshal = new RegistryUtils.ServiceRecordMarshal();
   }
@@ -65,53 +66,67 @@ public class TestMarshalling extends RegistryTestHelper {
   }
 
 
-  @Test(expected = NoRecordException.class)
+  @Test
   public void testUnmarshallNoData() throws Throwable {
-    marshal.fromBytes("src", new byte[]{});
+      Assertions.assertThrows(NoRecordException.class, () -> {
+          marshal.fromBytes("src", new byte[]{});
+      });
   }
 
-  @Test(expected = NoRecordException.class)
+  @Test
   public void testUnmarshallNotEnoughData() throws Throwable {
-    // this is nominally JSON -but without the service record header
-    marshal.fromBytes("src", new byte[]{'{','}'}, ServiceRecord.RECORD_TYPE);
-  }
+      Assertions.assertThrows(NoRecordException.class, () -> {
+          marshal.fromBytes("src", new byte[]{'{','}'}, ServiceRecord.RECORD_TYPE);
+      });
+  // this is nominally JSON -but without the service record header
+}
 
-  @Test(expected = InvalidRecordException.class)
+  @Test
   public void testUnmarshallNoBody() throws Throwable {
-    byte[] bytes = "this is not valid JSON at all and should fail".getBytes();
-    marshal.fromBytes("src", bytes);
+      Assertions.assertThrows(InvalidRecordException.class, () -> {
+          byte[] bytes = "this is not valid JSON at all and should fail".getBytes();
+          marshal.fromBytes("src", bytes);
+      });
   }
 
-  @Test(expected = InvalidRecordException.class)
+  @Test
   public void testUnmarshallWrongType() throws Throwable {
-    byte[] bytes = "{'type':''}".getBytes();
-    ServiceRecord serviceRecord = marshal.fromBytes("marshalling", bytes);
-    RegistryTypeUtils.validateServiceRecord("validating", serviceRecord);
+      Assertions.assertThrows(InvalidRecordException.class, () -> {
+          byte[] bytes = "{'type':''}".getBytes();
+          ServiceRecord serviceRecord = marshal.fromBytes("marshalling", bytes);
+          RegistryTypeUtils.validateServiceRecord("validating", serviceRecord);
+      });
   }
 
-  @Test(expected = NoRecordException.class)
+  @Test
   public void testUnmarshallWrongLongType() throws Throwable {
-    ServiceRecord record = new ServiceRecord();
-    record.type = "ThisRecordHasALongButNonMatchingType";
-    byte[] bytes = marshal.toBytes(record);
-    ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
+      Assertions.assertThrows(NoRecordException.class, () -> {
+          ServiceRecord record = new ServiceRecord();
+          record.type = "ThisRecordHasALongButNonMatchingType";
+          byte[] bytes = marshal.toBytes(record);
+          ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
         bytes, ServiceRecord.RECORD_TYPE);
+      });
   }
 
-  @Test(expected = NoRecordException.class)
+  @Test
   public void testUnmarshallNoType() throws Throwable {
-    ServiceRecord record = new ServiceRecord();
-    record.type = "NoRecord";
-    byte[] bytes = marshal.toBytes(record);
-    ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
+      Assertions.assertThrows(NoRecordException.class, () -> {
+          ServiceRecord record = new ServiceRecord();
+          record.type = "NoRecord";
+          byte[] bytes = marshal.toBytes(record);
+          ServiceRecord serviceRecord = marshal.fromBytes("marshalling",
         bytes, ServiceRecord.RECORD_TYPE);
+      });
   }
 
-  @Test(expected = InvalidRecordException.class)
+  @Test
   public void testRecordValidationWrongType() throws Throwable {
-    ServiceRecord record = new ServiceRecord();
-    record.type = "NotAServiceRecordType";
-    RegistryTypeUtils.validateServiceRecord("validating", record);
+      Assertions.assertThrows(InvalidRecordException.class, () -> {
+          ServiceRecord record = new ServiceRecord();
+          record.type = "NotAServiceRecordType";
+          RegistryTypeUtils.validateServiceRecord("validating", record);
+      });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryOperationUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryOperationUtils.java
@@ -19,13 +19,13 @@
 package org.apache.hadoop.registry.client.binding;
 
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link RegistryUtils} class
  */
-public class TestRegistryOperationUtils extends Assert {
+public class TestRegistryOperationUtils extends Assertions {
 
   @Test
   public void testUsernameExtractionEnvVarOverrride() throws Throwable {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryOperationUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryOperationUtils.java
@@ -31,7 +31,6 @@ public class TestRegistryOperationUtils extends Assertions {
   public void testUsernameExtractionEnvVarOverrride() throws Throwable {
     String whoami = RegistryUtils.getCurrentUsernameUnencoded("drwho");
     assertEquals("drwho", whoami);
-
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
@@ -24,10 +24,10 @@ import java.util.List;
 
 import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.registry.client.exceptions.InvalidPathnameException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class TestRegistryPathUtils extends Assert {
+public class TestRegistryPathUtils extends Assertions {
 
 
   public static final String EURO = "\u20AC";
@@ -103,8 +103,8 @@ public class TestRegistryPathUtils extends Assert {
   private static void assertCreatedPathEquals(String expected, String base,
       String path) throws IOException {
     String fullPath = createFullPath(base, path);
-    assertEquals("\"" + base + "\" + \"" + path + "\" =\"" + fullPath + "\"",
-        expected, fullPath);
+    assertEquals(
+       expected, fullPath, "\"" + base + "\" + \"" + path + "\" =\"" + fullPath + "\"");
   }
 
   @Test
@@ -146,9 +146,11 @@ public class TestRegistryPathUtils extends Assert {
     assertEquals("c",lastPathEntry("/a/b/c/"));
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testParentOfRoot() throws Throwable {
-    parentOf("/");
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          parentOf("/");
+      });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
@@ -59,7 +59,7 @@ public class TestRegistryPathUtils extends Assertions {
 
   protected void assertConverted(String expected, String in) {
     String out = RegistryPathUtils.encodeForRegistry(in);
-    assertEquals("Conversion of " + in, expected, out);
+    assertEquals(expected, out, "Conversion of " + in);
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/binding/TestRegistryPathUtils.java
@@ -103,8 +103,8 @@ public class TestRegistryPathUtils extends Assertions {
   private static void assertCreatedPathEquals(String expected, String base,
       String path) throws IOException {
     String fullPath = createFullPath(base, path);
-    assertEquals(
-       expected, fullPath, "\"" + base + "\" + \"" + path + "\" =\"" + fullPath + "\"");
+    assertEquals(expected, fullPath,
+        "\"" + base + "\" + \"" + path + "\" =\"" + fullPath + "\"");
   }
 
   @Test
@@ -148,9 +148,9 @@ public class TestRegistryPathUtils extends Assertions {
 
   @Test
   public void testParentOfRoot() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          parentOf("/");
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      parentOf("/");
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestCuratorService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestCuratorService.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Test the curator service
@@ -80,9 +79,9 @@ public class TestCuratorService extends AbstractZKRegistryTest {
 
   @Test
   public void testLsNotFound() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          List<String> ls = curatorService.zkList(MISSING);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      List<String> ls = curatorService.zkList(MISSING);
+    });
   }
 
   @Test
@@ -102,9 +101,9 @@ public class TestCuratorService extends AbstractZKRegistryTest {
 
   @Test
   public void testVerifyExistsMissing() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          pathMustExist("/file-not-found");
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      pathMustExist("/file-not-found");
+    });
   }
 
   @Test
@@ -126,9 +125,9 @@ public class TestCuratorService extends AbstractZKRegistryTest {
 
   @Test
   public void testMkdirChild() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          mkPath("/testMkdirChild/child", CreateMode.PERSISTENT);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      mkPath("/testMkdirChild/child", CreateMode.PERSISTENT);
+    });
   }
 
   @Test
@@ -218,9 +217,9 @@ public class TestCuratorService extends AbstractZKRegistryTest {
 
   @Test
   public void testUpdateMissing() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          curatorService.zkUpdate("/testupdatemissing", getTestBuffer());
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      curatorService.zkUpdate("/testupdatemissing", getTestBuffer());
+    });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestCuratorService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestCuratorService.java
@@ -29,14 +29,15 @@ import org.apache.hadoop.registry.client.impl.zk.CuratorService;
 import org.apache.hadoop.registry.client.impl.zk.RegistrySecurity;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.ACL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Test the curator service
@@ -51,12 +52,12 @@ public class TestCuratorService extends AbstractZKRegistryTest {
   public static final String MISSING = "/missing";
   private List<ACL> rootACL;
 
-  @Before
+  @BeforeEach
   public void startCurator() throws IOException {
     createCuratorService();
   }
 
-  @After
+  @AfterEach
   public void stopCurator() {
     ServiceOperations.stop(curatorService);
   }
@@ -77,9 +78,11 @@ public class TestCuratorService extends AbstractZKRegistryTest {
     curatorService.zkList("/");
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testLsNotFound() throws Throwable {
-    List<String> ls = curatorService.zkList(MISSING);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          List<String> ls = curatorService.zkList(MISSING);
+      });
   }
 
   @Test
@@ -97,9 +100,11 @@ public class TestCuratorService extends AbstractZKRegistryTest {
     pathMustExist("/");
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testVerifyExistsMissing() throws Throwable {
-    pathMustExist("/file-not-found");
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          pathMustExist("/file-not-found");
+      });
   }
 
   @Test
@@ -119,9 +124,11 @@ public class TestCuratorService extends AbstractZKRegistryTest {
     curatorService.zkPathMustExist(path);
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testMkdirChild() throws Throwable {
-    mkPath("/testMkdirChild/child", CreateMode.PERSISTENT);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          mkPath("/testMkdirChild/child", CreateMode.PERSISTENT);
+      });
   }
 
   @Test
@@ -209,9 +216,11 @@ public class TestCuratorService extends AbstractZKRegistryTest {
     curatorService.zkUpdate("/testcreateupdate", buffer);
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testUpdateMissing() throws Throwable {
-    curatorService.zkUpdate("/testupdatemissing", getTestBuffer());
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          curatorService.zkUpdate("/testupdatemissing", getTestBuffer());
+      });
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestFSRegistryOperationsService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestFSRegistryOperationsService.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.registry.client.impl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,10 +32,10 @@ import org.apache.hadoop.fs.PathNotFoundException;
 import org.apache.hadoop.registry.client.exceptions.InvalidPathnameException;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.YarnRegistryAttributes;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * FSRegistryOperationsService test, using the local filesystem.
@@ -45,20 +45,20 @@ public class TestFSRegistryOperationsService {
       new FSRegistryOperationsService();
   private static FileSystem fs;
 
-  @BeforeClass
+  @BeforeAll
   public static void initRegistry() throws IOException {
-    Assert.assertNotNull(registry);
+    Assertions.assertNotNull(registry);
     registry.init(new Configuration());
     fs = registry.getFs();
     fs.delete(new Path("test"), true);
   }
 
-  @Before
+  @BeforeEach
   public void createTestDir() throws IOException {
     fs.mkdirs(new Path("test"));
   }
 
-  @After
+  @AfterEach
   public void cleanTestDir() throws IOException {
     fs.delete(new Path("test"), true);
   }
@@ -69,17 +69,17 @@ public class TestFSRegistryOperationsService {
     boolean result = false;
     System.out.println("Make node with parent already made, nonrecursive");
     result = registry.mknode("test/registryTestNode", false);
-    Assert.assertTrue(result);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    Assertions.assertTrue(result);
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
 
     // Expected to fail
     try {
       System.out.println("Try to make node with no parent, nonrecursive");
       registry.mknode("test/parent/registryTestNode", false);
-      Assert.fail("Should not have created node");
+      Assertions.fail("Should not have created node");
     } catch (IOException e) {
     }
-    Assert.assertFalse(fs.exists(new Path("test/parent/registryTestNode")));
+    Assertions.assertFalse(fs.exists(new Path("test/parent/registryTestNode")));
   }
 
   @Test
@@ -87,14 +87,14 @@ public class TestFSRegistryOperationsService {
     boolean result = false;
     System.out.println("Make node with parent already made, recursive");
     result = registry.mknode("test/registryTestNode", true);
-    Assert.assertTrue(result);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    Assertions.assertTrue(result);
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
 
     result = false;
     System.out.println("Try to make node with no parent, recursive");
     result = registry.mknode("test/parent/registryTestNode", true);
-    Assert.assertTrue(result);
-    Assert.assertTrue(fs.exists(new Path("test/parent/registryTestNode")));
+    Assertions.assertTrue(result);
+    Assertions.assertTrue(fs.exists(new Path("test/parent/registryTestNode")));
 
   }
 
@@ -105,8 +105,8 @@ public class TestFSRegistryOperationsService {
 
     System.out.println(
         "Try to mknode existing path -- should be noop and return false");
-    Assert.assertFalse(registry.mknode("test/registryTestNode", true));
-    Assert.assertFalse(registry.mknode("test/registryTestNode", false));
+    Assertions.assertFalse(registry.mknode("test/registryTestNode", true));
+    Assertions.assertFalse(registry.mknode("test/registryTestNode", false));
   }
 
   @Test
@@ -118,12 +118,12 @@ public class TestFSRegistryOperationsService {
     fs.mkdirs(new Path("test/parent1/registryTestNode"));
 
     registry.bind("test/parent1/registryTestNode", record, 1);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         fs.exists(new Path("test/parent1/registryTestNode/_record")));
 
     // Test without pre-creating path
     registry.bind("test/parent2/registryTestNode", record, 1);
-    Assert.assertTrue(fs.exists(new Path("test/parent2/registryTestNode")));
+    Assertions.assertTrue(fs.exists(new Path("test/parent2/registryTestNode")));
 
   }
 
@@ -134,43 +134,43 @@ public class TestFSRegistryOperationsService {
 
     System.out.println("Bind record1");
     registry.bind("test/registryTestNode", record1, 1);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     System.out.println("Bind record2, overwrite = 1");
     registry.bind("test/registryTestNode", record2, 1);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     // The record should have been overwritten
     ServiceRecord readRecord = registry.resolve("test/registryTestNode");
-    Assert.assertTrue(readRecord.equals(record2));
+    Assertions.assertTrue(readRecord.equals(record2));
 
     System.out.println("Bind record3, overwrite = 0");
     try {
       registry.bind("test/registryTestNode", record1, 0);
-      Assert.fail("Should not overwrite record");
+      Assertions.fail("Should not overwrite record");
     } catch (IOException e) {
     }
 
     // The record should not be overwritten
     readRecord = registry.resolve("test/registryTestNode");
-    Assert.assertTrue(readRecord.equals(record2));
+    Assertions.assertTrue(readRecord.equals(record2));
   }
 
   @Test
   public void testResolve() throws IOException {
     ServiceRecord record = createRecord("0");
     registry.bind("test/registryTestNode", record, 1);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     System.out.println("Read record that exists");
     ServiceRecord readRecord = registry.resolve("test/registryTestNode");
-    Assert.assertNotNull(readRecord);
-    Assert.assertTrue(record.equals(readRecord));
+    Assertions.assertNotNull(readRecord);
+    Assertions.assertTrue(record.equals(readRecord));
 
     System.out.println("Try to read record that does not exist");
     try {
       readRecord = registry.resolve("test/nonExistentNode");
-      Assert.fail("Should throw an error, record does not exist");
+      Assertions.fail("Should throw an error, record does not exist");
     } catch (IOException e) {
     }
   }
@@ -182,11 +182,11 @@ public class TestFSRegistryOperationsService {
 
     System.out.println("Check for existing node");
     boolean exists = registry.exists("test/registryTestNode");
-    Assert.assertTrue(exists);
+    Assertions.assertTrue(exists);
 
     System.out.println("Check for  non-existing node");
     exists = registry.exists("test/nonExistentNode");
-    Assert.assertFalse(exists);
+    Assertions.assertFalse(exists);
   }
 
   @Test
@@ -198,24 +198,24 @@ public class TestFSRegistryOperationsService {
 
     try {
       registry.delete("test/registryTestNode", false);
-      Assert.fail("Deleted dir wich children, nonrecursive flag set");
+      Assertions.fail("Deleted dir wich children, nonrecursive flag set");
     } catch (IOException e) {
     }
     // Make sure nothing was deleted
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode")));
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete leaf path 'test/registryTestNode/child2'");
     registry.delete("test/registryTestNode/child2", false);
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode")));
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
-    Assert.assertFalse(fs.exists(new Path("test/registryTestNode/child2")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
+    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out
         .println("Recursively delete non-leaf path 'test/registryTestNode'");
     registry.delete("test/registryTestNode", true);
-    Assert.assertFalse(fs.exists(new Path("test/registryTestNode")));
+    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode")));
   }
 
   @Test
@@ -233,27 +233,27 @@ public class TestFSRegistryOperationsService {
     System.out.println("Delete dir with child nodes and record file");
     try {
       registry.delete("test/registryTestNode", false);
-      Assert.fail("Nonrecursive delete of non-empty dir");
+      Assertions.fail("Nonrecursive delete of non-empty dir");
     } catch (PathIsNotEmptyDirectoryException e) {
     }
 
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
-    Assert.assertTrue(
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    Assertions.assertTrue(
         fs.exists(new Path("test/registryTestNode/child1/_record")));
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete dir with record file and no child dirs");
     registry.delete("test/registryTestNode/child1", false);
-    Assert.assertFalse(fs.exists(new Path("test/registryTestNode/child1")));
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode/child1")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete dir with child dir and no record file");
     try {
       registry.delete("test/registryTestNode", false);
-      Assert.fail("Nonrecursive delete of non-empty dir");
+      Assertions.fail("Nonrecursive delete of non-empty dir");
     } catch (PathIsNotEmptyDirectoryException e) {
     }
-    Assert.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
   }
 
   @Test
@@ -271,20 +271,20 @@ public class TestFSRegistryOperationsService {
     List<String> ls = null;
 
     ls = registry.list("test/registryTestNode");
-    Assert.assertNotNull(ls);
-    Assert.assertEquals(2, ls.size());
+    Assertions.assertNotNull(ls);
+    Assertions.assertEquals(2, ls.size());
     System.out.println(ls);
-    Assert.assertTrue(ls.contains("child1"));
-    Assert.assertTrue(ls.contains("child2"));
+    Assertions.assertTrue(ls.contains("child1"));
+    Assertions.assertTrue(ls.contains("child2"));
 
     ls = null;
     ls = registry.list("test/registryTestNode/child1");
-    Assert.assertNotNull(ls);
-    Assert.assertTrue(ls.isEmpty());
+    Assertions.assertNotNull(ls);
+    Assertions.assertTrue(ls.isEmpty());
     ls = null;
     ls = registry.list("test/registryTestNode/child2");
-    Assert.assertNotNull(ls);
-    Assert.assertTrue(ls.isEmpty());
+    Assertions.assertNotNull(ls);
+    Assertions.assertTrue(ls.isEmpty());
   }
 
   private ServiceRecord createRecord(String id) {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestFSRegistryOperationsService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestFSRegistryOperationsService.java
@@ -18,7 +18,11 @@
 
 package org.apache.hadoop.registry.client.impl;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,9 +37,9 @@ import org.apache.hadoop.registry.client.exceptions.InvalidPathnameException;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.YarnRegistryAttributes;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * FSRegistryOperationsService test, using the local filesystem.
@@ -47,7 +51,7 @@ public class TestFSRegistryOperationsService {
 
   @BeforeAll
   public static void initRegistry() throws IOException {
-    Assertions.assertNotNull(registry);
+    assertNotNull(registry);
     registry.init(new Configuration());
     fs = registry.getFs();
     fs.delete(new Path("test"), true);
@@ -69,17 +73,17 @@ public class TestFSRegistryOperationsService {
     boolean result = false;
     System.out.println("Make node with parent already made, nonrecursive");
     result = registry.mknode("test/registryTestNode", false);
-    Assertions.assertTrue(result);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    assertTrue(result);
+    assertTrue(fs.exists(new Path("test/registryTestNode")));
 
     // Expected to fail
     try {
       System.out.println("Try to make node with no parent, nonrecursive");
       registry.mknode("test/parent/registryTestNode", false);
-      Assertions.fail("Should not have created node");
+      fail("Should not have created node");
     } catch (IOException e) {
     }
-    Assertions.assertFalse(fs.exists(new Path("test/parent/registryTestNode")));
+    assertFalse(fs.exists(new Path("test/parent/registryTestNode")));
   }
 
   @Test
@@ -87,14 +91,14 @@ public class TestFSRegistryOperationsService {
     boolean result = false;
     System.out.println("Make node with parent already made, recursive");
     result = registry.mknode("test/registryTestNode", true);
-    Assertions.assertTrue(result);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
+    assertTrue(result);
+    assertTrue(fs.exists(new Path("test/registryTestNode")));
 
     result = false;
     System.out.println("Try to make node with no parent, recursive");
     result = registry.mknode("test/parent/registryTestNode", true);
-    Assertions.assertTrue(result);
-    Assertions.assertTrue(fs.exists(new Path("test/parent/registryTestNode")));
+    assertTrue(result);
+    assertTrue(fs.exists(new Path("test/parent/registryTestNode")));
 
   }
 
@@ -105,8 +109,8 @@ public class TestFSRegistryOperationsService {
 
     System.out.println(
         "Try to mknode existing path -- should be noop and return false");
-    Assertions.assertFalse(registry.mknode("test/registryTestNode", true));
-    Assertions.assertFalse(registry.mknode("test/registryTestNode", false));
+    assertFalse(registry.mknode("test/registryTestNode", true));
+    assertFalse(registry.mknode("test/registryTestNode", false));
   }
 
   @Test
@@ -118,12 +122,12 @@ public class TestFSRegistryOperationsService {
     fs.mkdirs(new Path("test/parent1/registryTestNode"));
 
     registry.bind("test/parent1/registryTestNode", record, 1);
-    Assertions.assertTrue(
+    assertTrue(
         fs.exists(new Path("test/parent1/registryTestNode/_record")));
 
     // Test without pre-creating path
     registry.bind("test/parent2/registryTestNode", record, 1);
-    Assertions.assertTrue(fs.exists(new Path("test/parent2/registryTestNode")));
+    assertTrue(fs.exists(new Path("test/parent2/registryTestNode")));
 
   }
 
@@ -134,43 +138,43 @@ public class TestFSRegistryOperationsService {
 
     System.out.println("Bind record1");
     registry.bind("test/registryTestNode", record1, 1);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     System.out.println("Bind record2, overwrite = 1");
     registry.bind("test/registryTestNode", record2, 1);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     // The record should have been overwritten
     ServiceRecord readRecord = registry.resolve("test/registryTestNode");
-    Assertions.assertTrue(readRecord.equals(record2));
+    assertTrue(readRecord.equals(record2));
 
     System.out.println("Bind record3, overwrite = 0");
     try {
       registry.bind("test/registryTestNode", record1, 0);
-      Assertions.fail("Should not overwrite record");
+      fail("Should not overwrite record");
     } catch (IOException e) {
     }
 
     // The record should not be overwritten
     readRecord = registry.resolve("test/registryTestNode");
-    Assertions.assertTrue(readRecord.equals(record2));
+    assertTrue(readRecord.equals(record2));
   }
 
   @Test
   public void testResolve() throws IOException {
     ServiceRecord record = createRecord("0");
     registry.bind("test/registryTestNode", record, 1);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
 
     System.out.println("Read record that exists");
     ServiceRecord readRecord = registry.resolve("test/registryTestNode");
-    Assertions.assertNotNull(readRecord);
-    Assertions.assertTrue(record.equals(readRecord));
+    assertNotNull(readRecord);
+    assertTrue(record.equals(readRecord));
 
     System.out.println("Try to read record that does not exist");
     try {
       readRecord = registry.resolve("test/nonExistentNode");
-      Assertions.fail("Should throw an error, record does not exist");
+      fail("Should throw an error, record does not exist");
     } catch (IOException e) {
     }
   }
@@ -182,11 +186,11 @@ public class TestFSRegistryOperationsService {
 
     System.out.println("Check for existing node");
     boolean exists = registry.exists("test/registryTestNode");
-    Assertions.assertTrue(exists);
+    assertTrue(exists);
 
     System.out.println("Check for  non-existing node");
     exists = registry.exists("test/nonExistentNode");
-    Assertions.assertFalse(exists);
+    assertFalse(exists);
   }
 
   @Test
@@ -198,24 +202,24 @@ public class TestFSRegistryOperationsService {
 
     try {
       registry.delete("test/registryTestNode", false);
-      Assertions.fail("Deleted dir wich children, nonrecursive flag set");
+      fail("Deleted dir wich children, nonrecursive flag set");
     } catch (IOException e) {
     }
     // Make sure nothing was deleted
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    assertTrue(fs.exists(new Path("test/registryTestNode")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete leaf path 'test/registryTestNode/child2'");
     registry.delete("test/registryTestNode/child2", false);
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode")));
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
-    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode/child2")));
+    assertTrue(fs.exists(new Path("test/registryTestNode")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child1")));
+    assertFalse(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out
         .println("Recursively delete non-leaf path 'test/registryTestNode'");
     registry.delete("test/registryTestNode", true);
-    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode")));
+    assertFalse(fs.exists(new Path("test/registryTestNode")));
   }
 
   @Test
@@ -233,27 +237,27 @@ public class TestFSRegistryOperationsService {
     System.out.println("Delete dir with child nodes and record file");
     try {
       registry.delete("test/registryTestNode", false);
-      Assertions.fail("Nonrecursive delete of non-empty dir");
+      fail("Nonrecursive delete of non-empty dir");
     } catch (PathIsNotEmptyDirectoryException e) {
     }
 
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
-    Assertions.assertTrue(
+    assertTrue(fs.exists(new Path("test/registryTestNode/_record")));
+    assertTrue(
         fs.exists(new Path("test/registryTestNode/child1/_record")));
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete dir with record file and no child dirs");
     registry.delete("test/registryTestNode/child1", false);
-    Assertions.assertFalse(fs.exists(new Path("test/registryTestNode/child1")));
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    assertFalse(fs.exists(new Path("test/registryTestNode/child1")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
 
     System.out.println("Delete dir with child dir and no record file");
     try {
       registry.delete("test/registryTestNode", false);
-      Assertions.fail("Nonrecursive delete of non-empty dir");
+      fail("Nonrecursive delete of non-empty dir");
     } catch (PathIsNotEmptyDirectoryException e) {
     }
-    Assertions.assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
+    assertTrue(fs.exists(new Path("test/registryTestNode/child2")));
   }
 
   @Test
@@ -271,20 +275,20 @@ public class TestFSRegistryOperationsService {
     List<String> ls = null;
 
     ls = registry.list("test/registryTestNode");
-    Assertions.assertNotNull(ls);
-    Assertions.assertEquals(2, ls.size());
+    assertNotNull(ls);
+    assertEquals(2, ls.size());
     System.out.println(ls);
-    Assertions.assertTrue(ls.contains("child1"));
-    Assertions.assertTrue(ls.contains("child2"));
+    assertTrue(ls.contains("child1"));
+    assertTrue(ls.contains("child2"));
 
     ls = null;
     ls = registry.list("test/registryTestNode/child1");
-    Assertions.assertNotNull(ls);
-    Assertions.assertTrue(ls.isEmpty());
+    assertNotNull(ls);
+    assertTrue(ls.isEmpty());
     ls = null;
     ls = registry.list("test/registryTestNode/child2");
-    Assertions.assertNotNull(ls);
-    Assertions.assertTrue(ls.isEmpty());
+    assertNotNull(ls);
+    assertTrue(ls.isEmpty());
   }
 
   private ServiceRecord createRecord(String id) {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestMicroZookeeperService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestMicroZookeeperService.java
@@ -24,24 +24,18 @@ import org.apache.hadoop.registry.conf.RegistryConfiguration;
 import org.apache.hadoop.registry.server.services.MicroZookeeperService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
 /**
  * Simple tests to look at the micro ZK service itself
  */
+@Timeout(10)
 public class TestMicroZookeeperService extends Assertions {
 
   private MicroZookeeperService zookeeper;
-
-  @Rule
-  public final Timeout testTimeout = new Timeout(10000);
-  @Rule
-  public TestName methodName = new TestName();
 
   @AfterEach
   public void destroyZKServer() throws IOException {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestMicroZookeeperService.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/client/impl/TestMicroZookeeperService.java
@@ -22,10 +22,10 @@ import org.apache.hadoop.service.ServiceOperations;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.registry.conf.RegistryConfiguration;
 import org.apache.hadoop.registry.server.services.MicroZookeeperService;
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  * Simple tests to look at the micro ZK service itself
  */
-public class TestMicroZookeeperService extends Assert {
+public class TestMicroZookeeperService extends Assertions {
 
   private MicroZookeeperService zookeeper;
 
@@ -43,7 +43,7 @@ public class TestMicroZookeeperService extends Assert {
   @Rule
   public TestName methodName = new TestName();
 
-  @After
+  @AfterEach
   public void destroyZKServer() throws IOException {
 
     ServiceOperations.stop(zookeeper);

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/integration/TestYarnPolicySelector.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/integration/TestYarnPolicySelector.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.registry.client.types.RegistryPathStatus;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.server.integration.SelectByYarnPersistence;
 import org.apache.hadoop.registry.server.services.RegistryAdminService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestYarnPolicySelector extends RegistryTestHelper {
 
@@ -37,7 +37,7 @@ public class TestYarnPolicySelector extends RegistryTestHelper {
   public void assertSelected(boolean outcome,
       RegistryAdminService.NodeSelector selector) {
     boolean select = selector.shouldSelect("/", status, record);
-    assertEquals(selector.toString(), outcome, select);
+    assertEquals(outcome, select, selector.toString());
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/operations/TestRegistryOperations.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/operations/TestRegistryOperations.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 
 public class TestRegistryOperations extends AbstractRegistryTest {
   protected static final Logger LOG =
@@ -111,23 +110,23 @@ public class TestRegistryOperations extends AbstractRegistryTest {
 
   @Test
   public void testStatEmptyPath() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          operations.stat(ENTRY_PATH);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      operations.stat(ENTRY_PATH);
+    });
   }
 
   @Test
   public void testLsEmptyPath() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          operations.list(PARENT_PATH);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      operations.list(PARENT_PATH);
+    });
   }
 
   @Test
   public void testResolveEmptyPath() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          operations.resolve(ENTRY_PATH);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      operations.resolve(ENTRY_PATH);
+    });
   }
 
   @Test
@@ -180,12 +179,12 @@ public class TestRegistryOperations extends AbstractRegistryTest {
 
   @Test
   public void testPutNoParent2() throws Throwable {
-      Assertions.assertThrows(PathNotFoundException.class, () -> {
-          ServiceRecord record = new ServiceRecord();
-          record.set(YarnRegistryAttributes.YARN_ID, "testPutNoParent");
-          String path = "/path/without/parent";
-          operations.bind(path, record, 0);
-      });
+    assertThrows(PathNotFoundException.class, () -> {
+      ServiceRecord record = new ServiceRecord();
+      record.set(YarnRegistryAttributes.YARN_ID, "testPutNoParent");
+      String path = "/path/without/parent";
+      operations.bind(path, record, 0);
+    });
   }
 
   @Test
@@ -299,9 +298,9 @@ public class TestRegistryOperations extends AbstractRegistryTest {
       entries += child + " ";
     }
     assertTrue(
-       names.containsKey("r1"), "No 'r1' in " + entries);
+        names.containsKey("r1"), "No 'r1' in " + entries);
     assertTrue(
-       names.containsKey("r2"), "No 'r2' in " + entries);
+        names.containsKey("r2"), "No 'r2' in " + entries);
 
     Map<String, RegistryPathStatus> stats =
         RegistryUtils.statChildren(operations, path);

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/operations/TestRegistryOperations.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/operations/TestRegistryOperations.java
@@ -31,13 +31,14 @@ import org.apache.hadoop.registry.client.types.yarn.PersistencePolicies;
 import org.apache.hadoop.registry.client.types.RegistryPathStatus;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.registry.client.types.yarn.YarnRegistryAttributes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 
 public class TestRegistryOperations extends AbstractRegistryTest {
   protected static final Logger LOG =
@@ -108,19 +109,25 @@ public class TestRegistryOperations extends AbstractRegistryTest {
     operations.delete(PARENT_PATH, true);
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testStatEmptyPath() throws Throwable {
-    operations.stat(ENTRY_PATH);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          operations.stat(ENTRY_PATH);
+      });
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testLsEmptyPath() throws Throwable {
-    operations.list(PARENT_PATH);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          operations.list(PARENT_PATH);
+      });
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testResolveEmptyPath() throws Throwable {
-    operations.resolve(ENTRY_PATH);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          operations.resolve(ENTRY_PATH);
+      });
   }
 
   @Test
@@ -171,12 +178,14 @@ public class TestRegistryOperations extends AbstractRegistryTest {
 
   }
 
-  @Test(expected = PathNotFoundException.class)
+  @Test
   public void testPutNoParent2() throws Throwable {
-    ServiceRecord record = new ServiceRecord();
-    record.set(YarnRegistryAttributes.YARN_ID, "testPutNoParent");
-    String path = "/path/without/parent";
-    operations.bind(path, record, 0);
+      Assertions.assertThrows(PathNotFoundException.class, () -> {
+          ServiceRecord record = new ServiceRecord();
+          record.set(YarnRegistryAttributes.YARN_ID, "testPutNoParent");
+          String path = "/path/without/parent";
+          operations.bind(path, record, 0);
+      });
   }
 
   @Test
@@ -281,7 +290,7 @@ public class TestRegistryOperations extends AbstractRegistryTest {
 
     // listings now
     List<String> list = operations.list(path);
-    assertEquals("Wrong no. of children", 2, list.size());
+    assertEquals(2, list.size(), "Wrong no. of children");
     // there's no order here, so create one
     Map<String, String> names = new HashMap<String, String>();
     String entries = "";
@@ -289,14 +298,14 @@ public class TestRegistryOperations extends AbstractRegistryTest {
       names.put(child, child);
       entries += child + " ";
     }
-    assertTrue("No 'r1' in " + entries,
-        names.containsKey("r1"));
-    assertTrue("No 'r2' in " + entries,
-        names.containsKey("r2"));
+    assertTrue(
+       names.containsKey("r1"), "No 'r1' in " + entries);
+    assertTrue(
+       names.containsKey("r2"), "No 'r2' in " + entries);
 
     Map<String, RegistryPathStatus> stats =
         RegistryUtils.statChildren(operations, path);
-    assertEquals("Wrong no. of children", 2, stats.size());
+    assertEquals(2, stats.size(), "Wrong no. of children");
     assertEquals(r1stat, stats.get("r1"));
     assertEquals(r2stat, stats.get("r2"));
   }
@@ -322,7 +331,7 @@ public class TestRegistryOperations extends AbstractRegistryTest {
         RegistryUtils.homePathForUser("hbase/localhost@HADOOP.APACHE.ORG"),
         true);
     home = RegistryUtils.homePathForUser("ADMINISTRATOR/127.0.0.1");
-    assertTrue("No 'administrator' in " + home, home.contains("administrator"));
+    assertTrue(home.contains("administrator"), "No 'administrator' in " + home);
     operations.mknode(
         home,
         true);

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/AbstractSecureRegistryTest.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/AbstractSecureRegistryTest.java
@@ -32,10 +32,10 @@ import org.apache.hadoop.registry.server.services.AddingCompositeService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperServiceKeys;
 import org.apache.hadoop.util.Shell;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
@@ -127,7 +127,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
    * All class initialization for this test class
    * @throws Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void beforeSecureRegistryTestClass() throws Exception {
     registrySecurity = new RegistrySecurity("registrySecurity");
     registrySecurity.init(CONF);
@@ -137,7 +137,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
     initHadoopSecurity();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterSecureRegistryTestClass() throws
       Exception {
     describe(LOG, "teardown of class");
@@ -148,7 +148,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
   /**
    * give our thread a name
    */
-  @Before
+  @BeforeEach
   public void nameThread() {
     Thread.currentThread().setName("JUnit");
   }
@@ -158,12 +158,12 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
    * not being picked up. This method addresses that by setting them
    * before every test case
    */
-  @Before
+  @BeforeEach
   public void beforeSecureRegistryTest() {
 
   }
 
-  @After
+  @AfterEach
   public void afterSecureRegistryTest() throws IOException {
     describe(LOG, "teardown of instance");
     teardown.close();
@@ -303,7 +303,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
       String filename) throws Exception {
     assertNotEmpty("empty principal", principal);
     assertNotEmpty("empty host", filename);
-    assertNotNull("Null KDC", kdc);
+    assertNotNull(kdc, "Null KDC");
     File keytab = new File(kdcWorkDir, filename);
     kdc.createPrincipal(keytab,
         principal,
@@ -357,7 +357,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
    * @throws Exception on any failure
    */
   protected synchronized void startSecureZK() throws Exception {
-    assertNull("Zookeeper is already running", secureZK);
+    assertNull(secureZK, "Zookeeper is already running");
 
     zookeeperLogin = login(zkServerPrincipal,
         ZOOKEEPER_SERVER_CONTEXT,

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/AbstractSecureRegistryTest.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/AbstractSecureRegistryTest.java
@@ -31,14 +31,14 @@ import org.apache.hadoop.registry.client.impl.zk.ZookeeperConfigOptions;
 import org.apache.hadoop.registry.server.services.AddingCompositeService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperService;
 import org.apache.hadoop.registry.server.services.MicroZookeeperServiceKeys;
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.Shell;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +59,7 @@ import java.util.Set;
  * Add kerberos tests. This is based on the (JUnit3) KerberosSecurityTestcase
  * and its test case, <code>TestMiniKdc</code>
  */
+@Timeout(900)
 public class AbstractSecureRegistryTest extends RegistryTestHelper {
   public static final String REALM = "EXAMPLE.COM";
   public static final String ZOOKEEPER = "zookeeper";
@@ -67,7 +68,7 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
   public static final String ZOOKEEPER_REALM = "zookeeper@" + REALM;
   public static final String ZOOKEEPER_CLIENT_CONTEXT = ZOOKEEPER;
   public static final String ZOOKEEPER_SERVER_CONTEXT = "ZOOKEEPER_SERVER";
-  ;
+
   public static final String ZOOKEEPER_LOCALHOST_REALM =
       ZOOKEEPER_LOCALHOST + "@" + REALM;
   public static final String ALICE = "alice";
@@ -113,11 +114,8 @@ public class AbstractSecureRegistryTest extends RegistryTestHelper {
   protected static Properties kdcConf;
   protected static RegistrySecurity registrySecurity;
 
-  @Rule
-  public final Timeout testTimeout = new Timeout(900000);
-
-  @Rule
-  public TestName methodName = new TestName();
+  @RegisterExtension
+  private TestName methodName = new TestName();
   protected MicroZookeeperService secureZK;
   protected static File jaasFile;
   private LoginContext zookeeperLogin;

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
@@ -131,16 +131,15 @@ public class TestRegistrySecurityHelper extends Assertions {
 
   @Test
   public void testBuildAclsNullRealm() throws Throwable {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-          registrySecurity.buildACLs(
+    assertThrows(IllegalArgumentException.class, () -> {
+      registrySecurity.buildACLs(
         SASL_YARN_SHORT +
         ", " +
         SASL_MAPRED_SHORT,
         "", ZooDefs.Perms.ALL);
-          fail("");
-      });
-  
-}
+      fail("");
+    });
+  }
 
   @Test
   public void testACLDefaultRealmOnlySASL() throws Throwable {
@@ -203,9 +202,8 @@ public class TestRegistrySecurityHelper extends Assertions {
     try {
       security.init(conf);
     } catch (Exception e) {
-      assertTrue(
-      
-         e.toString().contains(RegistrySecurity.E_NO_KERBEROS), "did not find "+ RegistrySecurity.E_NO_KERBEROS + " in " + e);
+      assertTrue(e.toString().contains(RegistrySecurity.E_NO_KERBEROS),
+          "did not find "+ RegistrySecurity.E_NO_KERBEROS + " in " + e);
     }
   }
 

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
@@ -133,10 +133,10 @@ public class TestRegistrySecurityHelper extends Assertions {
   public void testBuildAclsNullRealm() throws Throwable {
     assertThrows(IllegalArgumentException.class, () -> {
       registrySecurity.buildACLs(
-        SASL_YARN_SHORT +
-        ", " +
-        SASL_MAPRED_SHORT,
-        "", ZooDefs.Perms.ALL);
+          SASL_YARN_SHORT +
+          ", " +
+          SASL_MAPRED_SHORT,
+          "", ZooDefs.Perms.ALL);
       fail("");
     });
   }

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestRegistrySecurityHelper.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.registry.client.api.RegistryConstants;
 import org.apache.hadoop.registry.client.impl.zk.RegistrySecurity;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,7 @@ import static org.apache.hadoop.registry.client.api.RegistryConstants.*;
 /**
  * Test for registry security operations
  */
-public class TestRegistrySecurityHelper extends Assert {
+public class TestRegistrySecurityHelper extends Assertions {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRegistrySecurityHelper.class);
 
@@ -55,7 +55,7 @@ public class TestRegistrySecurityHelper extends Assert {
   public static final String REALM_EXAMPLE_COM = "example.com";
   private static RegistrySecurity registrySecurity;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTestRegistrySecurityHelper() throws IOException {
     Configuration conf = new Configuration();
     conf.setBoolean(KEY_REGISTRY_SECURE, true);
@@ -129,16 +129,18 @@ public class TestRegistrySecurityHelper extends Assert {
     assertEquals(SASL_MAPRED_SHORT, pairs.get(1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuildAclsNullRealm() throws Throwable {
-    registrySecurity.buildACLs(
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          registrySecurity.buildACLs(
         SASL_YARN_SHORT +
         ", " +
         SASL_MAPRED_SHORT,
         "", ZooDefs.Perms.ALL);
-    fail("");
-
-  }
+          fail("");
+      });
+  
+}
 
   @Test
   public void testACLDefaultRealmOnlySASL() throws Throwable {
@@ -202,8 +204,8 @@ public class TestRegistrySecurityHelper extends Assert {
       security.init(conf);
     } catch (Exception e) {
       assertTrue(
-          "did not find "+ RegistrySecurity.E_NO_KERBEROS + " in " + e,
-          e.toString().contains(RegistrySecurity.E_NO_KERBEROS));
+      
+         e.toString().contains(RegistrySecurity.E_NO_KERBEROS), "did not find "+ RegistrySecurity.E_NO_KERBEROS + " in " + e);
     }
   }
 

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureLogins.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureLogins.java
@@ -191,8 +191,8 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
 
   @Test
   public void testKerberosRulesValid() throws Throwable {
-    assertTrue(
-       KerberosName.hasRulesBeenSet(), "!KerberosName.hasRulesBeenSet()");
+    assertTrue(KerberosName.hasRulesBeenSet(),
+        "!KerberosName.hasRulesBeenSet()");
     String rules = KerberosName.getRules();
     assertEquals(kerberosRule, rules);
     LOG.info(rules);
@@ -218,10 +218,9 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
     RegistrySecurity.UgiInfo ugiInfo =
         new RegistrySecurity.UgiInfo(ugi);
     LOG.info("logged in as: {}", ugiInfo);
-    assertTrue(
-       UserGroupInformation.isSecurityEnabled(), "security is not enabled: " + ugiInfo);
-    assertTrue(
-       ugi.isFromKeytab(), "login is keytab based: " + ugiInfo);
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "security is not enabled: " + ugiInfo);
+    assertTrue(ugi.isFromKeytab(), "login is keytab based: " + ugiInfo);
 
     // now we are here, build a SASL ACL
     ACL acl = ugi.doAs(new PrivilegedExceptionAction<ACL>() {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureLogins.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureLogins.java
@@ -49,7 +49,7 @@ import static org.apache.hadoop.security.authentication.util.KerberosName.MECHAN
 import static org.apache.hadoop.security.authentication.util.KerberosName.MECHANISM_MIT;
 import static org.apache.hadoop.util.PlatformName.IBM_JAVA;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
   @Test
   public void testJaasFileSetup() throws Throwable {
     // the JVM has seemed inconsistent on setting up here
-    assertNotNull("jaasFile", jaasFile);
+    assertNotNull(jaasFile, "jaasFile");
     String confFilename = System.getProperty(Environment.JAAS_CONF_KEY);
     assertEquals(jaasFile.getAbsolutePath(), confFilename);
   }
@@ -77,7 +77,7 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
   @Test
   public void testJaasFileBinding() throws Throwable {
     // the JVM has seemed inconsistent on setting up here
-    assertNotNull("jaasFile", jaasFile);
+    assertNotNull(jaasFile, "jaasFile");
     RegistrySecurity.bindJVMtoJAASFile(jaasFile);
     String confFilename = System.getProperty(Environment.JAAS_CONF_KEY);
     assertEquals(jaasFile.getAbsolutePath(), confFilename);
@@ -92,7 +92,7 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
     try {
       logLoginDetails(ALICE_LOCALHOST, client);
       String confFilename = System.getProperty(Environment.JAAS_CONF_KEY);
-      assertNotNull("Unset: "+ Environment.JAAS_CONF_KEY, confFilename);
+      assertNotNull(confFilename, "Unset: "+ Environment.JAAS_CONF_KEY);
       String config = FileUtils.readFileToString(new File(confFilename), StandardCharsets.UTF_8);
       LOG.info("{}=\n{}", confFilename, config);
       RegistrySecurity.setZKSaslClientProperties(ALICE, ALICE_CLIENT_CONTEXT);
@@ -175,10 +175,10 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
         new HashMap<String, String>(), options);
     Method methodLogin = kerb5LoginObject.getClass().getMethod("login");
     boolean loginOk = (Boolean) methodLogin.invoke(kerb5LoginObject);
-    assertTrue("Failed to login", loginOk);
+    assertTrue(loginOk, "Failed to login");
     Method methodCommit = kerb5LoginObject.getClass().getMethod("commit");
     boolean commitOk = (Boolean) methodCommit.invoke(kerb5LoginObject);
-    assertTrue("Failed to Commit", commitOk);
+    assertTrue(commitOk, "Failed to Commit");
   }
 
   @Test
@@ -191,8 +191,8 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
 
   @Test
   public void testKerberosRulesValid() throws Throwable {
-    assertTrue("!KerberosName.hasRulesBeenSet()",
-        KerberosName.hasRulesBeenSet());
+    assertTrue(
+       KerberosName.hasRulesBeenSet(), "!KerberosName.hasRulesBeenSet()");
     String rules = KerberosName.getRules();
     assertEquals(kerberosRule, rules);
     LOG.info(rules);
@@ -218,10 +218,10 @@ public class TestSecureLogins extends AbstractSecureRegistryTest {
     RegistrySecurity.UgiInfo ugiInfo =
         new RegistrySecurity.UgiInfo(ugi);
     LOG.info("logged in as: {}", ugiInfo);
-    assertTrue("security is not enabled: " + ugiInfo,
-        UserGroupInformation.isSecurityEnabled());
-    assertTrue("login is keytab based: " + ugiInfo,
-        ugi.isFromKeytab());
+    assertTrue(
+       UserGroupInformation.isSecurityEnabled(), "security is not enabled: " + ugiInfo);
+    assertTrue(
+       ugi.isFromKeytab(), "login is keytab based: " + ugiInfo);
 
     // now we are here, build a SASL ACL
     ACL acl = ugi.doAs(new PrivilegedExceptionAction<ACL>() {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/secure/TestSecureRegistry.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.registry.client.impl.zk.ZKPathDumper;
 import org.apache.hadoop.registry.client.impl.zk.CuratorService;
 import org.apache.hadoop.registry.client.impl.zk.RegistrySecurity;
 import org.apache.zookeeper.CreateMode;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,12 +43,12 @@ public class TestSecureRegistry extends AbstractSecureRegistryTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestSecureRegistry.class);
 
-  @Before
+  @BeforeEach
   public void beforeTestSecureZKService() throws Throwable {
       enableKerberosDebugging();
   }
 
-  @After
+  @AfterEach
   public void afterTestSecureZKService() throws Throwable {
     disableKerberosDebugging();
     RegistrySecurity.clearZKSaslClientProperties();

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -21,10 +21,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.registry.client.api.RegistryConstants;
 import org.apache.hadoop.registry.client.binding.RegistryUtils;
 import org.apache.hadoop.registry.client.types.ServiceRecord;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.xbill.DNS.AAAARecord;
 import org.xbill.DNS.ARecord;
 import org.xbill.DNS.CNAMERecord;
@@ -61,7 +62,7 @@ import static org.apache.hadoop.registry.client.api.RegistryConstants.*;
 /**
  *
  */
-public class TestRegistryDNS extends Assert {
+public class TestRegistryDNS extends Assertions {
 
   private RegistryDNS registryDNS;
   private RegistryUtils.ServiceRecordMarshal marshal;
@@ -159,7 +160,7 @@ public class TestRegistryDNS extends Assert {
       + "  \"yarn:component\" : \"httpd\""
       + "}\n";
 
-  @Before
+  @BeforeEach
   public void initialize() throws Exception {
     setRegistryDNS(new RegistryDNS("TestRegistry"));
     Configuration conf = createConfiguration();
@@ -182,7 +183,7 @@ public class TestRegistryDNS extends Assert {
     return false;
   }
 
-  @After
+  @AfterEach
   public void closeRegistry() throws Exception {
     getRegistryDNS().stopExecutor();
   }
@@ -202,30 +203,30 @@ public class TestRegistryDNS extends Assert {
     recs = assertDNSQuery("management-api.test1.root.dev.test.", 2);
     assertEquals("wrong target name", "test1.root.dev.test.",
         ((CNAMERecord) recs.get(0)).getTarget().toString());
-    assertTrue("not an ARecord",
-        recs.get(isSecure() ? 2 : 1) instanceof ARecord);
+    assertTrue(
+       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.",
         Type.SRV, 1);
-    assertTrue("not an SRV record", recs.get(0) instanceof SRVRecord);
-    assertEquals("wrong port", 1026, ((SRVRecord) recs.get(0)).getPort());
+    assertTrue(recs.get(0) instanceof SRVRecord, "not an SRV record");
+    assertEquals(1026, ((SRVRecord) recs.get(0)).getPort(), "wrong port");
 
     recs = assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.", 2);
     assertEquals("wrong target name", "test1.root.dev.test.",
         ((CNAMERecord) recs.get(0)).getTarget().toString());
-    assertTrue("not an ARecord",
-        recs.get(isSecure() ? 2 : 1) instanceof ARecord);
+    assertTrue(
+       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("http-api.test1.root.dev.test.", 2);
     assertEquals("wrong target name", "test1.root.dev.test.",
         ((CNAMERecord) recs.get(0)).getTarget().toString());
-    assertTrue("not an ARecord",
-        recs.get(isSecure() ? 2 : 1) instanceof ARecord);
+    assertTrue(
+       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("http-api.test1.root.dev.test.", Type.SRV,
         1);
-    assertTrue("not an SRV record", recs.get(0) instanceof SRVRecord);
-    assertEquals("wrong port", 1027, ((SRVRecord) recs.get(0)).getPort());
+    assertTrue(recs.get(0) instanceof SRVRecord, "not an SRV record");
+    assertEquals(1027, ((SRVRecord) recs.get(0)).getPort(), "wrong port");
 
     assertDNSQuery("test1.root.dev.test.", Type.TXT, 3);
     assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.", Type.TXT, 1);
@@ -249,7 +250,7 @@ public class TestRegistryDNS extends Assert {
         ((ARecord) recs.get(0)).getAddress().getHostAddress());
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
-    assertTrue("not an ARecord", recs.get(0) instanceof ARecord);
+    assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
   }
 
   @Test
@@ -267,8 +268,8 @@ public class TestRegistryDNS extends Assert {
     Message query = Message.newQuery(question);
     byte[] responseBytes = registryDNS.generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("Excepting NXDOMAIN as Record must not have regsisterd wrong",
-        Rcode.NXDOMAIN, response.getRcode());
+    assertEquals(
+       Rcode.NXDOMAIN, response.getRcode(), "Excepting NXDOMAIN as Record must not have regsisterd wrong");
   }
 
   @Test
@@ -285,12 +286,12 @@ public class TestRegistryDNS extends Assert {
         "ctr-e50-1451931954322-0016-01-000002.dev.test.");
     assertEquals("wrong result", "172.17.0.19",
         ((ARecord) recs.get(0)).getAddress().getHostAddress());
-    assertEquals("wrong ttl", 30L, recs.get(0).getTTL());
+    assertEquals(30L, recs.get(0).getTTL(), "wrong ttl");
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
-    assertTrue("not an ARecord", recs.get(0) instanceof ARecord);
+    assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
 
-    assertEquals("wrong ttl", 30L, recs.get(0).getTTL());
+    assertEquals(30L, recs.get(0).getTTL(), "wrong ttl");
   }
 
   @Test
@@ -354,8 +355,8 @@ public class TestRegistryDNS extends Assert {
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("Missing record should be: ", Rcode.NXDOMAIN,
-        response.getRcode());
+    assertEquals(Rcode.NXDOMAIN
+,         response.getRcode(), "Missing record should be: ");
   }
 
   @Test
@@ -375,7 +376,7 @@ public class TestRegistryDNS extends Assert {
 
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("wrong status", Rcode.NXDOMAIN, response.getRcode());
+    assertEquals(Rcode.NXDOMAIN, response.getRcode(), "wrong status");
   }
 
   private List<Record> assertDNSQuery(String lookup) throws IOException {
@@ -396,13 +397,13 @@ public class TestRegistryDNS extends Assert {
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("not successful", Rcode.NOERROR, response.getRcode());
-    assertNotNull("Null response", response);
-    assertEquals("Questions do not match", query.getQuestion(),
-        response.getQuestion());
+    assertEquals(Rcode.NOERROR, response.getRcode(), "not successful");
+    assertNotNull(response, "Null response");
+    assertEquals(query.getQuestion()
+,         response.getQuestion(), "Questions do not match");
     List<Record> recs = response.getSection(Section.ANSWER);
-    assertEquals("wrong number of answer records",
-        isSecure() ? numRecs * 2 : numRecs, recs.size());
+    assertEquals(
+       isSecure() ? numRecs * 2 : numRecs, recs.size(), "wrong number of answer records");
     if (isSecure()) {
       boolean signed = false;
       for (Record record : recs) {
@@ -411,7 +412,7 @@ public class TestRegistryDNS extends Assert {
           break;
         }
       }
-      assertTrue("No signatures found", signed);
+      assertTrue(signed, "No signatures found");
     }
     return recs;
   }
@@ -425,10 +426,10 @@ public class TestRegistryDNS extends Assert {
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("not successful", Rcode.NOERROR, response.getRcode());
-    assertNotNull("Null response", response);
-    assertEquals("Questions do not match", query.getQuestion(),
-        response.getQuestion());
+    assertEquals(Rcode.NOERROR, response.getRcode(), "not successful");
+    assertNotNull(response, "Null response");
+    assertEquals(query.getQuestion()
+,         response.getQuestion(), "Questions do not match");
     List<Record> recs = response.getSection(Section.ANSWER);
     assertEquals(answerCount, recs.size());
     assertEquals(type, recs.get(0).getType());
@@ -484,7 +485,7 @@ public class TestRegistryDNS extends Assert {
     InetAddress address =
         BaseServiceRecordProcessor
             .getIpv6Address(InetAddress.getByName("172.17.0.19"));
-    assertTrue("not an ipv6 address", address instanceof Inet6Address);
+    assertTrue(address instanceof Inet6Address, "not an ipv6 address");
     assertEquals("wrong IP", "172.17.0.19",
         InetAddress.getByAddress(address.getAddress()).getHostAddress());
   }
@@ -505,7 +506,7 @@ public class TestRegistryDNS extends Assert {
         ((AAAARecord) recs.get(0)).getAddress().getHostAddress());
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", Type.AAAA, 1);
-    assertTrue("not an ARecord", recs.get(0) instanceof AAAARecord);
+    assertTrue(recs.get(0) instanceof AAAARecord, "not an ARecord");
   }
 
   @Test
@@ -524,13 +525,13 @@ public class TestRegistryDNS extends Assert {
 
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals("not successful", Rcode.NXDOMAIN, response.getRcode());
-    assertNotNull("Null response", response);
-    assertEquals("Questions do not match", query.getQuestion(),
-        response.getQuestion());
+    assertEquals(Rcode.NXDOMAIN, response.getRcode(), "not successful");
+    assertNotNull(response, "Null response");
+    assertEquals(query.getQuestion()
+,         response.getQuestion(), "Questions do not match");
     List<Record> sectionArray = response.getSection(Section.AUTHORITY);
-    assertEquals("Wrong number of recs in AUTHORITY", isSecure() ? 2 : 1,
-        sectionArray.size());
+    assertEquals(isSecure() ? 2 : 1
+,         sectionArray.size(), "Wrong number of recs in AUTHORITY");
     boolean soaFound = false;
     for (Record rec : sectionArray) {
       soaFound = rec.getType() == Type.SOA;
@@ -538,8 +539,8 @@ public class TestRegistryDNS extends Assert {
         break;
       }
     }
-    assertTrue("wrong record type",
-        soaFound);
+    assertTrue(
+       soaFound, "wrong record type");
 
   }
 
@@ -580,7 +581,7 @@ public class TestRegistryDNS extends Assert {
         ((ARecord) recs.get(0)).getAddress().getHostAddress());
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
-    assertTrue("not an ARecord", recs.get(0) instanceof ARecord);
+    assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
 
     // lookup dyanmic reverse records
     recs = assertDNSQuery("19.0.17.172.in-addr.arpa.", Type.PTR, 1);
@@ -643,7 +644,7 @@ public class TestRegistryDNS extends Assert {
   public void testExampleDotCom() throws Exception {
     Name name = Name.fromString("example.com.");
     Record[] records = getRegistryDNS().getRecords(name, Type.SOA);
-    assertNotNull("example.com exists:", records);
+    assertNotNull(records, "example.com exists:");
   }
 
   @Test
@@ -696,15 +697,16 @@ public class TestRegistryDNS extends Assert {
     // start assessing whether correct records are available
     List<Record> recs =
         assertDNSQuery("httpd.test1.root.dev.test.", 2);
-    assertTrue("not an ARecord", recs.get(0) instanceof ARecord);
-    assertTrue("not an ARecord", recs.get(1) instanceof ARecord);
+    assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
+    assertTrue(recs.get(1) instanceof ARecord, "not an ARecord");
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testUpstreamFault() throws Exception {
     Name name = Name.fromString("19.0.17.172.in-addr.arpa.");
     Record[] recs = getRegistryDNS().getRecords(name, Type.CNAME);
-    assertNull("Record is not null", recs);
+    assertNull(recs, "Record is not null");
   }
 
   public RegistryDNS getRegistryDNS() {

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -197,12 +197,12 @@ public class TestRegistryDNS extends Assertions {
 
     // start assessing whether correct records are available
     List<Record> recs = assertDNSQuery("test1.root.dev.test.");
-    assertEquals("wrong result", "192.168.1.5",
-        ((ARecord) recs.get(0)).getAddress().getHostAddress());
+    assertEquals("192.168.1.5",
+        ((ARecord) recs.get(0)).getAddress().getHostAddress(), "wrong result");
 
     recs = assertDNSQuery("management-api.test1.root.dev.test.", 2);
-    assertEquals("wrong target name", "test1.root.dev.test.",
-        ((CNAMERecord) recs.get(0)).getTarget().toString());
+    assertEquals("test1.root.dev.test.",
+        ((CNAMERecord) recs.get(0)).getTarget().toString(), "wrong target name");
     assertTrue(
        recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
@@ -212,16 +212,15 @@ public class TestRegistryDNS extends Assertions {
     assertEquals(1026, ((SRVRecord) recs.get(0)).getPort(), "wrong port");
 
     recs = assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.", 2);
-    assertEquals("wrong target name", "test1.root.dev.test.",
-        ((CNAMERecord) recs.get(0)).getTarget().toString());
+    assertEquals("test1.root.dev.test.",
+        ((CNAMERecord) recs.get(0)).getTarget().toString(), "wrong target name");
     assertTrue(
        recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("http-api.test1.root.dev.test.", 2);
-    assertEquals("wrong target name", "test1.root.dev.test.",
-        ((CNAMERecord) recs.get(0)).getTarget().toString());
-    assertTrue(
-       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
+    assertEquals("test1.root.dev.test.",
+        ((CNAMERecord) recs.get(0)).getTarget().toString(), "wrong target name");
+    assertTrue(recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("http-api.test1.root.dev.test.", Type.SRV,
         1);
@@ -246,8 +245,8 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs =
         assertDNSQuery("ctr-e50-1451931954322-0016-01-000002.dev.test.");
-    assertEquals("wrong result", "172.17.0.19",
-        ((ARecord) recs.get(0)).getAddress().getHostAddress());
+    assertEquals("172.17.0.19",
+        ((ARecord) recs.get(0)).getAddress().getHostAddress(), "wrong result");
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
     assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
@@ -268,8 +267,8 @@ public class TestRegistryDNS extends Assertions {
     Message query = Message.newQuery(question);
     byte[] responseBytes = registryDNS.generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals(
-       Rcode.NXDOMAIN, response.getRcode(), "Excepting NXDOMAIN as Record must not have regsisterd wrong");
+    assertEquals(Rcode.NXDOMAIN, response.getRcode(),
+        "Excepting NXDOMAIN as Record must not have regsisterd wrong");
   }
 
   @Test
@@ -284,8 +283,8 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs = assertDNSQuery(
         "ctr-e50-1451931954322-0016-01-000002.dev.test.");
-    assertEquals("wrong result", "172.17.0.19",
-        ((ARecord) recs.get(0)).getAddress().getHostAddress());
+    assertEquals("172.17.0.19",
+        ((ARecord) recs.get(0)).getAddress().getHostAddress(), "wrong result");
     assertEquals(30L, recs.get(0).getTTL(), "wrong ttl");
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
@@ -306,9 +305,8 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs = assertDNSQuery(
         "19.0.17.172.in-addr.arpa.", Type.PTR, 1);
-    assertEquals("wrong result",
-        "httpd-1.test1.root.dev.test.",
-        ((PTRRecord) recs.get(0)).getTarget().toString());
+    assertEquals("httpd-1.test1.root.dev.test.",
+        ((PTRRecord) recs.get(0)).getTarget().toString(), "wrong result");
   }
 
   @Test
@@ -333,9 +331,8 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs = assertDNSQuery(
         "19.0.17.172.in-addr.arpa.", Type.PTR, 1);
-    assertEquals("wrong result",
-        "httpd-1.test1.root.dev.test.",
-        ((PTRRecord) recs.get(0)).getTarget().toString());
+    assertEquals("httpd-1.test1.root.dev.test.",
+        ((PTRRecord) recs.get(0)).getTarget().toString(), "wrong result");
   }
 
   @Test
@@ -355,8 +352,8 @@ public class TestRegistryDNS extends Assertions {
     query.addRecord(optRecord, Section.ADDITIONAL);
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
-    assertEquals(Rcode.NXDOMAIN
-,         response.getRcode(), "Missing record should be: ");
+    assertEquals(Rcode.NXDOMAIN, response.getRcode(),
+        "Missing record should be: ");
   }
 
   @Test
@@ -399,11 +396,11 @@ public class TestRegistryDNS extends Assertions {
     Message response = new Message(responseBytes);
     assertEquals(Rcode.NOERROR, response.getRcode(), "not successful");
     assertNotNull(response, "Null response");
-    assertEquals(query.getQuestion()
-,         response.getQuestion(), "Questions do not match");
+    assertEquals(query.getQuestion(),
+        response.getQuestion(), "Questions do not match");
     List<Record> recs = response.getSection(Section.ANSWER);
-    assertEquals(
-       isSecure() ? numRecs * 2 : numRecs, recs.size(), "wrong number of answer records");
+    assertEquals(isSecure() ? numRecs * 2 : numRecs, recs.size(),
+        "wrong number of answer records");
     if (isSecure()) {
       boolean signed = false;
       for (Record record : recs) {
@@ -428,8 +425,8 @@ public class TestRegistryDNS extends Assertions {
     Message response = new Message(responseBytes);
     assertEquals(Rcode.NOERROR, response.getRcode(), "not successful");
     assertNotNull(response, "Null response");
-    assertEquals(query.getQuestion()
-,         response.getQuestion(), "Questions do not match");
+    assertEquals(query.getQuestion(), response.getQuestion(),
+        "Questions do not match");
     List<Record> recs = response.getSection(Section.ANSWER);
     assertEquals(answerCount, recs.size());
     assertEquals(type, recs.get(0).getType());
@@ -486,8 +483,8 @@ public class TestRegistryDNS extends Assertions {
         BaseServiceRecordProcessor
             .getIpv6Address(InetAddress.getByName("172.17.0.19"));
     assertTrue(address instanceof Inet6Address, "not an ipv6 address");
-    assertEquals("wrong IP", "172.17.0.19",
-        InetAddress.getByAddress(address.getAddress()).getHostAddress());
+    assertEquals("172.17.0.19",
+        InetAddress.getByAddress(address.getAddress()).getHostAddress(), "wrong IP");
   }
 
   @Test
@@ -502,8 +499,8 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs = assertDNSQuery(
         "ctr-e50-1451931954322-0016-01-000002.dev.test.", Type.AAAA, 1);
-    assertEquals("wrong result", "172.17.0.19",
-        ((AAAARecord) recs.get(0)).getAddress().getHostAddress());
+    assertEquals("172.17.0.19",
+        ((AAAARecord) recs.get(0)).getAddress().getHostAddress(), "wrong result");
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", Type.AAAA, 1);
     assertTrue(recs.get(0) instanceof AAAARecord, "not an ARecord");
@@ -527,11 +524,11 @@ public class TestRegistryDNS extends Assertions {
     Message response = new Message(responseBytes);
     assertEquals(Rcode.NXDOMAIN, response.getRcode(), "not successful");
     assertNotNull(response, "Null response");
-    assertEquals(query.getQuestion()
-,         response.getQuestion(), "Questions do not match");
+    assertEquals(query.getQuestion(),
+        response.getQuestion(), "Questions do not match");
     List<Record> sectionArray = response.getSection(Section.AUTHORITY);
-    assertEquals(isSecure() ? 2 : 1
-,         sectionArray.size(), "Wrong number of recs in AUTHORITY");
+    assertEquals(isSecure() ? 2 : 1,
+        sectionArray.size(), "Wrong number of recs in AUTHORITY");
     boolean soaFound = false;
     for (Record rec : sectionArray) {
       soaFound = rec.getType() == Type.SOA;
@@ -539,8 +536,7 @@ public class TestRegistryDNS extends Assertions {
         break;
       }
     }
-    assertTrue(
-       soaFound, "wrong record type");
+    assertTrue(soaFound, "wrong record type");
 
   }
 
@@ -577,17 +573,17 @@ public class TestRegistryDNS extends Assertions {
     // start assessing whether correct records are available
     List<Record> recs =
         assertDNSQuery("ctr-e50-1451931954322-0016-01-000002.dev.test.");
-    assertEquals("wrong result", "172.17.0.19",
-        ((ARecord) recs.get(0)).getAddress().getHostAddress());
+    assertEquals("172.17.0.19",
+        ((ARecord) recs.get(0)).getAddress().getHostAddress(), "wrong result");
 
     recs = assertDNSQuery("httpd-1.test1.root.dev.test.", 1);
     assertTrue(recs.get(0) instanceof ARecord, "not an ARecord");
 
     // lookup dyanmic reverse records
     recs = assertDNSQuery("19.0.17.172.in-addr.arpa.", Type.PTR, 1);
-    assertEquals("wrong result",
+    assertEquals(
         "httpd-1.test1.root.dev.test.",
-        ((PTRRecord) recs.get(0)).getTarget().toString());
+        ((PTRRecord) recs.get(0)).getTarget().toString(),"wrong result");
 
     // now lookup static reverse records
     Name name = Name.fromString("5.0.17.172.in-addr.arpa.");
@@ -598,8 +594,8 @@ public class TestRegistryDNS extends Assertions {
     byte[] responseBytes = getRegistryDNS().generateReply(query, null);
     Message response = new Message(responseBytes);
     recs = response.getSection(Section.ANSWER);
-    assertEquals("wrong result", "cn005.dev.test.",
-        ((PTRRecord) recs.get(0)).getTarget().toString());
+    assertEquals("cn005.dev.test.",
+        ((PTRRecord) recs.get(0)).getTarget().toString(), "wrong result");
   }
 
   @Test
@@ -609,7 +605,7 @@ public class TestRegistryDNS extends Assertions {
     conf.set(KEY_DNS_ZONE_MASK, "255.255.224.0");
 
     Name name = getRegistryDNS().getReverseZoneName(conf);
-    assertEquals("wrong name", "26.172.in-addr.arpa.", name.toString());
+    assertEquals("26.172.in-addr.arpa.", name.toString(), "wrong name");
   }
 
   @Test

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestRegistryDNS.java
@@ -203,8 +203,7 @@ public class TestRegistryDNS extends Assertions {
     recs = assertDNSQuery("management-api.test1.root.dev.test.", 2);
     assertEquals("test1.root.dev.test.",
         ((CNAMERecord) recs.get(0)).getTarget().toString(), "wrong target name");
-    assertTrue(
-       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
+    assertTrue(recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.",
         Type.SRV, 1);
@@ -214,8 +213,7 @@ public class TestRegistryDNS extends Assertions {
     recs = assertDNSQuery("appmaster-ipc-api.test1.root.dev.test.", 2);
     assertEquals("test1.root.dev.test.",
         ((CNAMERecord) recs.get(0)).getTarget().toString(), "wrong target name");
-    assertTrue(
-       recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
+    assertTrue(recs.get(isSecure() ? 2 : 1) instanceof ARecord, "not an ARecord");
 
     recs = assertDNSQuery("http-api.test1.root.dev.test.", 2);
     assertEquals("test1.root.dev.test.",
@@ -583,7 +581,7 @@ public class TestRegistryDNS extends Assertions {
     recs = assertDNSQuery("19.0.17.172.in-addr.arpa.", Type.PTR, 1);
     assertEquals(
         "httpd-1.test1.root.dev.test.",
-        ((PTRRecord) recs.get(0)).getTarget().toString(),"wrong result");
+        ((PTRRecord) recs.get(0)).getTarget().toString(), "wrong result");
 
     // now lookup static reverse records
     Name name = Name.fromString("5.0.17.172.in-addr.arpa.");

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
@@ -57,7 +57,7 @@ public class TestReverseZoneUtils {
   public void testThrowUnknownHostExceptionIfIpIsInvalid() throws Exception {
     assertThrows(UnknownHostException.class, () -> {
       ReverseZoneUtils.getReverseZoneNetworkAddress(
-        "213124.21231.14123.13", RANGE, INDEX);
+          "213124.21231.14123.13", RANGE, INDEX);
     });
   }
 

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
@@ -17,9 +17,9 @@
 package org.apache.hadoop.registry.server.dns;
 
 import java.net.UnknownHostException;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 
 /**

--- a/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
+++ b/hadoop-common-project/hadoop-registry/src/test/java/org/apache/hadoop/registry/server/dns/TestReverseZoneUtils.java
@@ -18,9 +18,9 @@ package org.apache.hadoop.registry.server.dns;
 
 import java.net.UnknownHostException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.Rule;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests for the reverse zone utilities.
@@ -29,8 +29,6 @@ public class TestReverseZoneUtils {
   private static final String NET = "172.17.4.0";
   private static final int RANGE = 256;
   private static final int INDEX = 0;
-
-  @Rule public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testGetReverseZoneNetworkAddress() throws Exception {
@@ -50,22 +48,25 @@ public class TestReverseZoneUtils {
   @Test
   public void testThrowIllegalArgumentExceptionIfIndexIsNegative()
       throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    ReverseZoneUtils.getReverseZoneNetworkAddress(NET, RANGE, -1);
+    assertThrows(IllegalArgumentException.class, () -> {
+      ReverseZoneUtils.getReverseZoneNetworkAddress(NET, RANGE, -1);
+    });
   }
 
   @Test
   public void testThrowUnknownHostExceptionIfIpIsInvalid() throws Exception {
-    exception.expect(UnknownHostException.class);
-    ReverseZoneUtils
-        .getReverseZoneNetworkAddress("213124.21231.14123.13", RANGE, INDEX);
+    assertThrows(UnknownHostException.class, () -> {
+      ReverseZoneUtils.getReverseZoneNetworkAddress(
+        "213124.21231.14123.13", RANGE, INDEX);
+    });
   }
 
   @Test
   public void testThrowIllegalArgumentExceptionIfRangeIsNegative()
       throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    ReverseZoneUtils.getReverseZoneNetworkAddress(NET, -1, INDEX);
+    assertThrows(IllegalArgumentException.class, () -> {
+      ReverseZoneUtils.getReverseZoneNetworkAddress(NET, -1, INDEX);
+    });
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19419. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-registry.

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

