### PR TITLE
HADOOP-19414. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-auth.

### DIFF
--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -205,6 +205,11 @@
       <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
  </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/client/AuthenticatorTestCase.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/client/AuthenticatorTestCase.java
@@ -13,6 +13,11 @@
  */
 package org.apache.hadoop.security.authentication.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
@@ -54,8 +59,6 @@ import java.net.URL;
 import java.security.Principal;
 import java.util.EnumSet;
 import java.util.Properties;
-
-import org.junit.Assert;
 
 public class AuthenticatorTestCase {
   private Server server;
@@ -170,11 +173,11 @@ public class AuthenticatorTestCase {
     try {
       URL url = new URL(getBaseURL());
       AuthenticatedURL.Token token = new AuthenticatedURL.Token();
-      Assert.assertFalse(token.isSet());
+      assertFalse(token.isSet());
       TestConnectionConfigurator connConf = new TestConnectionConfigurator();
       AuthenticatedURL aUrl = new AuthenticatedURL(authenticator, connConf);
       HttpURLConnection conn = aUrl.openConnection(url, token);
-      Assert.assertTrue(connConf.invoked);
+      assertTrue(connConf.invoked);
       String tokenStr = token.toString();
       if (doPost) {
         conn.setRequestMethod("POST");
@@ -186,18 +189,18 @@ public class AuthenticatorTestCase {
         writer.write(POST);
         writer.close();
       }
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+      assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
       if (doPost) {
         BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
         String echo = reader.readLine();
-        Assert.assertEquals(POST, echo);
-        Assert.assertNull(reader.readLine());
+        assertEquals(POST, echo);
+        assertNull(reader.readLine());
       }
       aUrl = new AuthenticatedURL();
       conn = aUrl.openConnection(url, token);
       conn.connect();
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
-      Assert.assertEquals(tokenStr, token.toString());
+      assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+      assertEquals(tokenStr, token.toString());
     } finally {
       stop();
     }
@@ -233,7 +236,7 @@ public class AuthenticatorTestCase {
     try {
       response = httpClient.execute(request);
       final int httpStatus = response.getStatusLine().getStatusCode();
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, httpStatus);
+      assertEquals(HttpURLConnection.HTTP_OK, httpStatus);
     } finally {
       if (response != null) EntityUtils.consumeQuietly(response.getEntity());
     }
@@ -255,7 +258,7 @@ public class AuthenticatorTestCase {
         // Important that the entity is not repeatable -- this means if
         // we have to renegotiate (e.g. b/c the cookie wasn't handled properly)
         // the test will fail.
-        Assert.assertFalse(entity.isRepeatable());
+        assertFalse(entity.isRepeatable());
         post.setEntity(entity);
         doHttpClientRequest(httpClient, post);
       }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/client/TestPseudoAuthenticator.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/client/TestPseudoAuthenticator.java
@@ -13,10 +13,12 @@
  */
 package org.apache.hadoop.security.authentication.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.server.PseudoAuthenticationHandler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -34,7 +36,7 @@ public class TestPseudoAuthenticator {
   @Test
   public void testGetUserName() throws Exception {
     PseudoAuthenticator authenticator = new PseudoAuthenticator();
-    Assert.assertEquals(System.getProperty("user.name"), authenticator.getUserName());
+    assertEquals(System.getProperty("user.name"), authenticator.getUserName());
   }
 
   @Test
@@ -47,7 +49,7 @@ public class TestPseudoAuthenticator {
       URL url = new URL(auth.getBaseURL());
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.connect();
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+      assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     } finally {
       auth.stop();
     }
@@ -63,9 +65,9 @@ public class TestPseudoAuthenticator {
       URL url = new URL(auth.getBaseURL());
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.connect();
-      Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
-      Assert.assertTrue(conn.getHeaderFields().containsKey("WWW-Authenticate"));
-      Assert.assertEquals("Authentication required", conn.getResponseMessage());
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
+      assertTrue(conn.getHeaderFields().containsKey("WWW-Authenticate"));
+      assertEquals("Authentication required", conn.getResponseMessage());
     } finally {
       auth.stop();
     }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationToken.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestAuthenticationToken.java
@@ -13,18 +13,21 @@
  */
 package org.apache.hadoop.security.authentication.server;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
 
 public class TestAuthenticationToken {
 
   @Test
   public void testAnonymous() {
-    Assert.assertNotNull(AuthenticationToken.ANONYMOUS);
-    Assert.assertEquals(null, AuthenticationToken.ANONYMOUS.getUserName());
-    Assert.assertEquals(null, AuthenticationToken.ANONYMOUS.getName());
-    Assert.assertEquals(null, AuthenticationToken.ANONYMOUS.getType());
-    Assert.assertEquals(-1, AuthenticationToken.ANONYMOUS.getExpires());
-    Assert.assertFalse(AuthenticationToken.ANONYMOUS.isExpired());
+    assertNotNull(AuthenticationToken.ANONYMOUS);
+    assertEquals(null, AuthenticationToken.ANONYMOUS.getUserName());
+    assertEquals(null, AuthenticationToken.ANONYMOUS.getName());
+    assertEquals(null, AuthenticationToken.ANONYMOUS.getType());
+    assertEquals(-1, AuthenticationToken.ANONYMOUS.getExpires());
+    assertFalse(AuthenticationToken.ANONYMOUS.isExpired());
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestLdapAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestLdapAuthenticationHandler.java
@@ -13,6 +13,14 @@
  */
 package org.apache.hadoop.security.authentication.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -32,12 +40,10 @@ import org.apache.directory.server.core.annotations.CreatePartition;
 import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
 import org.apache.directory.server.core.integ.ApacheDSTestExtension;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 
 /**
  * This unit test verifies the functionality of LDAP authentication handler.
@@ -89,78 +95,78 @@ public class TestLdapAuthenticationHandler extends AbstractLdapTestUnit {
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testRequestWithoutAuthorization() throws Exception {
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
 
-    Assertions.assertNull(handler.authenticate(request, response));
-    Mockito.verify(response).setHeader(WWW_AUTHENTICATE, HttpConstants.BASIC);
-    Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    assertNull(handler.authenticate(request, response));
+    verify(response).setHeader(WWW_AUTHENTICATE, HttpConstants.BASIC);
+    verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testRequestWithInvalidAuthorization() throws Exception {
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
 
     final Base64 base64 = new Base64(0);
     String credentials = "bjones:invalidpassword";
-    Mockito.when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
+    when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
         .thenReturn(base64.encodeToString(credentials.getBytes()));
-    Assertions.assertNull(handler.authenticate(request, response));
-    Mockito.verify(response).setHeader(WWW_AUTHENTICATE, HttpConstants.BASIC);
-    Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    assertNull(handler.authenticate(request, response));
+    verify(response).setHeader(WWW_AUTHENTICATE, HttpConstants.BASIC);
+    verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testRequestWithIncompleteAuthorization() throws Exception {
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
 
-    Mockito.when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
+    when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
         .thenReturn(HttpConstants.BASIC);
-    Assertions.assertNull(handler.authenticate(request, response));
+    assertNull(handler.authenticate(request, response));
   }
 
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testRequestWithAuthorization() throws Exception {
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
 
     final Base64 base64 = new Base64(0);
     String credentials = base64.encodeToString("bjones:p@ssw0rd".getBytes());
     String authHeader = HttpConstants.BASIC + " " + credentials;
-    Mockito.when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
+    when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
         .thenReturn(authHeader);
     AuthenticationToken token = handler.authenticate(request, response);
-    Assertions.assertNotNull(token);
-    Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);
-    Assertions.assertEquals(token.getType(), TYPE);
-    Assertions.assertEquals(token.getUserName(), "bjones");
-    Assertions.assertEquals(token.getName(), "bjones");
+    assertNotNull(token);
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    assertEquals(token.getType(), TYPE);
+    assertEquals(token.getUserName(), "bjones");
+    assertEquals(token.getName(), "bjones");
   }
 
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testRequestWithWrongCredentials() throws Exception {
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
 
     final Base64 base64 = new Base64(0);
     String credentials = base64.encodeToString("bjones:foo123".getBytes());
     String authHeader = HttpConstants.BASIC + " " + credentials;
-    Mockito.when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
+    when(request.getHeader(HttpConstants.AUTHORIZATION_HEADER))
         .thenReturn(authHeader);
 
     try {
       handler.authenticate(request, response);
-      Assertions.fail();
+      fail();
     } catch (AuthenticationException ex) {
       // Expected
     } catch (Exception ex) {
-      Assertions.fail();
+      fail();
     }
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestPseudoAuthenticationHandler.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/server/TestPseudoAuthenticationHandler.java
@@ -13,10 +13,14 @@
  */
 package org.apache.hadoop.security.authentication.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -32,7 +36,7 @@ public class TestPseudoAuthenticationHandler {
       Properties props = new Properties();
       props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED, "false");
       handler.init(props);
-      Assert.assertEquals(false, handler.getAcceptAnonymous());
+      assertEquals(false, handler.getAcceptAnonymous());
     } finally {
       handler.destroy();
     }
@@ -41,7 +45,7 @@ public class TestPseudoAuthenticationHandler {
   @Test
   public void testType() throws Exception {
     PseudoAuthenticationHandler handler = new PseudoAuthenticationHandler();
-    Assert.assertEquals(PseudoAuthenticationHandler.TYPE, handler.getType());
+    assertEquals(PseudoAuthenticationHandler.TYPE, handler.getType());
   }
 
   @Test
@@ -52,12 +56,12 @@ public class TestPseudoAuthenticationHandler {
       props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED, "true");
       handler.init(props);
 
-      HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-      HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      HttpServletResponse response = mock(HttpServletResponse.class);
 
       AuthenticationToken token = handler.authenticate(request, response);
 
-      Assert.assertEquals(AuthenticationToken.ANONYMOUS, token);
+      assertEquals(AuthenticationToken.ANONYMOUS, token);
     } finally {
       handler.destroy();
     }
@@ -71,11 +75,11 @@ public class TestPseudoAuthenticationHandler {
       props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED, "false");
       handler.init(props);
 
-      HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-      HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      HttpServletResponse response = mock(HttpServletResponse.class);
 
       AuthenticationToken token = handler.authenticate(request, response);
-      Assert.assertNull(token);
+      assertNull(token);
     } finally {
       handler.destroy();
     }
@@ -88,16 +92,16 @@ public class TestPseudoAuthenticationHandler {
       props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED, Boolean.toString(anonymous));
       handler.init(props);
 
-      HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-      HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-      Mockito.when(request.getQueryString()).thenReturn(PseudoAuthenticator.USER_NAME + "=" + "user");
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      HttpServletResponse response = mock(HttpServletResponse.class);
+      when(request.getQueryString()).thenReturn(PseudoAuthenticator.USER_NAME + "=" + "user");
 
       AuthenticationToken token = handler.authenticate(request, response);
 
-      Assert.assertNotNull(token);
-      Assert.assertEquals("user", token.getUserName());
-      Assert.assertEquals("user", token.getName());
-      Assert.assertEquals(PseudoAuthenticationHandler.TYPE, token.getType());
+      assertNotNull(token);
+      assertEquals("user", token.getUserName());
+      assertEquals("user", token.getName());
+      assertEquals(PseudoAuthenticationHandler.TYPE, token.getType());
     } finally {
       handler.destroy();
     }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestAuthToken.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestAuthToken.java
@@ -13,9 +13,13 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAuthToken {
 
@@ -23,51 +27,51 @@ public class TestAuthToken {
   public void testConstructor() throws Exception {
     try {
       new AuthToken(null, "p", "t");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       new AuthToken("", "p", "t");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       new AuthToken("u", null, "t");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       new AuthToken("u", "", "t");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       new AuthToken("u", "p", null);
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       new AuthToken("u", "p", "");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     new AuthToken("u", "p", "t");
   }
@@ -77,13 +81,13 @@ public class TestAuthToken {
     long expires = System.currentTimeMillis() + 50;
     AuthToken token = new AuthToken("u", "p", "t");
     token.setExpires(expires);
-    Assert.assertEquals("u", token.getUserName());
-    Assert.assertEquals("p", token.getName());
-    Assert.assertEquals("t", token.getType());
-    Assert.assertEquals(expires, token.getExpires());
-    Assert.assertFalse(token.isExpired());
+    assertEquals("u", token.getUserName());
+    assertEquals("p", token.getName());
+    assertEquals("t", token.getType());
+    assertEquals(expires, token.getExpires());
+    assertFalse(token.isExpired());
     Thread.sleep(70);               // +20 msec fuzz for timer granularity.
-    Assert.assertTrue(token.isExpired());
+    assertTrue(token.isExpired());
   }
 
   @Test
@@ -93,12 +97,12 @@ public class TestAuthToken {
     token.setExpires(expires);
     String str = token.toString();
     token = AuthToken.parse(str);
-    Assert.assertEquals("p", token.getName());
-    Assert.assertEquals("t", token.getType());
-    Assert.assertEquals(expires, token.getExpires());
-    Assert.assertFalse(token.isExpired());
+    assertEquals("p", token.getName());
+    assertEquals("t", token.getType());
+    assertEquals(expires, token.getExpires());
+    assertFalse(token.isExpired());
     Thread.sleep(70);               // +20 msec fuzz for timer granularity.
-    Assert.assertTrue(token.isExpired());
+    assertTrue(token.isExpired());
   }
 
   @Test
@@ -117,11 +121,11 @@ public class TestAuthToken {
     String str = ostr.substring(0, ostr.indexOf("e="));
     try {
       AuthToken.parse(str);
-      Assert.fail();
+      fail();
     } catch (AuthenticationException ex) {
       // Expected
     } catch (Exception ex) {
-      Assert.fail();
+      fail();
     }
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestCertificateUtil.java
@@ -17,16 +17,16 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.interfaces.RSAPublicKey;
 
 import javax.servlet.ServletException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCertificateUtil {
 

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestFileSignerSecretProvider.java
@@ -14,17 +14,17 @@
 package org.apache.hadoop.security.authentication.util;
 
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 import java.util.Properties;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFileSignerSecretProvider {
 
@@ -46,11 +46,11 @@ public class TestFileSignerSecretProvider {
             AuthenticationFilter.SIGNATURE_SECRET_FILE,
         secretFile.getAbsolutePath());
     secretProvider.init(secretProviderProps, null, -1);
-    Assert.assertArrayEquals(secretValue.getBytes(),
+    assertArrayEquals(secretValue.getBytes(),
         secretProvider.getCurrentSecret());
     byte[][] allSecrets = secretProvider.getAllSecrets();
-    Assert.assertEquals(1, allSecrets.length);
-    Assert.assertArrayEquals(secretValue.getBytes(), allSecrets[0]);
+    assertEquals(1, allSecrets.length);
+    assertArrayEquals(secretValue.getBytes(), allSecrets[0]);
   }
 
   @Test
@@ -66,11 +66,8 @@ public class TestFileSignerSecretProvider {
             secretFile.getAbsolutePath());
 
     Exception exception =
-        assertThrows(RuntimeException.class, new ThrowingRunnable() {
-          @Override
-          public void run() throws Throwable {
-            secretProvider.init(secretProviderProps, null, -1);
-          }
+        assertThrows(RuntimeException.class, () -> {
+          secretProvider.init(secretProviderProps, null, -1);
         });
     assertTrue(exception.getMessage().startsWith(
         "No secret in signature secret file:"));

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestJaasConfiguration.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestJaasConfiguration.java
@@ -13,10 +13,12 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Map;
 import javax.security.auth.login.AppConfigurationEntry;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJaasConfiguration {
 
@@ -36,20 +38,20 @@ public class TestJaasConfiguration {
             new JaasConfiguration("foo", "foo/localhost",
             "/some/location/foo.keytab");
     AppConfigurationEntry[] entries = jConf.getAppConfigurationEntry("bar");
-    Assert.assertNull(entries);
+    assertNull(entries);
     entries = jConf.getAppConfigurationEntry("foo");
-    Assert.assertEquals(1, entries.length);
+    assertEquals(1, entries.length);
     AppConfigurationEntry entry = entries[0];
-    Assert.assertEquals(AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-            entry.getControlFlag());
-    Assert.assertEquals(krb5LoginModuleName, entry.getLoginModuleName());
+    assertEquals(AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        entry.getControlFlag());
+    assertEquals(krb5LoginModuleName, entry.getLoginModuleName());
     Map<String, ?> options = entry.getOptions();
-    Assert.assertEquals("/some/location/foo.keytab", options.get("keyTab"));
-    Assert.assertEquals("foo/localhost", options.get("principal"));
-    Assert.assertEquals("true", options.get("useKeyTab"));
-    Assert.assertEquals("true", options.get("storeKey"));
-    Assert.assertEquals("false", options.get("useTicketCache"));
-    Assert.assertEquals("true", options.get("refreshKrb5Config"));
-    Assert.assertEquals(6, options.size());
+    assertEquals("/some/location/foo.keytab", options.get("keyTab"));
+    assertEquals("foo/localhost", options.get("principal"));
+    assertEquals("true", options.get("useKeyTab"));
+    assertEquals("true", options.get("storeKey"));
+    assertEquals("false", options.get("useTicketCache"));
+    assertEquals("true", options.get("refreshKrb5Config"));
+    assertEquals(6, options.size());
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestKerberosName.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestKerberosName.java
@@ -18,18 +18,20 @@
 
 package org.apache.hadoop.security.authentication.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 
 import org.apache.hadoop.security.authentication.KerberosTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestKerberosName {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     System.setProperty("java.security.krb5.realm", KerberosTestUtils.getRealm());
     System.setProperty("java.security.krb5.kdc", "localhost:88");
@@ -50,7 +52,7 @@ public class TestKerberosName {
     KerberosName nm = new KerberosName(from);
     String simple = nm.getShortName();
     System.out.println("to " + simple);
-    Assert.assertEquals("short name incorrect", to, simple);
+    assertEquals(to, simple, "short name incorrect");
   }
 
   @Test
@@ -67,7 +69,7 @@ public class TestKerberosName {
     System.out.println("Checking " + name + " to ensure it is bad.");
     try {
       new KerberosName(name);
-      Assert.fail("didn't get exception for " + name);
+      fail("didn't get exception for " + name);
     } catch (IllegalArgumentException iae) {
       // PASS
     }
@@ -78,7 +80,7 @@ public class TestKerberosName {
     KerberosName nm = new KerberosName(from);
     try {
       nm.getShortName();
-      Assert.fail("didn't get exception for " + from);
+      fail("didn't get exception for " + from);
     } catch (IOException ie) {
       // PASS
     }
@@ -105,19 +107,19 @@ public class TestKerberosName {
     final String principalNameWoHost = "HTTP@EXAMPLE.COM";
 
     final KerberosName kerbNameFull = new KerberosName(principalNameFull);
-    Assert.assertEquals("HTTP", kerbNameFull.getServiceName());
-    Assert.assertEquals("abc.com", kerbNameFull.getHostName());
-    Assert.assertEquals("EXAMPLE.COM", kerbNameFull.getRealm());
+    assertEquals("HTTP", kerbNameFull.getServiceName());
+    assertEquals("abc.com", kerbNameFull.getHostName());
+    assertEquals("EXAMPLE.COM", kerbNameFull.getRealm());
 
     final KerberosName kerbNamewoRealm = new KerberosName(principalNameWoRealm);
-    Assert.assertEquals("HTTP", kerbNamewoRealm.getServiceName());
-    Assert.assertEquals("abc.com", kerbNamewoRealm.getHostName());
-    Assert.assertEquals(null, kerbNamewoRealm.getRealm());
+    assertEquals("HTTP", kerbNamewoRealm.getServiceName());
+    assertEquals("abc.com", kerbNamewoRealm.getHostName());
+    assertEquals(null, kerbNamewoRealm.getRealm());
 
     final KerberosName kerbNameWoHost = new KerberosName(principalNameWoHost);
-    Assert.assertEquals("HTTP", kerbNameWoHost.getServiceName());
-    Assert.assertEquals(null, kerbNameWoHost.getHostName());
-    Assert.assertEquals("EXAMPLE.COM", kerbNameWoHost.getRealm());
+    assertEquals("HTTP", kerbNameWoHost.getServiceName());
+    assertEquals(null, kerbNameWoHost.getHostName());
+    assertEquals("EXAMPLE.COM", kerbNameWoHost.getRealm());
   }
 
   @Test
@@ -136,12 +138,14 @@ public class TestKerberosName {
     checkTranslation("Joe/guestguest@FOO.COM", "joe");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidRuleMechanism() throws Exception {
-    KerberosName.setRuleMechanism("INVALID_MECHANISM");
+    assertThrows(IllegalArgumentException.class, () -> {
+      KerberosName.setRuleMechanism("INVALID_MECHANISM");
+    });
   }
 
-  @After
+  @AfterEach
   public void clear() {
     System.clearProperty("java.security.krb5.realm");
     System.clearProperty("java.security.krb5.kdc");

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestKerberosUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestKerberosUtil.java
@@ -16,7 +16,10 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,9 +37,8 @@ import org.apache.kerby.kerberos.kerb.type.KerberosTime;
 import org.apache.kerby.kerberos.kerb.type.base.EncryptionKey;
 import org.apache.kerby.kerberos.kerb.type.base.EncryptionType;
 import org.apache.kerby.kerberos.kerb.type.base.PrincipalName;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class TestKerberosUtil {
   static String testKeytab = "test.keytab";
@@ -48,7 +50,7 @@ public class TestKerberosUtil {
       "HTTP/testhostanother@testRealm"
   };
 
-  @After
+  @AfterEach
   public void deleteKeytab() {
     File keytabFile = new File(testKeytab);
     if (keytabFile.exists()){
@@ -71,41 +73,38 @@ public class TestKerberosUtil {
       atDefaultRealm = "@" + defaultRealm;
     }
     // check that the test environment is as expected
-    Assert.assertEquals("testGetServerPrincipal assumes localhost realm is default",
-        KerberosUtil.getDomainRealm(service + "/" + localHostname.toLowerCase(Locale.US)),
-        defaultRealm);
-    Assert.assertEquals("testGetServerPrincipal assumes realm of testHost 'FooBar' is default",
-        KerberosUtil.getDomainRealm(service + "/" + testHost.toLowerCase(Locale.US)),
-        defaultRealm);
+    assertEquals(KerberosUtil.getDomainRealm(service + "/" + localHostname.toLowerCase(Locale.US)),
+        defaultRealm, "testGetServerPrincipal assumes localhost realm is default");
+    assertEquals(KerberosUtil.getDomainRealm(service + "/" + testHost.toLowerCase(Locale.US)),
+        defaultRealm, "testGetServerPrincipal assumes realm of testHost 'FooBar' is default");
 
     // send null hostname
-    Assert.assertEquals("When no hostname is sent",
-        service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
-        KerberosUtil.getServicePrincipal(service, null));
+    assertEquals(service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
+        KerberosUtil.getServicePrincipal(service, null),
+        "When no hostname is sent");
     // send empty hostname
-    Assert.assertEquals("When empty hostname is sent",
-        service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
-        KerberosUtil.getServicePrincipal(service, ""));
+    assertEquals(service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
+        KerberosUtil.getServicePrincipal(service, ""),
+        "When empty hostname is sent");
     // send 0.0.0.0 hostname
-    Assert.assertEquals("When 0.0.0.0 hostname is sent",
-        service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
-        KerberosUtil.getServicePrincipal(service, "0.0.0.0"));
+    assertEquals(service + "/" + localHostname.toLowerCase(Locale.US) + atDefaultRealm,
+        KerberosUtil.getServicePrincipal(service, "0.0.0.0"),
+        "When 0.0.0.0 hostname is sent");
     // send uppercase hostname
-    Assert.assertEquals("When uppercase hostname is sent",
-        service + "/" + testHost.toLowerCase(Locale.US) + atDefaultRealm,
-        KerberosUtil.getServicePrincipal(service, testHost));
+    assertEquals(service + "/" + testHost.toLowerCase(Locale.US) + atDefaultRealm,
+        KerberosUtil.getServicePrincipal(service, testHost),
+        "When uppercase hostname is sent");
     // send lowercase hostname
-    Assert.assertEquals("When lowercase hostname is sent",
-        service + "/" + testHost.toLowerCase(Locale.US) + atDefaultRealm,
-        KerberosUtil.getServicePrincipal(
-            service, testHost.toLowerCase(Locale.US)));
+    assertEquals(service + "/" + testHost.toLowerCase(Locale.US) + atDefaultRealm,
+        KerberosUtil.getServicePrincipal(service, testHost.toLowerCase(Locale.US)),
+        "When lowercase hostname is sent");
   }
 
   @Test
   public void testGetPrincipalNamesMissingKeytab() {
     try {
       KerberosUtil.getPrincipalNames(testKeytab);
-      Assert.fail("Exception should have been thrown");
+      fail("Exception should have been thrown");
     } catch (IllegalArgumentException e) {
       //expects exception
     } catch (IOException e) {
@@ -117,7 +116,7 @@ public class TestKerberosUtil {
     createKeyTab(testKeytab, new String[]{"test/testhost@testRealm"});
     try {
       KerberosUtil.getPrincipalNames(testKeytab, null);
-      Assert.fail("Exception should have been thrown");
+      fail("Exception should have been thrown");
     } catch (Exception e) {
       //expects exception
     }
@@ -128,16 +127,15 @@ public class TestKerberosUtil {
     createKeyTab(testKeytab, testPrincipals); 
     // read all principals in the keytab file
     String[] principals = KerberosUtil.getPrincipalNames(testKeytab);
-    Assert.assertNotNull("principals cannot be null", principals);
+    assertNotNull(principals, "principals cannot be null");
     
     int expectedSize = 0;
     List<String> principalList = Arrays.asList(principals);
     for (String principal : testPrincipals) {
-      Assert.assertTrue("missing principal "+principal,
-          principalList.contains(principal));
+      assertTrue(principalList.contains(principal), "missing principal "+principal);
       expectedSize++;
     }
-    Assert.assertEquals(expectedSize, principals.length);
+    assertEquals(expectedSize, principals.length);
   }
   
   @Test
@@ -148,18 +146,18 @@ public class TestKerberosUtil {
     Pattern httpPattern = Pattern.compile("HTTP/.*");
     String[] httpPrincipals =
         KerberosUtil.getPrincipalNames(testKeytab, httpPattern);
-    Assert.assertNotNull("principals cannot be null", httpPrincipals);
+    assertNotNull(httpPrincipals, "principals cannot be null");
     
     int expectedSize = 0;
     List<String> httpPrincipalList = Arrays.asList(httpPrincipals);
     for (String principal : testPrincipals) {
       if (httpPattern.matcher(principal).matches()) {
-        Assert.assertTrue("missing principal "+principal,
-            httpPrincipalList.contains(principal));
+        assertTrue(httpPrincipalList.contains(principal),
+            "missing principal "+principal);
         expectedSize++;
       }
     }
-    Assert.assertEquals(expectedSize, httpPrincipals.length);
+    assertEquals(expectedSize, httpPrincipals.length);
   }
   
   private void createKeyTab(String fileName, String[] principalNames)

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRandomSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRandomSignerSecretProvider.java
@@ -17,9 +17,11 @@ import java.util.Random;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -50,28 +52,28 @@ public class TestRandomSignerSecretProvider {
 
       byte[] currentSecret = secretProvider.getCurrentSecret();
       byte[][] allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret1, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret1, allSecrets[0]);
-      Assert.assertNull(allSecrets[1]);
+      assertArrayEquals(secret1, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret1, allSecrets[0]);
+      assertNull(allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeastOnce()).rollSecret();
       secretProvider.realRollSecret();
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret2, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret2, allSecrets[0]);
-      Assert.assertArrayEquals(secret1, allSecrets[1]);
+      assertArrayEquals(secret2, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret2, allSecrets[0]);
+      assertArrayEquals(secret1, allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeast(2)).rollSecret();
       secretProvider.realRollSecret();
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret3, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret3, allSecrets[0]);
-      Assert.assertArrayEquals(secret2, allSecrets[1]);
+      assertArrayEquals(secret3, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret3, allSecrets[0]);
+      assertArrayEquals(secret2, allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeast(3)).rollSecret();
       secretProvider.realRollSecret();
     } finally {

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRolloverSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestRolloverSignerSecretProvider.java
@@ -13,8 +13,11 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 
 public class TestRolloverSignerSecretProvider {
 
@@ -32,26 +35,26 @@ public class TestRolloverSignerSecretProvider {
 
       byte[] currentSecret = secretProvider.getCurrentSecret();
       byte[][] allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret1, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret1, allSecrets[0]);
-      Assert.assertNull(allSecrets[1]);
+      assertArrayEquals(secret1, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret1, allSecrets[0]);
+      assertNull(allSecrets[1]);
       Thread.sleep(rolloverFrequency + 2000);
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret2, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret2, allSecrets[0]);
-      Assert.assertArrayEquals(secret1, allSecrets[1]);
+      assertArrayEquals(secret2, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret2, allSecrets[0]);
+      assertArrayEquals(secret1, allSecrets[1]);
       Thread.sleep(rolloverFrequency + 2000);
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret3, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret3, allSecrets[0]);
-      Assert.assertArrayEquals(secret2, allSecrets[1]);
+      assertArrayEquals(secret3, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret3, allSecrets[0]);
+      assertArrayEquals(secret2, allSecrets[1]);
       Thread.sleep(rolloverFrequency + 2000);
     } finally {
       secretProvider.destroy();

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSigner.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSigner.java
@@ -13,11 +13,14 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Properties;
 import javax.servlet.ServletContext;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSigner {
 
@@ -26,19 +29,19 @@ public class TestSigner {
     Signer signer = new Signer(createStringSignerSecretProvider());
     try {
       signer.sign(null);
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
     try {
       signer.sign("");
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
   }
 
@@ -48,8 +51,8 @@ public class TestSigner {
     String s1 = signer.sign("ok");
     String s2 = signer.sign("ok");
     String s3 = signer.sign("wrong");
-    Assert.assertEquals(s1, s2);
-    Assert.assertNotEquals(s1, s3);
+    assertEquals(s1, s2);
+    assertNotEquals(s1, s3);
   }
 
   @Test
@@ -58,7 +61,7 @@ public class TestSigner {
     String t = "test";
     String s = signer.sign(t);
     String e = signer.verifyAndExtract(s);
-    Assert.assertEquals(t, e);
+    assertEquals(t, e);
   }
 
   @Test
@@ -66,11 +69,11 @@ public class TestSigner {
     Signer signer = new Signer(createStringSignerSecretProvider());
     try {
       signer.verifyAndExtract("test");
-      Assert.fail();
+      fail();
     } catch (SignerException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
   }
 
@@ -82,11 +85,11 @@ public class TestSigner {
     s += "x";
     try {
       signer.verifyAndExtract(s);
-      Assert.fail();
+      fail();
     } catch (SignerException ex) {
       // Expected
     } catch (Throwable ex) {
-      Assert.fail();
+      fail();
     }
   }
 
@@ -106,27 +109,27 @@ public class TestSigner {
     String t1 = "test";
     String s1 = signer.sign(t1);
     String e1 = signer.verifyAndExtract(s1);
-    Assert.assertEquals(t1, e1);
+    assertEquals(t1, e1);
     secretProvider.setPreviousSecret("secretA");
     String t2 = "test";
     String s2 = signer.sign(t2);
     String e2 = signer.verifyAndExtract(s2);
-    Assert.assertEquals(t2, e2);
-    Assert.assertEquals(s1, s2); //check is using current secret for signing
+    assertEquals(t2, e2);
+    assertEquals(s1, s2); //check is using current secret for signing
     secretProvider.setCurrentSecret("secretC");
     secretProvider.setPreviousSecret("secretB");
     String t3 = "test";
     String s3 = signer.sign(t3);
     String e3 = signer.verifyAndExtract(s3);
-    Assert.assertEquals(t3, e3);
-    Assert.assertNotEquals(s1, s3); //check not using current secret for signing
+    assertEquals(t3, e3);
+    assertNotEquals(s1, s3); //check not using current secret for signing
     String e1b = signer.verifyAndExtract(s1);
-    Assert.assertEquals(t1, e1b); // previous secret still valid
+    assertEquals(t1, e1b); // previous secret still valid
     secretProvider.setCurrentSecret("secretD");
     secretProvider.setPreviousSecret("secretC");
     try {
       signer.verifyAndExtract(s1);  // previous secret no longer valid
-      Assert.fail();
+      fail();
     } catch (SignerException ex) {
       // Expected
     }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestStringSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestStringSignerSecretProvider.java
@@ -13,10 +13,12 @@
  */
 package org.apache.hadoop.security.authentication.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Properties;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStringSignerSecretProvider {
 
@@ -30,9 +32,9 @@ public class TestStringSignerSecretProvider {
             AuthenticationFilter.SIGNATURE_SECRET, "secret");
     secretProvider.init(secretProviderProps, null, -1);
     byte[] secretBytes = secretStr.getBytes();
-    Assert.assertArrayEquals(secretBytes, secretProvider.getCurrentSecret());
+    assertArrayEquals(secretBytes, secretProvider.getCurrentSecret());
     byte[][] allSecrets = secretProvider.getAllSecrets();
-    Assert.assertEquals(1, allSecrets.length);
-    Assert.assertArrayEquals(secretBytes, allSecrets[0]);
+    assertEquals(1, allSecrets.length);
+    assertArrayEquals(secretBytes, allSecrets[0]);
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestZKSignerSecretProvider.java
@@ -21,10 +21,13 @@ import javax.servlet.ServletContext;
 import org.apache.curator.test.TestingServer;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -44,12 +47,12 @@ public class TestZKSignerSecretProvider {
         RolloverSignerSecretProvider.LOG.getName()).setLevel(Level.DEBUG);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     zkServer = new TestingServer();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (zkServer != null) {
       zkServer.stop();
@@ -80,28 +83,28 @@ public class TestZKSignerSecretProvider {
 
       byte[] currentSecret = secretProvider.getCurrentSecret();
       byte[][] allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret1, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret1, allSecrets[0]);
-      Assert.assertNull(allSecrets[1]);
+      assertArrayEquals(secret1, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret1, allSecrets[0]);
+      assertNull(allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeastOnce()).rollSecret();
       secretProvider.realRollSecret();
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret2, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret2, allSecrets[0]);
-      Assert.assertArrayEquals(secret1, allSecrets[1]);
+      assertArrayEquals(secret2, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret2, allSecrets[0]);
+      assertArrayEquals(secret1, allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeast(2)).rollSecret();
       secretProvider.realRollSecret();
 
       currentSecret = secretProvider.getCurrentSecret();
       allSecrets = secretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret3, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret3, allSecrets[0]);
-      Assert.assertArrayEquals(secret2, allSecrets[1]);
+      assertArrayEquals(secret3, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret3, allSecrets[0]);
+      assertArrayEquals(secret2, allSecrets[1]);
       verify(secretProvider, timeout(timeout).atLeast(3)).rollSecret();
       secretProvider.realRollSecret();
     } finally {
@@ -167,18 +170,18 @@ public class TestZKSignerSecretProvider {
 
       byte[] currentSecret = oldSecretProvider.getCurrentSecret();
       byte[][] allSecrets = oldSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret1, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret1, allSecrets[0]);
-      Assert.assertNull(allSecrets[1]);
+      assertArrayEquals(secret1, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret1, allSecrets[0]);
+      assertNull(allSecrets[1]);
       oldSecretProvider.realRollSecret();
 
       currentSecret = oldSecretProvider.getCurrentSecret();
       allSecrets = oldSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret2, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret2, allSecrets[0]);
-      Assert.assertArrayEquals(secret1, allSecrets[1]);
+      assertArrayEquals(secret2, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret2, allSecrets[0]);
+      assertArrayEquals(secret1, allSecrets[1]);
     } finally {
       oldSecretProvider.destroy();
     }
@@ -191,34 +194,34 @@ public class TestZKSignerSecretProvider {
 
       byte[] currentSecret = newSecretProvider.getCurrentSecret();
       byte[][] allSecrets = newSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret2, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret2, allSecrets[0]);
-      Assert.assertArrayEquals(secret1, allSecrets[1]);
+      assertArrayEquals(secret2, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret2, allSecrets[0]);
+      assertArrayEquals(secret1, allSecrets[1]);
       newSecretProvider.realRollSecret();
 
       currentSecret = newSecretProvider.getCurrentSecret();
       allSecrets = newSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret3, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret3, allSecrets[0]);
-      Assert.assertArrayEquals(secret2, allSecrets[1]);
+      assertArrayEquals(secret3, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret3, allSecrets[0]);
+      assertArrayEquals(secret2, allSecrets[1]);
       newSecretProvider.realRollSecret();
 
       currentSecret = newSecretProvider.getCurrentSecret();
       allSecrets = newSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret6, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret6, allSecrets[0]);
-      Assert.assertArrayEquals(secret3, allSecrets[1]);
+      assertArrayEquals(secret6, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret6, allSecrets[0]);
+      assertArrayEquals(secret3, allSecrets[1]);
       newSecretProvider.realRollSecret();
 
       currentSecret = newSecretProvider.getCurrentSecret();
       allSecrets = newSecretProvider.getAllSecrets();
-      Assert.assertArrayEquals(secret7, currentSecret);
-      Assert.assertEquals(2, allSecrets.length);
-      Assert.assertArrayEquals(secret7, allSecrets[0]);
-      Assert.assertArrayEquals(secret6, allSecrets[1]);
+      assertArrayEquals(secret7, currentSecret);
+      assertEquals(2, allSecrets.length);
+      assertArrayEquals(secret7, allSecrets[0]);
+      assertArrayEquals(secret6, allSecrets[1]);
     } finally {
       newSecretProvider.destroy();
     }
@@ -290,14 +293,14 @@ public class TestZKSignerSecretProvider {
       byte[][] allSecretsA = secretProviderA.getAllSecrets();
       byte[] currentSecretB = secretProviderB.getCurrentSecret();
       byte[][] allSecretsB = secretProviderB.getAllSecrets();
-      Assert.assertArrayEquals(secretA1, currentSecretA);
-      Assert.assertArrayEquals(secretA1, currentSecretB);
-      Assert.assertEquals(2, allSecretsA.length);
-      Assert.assertEquals(2, allSecretsB.length);
-      Assert.assertArrayEquals(secretA1, allSecretsA[0]);
-      Assert.assertArrayEquals(secretA1, allSecretsB[0]);
-      Assert.assertNull(allSecretsA[1]);
-      Assert.assertNull(allSecretsB[1]);
+      assertArrayEquals(secretA1, currentSecretA);
+      assertArrayEquals(secretA1, currentSecretB);
+      assertEquals(2, allSecretsA.length);
+      assertEquals(2, allSecretsB.length);
+      assertArrayEquals(secretA1, allSecretsA[0]);
+      assertArrayEquals(secretA1, allSecretsB[0]);
+      assertNull(allSecretsA[1]);
+      assertNull(allSecretsB[1]);
       verify(secretProviderA, timeout(timeout).atLeastOnce()).rollSecret();
       verify(secretProviderB, timeout(timeout).atLeastOnce()).rollSecret();
       secretProviderA.realRollSecret();
@@ -305,17 +308,17 @@ public class TestZKSignerSecretProvider {
 
       currentSecretA = secretProviderA.getCurrentSecret();
       allSecretsA = secretProviderA.getAllSecrets();
-      Assert.assertArrayEquals(secretA2, currentSecretA);
-      Assert.assertEquals(2, allSecretsA.length);
-      Assert.assertArrayEquals(secretA2, allSecretsA[0]);
-      Assert.assertArrayEquals(secretA1, allSecretsA[1]);
+      assertArrayEquals(secretA2, currentSecretA);
+      assertEquals(2, allSecretsA.length);
+      assertArrayEquals(secretA2, allSecretsA[0]);
+      assertArrayEquals(secretA1, allSecretsA[1]);
 
       currentSecretB = secretProviderB.getCurrentSecret();
       allSecretsB = secretProviderB.getAllSecrets();
-      Assert.assertArrayEquals(secretA2, currentSecretB);
-      Assert.assertEquals(2, allSecretsA.length);
-      Assert.assertArrayEquals(secretA2, allSecretsB[0]);
-      Assert.assertArrayEquals(secretA1, allSecretsB[1]);
+      assertArrayEquals(secretA2, currentSecretB);
+      assertEquals(2, allSecretsA.length);
+      assertArrayEquals(secretA2, allSecretsB[0]);
+      assertArrayEquals(secretA1, allSecretsB[1]);
       verify(secretProviderA, timeout(timeout).atLeast(2)).rollSecret();
       verify(secretProviderB, timeout(timeout).atLeastOnce()).rollSecret();
 
@@ -340,18 +343,18 @@ public class TestZKSignerSecretProvider {
       allSecretsA = secretProviderA.getAllSecrets();
       currentSecretB = secretProviderB.getCurrentSecret();
       allSecretsB = secretProviderB.getAllSecrets();
-      Assert.assertArrayEquals(currentSecretA, currentSecretB);
-      Assert.assertEquals(2, allSecretsA.length);
-      Assert.assertEquals(2, allSecretsB.length);
-      Assert.assertArrayEquals(allSecretsA[0], allSecretsB[0]);
-      Assert.assertArrayEquals(allSecretsA[1], allSecretsB[1]);
+      assertArrayEquals(currentSecretA, currentSecretB);
+      assertEquals(2, allSecretsA.length);
+      assertEquals(2, allSecretsB.length);
+      assertArrayEquals(allSecretsA[0], allSecretsB[0]);
+      assertArrayEquals(allSecretsA[1], allSecretsB[1]);
       switch (order) {
         case 1:
-          Assert.assertArrayEquals(secretA4, allSecretsA[0]);
-          break;
+        assertArrayEquals(secretA4, allSecretsA[0]);
+        break;
         case 2:
-          Assert.assertArrayEquals(secretB4, allSecretsA[0]);
-          break;
+        assertArrayEquals(secretB4, allSecretsA[0]);
+        break;
       }
     } finally {
       secretProviderB.destroy();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19414. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-auth.

### How was this patch tested?

Junit test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

