### PR TITLE
HADOOP-19547. Migrate FileContextPermissionBase to Junit 5

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextPermissionBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextPermissionBase.java
@@ -24,21 +24,20 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.slf4j.event.Level;
 
 import static org.apache.hadoop.fs.FileContextTestHelper.*;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * <p>
@@ -52,7 +51,7 @@ import static org.junit.Assert.fail;
  * test and override {@link #setUp()} to initialize the <code>fc</code> 
  * {@link FileContext} instance variable.
  * 
- * Since this a junit 4 you can also do a single setup before 
+ * Since this a junit 4+ you can also do a single setup before
  * the start of any tests.
  * E.g.
  *     @BeforeClass   public static void clusterSetupAtBegining()
@@ -80,22 +79,22 @@ public abstract class FileContextPermissionBase {
   
   protected abstract FileContext getFileContext() throws Exception;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     fileContextTestHelper = getFileContextHelper();
     fc = getFileContext();
     fc.mkdir(fileContextTestHelper.getTestRootPath(fc), FileContext.DEFAULT_PERM, true);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fc.delete(fileContextTestHelper.getTestRootPath(fc), true);
   }
   
   private void cleanupFile(FileContext fc, Path name) throws IOException {
-    Assert.assertTrue(exists(fc, name));
+    assertTrue(exists(fc, name));
     fc.delete(name, true);
-    Assert.assertTrue(!exists(fc, name));
+    assertTrue(!exists(fc, name));
   }
 
   @Test
@@ -158,12 +157,12 @@ public abstract class FileContextPermissionBase {
     try {
       String g0 = groups.get(0);
       fc.setOwner(f, null, g0);
-      Assert.assertEquals(g0, fc.getFileStatus(f).getGroup());
+      assertEquals(fc.getFileStatus(f).getGroup(), g0);
 
       if (groups.size() > 1) {
         String g1 = groups.get(1);
         fc.setOwner(f, null, g1);
-        Assert.assertEquals(g1, fc.getFileStatus(f).getGroup());
+        assertEquals(fc.getFileStatus(f).getGroup(), g1);
       } else {
         System.out.println("Not testing changing the group since user " +
                            "belongs to only one group.");
@@ -193,7 +192,7 @@ public abstract class FileContextPermissionBase {
       }
       
     });
-    assertEquals("otherUser",newFc.getUgi().getUserName());
+    assertEquals(newFc.getUgi().getUserName(), "otherUser");
   }
 
   static List<String> getGroups() throws IOException {
@@ -207,7 +206,7 @@ public abstract class FileContextPermissionBase {
   
   
   void doFilePermissionCheck(FsPermission expectedPerm, FsPermission actualPerm) {
-  Assert.assertEquals(expectedPerm.applyUMask(getFileMask()), actualPerm);
+    assertEquals(expectedPerm.applyUMask(getFileMask()), actualPerm);
   }
   
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFcLocalFsPermission.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFcLocalFsPermission.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.fs;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test permissions for localFs using FileContext API.
@@ -27,13 +27,13 @@ public class TestFcLocalFsPermission extends
   FileContextPermissionBase {
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     super.tearDown();
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestFcPermissionsLocalFs.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestFcPermissionsLocalFs.java
@@ -20,21 +20,21 @@ package org.apache.hadoop.fs.viewfs;
 
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextPermissionBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.After;
-import org.junit.Before;
 
 
 public class TestFcPermissionsLocalFs  extends FileContextPermissionBase {
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }
   
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     super.tearDown();
     ViewFsTestSetup.tearDownForViewFsLocalFs(fileContextTestHelper);


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19547. Migrate FileContextPermissionBase to Junit 5,

Make sure that FileContextPermissionBase and its children are all migrated to Junit 5.

### How was this patch tested?

Ran the children on my JDK24 + Surefire 3.5.3 branch

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

