### PR TITLE
HADOOP-19543. [ABFS][FnsOverBlob] Remove Duplicates from Blob Endpoint Listing Across Iterations

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsClient.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -1353,7 +1352,7 @@ public class AbfsDfsClient extends AbfsClient {
         LOG.debug("ListPath listed {} paths with {} as continuation token",
             listResultSchema.paths().size(),
             getContinuationFromResponse(result));
-        List<FileStatus> fileStatuses = new ArrayList<>();
+        List<VersionedFileStatus> fileStatuses = new ArrayList<>();
         for (DfsListResultEntrySchema entry : listResultSchema.paths()) {
           fileStatuses.add(getVersionedFileStatusFromEntry(entry, uri));
         }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListResponseData.java
@@ -21,34 +21,33 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 /**
  * This class is used to hold the response data for list operations.
- * It contains a list of FileStatus objects, a map of rename pending JSON paths,
+ * It contains a list of VersionedFileStatus objects, a map of rename pending JSON paths,
  * continuation token and the executed REST operation.
  */
 public class ListResponseData {
 
-  private List<FileStatus> fileStatusList;
+  private List<VersionedFileStatus> fileStatusList;
   private Map<Path, Integer> renamePendingJsonPaths;
   private AbfsRestOperation executedRestOperation;
   private String continuationToken;
 
   /**
-   * Returns the list of FileStatus objects.
-   * @return the list of FileStatus objects
+   * Returns the list of VersionedFileStatus objects.
+   * @return the list of VersionedFileStatus objects
    */
-  public List<FileStatus> getFileStatusList() {
+  public List<VersionedFileStatus> getFileStatusList() {
     return fileStatusList;
   }
 
   /**
-   * Sets the list of FileStatus objects.
-   * @param fileStatusList the list of FileStatus objects
+   * Sets the list of VersionedFileStatus objects.
+   * @param fileStatusList the list of VersionedFileStatus objects
    */
-  public void setFileStatusList(final List<FileStatus> fileStatusList) {
+  public void setFileStatusList(final List<VersionedFileStatus> fileStatusList) {
     this.fileStatusList = fileStatusList;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/ListUtils.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
+import org.apache.hadoop.fs.FileStatus;
+
+/**
+ * Utility class for List operations.
+ */
+public final class ListUtils {
+
+  private ListUtils() {
+    // Private constructor to prevent instantiation
+  }
+
+  /**
+   * Utility method to remove duplicates from a list of FileStatus.
+   * ListBlob API of blob endpoint can return duplicate entries.
+   * @param originalList prone to have duplicates
+   * @return rectified list with no duplicates.
+   */
+  public static List<FileStatus> getUniqueListResult(List<FileStatus> originalList) {
+    if (originalList == null || originalList.isEmpty()) {
+      return originalList;
+    }
+
+    TreeMap<String, FileStatus> nameToEntryMap = new TreeMap<>();
+    String prefix = null;
+    List<FileStatus> rectifiedFileStatusList = new ArrayList<>();
+
+    for (FileStatus current : originalList) {
+      String fileName = current.getPath().getName();
+
+      if (prefix == null || !fileName.startsWith(prefix)) {
+        // Prefix pattern breaks here. Reset Map and prefix.
+        prefix = fileName;
+        nameToEntryMap.clear();
+      }
+
+      // Add the current entry if it is not already added.
+      if (!nameToEntryMap.containsKey(fileName)) {
+        nameToEntryMap.put(fileName, current);
+        rectifiedFileStatusList.add(current);
+      }
+    }
+
+    return rectifiedFileStatusList;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TestListUtils.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Test class for ListUtils.
+ */
+public class TestListUtils {
+
+  /**
+   * Test method to check the removal of duplicates from a list of FileStatus.
+   */
+  @Test
+  public void testRemoveDuplicates() {
+    List<FileStatus> originalList = new ArrayList<>();
+    validateList(originalList, 0);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/A")));
+    validateList(originalList, 1);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/A")));
+    originalList.add(getFileStatusObject(new Path("/A")));
+    validateList(originalList, 1);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1.bak2")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1.bak2")));
+    originalList.add(getFileStatusObject(new Path("/a.bak1")));
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc.bak1")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    validateList(originalList, 5);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1_bak2")));
+    originalList.add(getFileStatusObject(new Path("/a_bak1_bak2")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc")));
+    originalList.add(getFileStatusObject(new Path("/abc_bak1")));
+    validateList(originalList, 5);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    validateList(originalList, 2);
+
+    originalList = new ArrayList<>();
+    originalList.add(getFileStatusObject(new Path("/a")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    originalList.add(getFileStatusObject(new Path("/b")));
+    validateList(originalList, 2);
+  }
+
+  /**
+   * Validate the size of the list after removing duplicates.
+   * @param originalList list having duplicates
+   * @param expectedSize number of unique entries expected
+   */
+  private void validateList(List<FileStatus> originalList, int expectedSize) {
+    List<FileStatus> uniqueList = ListUtils.getUniqueListResult(originalList);
+    Assertions.assertThat(uniqueList)
+        .describedAs("List Size is not as expected after duplicate removal")
+        .hasSize(expectedSize);
+  }
+
+  /**
+   * Create a FileStatus object with the given path.
+   * @param path path to be set in the FileStatus object
+   * @return FileStatus object with the given path
+   */
+  private FileStatus getFileStatusObject(Path path) {
+    FileStatus status = new FileStatus();
+    status.setPath(path);
+    return status;
+  }
+}


### PR DESCRIPTION
PR in trunk: https://github.com/apache/hadoop/pull/7614
Commit CP'd: https://github.com/apache/hadoop/commit/810c42f88cc63a8054edc5a16baeb9a90e3bd523
JIRA: https://issues.apache.org/jira/browse/HADOOP-19543

### Description of PR
On FNS-Blob, the List Blobs API is known to return duplicate entries for non-empty explicit directories. One entry corresponds to the directory itself, and another corresponds to the marker blob that the driver internally creates and maintains to mark that path as a directory. We already know about this behaviour, and it was handled to remove such duplicate entries from the set of entries that were returned as part of current list iterations.

Due to a possible partition split, if such duplicate entries happen to be returned in separate iterations, there is no handling on this, and the caller might get back the result with duplicate entries, as happened in this case. The logic to remove duplicates was designed before the realization of the partition split.

This PR fixes this bug

### How was this patch tested?
A new test for the failing scenario was added and existing test suite was ran to validate changes across all combinations.