### PR TITLE
HADOOP-19416. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-kms.

### DIFF
--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -1633,38 +1633,38 @@ public class TestKMS {
 
         final KeyVersion currKv =
             doAs("GET", new PrivilegedExceptionAction<KeyVersion>() {
-          @Override
-          public KeyVersion run() throws Exception {
-            KeyProvider kp = createProvider(uri, conf);
-            try {
-              kp.getKeyVersion("k1@0");
-              KeyVersion kv = kp.getCurrentKey("k1");
-              return kv;
-            } catch (Exception ex) {
-              fail(ex.toString());
-            }
-            return null;
-          }
-        });
+              @Override
+              public KeyVersion run() throws Exception {
+                KeyProvider kp = createProvider(uri, conf);
+                try {
+                  kp.getKeyVersion("k1@0");
+                  KeyVersion kv = kp.getCurrentKey("k1");
+                  return kv;
+                } catch (Exception ex) {
+                    fail(ex.toString());
+                }
+                return null;
+              }
+            });
 
         final EncryptedKeyVersion encKv =
             doAs("GENERATE_EEK",
                 new PrivilegedExceptionAction<EncryptedKeyVersion>() {
-          @Override
-          public EncryptedKeyVersion run() throws Exception {
-            KeyProvider kp = createProvider(uri, conf);
-            try {
-              KeyProviderCryptoExtension kpCE = KeyProviderCryptoExtension.
-                      createKeyProviderCryptoExtension(kp);
-              EncryptedKeyVersion ek1 =
-                  kpCE.generateEncryptedKey(currKv.getName());
-              return ek1;
-            } catch (Exception ex) {
-              fail(ex.toString());
-            }
-            return null;
-          }
-        });
+                @Override
+                public EncryptedKeyVersion run() throws Exception {
+                  KeyProvider kp = createProvider(uri, conf);
+                  try {
+                    KeyProviderCryptoExtension kpCE = KeyProviderCryptoExtension.
+                            createKeyProviderCryptoExtension(kp);
+                    EncryptedKeyVersion ek1 =
+                        kpCE.generateEncryptedKey(currKv.getName());
+                    return ek1;
+                  } catch (Exception ex) {
+                    fail(ex.toString());
+                  }
+                  return null;
+                }
+            });
 
         doAs("GENERATE_EEK", new PrivilegedExceptionAction<Void>() {
           @Override

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -52,11 +52,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.slf4j.event.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,10 +99,13 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Timeout(180)
@@ -451,7 +452,7 @@ public class TestKMS {
   private static void assertReFind(String re, String value) {
     Pattern p = Pattern.compile(re);
     Matcher m = p.matcher(value);
-    Assertions.assertTrue(m.find(), "'" + p + "' does not match " + value);
+    assertTrue(m.find(), "'" + p + "' does not match " + value);
   }
 
   private URLConnection openJMXConnection(URL baseUrl, boolean kerberos)
@@ -528,7 +529,7 @@ public class TestKMS {
       public Void call() throws Exception {
         final Configuration conf = new Configuration();
         URL url = getKMSUrl();
-        Assertions.assertEquals(keystore != null,
+        assertEquals(keystore != null,
             url.getProtocol().equals("https"));
         final URI uri = createKMSUri(getKMSUrl());
 
@@ -541,14 +542,14 @@ public class TestKMS {
 
                 final KeyProvider kp = createProvider(uri, conf);
                 // getKeys() empty
-                Assertions.assertTrue(kp.getKeys().isEmpty());
+                assertTrue(kp.getKeys().isEmpty());
 
                 Thread.sleep(4000);
                 Token<?>[] tokens =
                     ((KeyProviderDelegationTokenExtension.DelegationTokenExtension)kp)
                     .addDelegationTokens("myuser", new Credentials());
-                Assertions.assertEquals(1, tokens.length);
-                Assertions.assertEquals("kms-dt", tokens[0].getKind().toString());
+                assertEquals(1, tokens.length);
+                assertEquals("kms-dt", tokens[0].getKind().toString());
                 return null;
               }
             });
@@ -558,14 +559,14 @@ public class TestKMS {
 
           KeyProvider kp = createProvider(uri, conf);
           // getKeys() empty
-          Assertions.assertTrue(kp.getKeys().isEmpty());
+          assertTrue(kp.getKeys().isEmpty());
 
           Thread.sleep(4000);
           Token<?>[] tokens =
               ((KeyProviderDelegationTokenExtension.DelegationTokenExtension)kp)
               .addDelegationTokens("myuser", new Credentials());
-          Assertions.assertEquals(1, tokens.length);
-          Assertions.assertEquals("kms-dt", tokens[0].getKind().toString());
+          assertEquals(1, tokens.length);
+          assertEquals("kms-dt", tokens[0].getKind().toString());
         }
         return null;
       }
@@ -625,8 +626,8 @@ public class TestKMS {
         Configuration conf = new Configuration();
         URI uri = createKMSUri(getKMSUrl());
         KeyProvider kp = createProvider(uri, conf);
-        Assertions.assertTrue(kp.getKeys().isEmpty());
-        Assertions.assertEquals(0, kp.getKeysMetadata().length);
+        assertTrue(kp.getKeys().isEmpty());
+        assertEquals(0, kp.getKeysMetadata().length);
 
         KeyProvider.Options options = new KeyProvider.Options(conf);
         options.setCipher("AES/CTR/NoPadding");
@@ -635,10 +636,10 @@ public class TestKMS {
         LOG.info("Creating key with name '{}'", specialKey);
 
         KeyProvider.KeyVersion kv0 = kp.createKey(specialKey, options);
-        Assertions.assertNotNull(kv0);
-        Assertions.assertEquals(specialKey, kv0.getName());
-        Assertions.assertNotNull(kv0.getVersionName());
-        Assertions.assertNotNull(kv0.getMaterial());
+        assertNotNull(kv0);
+        assertEquals(specialKey, kv0.getName());
+        assertNotNull(kv0.getVersionName());
+        assertNotNull(kv0.getMaterial());
         return null;
       }
     });
@@ -669,10 +670,10 @@ public class TestKMS {
         KeyProvider kp = createProvider(uri, conf);
 
         // getKeys() empty
-        Assertions.assertTrue(kp.getKeys().isEmpty());
+        assertTrue(kp.getKeys().isEmpty());
 
         // getKeysMetadata() empty
-        Assertions.assertEquals(0, kp.getKeysMetadata().length);
+        assertEquals(0, kp.getKeysMetadata().length);
 
         // createKey()
         KeyProvider.Options options = new KeyProvider.Options(conf);
@@ -680,39 +681,39 @@ public class TestKMS {
         options.setBitLength(128);
         options.setDescription("l1");
         KeyProvider.KeyVersion kv0 = kp.createKey("k1", options);
-        Assertions.assertNotNull(kv0);
-        Assertions.assertNotNull(kv0.getVersionName());
-        Assertions.assertNotNull(kv0.getMaterial());
+        assertNotNull(kv0);
+        assertNotNull(kv0.getVersionName());
+        assertNotNull(kv0.getMaterial());
 
         // getKeyVersion()
         KeyProvider.KeyVersion kv1 = kp.getKeyVersion(kv0.getVersionName());
-        Assertions.assertEquals(kv0.getVersionName(), kv1.getVersionName());
-        Assertions.assertNotNull(kv1.getMaterial());
+        assertEquals(kv0.getVersionName(), kv1.getVersionName());
+        assertNotNull(kv1.getMaterial());
 
         // getCurrent()
         KeyProvider.KeyVersion cv1 = kp.getCurrentKey("k1");
-        Assertions.assertEquals(kv0.getVersionName(), cv1.getVersionName());
-        Assertions.assertNotNull(cv1.getMaterial());
+        assertEquals(kv0.getVersionName(), cv1.getVersionName());
+        assertNotNull(cv1.getMaterial());
 
         // getKeyMetadata() 1 version
         KeyProvider.Metadata m1 = kp.getMetadata("k1");
-        Assertions.assertEquals("AES/CTR/NoPadding", m1.getCipher());
-        Assertions.assertEquals("AES", m1.getAlgorithm());
-        Assertions.assertEquals(128, m1.getBitLength());
-        Assertions.assertEquals(1, m1.getVersions());
-        Assertions.assertNotNull(m1.getCreated());
-        Assertions.assertTrue(started.before(m1.getCreated()));
+        assertEquals("AES/CTR/NoPadding", m1.getCipher());
+        assertEquals("AES", m1.getAlgorithm());
+        assertEquals(128, m1.getBitLength());
+        assertEquals(1, m1.getVersions());
+        assertNotNull(m1.getCreated());
+        assertTrue(started.before(m1.getCreated()));
 
         // getKeyVersions() 1 version
         List<KeyProvider.KeyVersion> lkv1 = kp.getKeyVersions("k1");
-        Assertions.assertEquals(1, lkv1.size());
-        Assertions.assertEquals(kv0.getVersionName(), lkv1.get(0).getVersionName());
-        Assertions.assertNotNull(kv1.getMaterial());
+        assertEquals(1, lkv1.size());
+        assertEquals(kv0.getVersionName(), lkv1.get(0).getVersionName());
+        assertNotNull(kv1.getMaterial());
 
         // rollNewVersion()
         KeyProvider.KeyVersion kv2 = kp.rollNewVersion("k1");
-        Assertions.assertNotSame(kv0.getVersionName(), kv2.getVersionName());
-        Assertions.assertNotNull(kv2.getMaterial());
+        assertNotSame(kv0.getVersionName(), kv2.getVersionName());
+        assertNotNull(kv2.getMaterial());
 
         // getKeyVersion()
         kv2 = kp.getKeyVersion(kv2.getVersionName());
@@ -720,49 +721,49 @@ public class TestKMS {
         for (int i = 0; i < kv1.getMaterial().length; i++) {
           eq = eq && kv1.getMaterial()[i] == kv2.getMaterial()[i];
         }
-        Assertions.assertFalse(eq);
+        assertFalse(eq);
 
         // getCurrent()
         KeyProvider.KeyVersion cv2 = kp.getCurrentKey("k1");
-        Assertions.assertEquals(kv2.getVersionName(), cv2.getVersionName());
-        Assertions.assertNotNull(cv2.getMaterial());
+        assertEquals(kv2.getVersionName(), cv2.getVersionName());
+        assertNotNull(cv2.getMaterial());
         eq = true;
         for (int i = 0; i < kv1.getMaterial().length; i++) {
           eq = eq && cv2.getMaterial()[i] == kv2.getMaterial()[i];
         }
-        Assertions.assertTrue(eq);
+        assertTrue(eq);
 
         // getKeyVersions() 2 versions
         List<KeyProvider.KeyVersion> lkv2 = kp.getKeyVersions("k1");
-        Assertions.assertEquals(2, lkv2.size());
-        Assertions.assertEquals(kv1.getVersionName(), lkv2.get(0).getVersionName());
-        Assertions.assertNotNull(lkv2.get(0).getMaterial());
-        Assertions.assertEquals(kv2.getVersionName(), lkv2.get(1).getVersionName());
-        Assertions.assertNotNull(lkv2.get(1).getMaterial());
+        assertEquals(2, lkv2.size());
+        assertEquals(kv1.getVersionName(), lkv2.get(0).getVersionName());
+        assertNotNull(lkv2.get(0).getMaterial());
+        assertEquals(kv2.getVersionName(), lkv2.get(1).getVersionName());
+        assertNotNull(lkv2.get(1).getMaterial());
 
         // getKeyMetadata() 2 version
         KeyProvider.Metadata m2 = kp.getMetadata("k1");
-        Assertions.assertEquals("AES/CTR/NoPadding", m2.getCipher());
-        Assertions.assertEquals("AES", m2.getAlgorithm());
-        Assertions.assertEquals(128, m2.getBitLength());
-        Assertions.assertEquals(2, m2.getVersions());
-        Assertions.assertNotNull(m2.getCreated());
-        Assertions.assertTrue(started.before(m2.getCreated()));
+        assertEquals("AES/CTR/NoPadding", m2.getCipher());
+        assertEquals("AES", m2.getAlgorithm());
+        assertEquals(128, m2.getBitLength());
+        assertEquals(2, m2.getVersions());
+        assertNotNull(m2.getCreated());
+        assertTrue(started.before(m2.getCreated()));
 
         // getKeys() 1 key
         List<String> ks1 = kp.getKeys();
-        Assertions.assertEquals(1, ks1.size());
-        Assertions.assertEquals("k1", ks1.get(0));
+        assertEquals(1, ks1.size());
+        assertEquals("k1", ks1.get(0));
 
         // getKeysMetadata() 1 key 2 versions
         KeyProvider.Metadata[] kms1 = kp.getKeysMetadata("k1");
-        Assertions.assertEquals(1, kms1.length);
-        Assertions.assertEquals("AES/CTR/NoPadding", kms1[0].getCipher());
-        Assertions.assertEquals("AES", kms1[0].getAlgorithm());
-        Assertions.assertEquals(128, kms1[0].getBitLength());
-        Assertions.assertEquals(2, kms1[0].getVersions());
-        Assertions.assertNotNull(kms1[0].getCreated());
-        Assertions.assertTrue(started.before(kms1[0].getCreated()));
+        assertEquals(1, kms1.length);
+        assertEquals("AES/CTR/NoPadding", kms1[0].getCipher());
+        assertEquals("AES", kms1[0].getAlgorithm());
+        assertEquals(128, kms1[0].getBitLength());
+        assertEquals(2, kms1[0].getVersions());
+        assertNotNull(kms1[0].getCreated());
+        assertTrue(started.before(kms1[0].getCreated()));
 
         // test generate and decryption of EEK
         KeyProvider.KeyVersion kv = kp.getCurrentKey("k1");
@@ -770,16 +771,16 @@ public class TestKMS {
             KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
 
         EncryptedKeyVersion ek1 = kpExt.generateEncryptedKey(kv.getName());
-        Assertions.assertEquals(KeyProviderCryptoExtension.EEK,
+        assertEquals(KeyProviderCryptoExtension.EEK,
             ek1.getEncryptedKeyVersion().getVersionName());
-        Assertions.assertNotNull(ek1.getEncryptedKeyVersion().getMaterial());
-        Assertions.assertEquals(kv.getMaterial().length,
+        assertNotNull(ek1.getEncryptedKeyVersion().getMaterial());
+        assertEquals(kv.getMaterial().length,
             ek1.getEncryptedKeyVersion().getMaterial().length);
         KeyProvider.KeyVersion k1 = kpExt.decryptEncryptedKey(ek1);
-        Assertions.assertEquals(KeyProviderCryptoExtension.EK, k1.getVersionName());
+        assertEquals(KeyProviderCryptoExtension.EK, k1.getVersionName());
         KeyProvider.KeyVersion k1a = kpExt.decryptEncryptedKey(ek1);
-        Assertions.assertArrayEquals(k1.getMaterial(), k1a.getMaterial());
-        Assertions.assertEquals(kv.getMaterial().length, k1.getMaterial().length);
+        assertArrayEquals(k1.getMaterial(), k1a.getMaterial());
+        assertEquals(kv.getMaterial().length, k1.getMaterial().length);
 
         EncryptedKeyVersion ek2 = kpExt.generateEncryptedKey(kv.getName());
         KeyProvider.KeyVersion k2 = kpExt.decryptEncryptedKey(ek2);
@@ -788,7 +789,7 @@ public class TestKMS {
             .getMaterial().length; i++) {
           isEq = k2.getMaterial()[i] == k1.getMaterial()[i];
         }
-        Assertions.assertFalse(isEq);
+        assertFalse(isEq);
 
         // test re-encrypt
         kpExt.rollNewVersion(ek1.getEncryptionKeyName());
@@ -831,25 +832,25 @@ public class TestKMS {
         // Check decryption after Key deletion
         try {
           kpExt.decryptEncryptedKey(ek1);
-          Assertions.fail("Should not be allowed !!");
+          fail("Should not be allowed !!");
         } catch (Exception e) {
-          Assertions.assertTrue(e.getMessage().contains("'k1@1' not found"));
+          assertTrue(e.getMessage().contains("'k1@1' not found"));
         }
 
         // getKey()
-        Assertions.assertNull(kp.getKeyVersion("k1"));
+        assertNull(kp.getKeyVersion("k1"));
 
         // getKeyVersions()
-        Assertions.assertNull(kp.getKeyVersions("k1"));
+        assertNull(kp.getKeyVersions("k1"));
 
         // getMetadata()
-        Assertions.assertNull(kp.getMetadata("k1"));
+        assertNull(kp.getMetadata("k1"));
 
         // getKeys() empty
-        Assertions.assertTrue(kp.getKeys().isEmpty());
+        assertTrue(kp.getKeys().isEmpty());
 
         // getKeysMetadata() empty
-        Assertions.assertEquals(0, kp.getKeysMetadata().length);
+        assertEquals(0, kp.getKeysMetadata().length);
 
         // createKey() no description, no tags
         options = new KeyProvider.Options(conf);
@@ -857,15 +858,15 @@ public class TestKMS {
         options.setBitLength(128);
         KeyVersion kVer2 = kp.createKey("k2", options);
         KeyProvider.Metadata meta = kp.getMetadata("k2");
-        Assertions.assertNull(meta.getDescription());
-        Assertions.assertEquals("k2", meta.getAttributes().get("key.acl.name"));
+        assertNull(meta.getDescription());
+        assertEquals("k2", meta.getAttributes().get("key.acl.name"));
 
         // test key ACL.. k2 is granted only MANAGEMENT Op access
         try {
           kpExt =
               KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
           kpExt.generateEncryptedKey(kVer2.getName());
-          Assertions.fail("User should not be allowed to encrypt !!");
+          fail("User should not be allowed to encrypt !!");
         } catch (Exception ex) {
           // 
         }
@@ -877,8 +878,8 @@ public class TestKMS {
         options.setDescription("d");
         kp.createKey("k3", options);
         meta = kp.getMetadata("k3");
-        Assertions.assertEquals("d", meta.getDescription());
-        Assertions.assertEquals("k3", meta.getAttributes().get("key.acl.name"));
+        assertEquals("d", meta.getDescription());
+        assertEquals("k3", meta.getAttributes().get("key.acl.name"));
 
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("a", "A");
@@ -891,8 +892,8 @@ public class TestKMS {
         options.setAttributes(attributes);
         kp.createKey("k4", options);
         meta = kp.getMetadata("k4");
-        Assertions.assertNull(meta.getDescription());
-        Assertions.assertEquals(attributes, meta.getAttributes());
+        assertNull(meta.getDescription());
+        assertEquals(attributes, meta.getAttributes());
 
         // createKey() description, tags
         options = new KeyProvider.Options(conf);
@@ -903,8 +904,8 @@ public class TestKMS {
         options.setAttributes(attributes);
         kp.createKey("k5", options);
         meta = kp.getMetadata("k5");
-        Assertions.assertEquals("d", meta.getDescription());
-        Assertions.assertEquals(attributes, meta.getAttributes());
+        assertEquals("d", meta.getDescription());
+        assertEquals(attributes, meta.getAttributes());
 
         // test rollover draining
         KeyProviderCryptoExtension kpce = KeyProviderCryptoExtension.
@@ -951,7 +952,7 @@ public class TestKMS {
             (LoadingCache<String, LinkedBlockingQueue<EncryptedKeyVersion>>)
                  FieldUtils.getField(ValueQueue.class, "keyQueues", true).get(vq);
 
-        EncryptedKeyVersion mockEKV = Mockito.mock(EncryptedKeyVersion.class);
+        EncryptedKeyVersion mockEKV = mock(EncryptedKeyVersion.class);
         when(mockEKV.getEncryptionKeyName()).thenReturn(keyName);
         when(mockEKV.getEncryptionKeyVersionName()).thenReturn(mockVersionName);
 
@@ -1038,14 +1039,14 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "test_key");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("k0", options);
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("k0");
-              Assertions.assertNull(rollVersion.getMaterial());
+              assertNull(rollVersion.getMaterial());
               KeyProviderCryptoExtension kpce =
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("k0");
-                Assertions.fail("User [CREATE] should not be allowed to generate_eek on k0");
+                fail("User [CREATE] should not be allowed to generate_eek on k0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1054,12 +1055,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assertions.fail("User [CREATE] should not be allowed to create kx");
+                fail("User [CREATE] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1078,14 +1079,14 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "some_key");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("kk0", options);
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("kk0");
-              Assertions.assertNull(rollVersion.getMaterial());
+              assertNull(rollVersion.getMaterial());
               KeyProviderCryptoExtension kpce =
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("kk0");
-                Assertions.fail("User [DECRYPT_EEK] should not be allowed to generate_eek on kk0");
+                fail("User [DECRYPT_EEK] should not be allowed to generate_eek on kk0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1094,7 +1095,7 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               kp.createKey("kkx", options);
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1111,12 +1112,12 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "test_key2");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("k1", options);
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("k1");
-              Assertions.assertNull(rollVersion.getMaterial());
+              assertNull(rollVersion.getMaterial());
               try {
                 kp.rollNewVersion("k0");
-                Assertions.fail("User [ROLLOVER] should not be allowed to rollover k0");
+                fail("User [ROLLOVER] should not be allowed to rollover k0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1124,7 +1125,7 @@ public class TestKMS {
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("k1");
-                Assertions.fail("User [ROLLOVER] should not be allowed to generate_eek on k1");
+                fail("User [ROLLOVER] should not be allowed to generate_eek on k1");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1133,12 +1134,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assertions.fail("User [ROLLOVER] should not be allowed to create kx");
+                fail("User [ROLLOVER] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1156,7 +1157,7 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("k2", options);
-                Assertions.fail("User [GET] should not be allowed to create key..");
+                fail("User [GET] should not be allowed to create key..");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1165,12 +1166,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assertions.fail("User [GET] should not be allowed to create kx");
+                fail("User [GET] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1192,10 +1193,10 @@ public class TestKMS {
               try {
                 return kpce.generateEncryptedKey("kx");
               } catch (Exception e) {
-                Assertions.fail("User [GENERATE_EEK] should be allowed to generate_eek on kx");
+                fail("User [GENERATE_EEK] should be allowed to generate_eek on kx");
               }
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1210,7 +1211,7 @@ public class TestKMS {
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               kpce.decryptEncryptedKey(ekv);
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1418,9 +1419,9 @@ public class TestKMS {
                     try {
                       kp.createKey("k4", new byte[16],
                           new KeyProvider.Options(conf));
-                      Assertions.fail("This should not succeed..");
+                      fail("This should not succeed..");
                     } catch (IOException e) {
-                      Assertions.assertTrue(
+                      assertTrue(
                       e
                               .getMessage().contains("401"), "HTTP exception must be a 401 : " + e.getMessage());
                     }
@@ -1473,85 +1474,85 @@ public class TestKMS {
             KeyProvider kp = createProvider(uri, conf);
             try {
               kp.createKey("k", new KeyProvider.Options(conf));
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.createKey("k", new byte[16], new KeyProvider.Options(conf));
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.rollNewVersion("k");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.rollNewVersion("k", new byte[16]);
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.getKeys();
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.getKeysMetadata("k");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               // we are using JavaKeyStoreProvider for testing, so we know how
               // the keyversion is created.
               kp.getKeyVersion("k@0");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.getCurrentKey("k");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.getMetadata("k");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             try {
               kp.getKeyVersions("k");
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
 
             return null;
@@ -1565,9 +1566,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv = kp.createKey("k0",
                   new KeyProvider.Options(conf));
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1580,7 +1581,7 @@ public class TestKMS {
             try {
               kp.deleteKey("k0");
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1593,9 +1594,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv = kp.createKey("k1", new byte[16],
                   new KeyProvider.Options(conf));
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1607,9 +1608,9 @@ public class TestKMS {
             KeyProvider kp = createProvider(uri, conf);
             try {
               KeyProvider.KeyVersion kv = kp.rollNewVersion("k1");
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1622,9 +1623,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv =
                   kp.rollNewVersion("k1", new byte[16]);
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1640,7 +1641,7 @@ public class TestKMS {
               KeyVersion kv = kp.getCurrentKey("k1");
               return kv;
             } catch (Exception ex) {
-              Assertions.fail(ex.toString());
+              fail(ex.toString());
             }
             return null;
           }
@@ -1659,7 +1660,7 @@ public class TestKMS {
                   kpCE.generateEncryptedKey(currKv.getName());
               return ek1;
             } catch (Exception ex) {
-              Assertions.fail(ex.toString());
+              fail(ex.toString());
             }
             return null;
           }
@@ -1689,7 +1690,7 @@ public class TestKMS {
                       createKeyProviderCryptoExtension(kp);
               kpCE.decryptEncryptedKey(encKv);
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1702,7 +1703,7 @@ public class TestKMS {
             try {
               kp.getKeys();
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1716,7 +1717,7 @@ public class TestKMS {
               kp.getMetadata("k1");
               kp.getKeysMetadata("k1");
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1741,11 +1742,11 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("k2",
                   new KeyProvider.Options(conf));
-              Assertions.fail();
+              fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
 
             return null;
@@ -1852,9 +1853,9 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck0");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1870,7 +1871,7 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck1");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assertions.fail("admin user must not be allowed to decrypt !!");
+              fail("admin user must not be allowed to decrypt !!");
             } catch (Exception ex) {
             }
             return null;
@@ -1887,7 +1888,7 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck2");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assertions.fail("admin user must not be allowed to decrypt !!");
+              fail("admin user must not be allowed to decrypt !!");
             } catch (Exception ex) {
             }
             return null;
@@ -1932,9 +1933,9 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("ck0",
                   new KeyProvider.Options(conf));
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1947,9 +1948,9 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("ck1",
                   new KeyProvider.Options(conf));
-              Assertions.assertNull(kv.getMaterial());
+              assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assertions.fail(ex.getMessage());
+              fail(ex.getMessage());
             }
             return null;
           }
@@ -1992,7 +1993,7 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
+      assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
     caughtTimeout = false;
@@ -2003,7 +2004,7 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
+      assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
     caughtTimeout = false;
@@ -2016,10 +2017,10 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
+      assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
-    Assertions.assertTrue(caughtTimeout);
+    assertTrue(caughtTimeout);
 
     sock.close();
   }
@@ -2135,7 +2136,7 @@ public class TestKMS {
                     .createKeyProviderDelegationTokenExtension(kp);
             keyProviderDelegationTokenExtension.addDelegationTokens("client",
                 credentials);
-            Assertions.assertNotNull(kp.createKey("kcc",
+            assertNotNull(kp.createKey("kcc",
                 new KeyProvider.Options(conf)));
             return null;
           }
@@ -2149,7 +2150,7 @@ public class TestKMS {
           @Override
           public Void run() throws Exception {
             final KeyProvider kp = createProvider(uri, conf);
-            Assertions.assertNotNull(kp.getMetadata("kcc"));
+            assertNotNull(kp.getMetadata("kcc"));
             return null;
           }
         });
@@ -2250,8 +2251,8 @@ public class TestKMS {
             final Token<?>[] tokens =
                 kpdte.addDelegationTokens("client1", credentials);
             Text tokenService = getTokenService(kp);
-            Assertions.assertEquals(1, credentials.getAllTokens().size());
-            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            assertEquals(1, credentials.getAllTokens().size());
+            assertEquals(KMSDelegationToken.TOKEN_KIND,
                 credentials.getToken(tokenService).getKind());
 
             // Test non-renewer user cannot renew.
@@ -2263,7 +2264,7 @@ public class TestKMS {
               LOG.info("Got dt for " + uri + "; " + token);
               try {
                 token.renew(clientConf);
-                Assertions.fail("client should not be allowed to renew token with"
+                fail("client should not be allowed to renew token with"
                     + "renewer=client1");
               } catch (Exception e) {
                 final DelegationTokenIdentifier identifier =
@@ -2304,10 +2305,10 @@ public class TestKMS {
                     long newTokenLife = token.renew(clientConf);
                     LOG.info("Renewed token of kind {}, new lifetime:{}",
                         token.getKind(), newTokenLife);
-                    Assertions.assertTrue(newTokenLife > tokenLife);
+                    assertTrue(newTokenLife > tokenLife);
                     renewed = true;
                   }
-                  Assertions.assertTrue(renewed);
+                  assertTrue(renewed);
 
                   // test delegation token cancellation
                   for (Token<?> token : tokens) {
@@ -2377,8 +2378,8 @@ public class TestKMS {
             final Credentials credentials = new Credentials();
             kpdte.addDelegationTokens("client", credentials);
             Text tokenService = getTokenService(kp);
-            Assertions.assertEquals(1, credentials.getAllTokens().size());
-            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND, credentials.
+            assertEquals(1, credentials.getAllTokens().size());
+            assertEquals(KMSDelegationToken.TOKEN_KIND, credentials.
                 getToken(tokenService).getKind());
             UserGroupInformation.getCurrentUser().addCredentials(credentials);
             LOG.info("Added kms dt to credentials: {}", UserGroupInformation.
@@ -2386,7 +2387,7 @@ public class TestKMS {
             Token<?> token =
                 UserGroupInformation.getCurrentUser().getCredentials()
                     .getToken(tokenService);
-            Assertions.assertNotNull(token);
+            assertNotNull(token);
             job1Token.add(token);
 
             // Decode the token to get max time.
@@ -2401,18 +2402,18 @@ public class TestKMS {
 
             // wait for token to expire.
             Thread.sleep(5100);
-            Assertions.assertTrue(
+            assertTrue(
                maxTime > 0 && maxTime < Time.now(), "maxTime " + maxTime + " is not less than now.");
             try {
               kp.getKeys();
-              Assertions.fail("Operation should fail since dt is expired.");
+              fail("Operation should fail since dt is expired.");
             } catch (Exception e) {
               LOG.info("Expected error.", e);
             }
             return null;
           }
         });
-        Assertions.assertFalse(job1Token.isEmpty());
+        assertFalse(job1Token.isEmpty());
 
         // job 2 (e.g. Another YARN log aggregation job, with user DT.
         doAs("client", new PrivilegedExceptionAction<Void>() {
@@ -2422,8 +2423,8 @@ public class TestKMS {
             final Credentials newCreds = new Credentials();
             kpdte.addDelegationTokens("client", newCreds);
             Text tokenService = getTokenService(kp);
-            Assertions.assertEquals(1, newCreds.getAllTokens().size());
-            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            assertEquals(1, newCreds.getAllTokens().size());
+            assertEquals(KMSDelegationToken.TOKEN_KIND,
                 newCreds.getToken(tokenService).
                     getKind());
 
@@ -2439,14 +2440,14 @@ public class TestKMS {
                 .getCurrentUser().getCredentials().getAllTokens());
             try {
               kp.getKeys();
-              Assertions.fail("Operation should fail since dt is expired.");
+              fail("Operation should fail since dt is expired.");
             } catch (Exception e) {
               LOG.info("Expected error.", e);
             }
 
             // Using the new DT should succeed.
-            Assertions.assertEquals(1, newCreds.getAllTokens().size());
-            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            assertEquals(1, newCreds.getAllTokens().size());
+            assertEquals(KMSDelegationToken.TOKEN_KIND,
                 newCreds.getToken(tokenService).
                     getKind());
             UserGroupInformation.getCurrentUser().addCredentials(newCreds);
@@ -2774,7 +2775,7 @@ public class TestKMS {
             fooUgi.doAs(new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {
-                Assertions.assertNotNull(kp.createKey("kbb",
+                assertNotNull(kp.createKey("kbb",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2788,11 +2789,11 @@ public class TestKMS {
               public Void run() throws Exception {
                 try {
                   kp.createKey("kcc", new KeyProvider.Options(conf));
-                  Assertions.fail();
+                  fail();
                 } catch (AuthorizationException ex) {
                   // OK
                 } catch (Exception ex) {
-                  Assertions.fail(ex.getMessage());
+                  fail(ex.getMessage());
                 }
                 return null;
               }
@@ -2804,7 +2805,7 @@ public class TestKMS {
             barUgi.doAs(new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {
-                Assertions.assertNotNull(kp.createKey("kdd",
+                assertNotNull(kp.createKey("kdd",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2946,7 +2947,7 @@ public class TestKMS {
               @Override
               public Void run() throws Exception {
                 KeyProvider kp = createProvider(uri, conf);
-                Assertions.assertNotNull(kp.createKey("kaa",
+                assertNotNull(kp.createKey("kaa",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2961,7 +2962,7 @@ public class TestKMS {
                 try {
                   KeyProvider kp = createProvider(uri, conf);
                   kp.createKey("kbb", new KeyProvider.Options(conf));
-                  Assertions.fail();
+                  fail();
                 } catch (Exception ex) {
                   GenericTestUtils.assertExceptionContains("Error while " +
                       "authenticating with endpoint", ex);
@@ -2980,7 +2981,7 @@ public class TestKMS {
               @Override
               public Void run() throws Exception {
                 KeyProvider kp = createProvider(uri, conf);
-                Assertions.assertNotNull(kp.createKey("kcc",
+                assertNotNull(kp.createKey("kcc",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -3062,7 +3063,7 @@ public class TestKMS {
           @Override
           public Void run() throws Exception {
             final KeyProvider kp = createProvider(uri, conf);
-            Assertions.assertTrue(kp.getKeys().isEmpty());
+            assertTrue(kp.getKeys().isEmpty());
             return null;
           }
         });

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -51,12 +51,11 @@ import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.http.client.utils.URIBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 import org.slf4j.Logger;
@@ -99,15 +98,16 @@ import java.util.regex.Pattern;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
+@Timeout(180)
 public class TestKMS {
   private static final Logger LOG = LoggerFactory.getLogger(TestKMS.class);
 
@@ -117,10 +117,7 @@ public class TestKMS {
   // closed at test tearDown.
   private List<KeyProvider> providersCreated = new LinkedList<>();
 
-  @Rule
-  public final Timeout testTimeout = new Timeout(180000);
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setUpMiniKdc();
     // resetting kerberos security
@@ -397,7 +394,7 @@ public class TestKMS {
     setUpMiniKdc(kdcConf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (kdc != null) {
       kdc.stop();
@@ -454,7 +451,7 @@ public class TestKMS {
   private static void assertReFind(String re, String value) {
     Pattern p = Pattern.compile(re);
     Matcher m = p.matcher(value);
-    Assert.assertTrue("'" + p + "' does not match " + value, m.find());
+    Assertions.assertTrue(m.find(), "'" + p + "' does not match " + value);
   }
 
   private URLConnection openJMXConnection(URL baseUrl, boolean kerberos)
@@ -531,7 +528,7 @@ public class TestKMS {
       public Void call() throws Exception {
         final Configuration conf = new Configuration();
         URL url = getKMSUrl();
-        Assert.assertEquals(keystore != null,
+        Assertions.assertEquals(keystore != null,
             url.getProtocol().equals("https"));
         final URI uri = createKMSUri(getKMSUrl());
 
@@ -544,14 +541,14 @@ public class TestKMS {
 
                 final KeyProvider kp = createProvider(uri, conf);
                 // getKeys() empty
-                Assert.assertTrue(kp.getKeys().isEmpty());
+                Assertions.assertTrue(kp.getKeys().isEmpty());
 
                 Thread.sleep(4000);
                 Token<?>[] tokens =
                     ((KeyProviderDelegationTokenExtension.DelegationTokenExtension)kp)
                     .addDelegationTokens("myuser", new Credentials());
-                Assert.assertEquals(1, tokens.length);
-                Assert.assertEquals("kms-dt", tokens[0].getKind().toString());
+                Assertions.assertEquals(1, tokens.length);
+                Assertions.assertEquals("kms-dt", tokens[0].getKind().toString());
                 return null;
               }
             });
@@ -561,14 +558,14 @@ public class TestKMS {
 
           KeyProvider kp = createProvider(uri, conf);
           // getKeys() empty
-          Assert.assertTrue(kp.getKeys().isEmpty());
+          Assertions.assertTrue(kp.getKeys().isEmpty());
 
           Thread.sleep(4000);
           Token<?>[] tokens =
               ((KeyProviderDelegationTokenExtension.DelegationTokenExtension)kp)
               .addDelegationTokens("myuser", new Credentials());
-          Assert.assertEquals(1, tokens.length);
-          Assert.assertEquals("kms-dt", tokens[0].getKind().toString());
+          Assertions.assertEquals(1, tokens.length);
+          Assertions.assertEquals("kms-dt", tokens[0].getKind().toString());
         }
         return null;
       }
@@ -611,7 +608,8 @@ public class TestKMS {
     testStartStop(true, true);
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testSpecialKeyNames() throws Exception {
     final String specialKey = "key %^[\n{]}|\"<>\\";
     Configuration conf = new Configuration();
@@ -627,8 +625,8 @@ public class TestKMS {
         Configuration conf = new Configuration();
         URI uri = createKMSUri(getKMSUrl());
         KeyProvider kp = createProvider(uri, conf);
-        Assert.assertTrue(kp.getKeys().isEmpty());
-        Assert.assertEquals(0, kp.getKeysMetadata().length);
+        Assertions.assertTrue(kp.getKeys().isEmpty());
+        Assertions.assertEquals(0, kp.getKeysMetadata().length);
 
         KeyProvider.Options options = new KeyProvider.Options(conf);
         options.setCipher("AES/CTR/NoPadding");
@@ -637,10 +635,10 @@ public class TestKMS {
         LOG.info("Creating key with name '{}'", specialKey);
 
         KeyProvider.KeyVersion kv0 = kp.createKey(specialKey, options);
-        Assert.assertNotNull(kv0);
-        Assert.assertEquals(specialKey, kv0.getName());
-        Assert.assertNotNull(kv0.getVersionName());
-        Assert.assertNotNull(kv0.getMaterial());
+        Assertions.assertNotNull(kv0);
+        Assertions.assertEquals(specialKey, kv0.getName());
+        Assertions.assertNotNull(kv0.getVersionName());
+        Assertions.assertNotNull(kv0.getMaterial());
         return null;
       }
     });
@@ -671,10 +669,10 @@ public class TestKMS {
         KeyProvider kp = createProvider(uri, conf);
 
         // getKeys() empty
-        Assert.assertTrue(kp.getKeys().isEmpty());
+        Assertions.assertTrue(kp.getKeys().isEmpty());
 
         // getKeysMetadata() empty
-        Assert.assertEquals(0, kp.getKeysMetadata().length);
+        Assertions.assertEquals(0, kp.getKeysMetadata().length);
 
         // createKey()
         KeyProvider.Options options = new KeyProvider.Options(conf);
@@ -682,39 +680,39 @@ public class TestKMS {
         options.setBitLength(128);
         options.setDescription("l1");
         KeyProvider.KeyVersion kv0 = kp.createKey("k1", options);
-        Assert.assertNotNull(kv0);
-        Assert.assertNotNull(kv0.getVersionName());
-        Assert.assertNotNull(kv0.getMaterial());
+        Assertions.assertNotNull(kv0);
+        Assertions.assertNotNull(kv0.getVersionName());
+        Assertions.assertNotNull(kv0.getMaterial());
 
         // getKeyVersion()
         KeyProvider.KeyVersion kv1 = kp.getKeyVersion(kv0.getVersionName());
-        Assert.assertEquals(kv0.getVersionName(), kv1.getVersionName());
-        Assert.assertNotNull(kv1.getMaterial());
+        Assertions.assertEquals(kv0.getVersionName(), kv1.getVersionName());
+        Assertions.assertNotNull(kv1.getMaterial());
 
         // getCurrent()
         KeyProvider.KeyVersion cv1 = kp.getCurrentKey("k1");
-        Assert.assertEquals(kv0.getVersionName(), cv1.getVersionName());
-        Assert.assertNotNull(cv1.getMaterial());
+        Assertions.assertEquals(kv0.getVersionName(), cv1.getVersionName());
+        Assertions.assertNotNull(cv1.getMaterial());
 
         // getKeyMetadata() 1 version
         KeyProvider.Metadata m1 = kp.getMetadata("k1");
-        Assert.assertEquals("AES/CTR/NoPadding", m1.getCipher());
-        Assert.assertEquals("AES", m1.getAlgorithm());
-        Assert.assertEquals(128, m1.getBitLength());
-        Assert.assertEquals(1, m1.getVersions());
-        Assert.assertNotNull(m1.getCreated());
-        Assert.assertTrue(started.before(m1.getCreated()));
+        Assertions.assertEquals("AES/CTR/NoPadding", m1.getCipher());
+        Assertions.assertEquals("AES", m1.getAlgorithm());
+        Assertions.assertEquals(128, m1.getBitLength());
+        Assertions.assertEquals(1, m1.getVersions());
+        Assertions.assertNotNull(m1.getCreated());
+        Assertions.assertTrue(started.before(m1.getCreated()));
 
         // getKeyVersions() 1 version
         List<KeyProvider.KeyVersion> lkv1 = kp.getKeyVersions("k1");
-        Assert.assertEquals(1, lkv1.size());
-        Assert.assertEquals(kv0.getVersionName(), lkv1.get(0).getVersionName());
-        Assert.assertNotNull(kv1.getMaterial());
+        Assertions.assertEquals(1, lkv1.size());
+        Assertions.assertEquals(kv0.getVersionName(), lkv1.get(0).getVersionName());
+        Assertions.assertNotNull(kv1.getMaterial());
 
         // rollNewVersion()
         KeyProvider.KeyVersion kv2 = kp.rollNewVersion("k1");
-        Assert.assertNotSame(kv0.getVersionName(), kv2.getVersionName());
-        Assert.assertNotNull(kv2.getMaterial());
+        Assertions.assertNotSame(kv0.getVersionName(), kv2.getVersionName());
+        Assertions.assertNotNull(kv2.getMaterial());
 
         // getKeyVersion()
         kv2 = kp.getKeyVersion(kv2.getVersionName());
@@ -722,49 +720,49 @@ public class TestKMS {
         for (int i = 0; i < kv1.getMaterial().length; i++) {
           eq = eq && kv1.getMaterial()[i] == kv2.getMaterial()[i];
         }
-        Assert.assertFalse(eq);
+        Assertions.assertFalse(eq);
 
         // getCurrent()
         KeyProvider.KeyVersion cv2 = kp.getCurrentKey("k1");
-        Assert.assertEquals(kv2.getVersionName(), cv2.getVersionName());
-        Assert.assertNotNull(cv2.getMaterial());
+        Assertions.assertEquals(kv2.getVersionName(), cv2.getVersionName());
+        Assertions.assertNotNull(cv2.getMaterial());
         eq = true;
         for (int i = 0; i < kv1.getMaterial().length; i++) {
           eq = eq && cv2.getMaterial()[i] == kv2.getMaterial()[i];
         }
-        Assert.assertTrue(eq);
+        Assertions.assertTrue(eq);
 
         // getKeyVersions() 2 versions
         List<KeyProvider.KeyVersion> lkv2 = kp.getKeyVersions("k1");
-        Assert.assertEquals(2, lkv2.size());
-        Assert.assertEquals(kv1.getVersionName(), lkv2.get(0).getVersionName());
-        Assert.assertNotNull(lkv2.get(0).getMaterial());
-        Assert.assertEquals(kv2.getVersionName(), lkv2.get(1).getVersionName());
-        Assert.assertNotNull(lkv2.get(1).getMaterial());
+        Assertions.assertEquals(2, lkv2.size());
+        Assertions.assertEquals(kv1.getVersionName(), lkv2.get(0).getVersionName());
+        Assertions.assertNotNull(lkv2.get(0).getMaterial());
+        Assertions.assertEquals(kv2.getVersionName(), lkv2.get(1).getVersionName());
+        Assertions.assertNotNull(lkv2.get(1).getMaterial());
 
         // getKeyMetadata() 2 version
         KeyProvider.Metadata m2 = kp.getMetadata("k1");
-        Assert.assertEquals("AES/CTR/NoPadding", m2.getCipher());
-        Assert.assertEquals("AES", m2.getAlgorithm());
-        Assert.assertEquals(128, m2.getBitLength());
-        Assert.assertEquals(2, m2.getVersions());
-        Assert.assertNotNull(m2.getCreated());
-        Assert.assertTrue(started.before(m2.getCreated()));
+        Assertions.assertEquals("AES/CTR/NoPadding", m2.getCipher());
+        Assertions.assertEquals("AES", m2.getAlgorithm());
+        Assertions.assertEquals(128, m2.getBitLength());
+        Assertions.assertEquals(2, m2.getVersions());
+        Assertions.assertNotNull(m2.getCreated());
+        Assertions.assertTrue(started.before(m2.getCreated()));
 
         // getKeys() 1 key
         List<String> ks1 = kp.getKeys();
-        Assert.assertEquals(1, ks1.size());
-        Assert.assertEquals("k1", ks1.get(0));
+        Assertions.assertEquals(1, ks1.size());
+        Assertions.assertEquals("k1", ks1.get(0));
 
         // getKeysMetadata() 1 key 2 versions
         KeyProvider.Metadata[] kms1 = kp.getKeysMetadata("k1");
-        Assert.assertEquals(1, kms1.length);
-        Assert.assertEquals("AES/CTR/NoPadding", kms1[0].getCipher());
-        Assert.assertEquals("AES", kms1[0].getAlgorithm());
-        Assert.assertEquals(128, kms1[0].getBitLength());
-        Assert.assertEquals(2, kms1[0].getVersions());
-        Assert.assertNotNull(kms1[0].getCreated());
-        Assert.assertTrue(started.before(kms1[0].getCreated()));
+        Assertions.assertEquals(1, kms1.length);
+        Assertions.assertEquals("AES/CTR/NoPadding", kms1[0].getCipher());
+        Assertions.assertEquals("AES", kms1[0].getAlgorithm());
+        Assertions.assertEquals(128, kms1[0].getBitLength());
+        Assertions.assertEquals(2, kms1[0].getVersions());
+        Assertions.assertNotNull(kms1[0].getCreated());
+        Assertions.assertTrue(started.before(kms1[0].getCreated()));
 
         // test generate and decryption of EEK
         KeyProvider.KeyVersion kv = kp.getCurrentKey("k1");
@@ -772,16 +770,16 @@ public class TestKMS {
             KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
 
         EncryptedKeyVersion ek1 = kpExt.generateEncryptedKey(kv.getName());
-        Assert.assertEquals(KeyProviderCryptoExtension.EEK,
+        Assertions.assertEquals(KeyProviderCryptoExtension.EEK,
             ek1.getEncryptedKeyVersion().getVersionName());
-        Assert.assertNotNull(ek1.getEncryptedKeyVersion().getMaterial());
-        Assert.assertEquals(kv.getMaterial().length,
+        Assertions.assertNotNull(ek1.getEncryptedKeyVersion().getMaterial());
+        Assertions.assertEquals(kv.getMaterial().length,
             ek1.getEncryptedKeyVersion().getMaterial().length);
         KeyProvider.KeyVersion k1 = kpExt.decryptEncryptedKey(ek1);
-        Assert.assertEquals(KeyProviderCryptoExtension.EK, k1.getVersionName());
+        Assertions.assertEquals(KeyProviderCryptoExtension.EK, k1.getVersionName());
         KeyProvider.KeyVersion k1a = kpExt.decryptEncryptedKey(ek1);
-        Assert.assertArrayEquals(k1.getMaterial(), k1a.getMaterial());
-        Assert.assertEquals(kv.getMaterial().length, k1.getMaterial().length);
+        Assertions.assertArrayEquals(k1.getMaterial(), k1a.getMaterial());
+        Assertions.assertEquals(kv.getMaterial().length, k1.getMaterial().length);
 
         EncryptedKeyVersion ek2 = kpExt.generateEncryptedKey(kv.getName());
         KeyProvider.KeyVersion k2 = kpExt.decryptEncryptedKey(ek2);
@@ -790,7 +788,7 @@ public class TestKMS {
             .getMaterial().length; i++) {
           isEq = k2.getMaterial()[i] == k1.getMaterial()[i];
         }
-        Assert.assertFalse(isEq);
+        Assertions.assertFalse(isEq);
 
         // test re-encrypt
         kpExt.rollNewVersion(ek1.getEncryptionKeyName());
@@ -833,25 +831,25 @@ public class TestKMS {
         // Check decryption after Key deletion
         try {
           kpExt.decryptEncryptedKey(ek1);
-          Assert.fail("Should not be allowed !!");
+          Assertions.fail("Should not be allowed !!");
         } catch (Exception e) {
-          Assert.assertTrue(e.getMessage().contains("'k1@1' not found"));
+          Assertions.assertTrue(e.getMessage().contains("'k1@1' not found"));
         }
 
         // getKey()
-        Assert.assertNull(kp.getKeyVersion("k1"));
+        Assertions.assertNull(kp.getKeyVersion("k1"));
 
         // getKeyVersions()
-        Assert.assertNull(kp.getKeyVersions("k1"));
+        Assertions.assertNull(kp.getKeyVersions("k1"));
 
         // getMetadata()
-        Assert.assertNull(kp.getMetadata("k1"));
+        Assertions.assertNull(kp.getMetadata("k1"));
 
         // getKeys() empty
-        Assert.assertTrue(kp.getKeys().isEmpty());
+        Assertions.assertTrue(kp.getKeys().isEmpty());
 
         // getKeysMetadata() empty
-        Assert.assertEquals(0, kp.getKeysMetadata().length);
+        Assertions.assertEquals(0, kp.getKeysMetadata().length);
 
         // createKey() no description, no tags
         options = new KeyProvider.Options(conf);
@@ -859,15 +857,15 @@ public class TestKMS {
         options.setBitLength(128);
         KeyVersion kVer2 = kp.createKey("k2", options);
         KeyProvider.Metadata meta = kp.getMetadata("k2");
-        Assert.assertNull(meta.getDescription());
-        Assert.assertEquals("k2", meta.getAttributes().get("key.acl.name"));
+        Assertions.assertNull(meta.getDescription());
+        Assertions.assertEquals("k2", meta.getAttributes().get("key.acl.name"));
 
         // test key ACL.. k2 is granted only MANAGEMENT Op access
         try {
           kpExt =
               KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
           kpExt.generateEncryptedKey(kVer2.getName());
-          Assert.fail("User should not be allowed to encrypt !!");
+          Assertions.fail("User should not be allowed to encrypt !!");
         } catch (Exception ex) {
           // 
         }
@@ -879,8 +877,8 @@ public class TestKMS {
         options.setDescription("d");
         kp.createKey("k3", options);
         meta = kp.getMetadata("k3");
-        Assert.assertEquals("d", meta.getDescription());
-        Assert.assertEquals("k3", meta.getAttributes().get("key.acl.name"));
+        Assertions.assertEquals("d", meta.getDescription());
+        Assertions.assertEquals("k3", meta.getAttributes().get("key.acl.name"));
 
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("a", "A");
@@ -893,8 +891,8 @@ public class TestKMS {
         options.setAttributes(attributes);
         kp.createKey("k4", options);
         meta = kp.getMetadata("k4");
-        Assert.assertNull(meta.getDescription());
-        Assert.assertEquals(attributes, meta.getAttributes());
+        Assertions.assertNull(meta.getDescription());
+        Assertions.assertEquals(attributes, meta.getAttributes());
 
         // createKey() description, tags
         options = new KeyProvider.Options(conf);
@@ -905,8 +903,8 @@ public class TestKMS {
         options.setAttributes(attributes);
         kp.createKey("k5", options);
         meta = kp.getMetadata("k5");
-        Assert.assertEquals("d", meta.getDescription());
-        Assert.assertEquals(attributes, meta.getAttributes());
+        Assertions.assertEquals("d", meta.getDescription());
+        Assertions.assertEquals(attributes, meta.getAttributes());
 
         // test rollover draining
         KeyProviderCryptoExtension kpce = KeyProviderCryptoExtension.
@@ -920,9 +918,9 @@ public class TestKMS {
         kpce.rollNewVersion("k6");
         kpce.invalidateCache("k6");
         EncryptedKeyVersion ekv2 = kpce.generateEncryptedKey("k6");
-        assertNotEquals("rollover did not generate a new key even after"
-            + " queue is drained", ekv1.getEncryptionKeyVersionName(),
-            ekv2.getEncryptionKeyVersionName());
+        assertNotEquals(ekv1.getEncryptionKeyVersionName()
+,             ekv2.getEncryptionKeyVersionName(), "rollover did not generate a new key even after"
+            + " queue is drained");
         return null;
       }
     });
@@ -965,22 +963,22 @@ public class TestKMS {
         KeyProvider.KeyVersion kv0 = kmscp.createKey(keyName, options);
         assertNotNull(kv0.getVersionName());
 
-        assertEquals("Default key version name is incorrect.", "k1@0",
-            kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName());
+        assertEquals("k1@0",
+            kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(), "Default key version name is incorrect.");
 
         kmscp.invalidateCache(keyName);
         kq.get(keyName).put(mockEKV);
-        assertEquals("Key version incorrect after invalidating cache + putting"
-                + " mock key.", mockVersionName,
-            kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName());
+        assertEquals(mockVersionName
+,             kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(), "Key version incorrect after invalidating cache + putting"
+                + " mock key.");
 
         // test new version is returned after invalidation.
         for (int i = 0; i < 100; ++i) {
           kq.get(keyName).put(mockEKV);
           kmscp.invalidateCache(keyName);
-          assertEquals("Cache invalidation guarantee failed.", "k1@0",
+          assertEquals("k1@0",
               kmscp.generateEncryptedKey(keyName)
-                  .getEncryptionKeyVersionName());
+                  .getEncryptionKeyVersionName(), "Cache invalidation guarantee failed.");
         }
         return null;
       }
@@ -1040,14 +1038,14 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "test_key");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("k0", options);
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("k0");
-              Assert.assertNull(rollVersion.getMaterial());
+              Assertions.assertNull(rollVersion.getMaterial());
               KeyProviderCryptoExtension kpce =
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("k0");
-                Assert.fail("User [CREATE] should not be allowed to generate_eek on k0");
+                Assertions.fail("User [CREATE] should not be allowed to generate_eek on k0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1056,12 +1054,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assert.fail("User [CREATE] should not be allowed to create kx");
+                Assertions.fail("User [CREATE] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1080,14 +1078,14 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "some_key");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("kk0", options);
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("kk0");
-              Assert.assertNull(rollVersion.getMaterial());
+              Assertions.assertNull(rollVersion.getMaterial());
               KeyProviderCryptoExtension kpce =
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("kk0");
-                Assert.fail("User [DECRYPT_EEK] should not be allowed to generate_eek on kk0");
+                Assertions.fail("User [DECRYPT_EEK] should not be allowed to generate_eek on kk0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1096,7 +1094,7 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               kp.createKey("kkx", options);
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1113,12 +1111,12 @@ public class TestKMS {
               newAttribs.put("key.acl.name", "test_key2");
               options.setAttributes(newAttribs);
               KeyProvider.KeyVersion kv = kp.createKey("k1", options);
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
               KeyVersion rollVersion = kp.rollNewVersion("k1");
-              Assert.assertNull(rollVersion.getMaterial());
+              Assertions.assertNull(rollVersion.getMaterial());
               try {
                 kp.rollNewVersion("k0");
-                Assert.fail("User [ROLLOVER] should not be allowed to rollover k0");
+                Assertions.fail("User [ROLLOVER] should not be allowed to rollover k0");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1126,7 +1124,7 @@ public class TestKMS {
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               try {
                 kpce.generateEncryptedKey("k1");
-                Assert.fail("User [ROLLOVER] should not be allowed to generate_eek on k1");
+                Assertions.fail("User [ROLLOVER] should not be allowed to generate_eek on k1");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1135,12 +1133,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assert.fail("User [ROLLOVER] should not be allowed to create kx");
+                Assertions.fail("User [ROLLOVER] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1158,7 +1156,7 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("k2", options);
-                Assert.fail("User [GET] should not be allowed to create key..");
+                Assertions.fail("User [GET] should not be allowed to create key..");
               } catch (Exception e) {
                 // Ignore
               }
@@ -1167,12 +1165,12 @@ public class TestKMS {
               options.setAttributes(newAttribs);
               try {
                 kp.createKey("kx", options);
-                Assert.fail("User [GET] should not be allowed to create kx");
+                Assertions.fail("User [GET] should not be allowed to create kx");
               } catch (Exception e) {
                 // Ignore
               }
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1194,10 +1192,10 @@ public class TestKMS {
               try {
                 return kpce.generateEncryptedKey("kx");
               } catch (Exception e) {
-                Assert.fail("User [GENERATE_EEK] should be allowed to generate_eek on kx");
+                Assertions.fail("User [GENERATE_EEK] should be allowed to generate_eek on kx");
               }
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1212,7 +1210,7 @@ public class TestKMS {
                   KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp);
               kpce.decryptEncryptedKey(ekv);
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1420,11 +1418,11 @@ public class TestKMS {
                     try {
                       kp.createKey("k4", new byte[16],
                           new KeyProvider.Options(conf));
-                      Assert.fail("This should not succeed..");
+                      Assertions.fail("This should not succeed..");
                     } catch (IOException e) {
-                      Assert.assertTrue(
-                          "HTTP exception must be a 401 : " + e.getMessage(), e
-                              .getMessage().contains("401"));
+                      Assertions.assertTrue(
+                      e
+                              .getMessage().contains("401"), "HTTP exception must be a 401 : " + e.getMessage());
                     }
                     return null;
                   }
@@ -1475,85 +1473,85 @@ public class TestKMS {
             KeyProvider kp = createProvider(uri, conf);
             try {
               kp.createKey("k", new KeyProvider.Options(conf));
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.createKey("k", new byte[16], new KeyProvider.Options(conf));
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.rollNewVersion("k");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.rollNewVersion("k", new byte[16]);
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.getKeys();
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.getKeysMetadata("k");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               // we are using JavaKeyStoreProvider for testing, so we know how
               // the keyversion is created.
               kp.getKeyVersion("k@0");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.getCurrentKey("k");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.getMetadata("k");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             try {
               kp.getKeyVersions("k");
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
 
             return null;
@@ -1567,9 +1565,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv = kp.createKey("k0",
                   new KeyProvider.Options(conf));
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1582,7 +1580,7 @@ public class TestKMS {
             try {
               kp.deleteKey("k0");
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1595,9 +1593,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv = kp.createKey("k1", new byte[16],
                   new KeyProvider.Options(conf));
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1609,9 +1607,9 @@ public class TestKMS {
             KeyProvider kp = createProvider(uri, conf);
             try {
               KeyProvider.KeyVersion kv = kp.rollNewVersion("k1");
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1624,9 +1622,9 @@ public class TestKMS {
             try {
               KeyProvider.KeyVersion kv =
                   kp.rollNewVersion("k1", new byte[16]);
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1642,7 +1640,7 @@ public class TestKMS {
               KeyVersion kv = kp.getCurrentKey("k1");
               return kv;
             } catch (Exception ex) {
-              Assert.fail(ex.toString());
+              Assertions.fail(ex.toString());
             }
             return null;
           }
@@ -1661,7 +1659,7 @@ public class TestKMS {
                   kpCE.generateEncryptedKey(currKv.getName());
               return ek1;
             } catch (Exception ex) {
-              Assert.fail(ex.toString());
+              Assertions.fail(ex.toString());
             }
             return null;
           }
@@ -1691,7 +1689,7 @@ public class TestKMS {
                       createKeyProviderCryptoExtension(kp);
               kpCE.decryptEncryptedKey(encKv);
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1704,7 +1702,7 @@ public class TestKMS {
             try {
               kp.getKeys();
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1718,7 +1716,7 @@ public class TestKMS {
               kp.getMetadata("k1");
               kp.getKeysMetadata("k1");
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1743,11 +1741,11 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("k2",
                   new KeyProvider.Options(conf));
-              Assert.fail();
+              Assertions.fail();
             } catch (AuthorizationException ex) {
               //NOP
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
 
             return null;
@@ -1854,9 +1852,9 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck0");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1872,7 +1870,7 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck1");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assert.fail("admin user must not be allowed to decrypt !!");
+              Assertions.fail("admin user must not be allowed to decrypt !!");
             } catch (Exception ex) {
             }
             return null;
@@ -1889,7 +1887,7 @@ public class TestKMS {
               EncryptedKeyVersion eek =
                   ((CryptoExtension)kp).generateEncryptedKey("ck2");
               ((CryptoExtension)kp).decryptEncryptedKey(eek);
-              Assert.fail("admin user must not be allowed to decrypt !!");
+              Assertions.fail("admin user must not be allowed to decrypt !!");
             } catch (Exception ex) {
             }
             return null;
@@ -1934,9 +1932,9 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("ck0",
                   new KeyProvider.Options(conf));
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1949,9 +1947,9 @@ public class TestKMS {
               KeyProvider kp = createProvider(uri, conf);
               KeyProvider.KeyVersion kv = kp.createKey("ck1",
                   new KeyProvider.Options(conf));
-              Assert.assertNull(kv.getMaterial());
+              Assertions.assertNull(kv.getMaterial());
             } catch (Exception ex) {
-              Assert.fail(ex.getMessage());
+              Assertions.fail(ex.getMessage());
             }
             return null;
           }
@@ -1994,7 +1992,7 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assert.assertTrue("Caught unexpected exception" + e.toString(), false);
+      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
     caughtTimeout = false;
@@ -2005,7 +2003,7 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assert.assertTrue("Caught unexpected exception" + e.toString(), false);
+      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
     caughtTimeout = false;
@@ -2018,10 +2016,10 @@ public class TestKMS {
     } catch (SocketTimeoutException e) {
       caughtTimeout = true;
     } catch (IOException e) {
-      Assert.assertTrue("Caught unexpected exception" + e.toString(), false);
+      Assertions.assertTrue(false, "Caught unexpected exception" + e.toString());
     }
 
-    Assert.assertTrue(caughtTimeout);
+    Assertions.assertTrue(caughtTimeout);
 
     sock.close();
   }
@@ -2137,7 +2135,7 @@ public class TestKMS {
                     .createKeyProviderDelegationTokenExtension(kp);
             keyProviderDelegationTokenExtension.addDelegationTokens("client",
                 credentials);
-            Assert.assertNotNull(kp.createKey("kcc",
+            Assertions.assertNotNull(kp.createKey("kcc",
                 new KeyProvider.Options(conf)));
             return null;
           }
@@ -2151,7 +2149,7 @@ public class TestKMS {
           @Override
           public Void run() throws Exception {
             final KeyProvider kp = createProvider(uri, conf);
-            Assert.assertNotNull(kp.getMetadata("kcc"));
+            Assertions.assertNotNull(kp.getMetadata("kcc"));
             return null;
           }
         });
@@ -2193,11 +2191,11 @@ public class TestKMS {
   }
 
   private Text getTokenService(KeyProvider provider) {
-    assertTrue("KeyProvider should be an instance of " +
-        "LoadBalancingKMSClientProvider", (provider instanceof
-            LoadBalancingKMSClientProvider));
-    assertEquals("Num client providers should be 1", 1,
-        ((LoadBalancingKMSClientProvider)provider).getProviders().length);
+    assertTrue((provider instanceof
+            LoadBalancingKMSClientProvider), "KeyProvider should be an instance of " +
+        "LoadBalancingKMSClientProvider");
+    assertEquals(1
+,         ((LoadBalancingKMSClientProvider)provider).getProviders().length, "Num client providers should be 1");
     final Text tokenService = new Text(
         (((LoadBalancingKMSClientProvider)provider).getProviders()[0])
         .getCanonicalServiceName());
@@ -2252,8 +2250,8 @@ public class TestKMS {
             final Token<?>[] tokens =
                 kpdte.addDelegationTokens("client1", credentials);
             Text tokenService = getTokenService(kp);
-            Assert.assertEquals(1, credentials.getAllTokens().size());
-            Assert.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            Assertions.assertEquals(1, credentials.getAllTokens().size());
+            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
                 credentials.getToken(tokenService).getKind());
 
             // Test non-renewer user cannot renew.
@@ -2265,7 +2263,7 @@ public class TestKMS {
               LOG.info("Got dt for " + uri + "; " + token);
               try {
                 token.renew(clientConf);
-                Assert.fail("client should not be allowed to renew token with"
+                Assertions.fail("client should not be allowed to renew token with"
                     + "renewer=client1");
               } catch (Exception e) {
                 final DelegationTokenIdentifier identifier =
@@ -2306,10 +2304,10 @@ public class TestKMS {
                     long newTokenLife = token.renew(clientConf);
                     LOG.info("Renewed token of kind {}, new lifetime:{}",
                         token.getKind(), newTokenLife);
-                    Assert.assertTrue(newTokenLife > tokenLife);
+                    Assertions.assertTrue(newTokenLife > tokenLife);
                     renewed = true;
                   }
-                  Assert.assertTrue(renewed);
+                  Assertions.assertTrue(renewed);
 
                   // test delegation token cancellation
                   for (Token<?> token : tokens) {
@@ -2323,8 +2321,7 @@ public class TestKMS {
                     LOG.info("Cancelled token of kind {}", token.getKind());
                     try {
                       token.renew(clientConf);
-                      Assert
-                          .fail("should not be able to renew a canceled token");
+                      fail("should not be able to renew a canceled token");
                     } catch (Exception e) {
                       LOG.info("Expected exception when renewing token", e);
                     }
@@ -2380,8 +2377,8 @@ public class TestKMS {
             final Credentials credentials = new Credentials();
             kpdte.addDelegationTokens("client", credentials);
             Text tokenService = getTokenService(kp);
-            Assert.assertEquals(1, credentials.getAllTokens().size());
-            Assert.assertEquals(KMSDelegationToken.TOKEN_KIND, credentials.
+            Assertions.assertEquals(1, credentials.getAllTokens().size());
+            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND, credentials.
                 getToken(tokenService).getKind());
             UserGroupInformation.getCurrentUser().addCredentials(credentials);
             LOG.info("Added kms dt to credentials: {}", UserGroupInformation.
@@ -2389,7 +2386,7 @@ public class TestKMS {
             Token<?> token =
                 UserGroupInformation.getCurrentUser().getCredentials()
                     .getToken(tokenService);
-            Assert.assertNotNull(token);
+            Assertions.assertNotNull(token);
             job1Token.add(token);
 
             // Decode the token to get max time.
@@ -2404,18 +2401,18 @@ public class TestKMS {
 
             // wait for token to expire.
             Thread.sleep(5100);
-            Assert.assertTrue("maxTime " + maxTime + " is not less than now.",
-                maxTime > 0 && maxTime < Time.now());
+            Assertions.assertTrue(
+               maxTime > 0 && maxTime < Time.now(), "maxTime " + maxTime + " is not less than now.");
             try {
               kp.getKeys();
-              Assert.fail("Operation should fail since dt is expired.");
+              Assertions.fail("Operation should fail since dt is expired.");
             } catch (Exception e) {
               LOG.info("Expected error.", e);
             }
             return null;
           }
         });
-        Assert.assertFalse(job1Token.isEmpty());
+        Assertions.assertFalse(job1Token.isEmpty());
 
         // job 2 (e.g. Another YARN log aggregation job, with user DT.
         doAs("client", new PrivilegedExceptionAction<Void>() {
@@ -2425,8 +2422,8 @@ public class TestKMS {
             final Credentials newCreds = new Credentials();
             kpdte.addDelegationTokens("client", newCreds);
             Text tokenService = getTokenService(kp);
-            Assert.assertEquals(1, newCreds.getAllTokens().size());
-            Assert.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            Assertions.assertEquals(1, newCreds.getAllTokens().size());
+            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
                 newCreds.getToken(tokenService).
                     getKind());
 
@@ -2442,14 +2439,14 @@ public class TestKMS {
                 .getCurrentUser().getCredentials().getAllTokens());
             try {
               kp.getKeys();
-              Assert.fail("Operation should fail since dt is expired.");
+              Assertions.fail("Operation should fail since dt is expired.");
             } catch (Exception e) {
               LOG.info("Expected error.", e);
             }
 
             // Using the new DT should succeed.
-            Assert.assertEquals(1, newCreds.getAllTokens().size());
-            Assert.assertEquals(KMSDelegationToken.TOKEN_KIND,
+            Assertions.assertEquals(1, newCreds.getAllTokens().size());
+            Assertions.assertEquals(KMSDelegationToken.TOKEN_KIND,
                 newCreds.getToken(tokenService).
                     getKind());
             UserGroupInformation.getCurrentUser().addCredentials(newCreds);
@@ -2777,7 +2774,7 @@ public class TestKMS {
             fooUgi.doAs(new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {
-                Assert.assertNotNull(kp.createKey("kbb",
+                Assertions.assertNotNull(kp.createKey("kbb",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2791,11 +2788,11 @@ public class TestKMS {
               public Void run() throws Exception {
                 try {
                   kp.createKey("kcc", new KeyProvider.Options(conf));
-                  Assert.fail();
+                  Assertions.fail();
                 } catch (AuthorizationException ex) {
                   // OK
                 } catch (Exception ex) {
-                  Assert.fail(ex.getMessage());
+                  Assertions.fail(ex.getMessage());
                 }
                 return null;
               }
@@ -2807,7 +2804,7 @@ public class TestKMS {
             barUgi.doAs(new PrivilegedExceptionAction<Void>() {
               @Override
               public Void run() throws Exception {
-                Assert.assertNotNull(kp.createKey("kdd",
+                Assertions.assertNotNull(kp.createKey("kdd",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2949,7 +2946,7 @@ public class TestKMS {
               @Override
               public Void run() throws Exception {
                 KeyProvider kp = createProvider(uri, conf);
-                Assert.assertNotNull(kp.createKey("kaa",
+                Assertions.assertNotNull(kp.createKey("kaa",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -2964,7 +2961,7 @@ public class TestKMS {
                 try {
                   KeyProvider kp = createProvider(uri, conf);
                   kp.createKey("kbb", new KeyProvider.Options(conf));
-                  Assert.fail();
+                  Assertions.fail();
                 } catch (Exception ex) {
                   GenericTestUtils.assertExceptionContains("Error while " +
                       "authenticating with endpoint", ex);
@@ -2983,7 +2980,7 @@ public class TestKMS {
               @Override
               public Void run() throws Exception {
                 KeyProvider kp = createProvider(uri, conf);
-                Assert.assertNotNull(kp.createKey("kcc",
+                Assertions.assertNotNull(kp.createKey("kcc",
                     new KeyProvider.Options(conf)));
                 return null;
               }
@@ -3065,7 +3062,7 @@ public class TestKMS {
           @Override
           public Void run() throws Exception {
             final KeyProvider kp = createProvider(uri, conf);
-            Assert.assertTrue(kp.getKeys().isEmpty());
+            Assertions.assertTrue(kp.getKeys().isEmpty());
             return null;
           }
         });

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMS.java
@@ -919,8 +919,9 @@ public class TestKMS {
         kpce.rollNewVersion("k6");
         kpce.invalidateCache("k6");
         EncryptedKeyVersion ekv2 = kpce.generateEncryptedKey("k6");
-        assertNotEquals(ekv1.getEncryptionKeyVersionName()
-,             ekv2.getEncryptionKeyVersionName(), "rollover did not generate a new key even after"
+        assertNotEquals(ekv1.getEncryptionKeyVersionName(),
+            ekv2.getEncryptionKeyVersionName(),
+            "rollover did not generate a new key even after"
             + " queue is drained");
         return null;
       }
@@ -964,22 +965,22 @@ public class TestKMS {
         KeyProvider.KeyVersion kv0 = kmscp.createKey(keyName, options);
         assertNotNull(kv0.getVersionName());
 
-        assertEquals("k1@0",
-            kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(), "Default key version name is incorrect.");
+        assertEquals("k1@0", kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(),
+            "Default key version name is incorrect.");
 
         kmscp.invalidateCache(keyName);
         kq.get(keyName).put(mockEKV);
-        assertEquals(mockVersionName
-,             kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(), "Key version incorrect after invalidating cache + putting"
-                + " mock key.");
+        assertEquals(mockVersionName,
+            kmscp.generateEncryptedKey(keyName).getEncryptionKeyVersionName(),
+            "Key version incorrect after invalidating cache + putting"
+            + " mock key.");
 
         // test new version is returned after invalidation.
         for (int i = 0; i < 100; ++i) {
           kq.get(keyName).put(mockEKV);
           kmscp.invalidateCache(keyName);
-          assertEquals("k1@0",
-              kmscp.generateEncryptedKey(keyName)
-                  .getEncryptionKeyVersionName(), "Cache invalidation guarantee failed.");
+          assertEquals("k1@0", kmscp.generateEncryptedKey(keyName)
+              .getEncryptionKeyVersionName(), "Cache invalidation guarantee failed.");
         }
         return null;
       }
@@ -1421,9 +1422,8 @@ public class TestKMS {
                           new KeyProvider.Options(conf));
                       fail("This should not succeed..");
                     } catch (IOException e) {
-                      assertTrue(
-                      e
-                              .getMessage().contains("401"), "HTTP exception must be a 401 : " + e.getMessage());
+                      assertTrue(e.getMessage().contains("401"),
+                          "HTTP exception must be a 401 : " + e.getMessage());
                     }
                     return null;
                   }
@@ -2192,11 +2192,10 @@ public class TestKMS {
   }
 
   private Text getTokenService(KeyProvider provider) {
-    assertTrue((provider instanceof
-            LoadBalancingKMSClientProvider), "KeyProvider should be an instance of " +
-        "LoadBalancingKMSClientProvider");
-    assertEquals(1
-,         ((LoadBalancingKMSClientProvider)provider).getProviders().length, "Num client providers should be 1");
+    assertTrue((provider instanceof LoadBalancingKMSClientProvider),
+        "KeyProvider should be an instance of " + "LoadBalancingKMSClientProvider");
+    assertEquals(1, ((LoadBalancingKMSClientProvider)provider).getProviders().length,
+        "Num client providers should be 1");
     final Text tokenService = new Text(
         (((LoadBalancingKMSClientProvider)provider).getProviders()[0])
         .getCanonicalServiceName());
@@ -2402,8 +2401,8 @@ public class TestKMS {
 
             // wait for token to expire.
             Thread.sleep(5100);
-            assertTrue(
-               maxTime > 0 && maxTime < Time.now(), "maxTime " + maxTime + " is not less than now.");
+            assertTrue(maxTime > 0 && maxTime < Time.now(),
+                "maxTime " + maxTime + " is not less than now.");
             try {
               kp.getKeys();
               fail("Operation should fail since dt is expired.");

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSACLs.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSACLs.java
@@ -20,11 +20,14 @@ package org.apache.hadoop.crypto.key.kms.server;
 import static org.apache.hadoop.crypto.key.kms.server.KMSConfiguration.*;
 import static org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KEY_ACL;
 import static org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KeyOpType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -38,7 +41,7 @@ public class TestKMSACLs {
   public void testDefaults() {
     final KMSACLs acls = new KMSACLs(new Configuration(false));
     for (KMSACLs.Type type : KMSACLs.Type.values()) {
-      Assertions.assertTrue(acls.hasAccess(type,
+      assertTrue(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser("foo")));
     }
   }
@@ -51,9 +54,9 @@ public class TestKMSACLs {
     }
     final KMSACLs acls = new KMSACLs(conf);
     for (KMSACLs.Type type : KMSACLs.Type.values()) {
-      Assertions.assertTrue(acls.hasAccess(type,
+      assertTrue(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser(type.toString())));
-      Assertions.assertFalse(acls.hasAccess(type,
+      assertFalse(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser("foo")));
     }
   }
@@ -69,16 +72,16 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "ALL", "invalid");
     conf.set(WHITELIST_KEY_ACL_PREFIX + "ALL", "invalid");
     final KMSACLs acls = new KMSACLs(conf);
-    Assertions.assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
+    assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
         + acls.keyAcls.size());
-    Assertions.assertTrue(acls.whitelistKeyAcls.size() == 1, "expected whitelist ACL size is 1 but got "
+    assertTrue(acls.whitelistKeyAcls.size() == 1, "expected whitelist ACL size is 1 but got "
         + acls.whitelistKeyAcls.size());
-    Assertions.assertFalse(
-       acls.whitelistKeyAcls.containsKey(KeyOpType.ALL), "ALL should not be allowed for whitelist ACLs.");
-    Assertions.assertTrue(acls.defaultKeyAcls.size() == 1, "expected default ACL size is 1 but got "
+    assertFalse(acls.whitelistKeyAcls.containsKey(KeyOpType.ALL),
+        "ALL should not be allowed for whitelist ACLs.");
+    assertTrue(acls.defaultKeyAcls.size() == 1, "expected default ACL size is 1 but got "
         + acls.defaultKeyAcls.size());
-    Assertions.assertTrue(
-       acls.defaultKeyAcls.size() == 1, "ALL should not be allowed for default ACLs.");
+    assertTrue(acls.defaultKeyAcls.size() == 1,
+        "ALL should not be allowed for default ACLs.");
   }
 
   @Test
@@ -95,15 +98,15 @@ public class TestKMSACLs {
     conf.set(WHITELIST_KEY_ACL_PREFIX + "DECRYPT_EEK", "whitelist1");
     conf.set(WHITELIST_KEY_ACL_PREFIX + "DECRYPT_EEK", "*");
     final KMSACLs acls = new KMSACLs(conf);
-    Assertions.assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
+    assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
         + acls.keyAcls.size());
     assertKeyAcl("test_key_1", acls, KeyOpType.DECRYPT_EEK, "decrypt2");
     assertKeyAcl("test_key_2", acls, KeyOpType.ALL, "all1", "all3");
     assertDefaultKeyAcl(acls, KeyOpType.MANAGEMENT);
     assertDefaultKeyAcl(acls, KeyOpType.DECRYPT_EEK);
     AccessControlList acl = acls.whitelistKeyAcls.get(KeyOpType.DECRYPT_EEK);
-    Assertions.assertNotNull(acl);
-    Assertions.assertTrue(acl.isAllAllowed());
+    assertNotNull(acl);
+    assertTrue(acl.isAllAllowed());
   }
 
   @Test
@@ -160,8 +163,8 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "DECRYPT_EEK", "*");
     acls.setKeyACLs(conf);
     AccessControlList acl = acls.defaultKeyAcls.get(KeyOpType.DECRYPT_EEK);
-    Assertions.assertTrue(acl.isAllAllowed());
-    Assertions.assertTrue(acl.getUsers().isEmpty());
+    assertTrue(acl.isAllAllowed());
+    assertTrue(acl.getUsers().isEmpty());
     // everything else should still be the same.
     assertDefaultKeyAcl(acls, KeyOpType.READ, "read2");
     assertDefaultKeyAcl(acls, KeyOpType.MANAGEMENT, "mgmt1", "mgmt2");
@@ -178,9 +181,9 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "DECRYPT_EEK", "new");
     acls.setKeyACLs(conf);
     assertDefaultKeyAcl(acls, KeyOpType.DECRYPT_EEK, "new");
-    Assertions.assertTrue(acls.keyAcls.isEmpty());
-    Assertions.assertTrue(acls.whitelistKeyAcls.isEmpty());
-    Assertions.assertEquals(1, acls.defaultKeyAcls.size(), "Got unexpected sized acls:"
+    assertTrue(acls.keyAcls.isEmpty());
+    assertTrue(acls.whitelistKeyAcls.isEmpty());
+    assertEquals(1, acls.defaultKeyAcls.size(), "Got unexpected sized acls:"
         + acls.defaultKeyAcls);
   }
 
@@ -198,23 +201,22 @@ public class TestKMSACLs {
 
   private void assertKeyAcl(final String keyName, final KMSACLs acls,
       final KeyOpType op, final String... names) {
-    Assertions.assertTrue(acls.keyAcls.containsKey(keyName));
+    assertTrue(acls.keyAcls.containsKey(keyName));
     final HashMap<KeyOpType, AccessControlList> keyacl =
         acls.keyAcls.get(keyName);
-    Assertions.assertNotNull(keyacl.get(op));
+    assertNotNull(keyacl.get(op));
     assertAcl(keyacl.get(op), op, names);
   }
 
   private void assertAcl(final AccessControlList acl,
       final KeyOpType op, final String... names) {
-    Assertions.assertNotNull(acl);
-    Assertions.assertFalse(acl.isAllAllowed());
+    assertNotNull(acl);
+    assertFalse(acl.isAllAllowed());
     final Collection<String> actual = acl.getUsers();
     final HashSet<String> expected = new HashSet<>();
     for (String name : names) {
       expected.add(name);
     }
-    Assertions.assertEquals(
-       expected, actual, "defaultKeyAcls don't match for op:" + op);
+    assertEquals(expected, actual, "defaultKeyAcls don't match for op:" + op);
   }
 }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSACLs.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSACLs.java
@@ -24,24 +24,21 @@ import static org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvide
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AccessControlList;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 
+@Timeout(180)
 public class TestKMSACLs {
-  @Rule
-  public final Timeout globalTimeout = new Timeout(180000);
-
   @Test
   public void testDefaults() {
     final KMSACLs acls = new KMSACLs(new Configuration(false));
     for (KMSACLs.Type type : KMSACLs.Type.values()) {
-      Assert.assertTrue(acls.hasAccess(type,
+      Assertions.assertTrue(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser("foo")));
     }
   }
@@ -54,9 +51,9 @@ public class TestKMSACLs {
     }
     final KMSACLs acls = new KMSACLs(conf);
     for (KMSACLs.Type type : KMSACLs.Type.values()) {
-      Assert.assertTrue(acls.hasAccess(type,
+      Assertions.assertTrue(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser(type.toString())));
-      Assert.assertFalse(acls.hasAccess(type,
+      Assertions.assertFalse(acls.hasAccess(type,
           UserGroupInformation.createRemoteUser("foo")));
     }
   }
@@ -72,16 +69,16 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "ALL", "invalid");
     conf.set(WHITELIST_KEY_ACL_PREFIX + "ALL", "invalid");
     final KMSACLs acls = new KMSACLs(conf);
-    Assert.assertTrue("expected key ACL size is 2 but got "
-        + acls.keyAcls.size(), acls.keyAcls.size() == 2);
-    Assert.assertTrue("expected whitelist ACL size is 1 but got "
-        + acls.whitelistKeyAcls.size(), acls.whitelistKeyAcls.size() == 1);
-    Assert.assertFalse("ALL should not be allowed for whitelist ACLs.",
-        acls.whitelistKeyAcls.containsKey(KeyOpType.ALL));
-    Assert.assertTrue("expected default ACL size is 1 but got "
-        + acls.defaultKeyAcls.size(), acls.defaultKeyAcls.size() == 1);
-    Assert.assertTrue("ALL should not be allowed for default ACLs.",
-        acls.defaultKeyAcls.size() == 1);
+    Assertions.assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
+        + acls.keyAcls.size());
+    Assertions.assertTrue(acls.whitelistKeyAcls.size() == 1, "expected whitelist ACL size is 1 but got "
+        + acls.whitelistKeyAcls.size());
+    Assertions.assertFalse(
+       acls.whitelistKeyAcls.containsKey(KeyOpType.ALL), "ALL should not be allowed for whitelist ACLs.");
+    Assertions.assertTrue(acls.defaultKeyAcls.size() == 1, "expected default ACL size is 1 but got "
+        + acls.defaultKeyAcls.size());
+    Assertions.assertTrue(
+       acls.defaultKeyAcls.size() == 1, "ALL should not be allowed for default ACLs.");
   }
 
   @Test
@@ -98,15 +95,15 @@ public class TestKMSACLs {
     conf.set(WHITELIST_KEY_ACL_PREFIX + "DECRYPT_EEK", "whitelist1");
     conf.set(WHITELIST_KEY_ACL_PREFIX + "DECRYPT_EEK", "*");
     final KMSACLs acls = new KMSACLs(conf);
-    Assert.assertTrue("expected key ACL size is 2 but got "
-        + acls.keyAcls.size(), acls.keyAcls.size() == 2);
+    Assertions.assertTrue(acls.keyAcls.size() == 2, "expected key ACL size is 2 but got "
+        + acls.keyAcls.size());
     assertKeyAcl("test_key_1", acls, KeyOpType.DECRYPT_EEK, "decrypt2");
     assertKeyAcl("test_key_2", acls, KeyOpType.ALL, "all1", "all3");
     assertDefaultKeyAcl(acls, KeyOpType.MANAGEMENT);
     assertDefaultKeyAcl(acls, KeyOpType.DECRYPT_EEK);
     AccessControlList acl = acls.whitelistKeyAcls.get(KeyOpType.DECRYPT_EEK);
-    Assert.assertNotNull(acl);
-    Assert.assertTrue(acl.isAllAllowed());
+    Assertions.assertNotNull(acl);
+    Assertions.assertTrue(acl.isAllAllowed());
   }
 
   @Test
@@ -163,8 +160,8 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "DECRYPT_EEK", "*");
     acls.setKeyACLs(conf);
     AccessControlList acl = acls.defaultKeyAcls.get(KeyOpType.DECRYPT_EEK);
-    Assert.assertTrue(acl.isAllAllowed());
-    Assert.assertTrue(acl.getUsers().isEmpty());
+    Assertions.assertTrue(acl.isAllAllowed());
+    Assertions.assertTrue(acl.getUsers().isEmpty());
     // everything else should still be the same.
     assertDefaultKeyAcl(acls, KeyOpType.READ, "read2");
     assertDefaultKeyAcl(acls, KeyOpType.MANAGEMENT, "mgmt1", "mgmt2");
@@ -181,10 +178,10 @@ public class TestKMSACLs {
     conf.set(DEFAULT_KEY_ACL_PREFIX + "DECRYPT_EEK", "new");
     acls.setKeyACLs(conf);
     assertDefaultKeyAcl(acls, KeyOpType.DECRYPT_EEK, "new");
-    Assert.assertTrue(acls.keyAcls.isEmpty());
-    Assert.assertTrue(acls.whitelistKeyAcls.isEmpty());
-    Assert.assertEquals("Got unexpected sized acls:"
-        + acls.defaultKeyAcls, 1, acls.defaultKeyAcls.size());
+    Assertions.assertTrue(acls.keyAcls.isEmpty());
+    Assertions.assertTrue(acls.whitelistKeyAcls.isEmpty());
+    Assertions.assertEquals(1, acls.defaultKeyAcls.size(), "Got unexpected sized acls:"
+        + acls.defaultKeyAcls);
   }
 
   private void assertDefaultKeyAcl(final KMSACLs acls, final KeyOpType op,
@@ -201,23 +198,23 @@ public class TestKMSACLs {
 
   private void assertKeyAcl(final String keyName, final KMSACLs acls,
       final KeyOpType op, final String... names) {
-    Assert.assertTrue(acls.keyAcls.containsKey(keyName));
+    Assertions.assertTrue(acls.keyAcls.containsKey(keyName));
     final HashMap<KeyOpType, AccessControlList> keyacl =
         acls.keyAcls.get(keyName);
-    Assert.assertNotNull(keyacl.get(op));
+    Assertions.assertNotNull(keyacl.get(op));
     assertAcl(keyacl.get(op), op, names);
   }
 
   private void assertAcl(final AccessControlList acl,
       final KeyOpType op, final String... names) {
-    Assert.assertNotNull(acl);
-    Assert.assertFalse(acl.isAllAllowed());
+    Assertions.assertNotNull(acl);
+    Assertions.assertFalse(acl.isAllAllowed());
     final Collection<String> actual = acl.getUsers();
     final HashSet<String> expected = new HashSet<>();
     for (String name : names) {
       expected.add(name);
     }
-    Assert.assertEquals("defaultKeyAcls don't match for op:" + op,
-        expected, actual);
+    Assertions.assertEquals(
+       expected, actual, "defaultKeyAcls don't match for op:" + op);
   }
 }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -35,13 +35,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.*;
 
+@Timeout(180)
 public class TestKMSAudit {
 
   private PrintStream originalOut;
@@ -63,10 +59,7 @@ public class TestKMSAudit {
     }
   }
 
-  @Rule
-  public final Timeout testTimeout = new Timeout(180000L, TimeUnit.MILLISECONDS);
-
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     originalOut = System.err;
     memOut = new ByteArrayOutputStream();
@@ -81,7 +74,7 @@ public class TestKMSAudit {
     this.kmsAudit = new KMSAudit(conf);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     System.setErr(originalOut);
     LogManager.resetConfiguration();
@@ -138,7 +131,7 @@ public class TestKMSAudit {
             + "OK\\[op=REENCRYPT_EEK_BATCH, key=k1, user=luser@REALM\\] testmsg"
             + "OK\\[op=REENCRYPT_EEK_BATCH, key=k1, user=luser@REALM\\] "
             + "testmsg");
-    Assert.assertTrue(doesMatch);
+    Assertions.assertTrue(doesMatch);
   }
 
   @Test
@@ -179,7 +172,7 @@ public class TestKMSAudit {
             + " interval=[^m]{1,4}ms\\] testmsg"
             + "OK\\[op=GENERATE_EEK, key=k3, user=luser@REALM, accessCount=1,"
             + " interval=[^m]{1,4}ms\\] testmsg");
-    Assert.assertTrue(doesMatch);
+    Assertions.assertTrue(doesMatch);
   }
 
   @Test
@@ -192,7 +185,7 @@ public class TestKMSAudit {
     kmsAudit.unauthenticated("remotehost", "method", "url", "testmsg");
     String out = getAndResetLogOutput();
     System.out.println(out);
-    Assert.assertTrue(out.matches(
+    Assertions.assertTrue(out.matches(
         "OK\\[op=GENERATE_EEK, key=k4, user=luser@REALM, accessCount=1, "
             + "interval=[^m]{1,4}ms\\] testmsg"
             + "OK\\[op=GENERATE_EEK, user=luser@REALM\\] testmsg"
@@ -211,8 +204,8 @@ public class TestKMSAudit {
     List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) FieldUtils.
         getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
 
-    Assert.assertEquals(1, loggers.size());
-    Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
+    Assertions.assertEquals(1, loggers.size());
+    Assertions.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 
     // Explicitly configure the simple logger. Duplicates are ignored.
     final Configuration conf = new Configuration();
@@ -222,15 +215,15 @@ public class TestKMSAudit {
     final KMSAudit audit = new KMSAudit(conf);
     loggers = (List<KMSAuditLogger>) FieldUtils.
         getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
-    Assert.assertEquals(1, loggers.size());
-    Assert.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
+    Assertions.assertEquals(1, loggers.size());
+    Assertions.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 
     // If any loggers unable to load, init should fail.
     conf.set(KMSConfiguration.KMS_AUDIT_LOGGER_KEY,
         SimpleKMSAuditLogger.class.getName() + ",unknown");
     try {
       new KMSAudit(conf);
-      Assert.fail("loggers configured but invalid, init should fail.");
+      Assertions.fail("loggers configured but invalid, init should fail.");
     } catch (Exception ex) {
       GenericTestUtils
           .assertExceptionContains(KMSConfiguration.KMS_AUDIT_LOGGER_KEY, ex);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -35,7 +35,14 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Timeout(180)
 public class TestKMSAudit {
@@ -131,7 +138,7 @@ public class TestKMSAudit {
             + "OK\\[op=REENCRYPT_EEK_BATCH, key=k1, user=luser@REALM\\] testmsg"
             + "OK\\[op=REENCRYPT_EEK_BATCH, key=k1, user=luser@REALM\\] "
             + "testmsg");
-    Assertions.assertTrue(doesMatch);
+    assertTrue(doesMatch);
   }
 
   @Test
@@ -172,7 +179,7 @@ public class TestKMSAudit {
             + " interval=[^m]{1,4}ms\\] testmsg"
             + "OK\\[op=GENERATE_EEK, key=k3, user=luser@REALM, accessCount=1,"
             + " interval=[^m]{1,4}ms\\] testmsg");
-    Assertions.assertTrue(doesMatch);
+    assertTrue(doesMatch);
   }
 
   @Test
@@ -185,7 +192,7 @@ public class TestKMSAudit {
     kmsAudit.unauthenticated("remotehost", "method", "url", "testmsg");
     String out = getAndResetLogOutput();
     System.out.println(out);
-    Assertions.assertTrue(out.matches(
+    assertTrue(out.matches(
         "OK\\[op=GENERATE_EEK, key=k4, user=luser@REALM, accessCount=1, "
             + "interval=[^m]{1,4}ms\\] testmsg"
             + "OK\\[op=GENERATE_EEK, user=luser@REALM\\] testmsg"
@@ -204,8 +211,8 @@ public class TestKMSAudit {
     List<KMSAuditLogger> loggers = (List<KMSAuditLogger>) FieldUtils.
         getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
 
-    Assertions.assertEquals(1, loggers.size());
-    Assertions.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
+    assertEquals(1, loggers.size());
+    assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 
     // Explicitly configure the simple logger. Duplicates are ignored.
     final Configuration conf = new Configuration();
@@ -215,15 +222,15 @@ public class TestKMSAudit {
     final KMSAudit audit = new KMSAudit(conf);
     loggers = (List<KMSAuditLogger>) FieldUtils.
         getField(KMSAudit.class, "auditLoggers", true).get(kmsAudit);
-    Assertions.assertEquals(1, loggers.size());
-    Assertions.assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
+    assertEquals(1, loggers.size());
+    assertEquals(SimpleKMSAuditLogger.class, loggers.get(0).getClass());
 
     // If any loggers unable to load, init should fail.
     conf.set(KMSConfiguration.KMS_AUDIT_LOGGER_KEY,
         SimpleKMSAuditLogger.class.getName() + ",unknown");
     try {
       new KMSAudit(conf);
-      Assertions.fail("loggers configured but invalid, init should fail.");
+      fail("loggers configured but invalid, init should fail.");
     } catch (Exception ex) {
       GenericTestUtils
           .assertExceptionContains(KMSConfiguration.KMS_AUDIT_LOGGER_KEY, ex);

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAuthenticationFilter.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAuthenticationFilter.java
@@ -23,17 +23,18 @@ import org.apache.hadoop.security.token.delegation.web
     .DelegationTokenAuthenticationHandler;
 import org.apache.hadoop.security.token.delegation.web
     .PseudoDelegationTokenAuthenticationHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test KMS Authentication Filter.
  */
 public class TestKMSAuthenticationFilter {
 
-  @Test public void testConfiguration() throws Exception {
+  @Test
+  public void testConfiguration() throws Exception {
     Configuration conf = new Configuration();
     conf.set("hadoop.kms.authentication.type", "simple");
 

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSMDCFilter.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSMDCFilter.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.crypto.key.kms.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -30,8 +30,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -48,7 +48,7 @@ public class TestKMSMDCFilter {
   private HttpServletRequest httpRequest;
   private HttpServletResponse httpResponse;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     filter = new KMSMDCFilter();
     httpRequest = Mockito.mock(HttpServletRequest.class);
@@ -66,10 +66,10 @@ public class TestKMSMDCFilter {
       @Override
       public void doFilter(ServletRequest request, ServletResponse response)
           throws IOException, ServletException {
-        assertEquals("filter.remoteClientAddress", REMOTE_ADDRESS,
-            KMSMDCFilter.getRemoteClientAddress());
-        assertEquals("filter.method", METHOD, KMSMDCFilter.getMethod());
-        assertEquals("filter.url", URL, KMSMDCFilter.getURL());
+        assertEquals(REMOTE_ADDRESS
+,             KMSMDCFilter.getRemoteClientAddress(), "filter.remoteClientAddress");
+        assertEquals(METHOD, KMSMDCFilter.getMethod(), "filter.method");
+        assertEquals(URL, KMSMDCFilter.getURL(), "filter.url");
       }
     };
 
@@ -79,10 +79,10 @@ public class TestKMSMDCFilter {
   }
 
   private void checkMDCValuesAreEmpty() {
-    assertNull("getRemoteClientAddress", KMSMDCFilter.getRemoteClientAddress());
-    assertNull("getMethod", KMSMDCFilter.getMethod());
-    assertNull("getURL", KMSMDCFilter.getURL());
-    assertNull("getUgi", KMSMDCFilter.getUgi());
+    assertNull(KMSMDCFilter.getRemoteClientAddress(), "getRemoteClientAddress");
+    assertNull(KMSMDCFilter.getMethod(), "getMethod");
+    assertNull(KMSMDCFilter.getURL(), "getURL");
+    assertNull(KMSMDCFilter.getUgi(), "getUgi");
   }
 
 }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSMDCFilter.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSMDCFilter.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.crypto.key.kms.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -32,7 +33,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /**
  * Test for {@link KMSMDCFilter}.
@@ -51,8 +51,8 @@ public class TestKMSMDCFilter {
   @BeforeEach
   public void setUp() throws IOException {
     filter = new KMSMDCFilter();
-    httpRequest = Mockito.mock(HttpServletRequest.class);
-    httpResponse = Mockito.mock(HttpServletResponse.class);
+    httpRequest = mock(HttpServletRequest.class);
+    httpResponse = mock(HttpServletResponse.class);
     KMSMDCFilter.setContext(null, null, null, null);
   }
 
@@ -66,8 +66,8 @@ public class TestKMSMDCFilter {
       @Override
       public void doFilter(ServletRequest request, ServletResponse response)
           throws IOException, ServletException {
-        assertEquals(REMOTE_ADDRESS
-,             KMSMDCFilter.getRemoteClientAddress(), "filter.remoteClientAddress");
+        assertEquals(REMOTE_ADDRESS,
+            KMSMDCFilter.getRemoteClientAddress(), "filter.remoteClientAddress");
         assertEquals(METHOD, KMSMDCFilter.getMethod(), "filter.method");
         assertEquals(URL, KMSMDCFilter.getURL(), "filter.url");
       }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSWithZK.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSWithZK.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.util.ZKSignerSecretProvider;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticatedURL;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.HttpURLConnection;
@@ -97,7 +97,7 @@ public class TestKMSWithZK {
         @Override
         public Object run() throws Exception {
           HttpURLConnection conn = aUrl.openConnection(url1, token);
-          Assert.assertEquals(HttpURLConnection.HTTP_OK,
+          Assertions.assertEquals(HttpURLConnection.HTTP_OK,
               conn.getResponseCode());
           return null;
         }
@@ -107,7 +107,7 @@ public class TestKMSWithZK {
         @Override
         public Object run() throws Exception {
           HttpURLConnection conn = aUrl.openConnection(url2, token);
-          Assert.assertEquals(HttpURLConnection.HTTP_OK,
+          Assertions.assertEquals(HttpURLConnection.HTTP_OK,
               conn.getResponseCode());
           return null;
         }
@@ -119,7 +119,7 @@ public class TestKMSWithZK {
           final DelegationTokenAuthenticatedURL.Token emptyToken =
               new DelegationTokenAuthenticatedURL.Token();
           HttpURLConnection conn = aUrl.openConnection(url2, emptyToken);
-          Assert.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+          Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
               conn.getResponseCode());
           return null;
         }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSWithZK.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSWithZK.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.crypto.key.kms.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.kms.KMSRESTConstants;
@@ -25,7 +27,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.util.ZKSignerSecretProvider;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticatedURL;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -97,7 +98,7 @@ public class TestKMSWithZK {
         @Override
         public Object run() throws Exception {
           HttpURLConnection conn = aUrl.openConnection(url1, token);
-          Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+          assertEquals(HttpURLConnection.HTTP_OK,
               conn.getResponseCode());
           return null;
         }
@@ -107,7 +108,7 @@ public class TestKMSWithZK {
         @Override
         public Object run() throws Exception {
           HttpURLConnection conn = aUrl.openConnection(url2, token);
-          Assertions.assertEquals(HttpURLConnection.HTTP_OK,
+          assertEquals(HttpURLConnection.HTTP_OK,
               conn.getResponseCode());
           return null;
         }
@@ -119,7 +120,7 @@ public class TestKMSWithZK {
           final DelegationTokenAuthenticatedURL.Token emptyToken =
               new DelegationTokenAuthenticatedURL.Token();
           HttpURLConnection conn = aUrl.openConnection(url2, emptyToken);
-          Assertions.assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
+          assertEquals(HttpURLConnection.HTTP_FORBIDDEN,
               conn.getResponseCode());
           return null;
         }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
@@ -221,27 +221,26 @@ public class TestKeyAuthorizationKeyProvider {
   @Test
   public void testDecryptWithKeyVersionNameKeyMismatch() throws Exception {
     assertThrows(IllegalArgumentException.class, () -> {
-          final Configuration conf = new Configuration();
-          KeyProvider kp =
-        new UserProvider.Factory().createProvider(new URI("user:///"), conf);
-          KeyACLs mock = mock(KeyACLs.class);
-          when(mock.isACLPresent("testKey", KeyOpType.MANAGEMENT)).thenReturn(true);
-          when(mock.isACLPresent("testKey", KeyOpType.GENERATE_EEK)).thenReturn(true);
-          when(mock.isACLPresent("testKey", KeyOpType.DECRYPT_EEK)).thenReturn(true);
-          when(mock.isACLPresent("testKey", KeyOpType.ALL)).thenReturn(true);
-          UserGroupInformation u1 = UserGroupInformation.createRemoteUser("u1");
-          UserGroupInformation u2 = UserGroupInformation.createRemoteUser("u2");
-          UserGroupInformation u3 = UserGroupInformation.createRemoteUser("u3");
-          UserGroupInformation sudo = UserGroupInformation.createRemoteUser("sudo");
-          when(mock.hasAccessToKey("testKey", u1,
+      final Configuration conf = new Configuration();
+      KeyProvider kp = new UserProvider.Factory().createProvider(new URI("user:///"), conf);
+      KeyACLs mock = mock(KeyACLs.class);
+      when(mock.isACLPresent("testKey", KeyOpType.MANAGEMENT)).thenReturn(true);
+      when(mock.isACLPresent("testKey", KeyOpType.GENERATE_EEK)).thenReturn(true);
+      when(mock.isACLPresent("testKey", KeyOpType.DECRYPT_EEK)).thenReturn(true);
+      when(mock.isACLPresent("testKey", KeyOpType.ALL)).thenReturn(true);
+      UserGroupInformation u1 = UserGroupInformation.createRemoteUser("u1");
+      UserGroupInformation u2 = UserGroupInformation.createRemoteUser("u2");
+      UserGroupInformation u3 = UserGroupInformation.createRemoteUser("u3");
+      UserGroupInformation sudo = UserGroupInformation.createRemoteUser("sudo");
+      when(mock.hasAccessToKey("testKey", u1,
         KeyOpType.MANAGEMENT)).thenReturn(true);
-          when(mock.hasAccessToKey("testKey", u2,
+      when(mock.hasAccessToKey("testKey", u2,
         KeyOpType.GENERATE_EEK)).thenReturn(true);
-          when(mock.hasAccessToKey("testKey", u3,
+      when(mock.hasAccessToKey("testKey", u3,
         KeyOpType.DECRYPT_EEK)).thenReturn(true);
-          when(mock.hasAccessToKey("testKey", sudo,
+      when(mock.hasAccessToKey("testKey", sudo,
         KeyOpType.ALL)).thenReturn(true);
-          final KeyProviderCryptoExtension kpExt =
+      final KeyProviderCryptoExtension kpExt =
         new KeyAuthorizationKeyProvider(
             KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp),
             mock);
@@ -267,7 +266,7 @@ public class TestKeyAuthorizationKeyProvider {
             return null;
           }
         }
-    );
-      });
+      );
+    });
   }
 }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
@@ -241,31 +241,31 @@ public class TestKeyAuthorizationKeyProvider {
       when(mock.hasAccessToKey("testKey", sudo,
         KeyOpType.ALL)).thenReturn(true);
       final KeyProviderCryptoExtension kpExt =
-        new KeyAuthorizationKeyProvider(
+          new KeyAuthorizationKeyProvider(
             KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp),
             mock);
-          sudo.doAs(
-        new PrivilegedExceptionAction<Void>() {
-          @Override
-          public Void run() throws Exception {
-            Options opt = newOptions(conf);
-            Map<String, String> m = new HashMap<String, String>();
-            m.put("key.acl.name", "testKey");
-            opt.setAttributes(m);
-            KeyVersion kv =
-                kpExt.createKey("foo", SecureRandom.getSeed(16), opt);
-            kpExt.rollNewVersion(kv.getName());
-            kpExt.rollNewVersion(kv.getName(), SecureRandom.getSeed(16));
-            EncryptedKeyVersion ekv = kpExt.generateEncryptedKey(kv.getName());
-            ekv = EncryptedKeyVersion.createForDecryption(
-                ekv.getEncryptionKeyName() + "x",
-                ekv.getEncryptionKeyVersionName(),
-                ekv.getEncryptedKeyIv(),
-                ekv.getEncryptedKeyVersion().getMaterial());
-            kpExt.decryptEncryptedKey(ekv);
-            return null;
+      sudo.doAs(
+          new PrivilegedExceptionAction<Void>() {
+            @Override
+            public Void run() throws Exception {
+              Options opt = newOptions(conf);
+              Map<String, String> m = new HashMap<String, String>();
+              m.put("key.acl.name", "testKey");
+              opt.setAttributes(m);
+              KeyVersion kv =
+                  kpExt.createKey("foo", SecureRandom.getSeed(16), opt);
+              kpExt.rollNewVersion(kv.getName());
+              kpExt.rollNewVersion(kv.getName(), SecureRandom.getSeed(16));
+              EncryptedKeyVersion ekv = kpExt.generateEncryptedKey(kv.getName());
+              ekv = EncryptedKeyVersion.createForDecryption(
+                  ekv.getEncryptionKeyName() + "x",
+                  ekv.getEncryptionKeyVersionName(),
+                  ekv.getEncryptedKeyIv(),
+                  ekv.getEncryptedKeyVersion().getMaterial());
+              kpExt.decryptEncryptedKey(ekv);
+              return null;
+            }
           }
-        }
       );
     });
   }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.crypto.key.UserProvider;
 import org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KeyACLs;
 import org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KeyOpType;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestKeyAuthorizationKeyProvider {
 
@@ -66,14 +66,14 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.createKey("foo", SecureRandom.getSeed(16),
                   newOptions(conf));
             } catch (IOException ioe) {
-              Assert.fail("User should be Authorized !!");
+              Assertions.fail("User should be Authorized !!");
             }
 
             // "bar" key not configured
             try {
               kpExt.createKey("bar", SecureRandom.getSeed(16),
                   newOptions(conf));
-              Assert.fail("User should NOT be Authorized !!");
+              Assertions.fail("User should NOT be Authorized !!");
             } catch (IOException ioe) {
               // Ignore
             }
@@ -90,7 +90,7 @@ public class TestKeyAuthorizationKeyProvider {
             try {
               kpExt.createKey("foo", SecureRandom.getSeed(16),
                   newOptions(conf));
-              Assert.fail("User should NOT be Authorized !!");
+              Assertions.fail("User should NOT be Authorized !!");
             } catch (IOException ioe) {
               // Ignore
             }
@@ -138,17 +138,17 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.rollNewVersion(kv.getName(), SecureRandom.getSeed(16));
               kpExt.deleteKey(kv.getName());
             } catch (IOException ioe) {
-              Assert.fail("User should be Authorized !!");
+              Assertions.fail("User should be Authorized !!");
             }
 
             KeyVersion retkv = null;
             try {
               retkv = kpExt.createKey("bar", SecureRandom.getSeed(16), opt);
               kpExt.generateEncryptedKey(retkv.getName());
-              Assert.fail("User should NOT be Authorized to generate EEK !!");
+              Assertions.fail("User should NOT be Authorized to generate EEK !!");
             } catch (IOException ioe) {
             }
-            Assert.assertNotNull(retkv);
+            Assertions.assertNotNull(retkv);
             return retkv;
           }
         }
@@ -161,7 +161,7 @@ public class TestKeyAuthorizationKeyProvider {
               public EncryptedKeyVersion run() throws Exception {
                 try {
                   kpExt.deleteKey(barKv.getName());
-                  Assert.fail("User should NOT be Authorized to "
+                  Assertions.fail("User should NOT be Authorized to "
                       + "perform any other operation !!");
                 } catch (IOException ioe) {
                 }
@@ -175,7 +175,7 @@ public class TestKeyAuthorizationKeyProvider {
           public KeyVersion run() throws Exception {
             try {
               kpExt.deleteKey(barKv.getName());
-              Assert.fail("User should NOT be Authorized to "
+              Assertions.fail("User should NOT be Authorized to "
                   + "perform any other operation !!");
             } catch (IOException ioe) {
             }
@@ -200,7 +200,7 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.decryptEncryptedKey(ekv);
               kpExt.deleteKey(kv.getName());
             } catch (IOException ioe) {
-              Assert.fail("User should be Allowed to do everything !!");
+              Assertions.fail("User should be Allowed to do everything !!");
             }
             return null;
           }
@@ -216,34 +216,34 @@ public class TestKeyAuthorizationKeyProvider {
   }
 
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecryptWithKeyVersionNameKeyMismatch() throws Exception {
-    final Configuration conf = new Configuration();
-    KeyProvider kp =
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          final Configuration conf = new Configuration();
+          KeyProvider kp =
         new UserProvider.Factory().createProvider(new URI("user:///"), conf);
-    KeyACLs mock = mock(KeyACLs.class);
-    when(mock.isACLPresent("testKey", KeyOpType.MANAGEMENT)).thenReturn(true);
-    when(mock.isACLPresent("testKey", KeyOpType.GENERATE_EEK)).thenReturn(true);
-    when(mock.isACLPresent("testKey", KeyOpType.DECRYPT_EEK)).thenReturn(true);
-    when(mock.isACLPresent("testKey", KeyOpType.ALL)).thenReturn(true);
-    UserGroupInformation u1 = UserGroupInformation.createRemoteUser("u1");
-    UserGroupInformation u2 = UserGroupInformation.createRemoteUser("u2");
-    UserGroupInformation u3 = UserGroupInformation.createRemoteUser("u3");
-    UserGroupInformation sudo = UserGroupInformation.createRemoteUser("sudo");
-    when(mock.hasAccessToKey("testKey", u1,
+          KeyACLs mock = mock(KeyACLs.class);
+          when(mock.isACLPresent("testKey", KeyOpType.MANAGEMENT)).thenReturn(true);
+          when(mock.isACLPresent("testKey", KeyOpType.GENERATE_EEK)).thenReturn(true);
+          when(mock.isACLPresent("testKey", KeyOpType.DECRYPT_EEK)).thenReturn(true);
+          when(mock.isACLPresent("testKey", KeyOpType.ALL)).thenReturn(true);
+          UserGroupInformation u1 = UserGroupInformation.createRemoteUser("u1");
+          UserGroupInformation u2 = UserGroupInformation.createRemoteUser("u2");
+          UserGroupInformation u3 = UserGroupInformation.createRemoteUser("u3");
+          UserGroupInformation sudo = UserGroupInformation.createRemoteUser("sudo");
+          when(mock.hasAccessToKey("testKey", u1,
         KeyOpType.MANAGEMENT)).thenReturn(true);
-    when(mock.hasAccessToKey("testKey", u2,
+          when(mock.hasAccessToKey("testKey", u2,
         KeyOpType.GENERATE_EEK)).thenReturn(true);
-    when(mock.hasAccessToKey("testKey", u3,
+          when(mock.hasAccessToKey("testKey", u3,
         KeyOpType.DECRYPT_EEK)).thenReturn(true);
-    when(mock.hasAccessToKey("testKey", sudo,
+          when(mock.hasAccessToKey("testKey", sudo,
         KeyOpType.ALL)).thenReturn(true);
-    final KeyProviderCryptoExtension kpExt =
+          final KeyProviderCryptoExtension kpExt =
         new KeyAuthorizationKeyProvider(
             KeyProviderCryptoExtension.createKeyProviderCryptoExtension(kp),
             mock);
-
-    sudo.doAs(
+          sudo.doAs(
         new PrivilegedExceptionAction<Void>() {
           @Override
           public Void run() throws Exception {
@@ -266,6 +266,8 @@ public class TestKeyAuthorizationKeyProvider {
           }
         }
     );
-  }
+      });
+  
+}
 
 }

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKeyAuthorizationKeyProvider.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.crypto.key.kms.server;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +40,6 @@ import org.apache.hadoop.crypto.key.UserProvider;
 import org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KeyACLs;
 import org.apache.hadoop.crypto.key.kms.server.KeyAuthorizationKeyProvider.KeyOpType;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestKeyAuthorizationKeyProvider {
@@ -66,14 +68,14 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.createKey("foo", SecureRandom.getSeed(16),
                   newOptions(conf));
             } catch (IOException ioe) {
-              Assertions.fail("User should be Authorized !!");
+              fail("User should be Authorized !!");
             }
 
             // "bar" key not configured
             try {
               kpExt.createKey("bar", SecureRandom.getSeed(16),
                   newOptions(conf));
-              Assertions.fail("User should NOT be Authorized !!");
+              fail("User should NOT be Authorized !!");
             } catch (IOException ioe) {
               // Ignore
             }
@@ -90,7 +92,7 @@ public class TestKeyAuthorizationKeyProvider {
             try {
               kpExt.createKey("foo", SecureRandom.getSeed(16),
                   newOptions(conf));
-              Assertions.fail("User should NOT be Authorized !!");
+              fail("User should NOT be Authorized !!");
             } catch (IOException ioe) {
               // Ignore
             }
@@ -138,17 +140,17 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.rollNewVersion(kv.getName(), SecureRandom.getSeed(16));
               kpExt.deleteKey(kv.getName());
             } catch (IOException ioe) {
-              Assertions.fail("User should be Authorized !!");
+              fail("User should be Authorized !!");
             }
 
             KeyVersion retkv = null;
             try {
               retkv = kpExt.createKey("bar", SecureRandom.getSeed(16), opt);
               kpExt.generateEncryptedKey(retkv.getName());
-              Assertions.fail("User should NOT be Authorized to generate EEK !!");
+              fail("User should NOT be Authorized to generate EEK !!");
             } catch (IOException ioe) {
             }
-            Assertions.assertNotNull(retkv);
+            assertNotNull(retkv);
             return retkv;
           }
         }
@@ -161,7 +163,7 @@ public class TestKeyAuthorizationKeyProvider {
               public EncryptedKeyVersion run() throws Exception {
                 try {
                   kpExt.deleteKey(barKv.getName());
-                  Assertions.fail("User should NOT be Authorized to "
+                  fail("User should NOT be Authorized to "
                       + "perform any other operation !!");
                 } catch (IOException ioe) {
                 }
@@ -175,7 +177,7 @@ public class TestKeyAuthorizationKeyProvider {
           public KeyVersion run() throws Exception {
             try {
               kpExt.deleteKey(barKv.getName());
-              Assertions.fail("User should NOT be Authorized to "
+              fail("User should NOT be Authorized to "
                   + "perform any other operation !!");
             } catch (IOException ioe) {
             }
@@ -200,7 +202,7 @@ public class TestKeyAuthorizationKeyProvider {
               kpExt.decryptEncryptedKey(ekv);
               kpExt.deleteKey(kv.getName());
             } catch (IOException ioe) {
-              Assertions.fail("User should be Allowed to do everything !!");
+              fail("User should be Allowed to do everything !!");
             }
             return null;
           }
@@ -218,7 +220,7 @@ public class TestKeyAuthorizationKeyProvider {
 
   @Test
   public void testDecryptWithKeyVersionNameKeyMismatch() throws Exception {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
           final Configuration conf = new Configuration();
           KeyProvider kp =
         new UserProvider.Factory().createProvider(new URI("user:///"), conf);
@@ -267,7 +269,5 @@ public class TestKeyAuthorizationKeyProvider {
         }
     );
       });
-  
-}
-
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19416. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-kms.

### How was this patch tested?

Junit test & mvn clean test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

