### PR TITLE
HADOOP-19545. Update to ApacheDS 2.0.0.AM27 and ldap-api 2.1.7

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -114,8 +114,8 @@
     <bouncycastle.version>1.78.1</bouncycastle.version>
 
     <!-- Required for testing LDAP integration -->
-    <apacheds.version>2.0.0.AM26</apacheds.version>
-    <ldap-api.version>2.0.0</ldap-api.version>
+    <apacheds.version>2.0.0.AM27</apacheds.version>
+    <ldap-api.version>2.1.7</ldap-api.version>
 
     <!-- Apache Commons dependencies -->
     <commons-cli.version>1.9.0</commons-cli.version>


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19545. Update to ApacheDS 2.0.0.AM27 and ldap-api 2.1.7

### How was this patch tested?

Ran hadoop-auth test suite on my JDK24 branch

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

