### PR TITLE
HADOOP-19530. Add --enable-native-access=ALL-UNNAMED JVM option

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
+++ b/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh
@@ -1589,6 +1589,7 @@ function hadoop_finalize_jpms_opts
     hadoop_add_param HADOOP_OPTS open.java.util.zip "--add-opens=java.base/java.util.zip=ALL-UNNAMED"
     hadoop_add_param HADOOP_OPTS open.sun.security.util "--add-opens=java.base/sun.security.util=ALL-UNNAMED"
     hadoop_add_param HADOOP_OPTS open.sun.security.x509 "--add-opens=java.base/sun.security.x509=ALL-UNNAMED"
+    hadoop_add_param HADOOP_OPTS enable.native.access "--enable-native-access=ALL-UNNAMED"
 }
 
 ## @description  Finish Java classpath prior to execution

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -182,6 +182,7 @@
       --add-opens=java.base/java.util.zip=ALL-UNNAMED
       --add-opens=java.base/sun.security.util=ALL-UNNAMED
       --add-opens=java.base/sun.security.x509=ALL-UNNAMED
+      --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx2048m -Xss2m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>


### PR DESCRIPTION
### Description of PR

Add the --enable-native-access=ALL-UNNAMED option to --enable-native-access=ALL-UNNAMED

### How was this patch tested?

Run a test my JDK24 branch. The warning was no longer displayed

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

