### PR TITLE
YARN-11813. Fix the fallback ordering between cgroup v2 and v1.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
@@ -109,6 +109,7 @@ class CGroupsV2HandlerImpl extends AbstractCGroupsHandler {
       LOG.info("Failed to read the cgroup controllers file in the preconfigured directory: {}. " +
               "The cgroup v2 hierarchy may not be mounted under the specified path, or the node might be using " +
               "cgroup v1.", this.cGroupsMountConfig.getV2MountPath());
+      LOG.debug("Exception while reading the cgroup.controllers file: ", e);
     }
     return controllerMappings;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
@@ -95,10 +95,21 @@ class CGroupsV2HandlerImpl extends AbstractCGroupsHandler {
   }
 
   @Override
-  protected Map<String, Set<String>> parsePreConfiguredMountPath() throws IOException {
+  protected Map<String, Set<String>> parsePreConfiguredMountPath() {
     Map<String, Set<String>> controllerMappings = new HashMap<>();
-    controllerMappings.put(this.cGroupsMountConfig.getV2MountPath(),
-        readControllersFile(this.cGroupsMountConfig.getV2MountPath()));
+    try {
+      controllerMappings.put(this.cGroupsMountConfig.getV2MountPath(),
+          readControllersFile(this.cGroupsMountConfig.getV2MountPath()));
+    } catch (IOException e) {
+      // Failing to read the cgroup.controllers file in the preconfigured might mean
+      // that the node is not using cgroup v2, or no cgroup v2 hierarchy is mounted
+      // under the specified path. If the node is using v1 we will fall back to cgroup v1
+      // in ResourceHandlerModule.initializeCGroupHandlers. If the cgroup v2 hierarchy is not mounted
+      // and no cgroup v1 hierarchy is mounted, we will fail to start the node manager.
+      LOG.info("Failed to read the cgroup controllers file in the preconfigured directory: {}. " +
+              "The cgroup v2 hierarchy may not be mounted under the specified path, or the node might be using " +
+              "cgroup v1.", this.cGroupsMountConfig.getV2MountPath());
+    }
     return controllerMappings;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/CGroupsV2HandlerImpl.java
@@ -104,11 +104,11 @@ class CGroupsV2HandlerImpl extends AbstractCGroupsHandler {
       // Failing to read the cgroup.controllers file in the preconfigured might mean
       // that the node is not using cgroup v2, or no cgroup v2 hierarchy is mounted
       // under the specified path. If the node is using v1 we will fall back to cgroup v1
-      // in ResourceHandlerModule.initializeCGroupHandlers. If the cgroup v2 hierarchy is not mounted
-      // and no cgroup v1 hierarchy is mounted, we will fail to start the node manager.
+      // in ResourceHandlerModule.initializeCGroupHandlers. If the cgroup v2 hierarchy is
+      // not mounted and no cgroup v1 hierarchy is mounted, we will fail to start the NM.
       LOG.info("Failed to read the cgroup controllers file in the preconfigured directory: {}. " +
-              "The cgroup v2 hierarchy may not be mounted under the specified path, or the node might be using " +
-              "cgroup v1.", this.cGroupsMountConfig.getV2MountPath());
+          "The cgroup v2 hierarchy may not be mounted under the specified path, or the node" +
+          " might be using cgroup v1.", this.cGroupsMountConfig.getV2MountPath());
       LOG.debug("Exception while reading the cgroup.controllers file: ", e);
     }
     return controllerMappings;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -77,7 +77,8 @@ public class ResourceHandlerModule {
       cGroupsCpuResourceHandler;
 
   private static void initializeCGroupHandlers(Configuration conf,
-                                               CGroupsHandler.CGroupController controller) throws ResourceHandlerException {
+                                               CGroupsHandler.CGroupController controller)
+      throws ResourceHandlerException {
     if (cgroupsV2Enabled) {
       initializeCGroupV2Handler(conf);
       if (!isMountedInCGroupsV2(controller)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/resources/ResourceHandlerModule.java
@@ -77,10 +77,16 @@ public class ResourceHandlerModule {
       cGroupsCpuResourceHandler;
 
   private static void initializeCGroupHandlers(Configuration conf,
-      CGroupsHandler.CGroupController controller) throws ResourceHandlerException {
-    initializeCGroupV1Handler(conf);
-    if (cgroupsV2Enabled && !isMountedInCGroupsV1(controller)) {
+                                               CGroupsHandler.CGroupController controller) throws ResourceHandlerException {
+    if (cgroupsV2Enabled) {
       initializeCGroupV2Handler(conf);
+      if (!isMountedInCGroupsV2(controller)) {
+        LOG.info("Cgroup v2 is enabled but {} is not mounted in cgroups v2, falling back to v1",
+            controller);
+        initializeCGroupV1Handler(conf);
+      }
+    } else {
+      initializeCGroupV1Handler(conf);
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The fallback ordering between cgroup v2 and v1 handlers are now changed, so that now if cgroup v2 is enabled it'll be used first, and if the controller is not mounted in v2 YARN will try to search for it in a v1 hierarchy. This needed some adjustments in the init procedure of the v2 handlers when preconfigured mount paths are used, but the end result should be similar.

### How was this patch tested?
Deployed to a cluster, and tested cgroup v1/v2 functionality,  by specifically recreating the error scenario described in the ticket.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

