### PR TITLE
HADOOP-19412. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-huaweicloud.

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFSMainOperations.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFSMainOperations.java
@@ -18,12 +18,13 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.TestFSMainOperationsLocalFileSystem;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * <p>
@@ -46,7 +47,7 @@ public class TestOBSFSMainOperations extends
     TestFSMainOperationsLocalFileSystem {
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     skipTestCheck();
     Configuration conf = new Configuration();
@@ -56,17 +57,17 @@ public class TestOBSFSMainOperations extends
 
   @Override
   public void testWorkingDirectory() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   @Override
   public void testListStatusThrowsExceptionForUnreadableDir() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   @Override
   public void testRenameDirectoryToItself() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   @Override
@@ -76,11 +77,11 @@ public class TestOBSFSMainOperations extends
 
   @Override
   public void testRenameFileToItself() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if(fSys != null) {
       super.tearDown();
@@ -88,6 +89,6 @@ public class TestOBSFSMainOperations extends
   }
 
   public void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 }

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextCreateMkdir.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextCreateMkdir.java
@@ -18,19 +18,20 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextCreateMkdirBaseTest;
 import org.apache.hadoop.fs.FileContextTestHelper;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.net.URI;
 import java.util.UUID;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotation.SuppressFBWarnings;
 
 /**
  * File context create mkdir test cases on obs file system.
@@ -38,9 +39,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class TestOBSFileContextCreateMkdir extends
     FileContextCreateMkdirBaseTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 
 

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextMainOperations.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextMainOperations.java
@@ -18,14 +18,15 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextMainOperationsBaseTest;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
@@ -35,9 +36,9 @@ import java.net.URI;
 public class TestOBSFileContextMainOperations extends
     FileContextMainOperationsBaseTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
@@ -67,11 +68,11 @@ public class TestOBSFileContextMainOperations extends
   @Override
   @Test
   public void testSetVerifyChecksum() {
-    Assume.assumeTrue("unsupport.", false);
+    assumeTrue(false, "unsupport.");
   }
 
   @Override
   public void testMkdirsFailsForSubdirectoryOfExistingFile() {
-    Assume.assumeTrue("unsupport.", false);
+    assumeTrue(false, "unsupport.");
   }
 }

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextURI.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextURI.java
@@ -83,7 +83,7 @@ public class TestOBSFileContextURI extends FileContextURIBase {
 
   @Override
   public void testFileStatus() {
-    assumeTrue( false, "unsupport.");
+    assumeTrue(false, "unsupport.");
   }
 
 }

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextURI.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextURI.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextURIBase;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.net.URI;
 
@@ -49,9 +50,9 @@ import java.net.URI;
  */
 public class TestOBSFileContextURI extends FileContextURIBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 
   @Override
@@ -77,12 +78,12 @@ public class TestOBSFileContextURI extends FileContextURIBase {
 
   @Override
   public void testMkdirsFailsForSubdirectoryOfExistingFile() {
-    Assume.assumeTrue("unsupport.", false);
+    assumeTrue(false, "unsupport.");
   }
 
   @Override
   public void testFileStatus() {
-    Assume.assumeTrue("unsupport.", false);
+    assumeTrue( false, "unsupport.");
   }
 
 }

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextUtil.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileContextUtil.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileContextUtilBase;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.net.URI;
 
@@ -44,9 +45,9 @@ import java.net.URI;
  */
 public class TestOBSFileContextUtil extends FileContextUtilBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 
   @Override

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileSystemContract.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSFileSystemContract.java
@@ -18,10 +18,11 @@
 
 package org.apache.hadoop.fs.obs;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystemContractBaseTest;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 
 /**
@@ -35,7 +36,7 @@ import org.junit.Before;
  **/
 public class TestOBSFileSystemContract extends FileSystemContractBaseTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     skipTestCheck();
     Configuration conf = new Configuration();
@@ -45,15 +46,15 @@ public class TestOBSFileSystemContract extends FileSystemContractBaseTest {
 
   @Override
   public void testMkdirsWithUmask() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   @Override
   public void testRenameRootDirForbidden() {
-    Assume.assumeTrue("unspport.", false);
+    assumeTrue(false, "unspport.");
   }
 
   public void skipTestCheck() {
-    Assume.assumeTrue(OBSContract.isContractTestEnabled());
+    assumeTrue(OBSContract.isContractTestEnabled());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19412. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-huaweicloud.

### How was this patch tested?

junit test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

