### PR TITLE
HADOOP-19550. Migrate ViewFileSystemBaseTest to Junit 5

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemLocalFileSystem.java
@@ -18,10 +18,6 @@
 package org.apache.hadoop.fs.viewfs;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.net.URI;
 
@@ -32,11 +28,17 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.hadoop.security.UserGroupInformation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,7 @@ public class TestViewFileSystemLocalFileSystem extends ViewFileSystemBaseTest {
       LoggerFactory.getLogger(TestViewFileSystemLocalFileSystem.class);
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create the test root on local_fs
     fsTarget = FileSystem.getLocal(new Configuration());
@@ -96,10 +98,10 @@ public class TestViewFileSystemLocalFileSystem extends ViewFileSystemBaseTest {
     FileSystem lfs = FileSystem.getLocal(testConf);
     for (final URI testUri : testUris) {
       final Path testFile = new Path(new Path(testUri), testFileName);
-      assertTrue(testFile + " should exist!",  lfs.exists(testFile));
+      assertTrue(lfs.exists(testFile), testFile + " should exist!");
       final FSDataInputStream fsdis = lfs.open(testFile);
       try {
-        assertEquals("Wrong file content", testString, fsdis.readUTF());
+        assertEquals(fsdis.readUTF(), testString, "Wrong file content");
       } finally {
         fsdis.close();
       }
@@ -122,14 +124,14 @@ public class TestViewFileSystemLocalFileSystem extends ViewFileSystemBaseTest {
       FileSystem.get(URI.create("viewfs://mt/"), conf);
       fail("Expected bad minReplication exception.");
     } catch (IOException ioe) {
-      assertTrue("No minReplication message",
-          ioe.getMessage().contains("Minimum replication"));
+      assertTrue(ioe.getMessage().contains("Minimum replication"),
+          "No minReplication message");
     }
   }
 
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fsTarget.delete(fileSystemTestHelper.getTestRootPath(fsTarget), true);
     super.tearDown();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/TestViewFileSystemWithAuthorityLocalFileSystem.java
@@ -26,12 +26,13 @@ import org.apache.hadoop.fs.FsConstants;
 import org.apache.hadoop.fs.Path;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import org.apache.hadoop.security.UserGroupInformation;
+
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -45,7 +46,7 @@ public class TestViewFileSystemWithAuthorityLocalFileSystem extends ViewFileSyst
   URI schemeWithAuthority;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // create the test root on local_fs
     fsTarget = FileSystem.getLocal(new Configuration());
@@ -59,7 +60,7 @@ public class TestViewFileSystemWithAuthorityLocalFileSystem extends ViewFileSyst
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fsTarget.delete(fileSystemTestHelper.getTestRootPath(fsTarget), true);
     super.tearDown();
@@ -75,16 +76,15 @@ public class TestViewFileSystemWithAuthorityLocalFileSystem extends ViewFileSyst
   @Override
   @Test
   public void testBasicPaths() {
-    Assert.assertEquals(schemeWithAuthority,
-        fsView.getUri());
-    Assert.assertEquals(fsView.makeQualified(
-        new Path("/user/" + System.getProperty("user.name"))),
-        fsView.getWorkingDirectory());
-    Assert.assertEquals(fsView.makeQualified(
-        new Path("/user/" + System.getProperty("user.name"))),
-        fsView.getHomeDirectory());
-    Assert.assertEquals(
-        new Path("/foo/bar").makeQualified(schemeWithAuthority, null),
-        fsView.makeQualified(new Path("/foo/bar")));
+    Assertions.assertEquals(fsView.getUri(), schemeWithAuthority);
+    Assertions.assertEquals(fsView.getWorkingDirectory(),
+        fsView.makeQualified(
+        new Path("/user/" + System.getProperty("user.name"))));
+    Assertions.assertEquals(fsView.getHomeDirectory(),
+        fsView.makeQualified(
+        new Path("/user/" + System.getProperty("user.name"))));
+    Assertions.assertEquals(
+        fsView.makeQualified(new Path("/foo/bar")),
+        new Path("/foo/bar").makeQualified(schemeWithAuthority, null));
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -116,7 +116,7 @@ abstract public class ViewFileSystemBaseTest {
 
   @TempDir
   public File temporaryFolder;
-  
+
   @BeforeEach
   public void setUp() throws Exception {
     initializeTargetTestRoot();
@@ -174,7 +174,7 @@ abstract public class ViewFileSystemBaseTest {
       LOG.info("MountPoint: " + mountPoint.getMountedOnPath() + " => "
           + mountPoint.getTargetFileSystemURIs()[0]);
     }
-    Assertions.assertEquals(mountPoints.length, getExpectedMountPoints()); 
+    Assertions.assertEquals(mountPoints.length, getExpectedMountPoints());
   }
   
   int getExpectedMountPoints() {
@@ -190,7 +190,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testGetDelegationTokens() throws IOException {
     Token<?>[] delTokens = 
         fsView.addDelegationTokens("sanjay", new Credentials());
-    Assertions.assertEquals(delTokens.length, getExpectedDelegationTokenCount()); 
+    Assertions.assertEquals(delTokens.length, getExpectedDelegationTokenCount());
   }
   
   int getExpectedDelegationTokenCount() {
@@ -735,7 +735,7 @@ abstract public class ViewFileSystemBaseTest {
     Assertions.assertTrue(fs.isFile(), "Created file shoudl appear as a file");
     fs = fileSystemTestHelper.containsPath(fsView, "/data/dirX", dirPaths);
     Assertions.assertNotNull(fs);
-    Assertions.assertTrue(fs.isDirectory(), "Created dir should appear as a dir"); 
+    Assertions.assertTrue(fs.isDirectory(), "Created dir should appear as a dir");
   }
 
   private FileStatus[] listStatusInternal(boolean located, Path dataPath) throws IOException {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/viewfs/ViewFileSystemBaseTest.java
@@ -60,10 +60,12 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.assertj.core.api.Assertions;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.fs.FileSystemTestHelper.*;
@@ -72,13 +74,8 @@ import static org.apache.hadoop.fs.viewfs.Constants.PERMISSION_555;
 import static org.apache.hadoop.fs.viewfs.Constants.CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * <p>
@@ -117,10 +114,10 @@ abstract public class ViewFileSystemBaseTest {
     return new FileSystemTestHelper();
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
+  @TempDir
+  public File temporaryFolder;
+  
+  @BeforeEach
   public void setUp() throws Exception {
     initializeTargetTestRoot();
     
@@ -141,7 +138,7 @@ abstract public class ViewFileSystemBaseTest {
     fsView = FileSystem.get(FsConstants.VIEWFS_URI, conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fsTarget.delete(fileSystemTestHelper.getTestRootPath(fsTarget), true);
   }
@@ -177,7 +174,7 @@ abstract public class ViewFileSystemBaseTest {
       LOG.info("MountPoint: " + mountPoint.getMountedOnPath() + " => "
           + mountPoint.getTargetFileSystemURIs()[0]);
     }
-    Assert.assertEquals(getExpectedMountPoints(), mountPoints.length); 
+    Assertions.assertEquals(mountPoints.length, getExpectedMountPoints()); 
   }
   
   int getExpectedMountPoints() {
@@ -193,7 +190,7 @@ abstract public class ViewFileSystemBaseTest {
   public void testGetDelegationTokens() throws IOException {
     Token<?>[] delTokens = 
         fsView.addDelegationTokens("sanjay", new Credentials());
-    Assert.assertEquals(getExpectedDelegationTokenCount(), delTokens.length); 
+    Assertions.assertEquals(delTokens.length, getExpectedDelegationTokenCount()); 
   }
   
   int getExpectedDelegationTokenCount() {
@@ -208,7 +205,7 @@ abstract public class ViewFileSystemBaseTest {
 
     int expectedTokenCount = getExpectedDelegationTokenCountWithCredentials();
 
-    Assert.assertEquals(expectedTokenCount, delTokens.size());
+    Assertions.assertEquals(delTokens.size(), expectedTokenCount);
     Credentials newCredentials = new Credentials();
     for (int i = 0; i < expectedTokenCount / 2; i++) {
       Token<?> token = delTokens.get(i);
@@ -217,7 +214,7 @@ abstract public class ViewFileSystemBaseTest {
 
     List<Token<?>> delTokens2 =
         Arrays.asList(fsView.addDelegationTokens("sanjay", newCredentials));
-    Assert.assertEquals((expectedTokenCount + 1) / 2, delTokens2.size());
+    Assertions.assertEquals(delTokens2.size(), (expectedTokenCount + 1) / 2);
   }
 
   int getExpectedDelegationTokenCountWithCredentials() {
@@ -226,17 +223,17 @@ abstract public class ViewFileSystemBaseTest {
 
   @Test
   public void testBasicPaths() {
-    Assert.assertEquals(FsConstants.VIEWFS_URI,
-        fsView.getUri());
-    Assert.assertEquals(fsView.makeQualified(
-        new Path("/user/" + System.getProperty("user.name"))),
-        fsView.getWorkingDirectory());
-    Assert.assertEquals(fsView.makeQualified(
-        new Path("/user/" + System.getProperty("user.name"))),
-        fsView.getHomeDirectory());
-    Assert.assertEquals(
-        new Path("/foo/bar").makeQualified(FsConstants.VIEWFS_URI, null),
-        fsView.makeQualified(new Path("/foo/bar")));
+    Assertions.assertEquals(fsView.getUri(), FsConstants.VIEWFS_URI);
+    Assertions.assertEquals(fsView.getWorkingDirectory(),
+        fsView.makeQualified(
+            new Path("/user/" + System.getProperty("user.name"))));
+    Assertions.assertEquals(
+        fsView.getHomeDirectory(),
+        fsView.makeQualified(
+        new Path("/user/" + System.getProperty("user.name"))));
+    Assertions.assertEquals(
+        fsView.makeQualified(new Path("/foo/bar")),
+        new Path("/foo/bar").makeQualified(FsConstants.VIEWFS_URI, null));
   }
 
   @Test
@@ -262,116 +259,116 @@ abstract public class ViewFileSystemBaseTest {
       throws IOException {
     // Create file
     fileSystemTestHelper.createFile(fsView, "/user/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.isFile(new Path("/user/foo")));
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.isFile(new Path(targetTestRoot,"user/foo")));
+    Assertions.assertTrue(fsView.isFile(new Path("/user/foo")),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot,"user/foo")),
+        "Target of created file should be type file");
     
     // Delete the created file
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/user/foo"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/user/foo")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"user/foo")));
+    Assertions.assertTrue(fsView.delete(new Path("/user/foo"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/user/foo")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/foo")),
+        "Target File should not exist after delete");
     
     // Create file with a 2 component dirs
     fileSystemTestHelper.createFile(fsView, "/internalDir/linkToDir2/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.isFile(new Path("/internalDir/linkToDir2/foo")));
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.isFile(new Path(targetTestRoot,"dir2/foo")));
+    Assertions.assertTrue(fsView.isFile(new Path("/internalDir/linkToDir2/foo")),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot,"dir2/foo")),
+        "Target of created file should be type file");
     
     // Delete the created file
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/internalDir/linkToDir2/foo"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/internalDir/linkToDir2/foo")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"dir2/foo")));
+    Assertions.assertTrue(fsView.delete(new Path("/internalDir/linkToDir2/foo"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/internalDir/linkToDir2/foo")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"dir2/foo")),
+        "Target File should not exist after delete");
     
     
     // Create file with a 3 component dirs
     fileSystemTestHelper.createFile(fsView, "/internalDir/internalDir2/linkToDir3/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.isFile(new Path("/internalDir/internalDir2/linkToDir3/foo")));
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.isFile(new Path(targetTestRoot,"dir3/foo")));
+    Assertions.assertTrue(fsView.isFile(new Path("/internalDir/internalDir2/linkToDir3/foo")),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot,"dir3/foo")),
+        "Target of created file should be type file");
     
     // Recursive Create file with missing dirs
     fileSystemTestHelper.createFile(fsView,
         "/internalDir/linkToDir2/missingDir/miss2/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.isFile(new Path("/internalDir/linkToDir2/missingDir/miss2/foo")));
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.isFile(new Path(targetTestRoot,"dir2/missingDir/miss2/foo")));
+    Assertions.assertTrue(fsView.isFile(new Path("/internalDir/linkToDir2/missingDir/miss2/foo")),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot,"dir2/missingDir/miss2/foo")),
+        "Target of created file should be type file");
 
     
     // Delete the created file
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(
-            new Path("/internalDir/internalDir2/linkToDir3/foo"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/internalDir/internalDir2/linkToDir3/foo")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"dir3/foo")));
+    Assertions.assertTrue(fsView.delete(
+            new Path("/internalDir/internalDir2/linkToDir3/foo"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/internalDir/internalDir2/linkToDir3/foo")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"dir3/foo")),
+        "Target File should not exist after delete");
     
       
     // mkdir
     fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/user/dirX"));
-    Assert.assertTrue("New dir should be type dir", 
-        fsView.isDirectory(new Path("/user/dirX")));
-    Assert.assertTrue("Target of new dir should be of type dir",
-        fsTarget.isDirectory(new Path(targetTestRoot,"user/dirX")));
+    Assertions.assertTrue(fsView.isDirectory(new Path("/user/dirX")),
+        "New dir should be type dir");
+    Assertions.assertTrue(fsTarget.isDirectory(new Path(targetTestRoot,"user/dirX")),
+        "Target of new dir should be of type dir");
     
     fsView.mkdirs(
         fileSystemTestHelper.getTestRootPath(fsView, "/user/dirX/dirY"));
-    Assert.assertTrue("New dir should be type dir", 
-        fsView.isDirectory(new Path("/user/dirX/dirY")));
-    Assert.assertTrue("Target of new dir should be of type dir",
-        fsTarget.isDirectory(new Path(targetTestRoot,"user/dirX/dirY")));
+    Assertions.assertTrue(fsView.isDirectory(new Path("/user/dirX/dirY")),
+        "New dir should be type dir");
+    Assertions.assertTrue(fsTarget.isDirectory(new Path(targetTestRoot,"user/dirX/dirY")),
+        "Target of new dir should be of type dir");
     
 
     // Delete the created dir
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/user/dirX/dirY"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/user/dirX/dirY")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"user/dirX/dirY")));
+    Assertions.assertTrue(fsView.delete(new Path("/user/dirX/dirY"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/user/dirX/dirY")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/dirX/dirY")),
+        "Target File should not exist after delete");
     
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/user/dirX"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/user/dirX")));
-    Assert.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/dirX")));
+    Assertions.assertTrue(fsView.delete(new Path("/user/dirX"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/user/dirX")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/dirX")));
     
     // Rename a file 
     fileSystemTestHelper.createFile(fsView, "/user/foo");
     fsView.rename(new Path("/user/foo"), new Path("/user/fooBar"));
-    Assert.assertFalse("Renamed src should not exist", 
-        fsView.exists(new Path("/user/foo")));
-    Assert.assertFalse("Renamed src should not exist in target",
-        fsTarget.exists(new Path(targetTestRoot,"user/foo")));
-    Assert.assertTrue("Renamed dest should  exist as file",
-        fsView.isFile(fileSystemTestHelper.getTestRootPath(fsView,"/user/fooBar")));
-    Assert.assertTrue("Renamed dest should  exist as file in target",
-        fsTarget.isFile(new Path(targetTestRoot,"user/fooBar")));
+    Assertions.assertFalse(fsView.exists(new Path("/user/foo")),
+        "Renamed src should not exist");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/foo")),
+        "Renamed src should not exist in target");
+    Assertions.assertTrue(fsView.isFile(fileSystemTestHelper.getTestRootPath(fsView,"/user/fooBar")),
+        "Renamed dest should  exist as file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot,"user/fooBar")),
+        "Renamed dest should  exist as file in target");
     
     fsView.mkdirs(new Path("/user/dirFoo"));
     fsView.rename(new Path("/user/dirFoo"), new Path("/user/dirFooBar"));
-    Assert.assertFalse("Renamed src should not exist", 
-        fsView.exists(new Path("/user/dirFoo")));
-    Assert.assertFalse("Renamed src should not exist in target",
-        fsTarget.exists(new Path(targetTestRoot,"user/dirFoo")));
-    Assert.assertTrue("Renamed dest should  exist as dir",
-        fsView.isDirectory(fileSystemTestHelper.getTestRootPath(fsView,"/user/dirFooBar")));
-    Assert.assertTrue("Renamed dest should  exist as dir in target",
-        fsTarget.isDirectory(new Path(targetTestRoot,"user/dirFooBar")));
+    Assertions.assertFalse(fsView.exists(new Path("/user/dirFoo")),
+        "Renamed src should not exist");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"user/dirFoo")),
+        "Renamed src should not exist in target");
+    Assertions.assertTrue(fsView.isDirectory(fileSystemTestHelper.getTestRootPath(fsView,"/user/dirFooBar")),
+        "Renamed dest should  exist as dir");
+    Assertions.assertTrue(fsTarget.isDirectory(new Path(targetTestRoot,"user/dirFooBar")),
+        "Renamed dest should  exist as dir in target");
     
     // Make a directory under a directory that's mounted from the root of another FS
     fsView.mkdirs(new Path("/targetRoot/dirFoo"));
-    Assert.assertTrue(fsView.exists(new Path("/targetRoot/dirFoo")));
+    Assertions.assertTrue(fsView.exists(new Path("/targetRoot/dirFoo")));
     boolean dirFooPresent = false;
     for (FileStatus fileStatus :
         listStatusInternal(located, new Path("/targetRoot/"))) {
@@ -379,7 +376,7 @@ abstract public class ViewFileSystemBaseTest {
         dirFooPresent = true;
       }
     }
-    Assert.assertTrue(dirFooPresent);
+    Assertions.assertTrue(dirFooPresent);
   }
   
   // rename across mount points that point to same target also fail 
@@ -557,33 +554,33 @@ abstract public class ViewFileSystemBaseTest {
     setUpNestedMountPoint();
     // Create file with nested mount point
     fileSystemTestHelper.createFile(fsView, "/user/userB/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.getFileStatus(new Path("/user/userB/foo")).isFile());
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.getFileStatus(new Path(targetTestRoot,"userB/foo")).isFile());
+    Assertions.assertTrue(fsView.getFileStatus(new Path("/user/userB/foo")).isFile(),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.getFileStatus(new Path(targetTestRoot,"userB/foo")).isFile(),
+        "Target of created file should be type file");
 
     // Delete the created file with nested mount point
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/user/userB/foo"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/user/userB/foo")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"userB/foo")));
+    Assertions.assertTrue(fsView.delete(new Path("/user/userB/foo"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/user/userB/foo")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"userB/foo")),
+        "Target File should not exist after delete");
 
     // Create file with a 2 component dirs with nested mount point
     fileSystemTestHelper.createFile(fsView, "/internalDir/linkToDir2/linkToDir2/foo");
-    Assert.assertTrue("Created file should be type file",
-        fsView.getFileStatus(new Path("/internalDir/linkToDir2/linkToDir2/foo")).isFile());
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.getFileStatus(new Path(targetTestRoot,"linkToDir2/foo")).isFile());
+    Assertions.assertTrue(fsView.getFileStatus(new Path("/internalDir/linkToDir2/linkToDir2/foo")).isFile(),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.getFileStatus(new Path(targetTestRoot,"linkToDir2/foo")).isFile(),
+        "Target of created file should be type file");
 
     // Delete the created file with nested mount point
-    Assert.assertTrue("Delete should succeed",
-        fsView.delete(new Path("/internalDir/linkToDir2/linkToDir2/foo"), false));
-    Assert.assertFalse("File should not exist after delete",
-        fsView.exists(new Path("/internalDir/linkToDir2/linkToDir2/foo")));
-    Assert.assertFalse("Target File should not exist after delete",
-        fsTarget.exists(new Path(targetTestRoot,"linkToDir2/foo")));
+    Assertions.assertTrue(fsView.delete(new Path("/internalDir/linkToDir2/linkToDir2/foo"), false),
+        "Delete should succeed");
+    Assertions.assertFalse(fsView.exists(new Path("/internalDir/linkToDir2/linkToDir2/foo")),
+        "File should not exist after delete");
+    Assertions.assertFalse(fsTarget.exists(new Path(targetTestRoot,"linkToDir2/foo")),
+        "Target File should not exist after delete");
   }
 
   private void setUpNestedMountPoint() throws IOException {
@@ -610,10 +607,10 @@ abstract public class ViewFileSystemBaseTest {
     FileSystemTestHelper.createFile(fsTarget, 
         targetFilePath, 10, 1024);
     Path viewFilePath = new Path("/data/largeFile");
-    Assert.assertTrue("Created File should be type File",
-        fsView.isFile(viewFilePath));
+    Assertions.assertTrue(fsView.isFile(viewFilePath),
+        "Created File should be type File");
     BlockLocation[] viewBL = fsView.getFileBlockLocations(fsView.getFileStatus(viewFilePath), 0, 10240+100);
-    Assert.assertEquals(SupportsBlocks ? 10 : 1, viewBL.length);
+    Assertions.assertEquals(SupportsBlocks ? 10 : 1, viewBL.length);
     BlockLocation[] targetBL = fsTarget.getFileBlockLocations(fsTarget.getFileStatus(targetFilePath), 0, 10240+100);
     compareBLs(viewBL, targetBL);
     
@@ -627,14 +624,12 @@ abstract public class ViewFileSystemBaseTest {
   }
   
   void compareBLs(BlockLocation[] viewBL, BlockLocation[] targetBL) {
-    Assert.assertEquals(targetBL.length, viewBL.length);
+    Assertions.assertEquals(viewBL.length, targetBL.length);
     int i = 0;
     for (BlockLocation vbl : viewBL) {
-      Assertions.assertThat(vbl.toString()).isEqualTo(targetBL[i].toString());
-      Assertions.assertThat(vbl.getOffset())
-          .isEqualTo(targetBL[i].getOffset());
-      Assertions.assertThat(vbl.getLength())
-          .isEqualTo(targetBL[i].getLength());
+      Assertions.assertEquals(vbl.toString(), targetBL[i].toString());
+      Assertions.assertEquals(vbl.getOffset(), targetBL[i].getOffset());
+      Assertions.assertEquals(vbl.getLength(), targetBL[i].getLength());
       i++;
     }
   }
@@ -668,35 +663,35 @@ abstract public class ViewFileSystemBaseTest {
 
     // list on internal dir
     dirPaths = listStatusInternal(located, new Path("/internalDir"));
-    Assert.assertEquals(2, dirPaths.length);
+    Assertions.assertEquals(dirPaths.length, 2);
 
     fs = fileSystemTestHelper.containsPath(fsView, "/internalDir/internalDir2", dirPaths);
-      Assert.assertNotNull(fs);
-      Assert.assertTrue("A mount should appear as symlink", fs.isDirectory());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isDirectory(), "A mount should appear as symlink");
     fs = fileSystemTestHelper.containsPath(fsView, "/internalDir/linkToDir2",
         dirPaths);
-      Assert.assertNotNull(fs);
-      Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isSymlink(), "A mount should appear as symlink");
   }
 
   private void verifyRootChildren(FileStatus[] dirPaths) throws IOException {
     FileStatus fs;
-    Assert.assertEquals(getExpectedDirPaths(), dirPaths.length);
+    Assertions.assertEquals(dirPaths.length, getExpectedDirPaths());
     fs = fileSystemTestHelper.containsPath(fsView, "/user", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isSymlink(), "A mount should appear as symlink");
     fs = fileSystemTestHelper.containsPath(fsView, "/data", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isSymlink(), "A mount should appear as symlink");
     fs = fileSystemTestHelper.containsPath(fsView, "/internalDir", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("A mount should appear as symlink", fs.isDirectory());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isDirectory(), "A mount should appear as symlink");
     fs = fileSystemTestHelper.containsPath(fsView, "/danglingLink", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isSymlink(), "A mount should appear as symlink");
     fs = fileSystemTestHelper.containsPath(fsView, "/linkToAFile", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("A mount should appear as symlink", fs.isSymlink());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isSymlink(), "A mount should appear as symlink");
   }
 
   int getExpectedDirPaths() {
@@ -720,27 +715,27 @@ abstract public class ViewFileSystemBaseTest {
     FileStatus[] dirPaths = listStatusInternal(located, dataPath);
 
     FileStatus fs;
-    Assert.assertEquals(0, dirPaths.length);
+    Assertions.assertEquals(dirPaths.length, 0);
     
     // add a file
     long len = fileSystemTestHelper.createFile(fsView, "/data/foo");
     dirPaths = listStatusInternal(located, dataPath);
-    Assert.assertEquals(1, dirPaths.length);
+    Assertions.assertEquals(dirPaths.length, 1);
     fs = fileSystemTestHelper.containsPath(fsView, "/data/foo", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("Created file shoudl appear as a file", fs.isFile());
-    Assert.assertEquals(len, fs.getLen());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isFile(), "Created file shoudl appear as a file");
+    Assertions.assertEquals(fs.getLen(), len);
     
     // add a dir
     fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/data/dirX"));
     dirPaths = listStatusInternal(located, dataPath);
-    Assert.assertEquals(2, dirPaths.length);
+    Assertions.assertEquals(dirPaths.length, 2);
     fs = fileSystemTestHelper.containsPath(fsView, "/data/foo", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("Created file shoudl appear as a file", fs.isFile());
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isFile(), "Created file shoudl appear as a file");
     fs = fileSystemTestHelper.containsPath(fsView, "/data/dirX", dirPaths);
-    Assert.assertNotNull(fs);
-    Assert.assertTrue("Created dir should appear as a dir", fs.isDirectory()); 
+    Assertions.assertNotNull(fs);
+    Assertions.assertTrue(fs.isDirectory(), "Created dir should appear as a dir"); 
   }
 
   private FileStatus[] listStatusInternal(boolean located, Path dataPath) throws IOException {
@@ -761,7 +756,7 @@ abstract public class ViewFileSystemBaseTest {
 
   @Test
   public void testFileStatusOnMountLink() throws IOException {
-    Assert.assertTrue(fsView.getFileStatus(new Path("/")).isDirectory());
+    Assertions.assertTrue(fsView.getFileStatus(new Path("/")).isDirectory());
     checkFileStatus(fsView, "/", fileType.isDir);
     checkFileStatus(fsView, "/user", fileType.isDir); // link followed => dir
     checkFileStatus(fsView, "/data", fileType.isDir);
@@ -772,14 +767,16 @@ abstract public class ViewFileSystemBaseTest {
     checkFileStatus(fsView, "/linkToAFile", fileType.isFile);
   }
   
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testgetFSonDanglingLink() throws IOException {
-    fsView.getFileStatus(new Path("/danglingLink"));
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.getFileStatus(new Path("/danglingLink")));
   }
   
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testgetFSonNonExistingInternalDir() throws IOException {
-    fsView.getFileStatus(new Path("/internalDir/nonExisting"));
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.getFileStatus(new Path("/internalDir/nonExisting")));
   }
   
   /*
@@ -788,57 +785,60 @@ abstract public class ViewFileSystemBaseTest {
   
   @Test
   public void testResolvePathInternalPaths() throws IOException {
-    Assert.assertEquals(new Path("/"), fsView.resolvePath(new Path("/")));
-    Assert.assertEquals(new Path("/internalDir"),
-        fsView.resolvePath(new Path("/internalDir")));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/")), new Path("/"));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/internalDir")),
+        new Path("/internalDir"));
   }
   @Test
   public void testResolvePathMountPoints() throws IOException {
-    Assert.assertEquals(new Path(targetTestRoot,"user"),
-        fsView.resolvePath(new Path("/user")));
-    Assert.assertEquals(new Path(targetTestRoot,"data"),
-        fsView.resolvePath(new Path("/data")));
-    Assert.assertEquals(new Path(targetTestRoot,"dir2"),
-        fsView.resolvePath(new Path("/internalDir/linkToDir2")));
-    Assert.assertEquals(new Path(targetTestRoot,"dir3"),
-        fsView.resolvePath(new Path("/internalDir/internalDir2/linkToDir3")));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/user")),
+        new Path(targetTestRoot,"user"));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/data")),
+        new Path(targetTestRoot,"data"));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/internalDir/linkToDir2")),
+        new Path(targetTestRoot,"dir2"));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/internalDir/internalDir2/linkToDir3")),
+        new Path(targetTestRoot,"dir3"));
 
   }
   
   @Test
   public void testResolvePathThroughMountPoints() throws IOException {
     fileSystemTestHelper.createFile(fsView, "/user/foo");
-    Assert.assertEquals(new Path(targetTestRoot,"user/foo"),
-        fsView.resolvePath(new Path("/user/foo")));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/user/foo")),
+        new Path(targetTestRoot,"user/foo"));
     
     fsView.mkdirs(
         fileSystemTestHelper.getTestRootPath(fsView, "/user/dirX"));
-    Assert.assertEquals(new Path(targetTestRoot,"user/dirX"),
-        fsView.resolvePath(new Path("/user/dirX")));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/user/dirX")),
+        new Path(targetTestRoot,"user/dirX"));
 
     
     fsView.mkdirs(
         fileSystemTestHelper.getTestRootPath(fsView, "/user/dirX/dirY"));
-    Assert.assertEquals(new Path(targetTestRoot,"user/dirX/dirY"),
-        fsView.resolvePath(new Path("/user/dirX/dirY")));
+    Assertions.assertEquals(fsView.resolvePath(new Path("/user/dirX/dirY")),
+        new Path(targetTestRoot,"user/dirX/dirY"));
   }
 
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testResolvePathDanglingLink() throws IOException {
-    fsView.resolvePath(new Path("/danglingLink"));
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.resolvePath(new Path("/danglingLink")));
   }
   
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testResolvePathMissingThroughMountPoints() throws IOException {
-    fsView.resolvePath(new Path("/user/nonExisting"));
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.resolvePath(new Path("/user/nonExisting")));
   }
   
 
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testResolvePathMissingThroughMountPoints2() throws IOException {
     fsView.mkdirs(
         fileSystemTestHelper.getTestRootPath(fsView, "/user/dirX"));
-    fsView.resolvePath(new Path("/user/dirX/nonExisting"));
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.resolvePath(new Path("/user/dirX/nonExisting")));
   }
   
   /**
@@ -851,119 +851,135 @@ abstract public class ViewFileSystemBaseTest {
  
  
   // Mkdir on existing internal mount table succeed except for /
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalMkdirSlash() throws IOException {
-    fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/")));
   }
   
   public void testInternalMkdirExisting1() throws IOException {
-    Assert.assertTrue("mkdir of existing dir should succeed", 
-        fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView,
-        "/internalDir")));
+    Assertions.assertTrue(fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView,
+        "/internalDir")), "mkdir of existing dir should succeed");
   }
 
   public void testInternalMkdirExisting2() throws IOException {
-    Assert.assertTrue("mkdir of existing dir should succeed", 
-        fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView,
-        "/internalDir/linkToDir2")));
+    Assertions.assertTrue(fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView,
+        "/internalDir/linkToDir2")), "mkdir of existing dir should succeed");
   }
   
   // Mkdir for new internal mount table should fail
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalMkdirNew() throws IOException {
-    fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/dirNew"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/dirNew")));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalMkdirNew2() throws IOException {
-    fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/internalDir/dirNew"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.mkdirs(fileSystemTestHelper.getTestRootPath(fsView, "/internalDir/dirNew")));
   }
   
   // Create File on internal mount table should fail
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalCreate1() throws IOException {
-    fileSystemTestHelper.createFile(fsView, "/foo"); // 1 component
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fileSystemTestHelper.createFile(fsView, "/foo")); // 1 component
   }
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalCreate2() throws IOException {  // 2 component
-    fileSystemTestHelper.createFile(fsView, "/internalDir/foo");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fileSystemTestHelper.createFile(fsView, "/internalDir/foo"));
   }
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalCreateMissingDir() throws IOException {
-    fileSystemTestHelper.createFile(fsView, "/missingDir/foo");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fileSystemTestHelper.createFile(fsView, "/missingDir/foo"));
   }
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalCreateMissingDir2() throws IOException {
-    fileSystemTestHelper.createFile(fsView, "/missingDir/miss2/foo");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fileSystemTestHelper.createFile(fsView, "/missingDir/miss2/foo"));
   }
   
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalCreateMissingDir3() throws IOException {
-    fileSystemTestHelper.createFile(fsView, "/internalDir/miss2/foo");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fileSystemTestHelper.createFile(fsView, "/internalDir/miss2/foo"));
   }
   
   // Delete on internal mount table should fail
   
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testInternalDeleteNonExisting() throws IOException {
-    fsView.delete(new Path("/NonExisting"), false);
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.delete(new Path("/NonExisting"), false));
   }
-  @Test(expected=FileNotFoundException.class) 
+  @Test
   public void testInternalDeleteNonExisting2() throws IOException {
-    fsView.delete(new Path("/internalDir/NonExisting"), false);
+    Assertions.assertThrows(FileNotFoundException.class,
+        () -> fsView.delete(new Path("/internalDir/NonExisting"), false));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalDeleteExisting() throws IOException {
-    fsView.delete(new Path("/internalDir"), false);
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.delete(new Path("/internalDir"), false));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalDeleteExisting2() throws IOException {
     fsView.getFileStatus(
             new Path("/internalDir/linkToDir2")).isDirectory();
-    fsView.delete(new Path("/internalDir/linkToDir2"), false);
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.delete(new Path("/internalDir/linkToDir2"), false));
   } 
   
   @Test
   public void testMkdirOfMountLink() throws IOException {
     // data exists - mkdirs returns true even though no permission in internal
     // mount table
-    Assert.assertTrue("mkdir of existing mount link should succeed", 
-        fsView.mkdirs(new Path("/data")));
+    Assertions.assertTrue(fsView.mkdirs(new Path("/data")),
+        "mkdir of existing mount link should succeed");
   }
   
   
   // Rename on internal mount table should fail
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalRename1() throws IOException {
-    fsView.rename(new Path("/internalDir"), new Path("/newDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.rename(new Path("/internalDir"), new Path("/newDir")));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalRename2() throws IOException {
     fsView.getFileStatus(new Path("/internalDir/linkToDir2")).isDirectory();
-    fsView.rename(new Path("/internalDir/linkToDir2"),
-        new Path("/internalDir/dir1"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.rename(new Path("/internalDir/linkToDir2"),
+        new Path("/internalDir/dir1")));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalRename3() throws IOException {
-    fsView.rename(new Path("/user"), new Path("/internalDir/linkToDir2"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.rename(new Path("/user"), new Path("/internalDir/linkToDir2")));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalRenameToSlash() throws IOException {
-    fsView.rename(new Path("/internalDir/linkToDir2/foo"), new Path("/"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.rename(new Path("/internalDir/linkToDir2/foo"), new Path("/")));
   }
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalRenameFromSlash() throws IOException {
-    fsView.rename(new Path("/"), new Path("/bar"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.rename(new Path("/"), new Path("/bar")));
   }
   
-  @Test(expected=AccessControlException.class) 
+  @Test
   public void testInternalSetOwner() throws IOException {
-    fsView.setOwner(new Path("/internalDir"), "foo", "bar");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.setOwner(new Path("/internalDir"), "foo", "bar"));
   }
   
   @Test
@@ -971,10 +987,10 @@ abstract public class ViewFileSystemBaseTest {
     Path path = fileSystemTestHelper.getTestRootPath(fsView, "/user/foo");
     fsView.createNonRecursive(path, false, 1024, (short)1, 1024L, null);
     FileStatus status = fsView.getFileStatus(new Path("/user/foo"));
-    Assert.assertTrue("Created file should be type file",
-        fsView.isFile(new Path("/user/foo")));
-    Assert.assertTrue("Target of created file should be type file",
-        fsTarget.isFile(new Path(targetTestRoot, "user/foo")));
+    Assertions.assertTrue(fsView.isFile(new Path("/user/foo")),
+        "Created file should be type file");
+    Assertions.assertTrue(fsTarget.isFile(new Path(targetTestRoot, "user/foo")),
+        "Target of created file should be type file");
   }
 
   @Test
@@ -991,11 +1007,11 @@ abstract public class ViewFileSystemBaseTest {
       throws IOException {
     // verify executable permission on root: cd /
     //
-    Assert.assertFalse("In root before cd",
-        fsView.getWorkingDirectory().isRoot());
+    Assertions.assertFalse(fsView.getWorkingDirectory().isRoot(),
+        "In root before cd");
     fsView.setWorkingDirectory(new Path("/"));
-    Assert.assertTrue("Not in root dir after cd",
-      fsView.getWorkingDirectory().isRoot());
+    Assertions.assertTrue(fsView.getWorkingDirectory().isRoot(),
+        "Not in root dir after cd");
 
     // verify readable
     //
@@ -1008,18 +1024,18 @@ abstract public class ViewFileSystemBaseTest {
         fsView.getFileStatus(fsView.getWorkingDirectory());
     final FsPermission perms = rootStatus.getPermission();
 
-    Assert.assertTrue("User-executable permission not set!",
-        perms.getUserAction().implies(FsAction.EXECUTE));
-    Assert.assertTrue("User-readable permission not set!",
-        perms.getUserAction().implies(FsAction.READ));
-    Assert.assertTrue("Group-executable permission not set!",
-        perms.getGroupAction().implies(FsAction.EXECUTE));
-    Assert.assertTrue("Group-readable permission not set!",
-        perms.getGroupAction().implies(FsAction.READ));
-    Assert.assertTrue("Other-executable permission not set!",
-        perms.getOtherAction().implies(FsAction.EXECUTE));
-    Assert.assertTrue("Other-readable permission not set!",
-        perms.getOtherAction().implies(FsAction.READ));
+    Assertions.assertTrue(perms.getUserAction().implies(FsAction.EXECUTE),
+        "User-executable permission not set!");
+    Assertions.assertTrue(perms.getUserAction().implies(FsAction.READ),
+        "User-readable permission not set!");
+    Assertions.assertTrue(perms.getGroupAction().implies(FsAction.EXECUTE),
+        "Group-executable permission not set!");
+    Assertions.assertTrue(perms.getGroupAction().implies(FsAction.READ),
+        "Group-readable permission not set!");
+    Assertions.assertTrue(perms.getOtherAction().implies(FsAction.EXECUTE),
+        "Other-executable permission not set!");
+    Assertions.assertTrue(perms.getOtherAction().implies(FsAction.READ),
+        "Other-readable permission not set!");
   }
 
   /**
@@ -1027,31 +1043,36 @@ abstract public class ViewFileSystemBaseTest {
    * any mount table entry.
    */
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalModifyAclEntries() throws IOException {
-    fsView.modifyAclEntries(new Path("/internalDir"),
-        new ArrayList<AclEntry>());
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.modifyAclEntries(new Path("/internalDir"),
+        new ArrayList<AclEntry>()));
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalRemoveAclEntries() throws IOException {
-    fsView.removeAclEntries(new Path("/internalDir"),
-        new ArrayList<AclEntry>());
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.removeAclEntries(new Path("/internalDir"),
+        new ArrayList<AclEntry>()));
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalRemoveDefaultAcl() throws IOException {
-    fsView.removeDefaultAcl(new Path("/internalDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.removeDefaultAcl(new Path("/internalDir")));
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalRemoveAcl() throws IOException {
-    fsView.removeAcl(new Path("/internalDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.removeAcl(new Path("/internalDir")));
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalSetAcl() throws IOException {
-    fsView.setAcl(new Path("/internalDir"), new ArrayList<AclEntry>());
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.setAcl(new Path("/internalDir"), new ArrayList<AclEntry>()));
   }
 
   @Test
@@ -1059,82 +1080,95 @@ abstract public class ViewFileSystemBaseTest {
     final UserGroupInformation currentUser =
         UserGroupInformation.getCurrentUser();
     AclStatus aclStatus = fsView.getAclStatus(new Path("/internalDir"));
-    assertEquals(aclStatus.getOwner(), currentUser.getUserName());
-    assertEquals(aclStatus.getGroup(), currentUser.getGroupNames()[0]);
-    assertEquals(aclStatus.getEntries(),
-        AclUtil.getMinimalAcl(PERMISSION_555));
-    assertFalse(aclStatus.isStickyBit());
+    Assertions.assertEquals(currentUser.getUserName(), aclStatus.getOwner());
+    Assertions.assertEquals(currentUser.getGroupNames()[0], aclStatus.getGroup());
+    Assertions.assertEquals(AclUtil.getMinimalAcl(PERMISSION_555), aclStatus.getEntries());
+    Assertions.assertFalse(aclStatus.isStickyBit());
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalSetXAttr() throws IOException {
-    fsView.setXAttr(new Path("/internalDir"), "xattrName", null);
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.setXAttr(new Path("/internalDir"), "xattrName", null));
   }
 
-  @Test(expected=NotInMountpointException.class)
+  @Test
   public void testInternalGetXAttr() throws IOException {
-    fsView.getXAttr(new Path("/internalDir"), "xattrName");
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> fsView.getXAttr(new Path("/internalDir"), "xattrName"));
   }
 
-  @Test(expected=NotInMountpointException.class)
+  @Test
   public void testInternalGetXAttrs() throws IOException {
-    fsView.getXAttrs(new Path("/internalDir"));
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> fsView.getXAttrs(new Path("/internalDir")));
   }
 
-  @Test(expected=NotInMountpointException.class)
+  @Test
   public void testInternalGetXAttrsWithNames() throws IOException {
-    fsView.getXAttrs(new Path("/internalDir"), new ArrayList<String>());
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> fsView.getXAttrs(new Path("/internalDir"), new ArrayList<String>()));
   }
 
-  @Test(expected=NotInMountpointException.class)
+  @Test
   public void testInternalListXAttr() throws IOException {
-    fsView.listXAttrs(new Path("/internalDir"));
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> fsView.listXAttrs(new Path("/internalDir")));
   }
 
-  @Test(expected=AccessControlException.class)
+  @Test
   public void testInternalRemoveXAttr() throws IOException {
-    fsView.removeXAttr(new Path("/internalDir"), "xattrName");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.removeXAttr(new Path("/internalDir"), "xattrName"));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalCreateSnapshot1() throws IOException {
-    fsView.createSnapshot(new Path("/internalDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.createSnapshot(new Path("/internalDir")));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalCreateSnapshot2() throws IOException {
-    fsView.createSnapshot(new Path("/internalDir"), "snap1");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.createSnapshot(new Path("/internalDir"), "snap1"));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalRenameSnapshot() throws IOException {
-    fsView.renameSnapshot(new Path("/internalDir"), "snapOldName",
-        "snapNewName");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.renameSnapshot(new Path("/internalDir"), "snapOldName",
+        "snapNewName"));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalDeleteSnapshot() throws IOException {
-    fsView.deleteSnapshot(new Path("/internalDir"), "snap1");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.deleteSnapshot(new Path("/internalDir"), "snap1"));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalSetStoragePolicy() throws IOException {
-    fsView.setStoragePolicy(new Path("/internalDir"), "HOT");
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.setStoragePolicy(new Path("/internalDir"), "HOT"));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalUnsetStoragePolicy() throws IOException {
-    fsView.unsetStoragePolicy(new Path("/internalDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.unsetStoragePolicy(new Path("/internalDir")));
   }
 
-  @Test(expected = AccessControlException.class)
+  @Test
   public void testInternalSatisfyStoragePolicy() throws IOException {
-    fsView.satisfyStoragePolicy(new Path("/internalDir"));
+    Assertions.assertThrows(AccessControlException.class,
+        () -> fsView.satisfyStoragePolicy(new Path("/internalDir")));
   }
 
-  @Test(expected = NotInMountpointException.class)
+  @Test
   public void testInternalgetStoragePolicy() throws IOException {
-    fsView.getStoragePolicy(new Path("/internalDir"));
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> fsView.getStoragePolicy(new Path("/internalDir")));
   }
 
   @Test
@@ -1144,7 +1178,7 @@ abstract public class ViewFileSystemBaseTest {
     for (FileSystem fs : fsView.getChildFileSystems()) {
       try {
         for (BlockStoragePolicySpi s : fs.getAllStoragePolicies()) {
-          assertTrue("Missing policy: " + s, policies.contains(s));
+          Assertions.assertTrue(policies.contains(s), "Missing policy: " + s);
         }
       } catch (UnsupportedOperationException e) {
         // ignore
@@ -1197,18 +1231,18 @@ abstract public class ViewFileSystemBaseTest {
 
     // Verify if Trash roots from ViewFileSystem matches that of the ones
     // from the target mounted FileSystem.
-    assertEquals(mountDataRootTrashPath.toUri().getPath(),
-        fsTargetRootTrashRoot.toUri().getPath());
-    assertEquals(mountDataFileTrashPath.toUri().getPath(),
-        fsTargetFileTrashPath.toUri().getPath());
-    assertEquals(mountDataRootTrashPath.toUri().getPath(),
+    Assertions.assertEquals(fsTargetRootTrashRoot.toUri().getPath(),
+        mountDataRootTrashPath.toUri().getPath());
+    Assertions.assertEquals(fsTargetFileTrashPath.toUri().getPath(),
         mountDataFileTrashPath.toUri().getPath());
+    Assertions.assertEquals(mountDataFileTrashPath.toUri().getPath(),
+        mountDataRootTrashPath.toUri().getPath());
 
 
     // Verify trash root for an non-existing file but on a valid mountpoint.
     Path trashRoot = fsView.getTrashRoot(mountDataNonExistingFilePath);
-    assertEquals(mountDataRootTrashPath.toUri().getPath(),
-        trashRoot.toUri().getPath());
+    Assertions.assertEquals(trashRoot.toUri().getPath(),
+        mountDataRootTrashPath.toUri().getPath());
 
     // Verify trash root for invalid mounts.
     Path invalidMountRootPath = new Path("/invalid_mount");
@@ -1238,12 +1272,12 @@ abstract public class ViewFileSystemBaseTest {
     newConf.setLong("fs.trash.interval", 1000);
     Trash lTrash = new Trash(fsTarget, newConf);
     boolean trashed = lTrash.moveToTrash(fsTargetFilePath);
-    Assert.assertTrue("File " + fileStatus + " move to " +
-        "trash failed.", trashed);
+    Assertions.assertTrue(trashed, "File " + fileStatus + " move to " +
+        "trash failed.");
 
     // Verify ViewFileSystem trash roots shows the ones from
     // target mounted FileSystem.
-    Assert.assertTrue("", fsView.getTrashRoots(true).size() > 0);
+    Assertions.assertTrue(fsView.getTrashRoots(true).size() > 0, "");
   }
 
   // Default implementation of getTrashRoot for a fallback FS mounted at root:
@@ -1269,14 +1303,14 @@ abstract public class ViewFileSystemBaseTest {
     Path dataTestPath = new Path("/data/dir/file");
     Path dataTrashRoot = fsView2.makeQualified(
         new Path("/data/" + TRASH_PREFIX + "/" + ugi.getShortUserName()));
-    Assert.assertEquals(dataTrashRoot, fsView2.getTrashRoot(dataTestPath));
+    Assertions.assertEquals(fsView2.getTrashRoot(dataTestPath), dataTrashRoot);
 
     // Case 2: path p not found in mount table.
     // Return a trash root in fallback FS.
     Path nonExistentPath = new Path("/nonExistentDir/nonExistentFile");
     Path expectedTrash =
         fsView2.makeQualified(getTrashRootInFallBackFS());
-    Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(nonExistentPath));
+    Assertions.assertEquals(fsView2.getTrashRoot(nonExistentPath), expectedTrash);
 
     // Case 3: turn off the CONFIG_VIEWFS_TRASH_FORCE_INSIDE_MOUNT_POINT flag.
     // Return a trash root in user home dir.
@@ -1284,8 +1318,8 @@ abstract public class ViewFileSystemBaseTest {
     fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path targetFSUserHomeTrashRoot = fsTarget.makeQualified(
         new Path(fsTarget.getHomeDirectory(), TRASH_PREFIX));
-    Assert.assertEquals(targetFSUserHomeTrashRoot,
-        fsView2.getTrashRoot(dataTestPath));
+    Assertions.assertEquals(fsView2.getTrashRoot(dataTestPath),
+        targetFSUserHomeTrashRoot);
 
     // Case 4: viewFS without fallback. Expect exception for a nonExistent path
     conf2 = new Configuration(conf);
@@ -1325,7 +1359,7 @@ abstract public class ViewFileSystemBaseTest {
     FileSystem fsView2 = FileSystem.get(FsConstants.VIEWFS_URI, conf2);
     Path expectedTrash = fsView2.makeQualified(
         new Path("/mnt/datavol1/very/deep/deep/trash/dir/.Trash"));
-    Assert.assertEquals(expectedTrash, fsView2.getTrashRoot(testPath));
+    Assertions.assertEquals(fsView2.getTrashRoot(testPath), expectedTrash);
   }
 
   /**
@@ -1340,7 +1374,7 @@ abstract public class ViewFileSystemBaseTest {
     // Case 1: verify correct trash roots from fsView and fsView2
     int beforeTrashRootNum = fsView.getTrashRoots(true).size();
     int beforeTrashRootNum2 = fsView2.getTrashRoots(true).size();
-    Assert.assertEquals(beforeTrashRootNum, beforeTrashRootNum2);
+    Assertions.assertEquals(beforeTrashRootNum2, beforeTrashRootNum);
 
     fsView.mkdirs(new Path("/data/" + TRASH_PREFIX + "/user1"));
     fsView.mkdirs(new Path("/data/" + TRASH_PREFIX + "/user2"));
@@ -1349,8 +1383,8 @@ abstract public class ViewFileSystemBaseTest {
     fsView.mkdirs(new Path("/user2/" + TRASH_PREFIX + "/user5"));
     int afterTrashRootsNum = fsView.getTrashRoots(true).size();
     int afterTrashRootsNum2 = fsView2.getTrashRoots(true).size();
-    Assert.assertEquals(beforeTrashRootNum, afterTrashRootsNum);
-    Assert.assertEquals(beforeTrashRootNum2 + 5, afterTrashRootsNum2);
+    Assertions.assertEquals(afterTrashRootsNum, beforeTrashRootNum);
+    Assertions.assertEquals(afterTrashRootsNum2, beforeTrashRootNum2 + 5);
 
     // Case 2: per-user mount point
     fsTarget.mkdirs(new Path(targetTestRoot, "Users/userA/.Trash/userA"));
@@ -1359,7 +1393,7 @@ abstract public class ViewFileSystemBaseTest {
         new Path(targetTestRoot, "Users/userA").toUri());
     FileSystem fsView3 = FileSystem.get(FsConstants.VIEWFS_URI, conf3);
     int trashRootsNum3 = fsView3.getTrashRoots(true).size();
-    Assert.assertEquals(afterTrashRootsNum2 + 1, trashRootsNum3);
+    Assertions.assertEquals(trashRootsNum3, afterTrashRootsNum2 + 1);
 
     // Case 3: single /Users mount point for all users
     fsTarget.mkdirs(new Path(targetTestRoot, "Users/.Trash/user1"));
@@ -1369,7 +1403,7 @@ abstract public class ViewFileSystemBaseTest {
         new Path(targetTestRoot, "Users").toUri());
     FileSystem fsView4 = FileSystem.get(FsConstants.VIEWFS_URI, conf4);
     int trashRootsNum4 = fsView4.getTrashRoots(true).size();
-    Assert.assertEquals(afterTrashRootsNum2 + 2, trashRootsNum4);
+    Assertions.assertEquals(trashRootsNum4, afterTrashRootsNum2 + 2);
 
     // Case 4: test trash roots in fallback FS
     fsTarget.mkdirs(new Path(targetTestRoot, ".Trash/user10"));
@@ -1379,7 +1413,7 @@ abstract public class ViewFileSystemBaseTest {
     ConfigUtil.addLinkFallback(conf5, targetTestRoot.toUri());
     FileSystem fsView5 = FileSystem.get(FsConstants.VIEWFS_URI, conf5);
     int trashRootsNum5 = fsView5.getTrashRoots(true).size();
-    Assert.assertEquals(afterTrashRootsNum2 + 3, trashRootsNum5);
+    Assertions.assertEquals(trashRootsNum5, afterTrashRootsNum2 + 3);
   }
 
   /**
@@ -1395,7 +1429,7 @@ abstract public class ViewFileSystemBaseTest {
 
     int beforeTrashRootNum = fsView.getTrashRoots(false).size();
     int beforeTrashRootNum2 = fsView2.getTrashRoots(false).size();
-    Assert.assertEquals(beforeTrashRootNum, beforeTrashRootNum2);
+    Assertions.assertEquals(beforeTrashRootNum2, beforeTrashRootNum);
 
     fsView.mkdirs(new Path("/data/" + TRASH_PREFIX + "/" + currentUser));
     fsView.mkdirs(new Path("/data/" + TRASH_PREFIX + "/user2"));
@@ -1404,8 +1438,8 @@ abstract public class ViewFileSystemBaseTest {
     fsView.mkdirs(new Path("/user2/" + TRASH_PREFIX + "/user5"));
     int afterTrashRootsNum = fsView.getTrashRoots(false).size();
     int afterTrashRootsNum2 = fsView2.getTrashRoots(false).size();
-    Assert.assertEquals(beforeTrashRootNum, afterTrashRootsNum);
-    Assert.assertEquals(beforeTrashRootNum2 + 2, afterTrashRootsNum2);
+    Assertions.assertEquals(afterTrashRootsNum, beforeTrashRootNum);
+    Assertions.assertEquals(afterTrashRootsNum2, beforeTrashRootNum2 + 2);
 
     // Test trash roots in fallback FS
     Configuration conf3 = new Configuration(conf2);
@@ -1413,52 +1447,50 @@ abstract public class ViewFileSystemBaseTest {
     ConfigUtil.addLinkFallback(conf3, targetTestRoot.toUri());
     FileSystem fsView3 = FileSystem.get(FsConstants.VIEWFS_URI, conf3);
     int trashRootsNum3 = fsView3.getTrashRoots(false).size();
-    Assert.assertEquals(afterTrashRootsNum2 + 1, trashRootsNum3);
+    Assertions.assertEquals(trashRootsNum3, afterTrashRootsNum2 + 1);
   }
 
-  @Test(expected = NotInMountpointException.class)
+  @Test
   public void testViewFileSystemUtil() throws Exception {
     Configuration newConf = new Configuration(conf);
 
     FileSystem fileSystem = FileSystem.get(FsConstants.LOCAL_FS_URI,
         newConf);
-    Assert.assertFalse("Unexpected FileSystem: " + fileSystem,
-        ViewFileSystemUtil.isViewFileSystem(fileSystem));
+    Assertions.assertFalse(ViewFileSystemUtil.isViewFileSystem(fileSystem),
+        "Unexpected FileSystem: " + fileSystem);
 
     fileSystem = FileSystem.get(FsConstants.VIEWFS_URI,
         newConf);
-    Assert.assertTrue("Unexpected FileSystem: " + fileSystem,
-        ViewFileSystemUtil.isViewFileSystem(fileSystem));
+    Assertions.assertTrue(ViewFileSystemUtil.isViewFileSystem(fileSystem),
+        "Unexpected FileSystem: " + fileSystem);
 
     // Case 1: Verify FsStatus of root path returns all MountPoints status.
     Map<MountPoint, FsStatus> mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem, InodeTree.SlashPath);
-    Assert.assertEquals(getExpectedMountPoints(), mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), getExpectedMountPoints());
 
     // Case 2: Verify FsStatus of an internal dir returns all
     // MountPoints status.
     mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem, new Path("/internalDir"));
-    Assert.assertEquals(getExpectedMountPoints(), mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), getExpectedMountPoints());
 
     // Case 3: Verify FsStatus of a matching MountPoint returns exactly
     // the corresponding MountPoint status.
     mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem, new Path("/user"));
-    Assert.assertEquals(1, mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), 1);
     for (Entry<MountPoint, FsStatus> entry : mountPointFsStatusMap.entrySet()) {
-      Assert.assertEquals(entry.getKey().getMountedOnPath().toString(),
-          "/user");
+      Assertions.assertEquals("/user", entry.getKey().getMountedOnPath().toString());
     }
 
     // Case 4: Verify FsStatus of a path over a MountPoint returns the
     // corresponding MountPoint status.
     mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem, new Path("/user/cloud"));
-    Assert.assertEquals(1, mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), 1);
     for (Entry<MountPoint, FsStatus> entry : mountPointFsStatusMap.entrySet()) {
-      Assert.assertEquals(entry.getKey().getMountedOnPath().toString(),
-          "/user");
+      Assertions.assertEquals("/user", entry.getKey().getMountedOnPath().toString());
     }
 
     // Case 5: Verify FsStatus of any level of an internal dir
@@ -1466,20 +1498,21 @@ abstract public class ViewFileSystemBaseTest {
     mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem,
             new Path("/internalDir/internalDir2"));
-    Assert.assertEquals(getExpectedMountPoints(), mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), getExpectedMountPoints());
 
     // Case 6: Verify FsStatus of a MountPoint URI returns
     // the MountPoint status.
     mountPointFsStatusMap =
         ViewFileSystemUtil.getStatus(fileSystem, new Path("viewfs:/user/"));
-    Assert.assertEquals(1, mountPointFsStatusMap.size());
+    Assertions.assertEquals(mountPointFsStatusMap.size(), 1);
     for (Entry<MountPoint, FsStatus> entry : mountPointFsStatusMap.entrySet()) {
-      Assert.assertEquals(entry.getKey().getMountedOnPath().toString(),
-          "/user");
+      Assertions.assertEquals("/user", entry.getKey().getMountedOnPath().toString());
     }
 
     // Case 7: Verify FsStatus of a non MountPoint path throws exception
-    ViewFileSystemUtil.getStatus(fileSystem, new Path("/non-existing"));
+    final FileSystem fsCopy = fileSystem;
+    Assertions.assertThrows(NotInMountpointException.class,
+        () -> ViewFileSystemUtil.getStatus(fsCopy, new Path("/non-existing")));
   }
 
   @Test
@@ -1492,10 +1525,10 @@ abstract public class ViewFileSystemBaseTest {
       public Object run() throws IOException {
         UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
         String doAsUserName = ugi.getUserName();
-        assertEquals(doAsUserName, "user@HADOOP.COM");
+        Assertions.assertEquals("user@HADOOP.COM", doAsUserName);
         FileSystem vfs = FileSystem.get(FsConstants.VIEWFS_URI, conf);
         FileStatus stat = vfs.getFileStatus(new Path("/internalDir"));
-        assertEquals(userUgi.getShortUserName(), stat.getOwner());
+        Assertions.assertEquals(stat.getOwner(), userUgi.getShortUserName());
         return null;
       }
     });
@@ -1513,9 +1546,9 @@ abstract public class ViewFileSystemBaseTest {
     long usedSpaceByPathViaViewFs = fsView.getUsed(new Path("/user"));
     long usedSpaceByPathViaTargetFs =
         fsTarget.getUsed(new Path(targetTestRoot, "user"));
-    assertEquals("Space used not matching between ViewFileSystem and " +
-        "the mounted FileSystem!",
-        usedSpaceByPathViaTargetFs, usedSpaceByPathViaViewFs);
+    Assertions.assertEquals(usedSpaceByPathViaTargetFs, usedSpaceByPathViaViewFs,
+        "Space used not matching between ViewFileSystem and " +
+            "the mounted FileSystem!");
 
     Path mountDataRootPath = new Path("/data");
     String fsTargetFileName = "debug.log";
@@ -1525,15 +1558,15 @@ abstract public class ViewFileSystemBaseTest {
 
     usedSpaceByPathViaViewFs = fsView.getUsed(mountDataFilePath);
     usedSpaceByPathViaTargetFs = fsTarget.getUsed(fsTargetFilePath);
-    assertEquals("Space used not matching between ViewFileSystem and " +
-        "the mounted FileSystem!",
-        usedSpaceByPathViaTargetFs, usedSpaceByPathViaViewFs);
+    Assertions.assertEquals(usedSpaceByPathViaTargetFs, usedSpaceByPathViaViewFs,
+        "Space used not matching between ViewFileSystem and " +
+            "the mounted FileSystem!");
   }
 
   @Test
   public void testLinkTarget() throws Exception {
 
-    Assume.assumeTrue(fsTarget.supportsSymlinks() &&
+    Assumptions.assumeTrue(fsTarget.supportsSymlinks() &&
         fsTarget.areSymlinksEnabled());
 
     // Symbolic link
@@ -1553,8 +1586,8 @@ abstract public class ViewFileSystemBaseTest {
     final Path actualMountLinkTarget = fsView.getLinkTarget(
         mountTargetSymLinkPath);
 
-    assertEquals("Resolved link target path not matching!",
-        expectedMountLinkTarget, actualMountLinkTarget);
+    Assertions.assertEquals(expectedMountLinkTarget, actualMountLinkTarget,
+        "Resolved link target path not matching!");
 
     // Relative symbolic link
     final String relativeFileName = "dir2/../" + targetFileName;
@@ -1570,8 +1603,8 @@ abstract public class ViewFileSystemBaseTest {
     final Path actualMountRelLinkTarget = fsView.getLinkTarget(
         mountTargetRelativeSymLinkPath);
 
-    assertEquals("Resolved relative link target path not matching!",
-        expectedMountRelLinkTarget, actualMountRelLinkTarget);
+    Assertions.assertEquals(expectedMountRelLinkTarget, actualMountRelLinkTarget,
+        "Resolved relative link target path not matching!");
 
     try {
       fsView.getLinkTarget(new Path("/linkToAFile"));
@@ -1606,10 +1639,10 @@ abstract public class ViewFileSystemBaseTest {
     FileSystem fs = cache.get(fsTarget.getUri(), conf);
 
     // InnerCache caches filesystem.
-    assertSame(fs, cache.get(fsTarget.getUri(), conf));
+    Assertions.assertSame(cache.get(fsTarget.getUri(), conf), fs);
 
     // InnerCache and FileSystem.CACHE are independent.
-    assertNotSame(fs, FileSystem.get(fsTarget.getUri(), conf));
+    Assertions.assertNotSame(FileSystem.get(fsTarget.getUri(), conf), fs);
 
     // close InnerCache.
     cache.closeAll();
@@ -1634,14 +1667,14 @@ abstract public class ViewFileSystemBaseTest {
     URI uri = new URI("viewfs://" + clusterName + "/");
 
     ViewFileSystem viewFs = (ViewFileSystem) FileSystem.get(uri, config);
-    assertTrue("viewfs should have at least one child fs.",
-        viewFs.getChildFileSystems().length > 0);
+    Assertions.assertTrue(viewFs.getChildFileSystems().length > 0,
+        "viewfs should have at least one child fs.");
     // viewFs is cached in FileSystem.CACHE
-    assertSame(viewFs, FileSystem.get(uri, config));
+    Assertions.assertSame(FileSystem.get(uri, config), viewFs);
 
     // child fs is not cached in FileSystem.CACHE
     FileSystem child = viewFs.getChildFileSystems()[0];
-    assertNotSame(child, FileSystem.get(child.getUri(), config));
+    Assertions.assertNotSame(FileSystem.get(child.getUri(), config), child);
 
     viewFs.close();
     for (FileSystem childfs : viewFs.getChildFileSystems()) {
@@ -1669,9 +1702,9 @@ abstract public class ViewFileSystemBaseTest {
         .get(new URI("viewfs://" + clusterName + "/"), config);
     viewFs.resolvePath(
         new Path(String.format("viewfs://%s/%s", clusterName, "/user")));
-    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 1);
     viewFs.close();
-    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize);
   }
 
   @Test
@@ -1686,12 +1719,12 @@ abstract public class ViewFileSystemBaseTest {
     ViewFileSystem viewFs = (ViewFileSystem) FileSystem
         .get(new URI("viewfs://" + clusterName + "/"), config);
     viewFs.mkdirs(testDir);
-    assertTrue(viewFs.exists(testDir));
-    assertTrue(fsTarget.exists(realTestPath));
+    Assertions.assertTrue(viewFs.exists(testDir));
+    Assertions.assertTrue(fsTarget.exists(realTestPath));
 
     viewFs.deleteOnExit(testDir);
     viewFs.close();
-    assertFalse(fsTarget.exists(realTestPath));
+    Assertions.assertFalse(fsTarget.exists(realTestPath));
   }
 
   @Test
@@ -1711,15 +1744,15 @@ abstract public class ViewFileSystemBaseTest {
 
     ContentSummary summaryAfter =
         fsView.getContentSummary(new Path("/internalDir"));
-    assertEquals("The file count didn't match",
-        summaryBefore.getFileCount() + 1,
-        summaryAfter.getFileCount());
-    assertEquals("The size didn't match",
-        summaryBefore.getLength() + expected.length(),
-        summaryAfter.getLength());
-    assertEquals("The directory count didn't match",
-        summaryBefore.getDirectoryCount() + 1,
-        summaryAfter.getDirectoryCount());
+    Assertions.assertEquals(summaryBefore.getFileCount() + 1,
+        summaryAfter.getFileCount(),
+        "The file count didn't match");
+    Assertions.assertEquals(summaryBefore.getLength() + expected.length(),
+        summaryAfter.getLength(),
+        "The size didn't match");
+    Assertions.assertEquals(summaryBefore.getDirectoryCount() + 1,
+        summaryAfter.getDirectoryCount(),
+        "The directory count didn't match");
   }
 
   @Test
@@ -1727,7 +1760,7 @@ abstract public class ViewFileSystemBaseTest {
     ContentSummary summaryBefore =
         fsView.getContentSummary(new Path("/internalDir"));
     String expected = "GET CONTENT SUMMARY";
-    File localFile = temporaryFolder.newFile("localFile");
+    File localFile = temporaryFolder.toPath().resolve("localFile").toFile();
     try (FileOutputStream fos = new FileOutputStream(localFile)) {
       fos.write(expected.getBytes());
     }
@@ -1737,12 +1770,12 @@ abstract public class ViewFileSystemBaseTest {
     try (FileSystem fs = FileSystem.get(FsConstants.VIEWFS_URI, conf)) {
       ContentSummary summaryAfter =
           fs.getContentSummary(new Path("/internalDir"));
-      assertEquals("The file count didn't match",
+      Assertions.assertEquals(summaryAfter.getFileCount(),
           summaryBefore.getFileCount() + 1,
-          summaryAfter.getFileCount());
-      assertEquals("The directory count didn't match",
+          "The file count didn't match");
+      Assertions.assertEquals(summaryAfter.getLength(),
           summaryBefore.getLength() + expected.length(),
-          summaryAfter.getLength());
+          "The directory count didn't match");
     }
   }
 
@@ -1766,7 +1799,7 @@ abstract public class ViewFileSystemBaseTest {
     // cache size will remain the same
     // cache is disabled for viewfs scheme, so the viewfs:// instance won't
     // go in the cache even after the initialization
-    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize);
 
     // This resolve path will initialize the file system corresponding
     // to the mount table entry of the path "/user"
@@ -1774,17 +1807,17 @@ abstract public class ViewFileSystemBaseTest {
         new Path(String.format("viewfs://%s/%s", clusterName, "/user")));
 
     // Cache size will increase by 1.
-    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 1);
     // This resolve path will initialize the file system corresponding
     // to the mount table entry of the path "/mock"
     viewFs.resolvePath(new Path(String.format("viewfs://%s/%s", clusterName,
         "/mock")));
     // One more file system instance will get initialized.
-    assertEquals(cacheSize + 2, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 2);
     viewFs.close();
     // Initialized FileSystem instances will not be removed from cache as
     // viewfs inner cache is disabled
-    assertEquals(cacheSize + 2, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 2);
   }
 
   @Test
@@ -1808,13 +1841,13 @@ abstract public class ViewFileSystemBaseTest {
     // cache size will remain the same
     // cache is disabled for viewfs scheme, so the viewfs:// instance won't
     // go in the cache even after the initialization
-    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize);
 
     // This is not going to initialize any filesystem instance
     viewFs.setVerifyChecksum(true);
 
     // Cache size will remain the same
-    assertEquals(cacheSize, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize);
 
     // This resolve path will initialize the file system corresponding
     // to the mount table entry of the path "/user"
@@ -1822,12 +1855,12 @@ abstract public class ViewFileSystemBaseTest {
         new Path(String.format("viewfs://%s/%s", clusterName, "/user")));
 
     // Cache size will increase by 1.
-    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 1);
 
     viewFs.close();
     // Initialized FileSystem instances will not be removed from cache as
     // viewfs inner cache is disabled
-    assertEquals(cacheSize + 1, TestFileUtil.getCacheSize());
+    Assertions.assertEquals(TestFileUtil.getCacheSize(), cacheSize + 1);
   }
 
   @Test
@@ -1843,8 +1876,8 @@ abstract public class ViewFileSystemBaseTest {
           new URI("viewfs://" + clusterName + "/"), config);
       fail("FileSystem should not initialize. Should fail with IOException");
     } catch (IOException ex) {
-      assertTrue("Should get URISyntax Exception",
-          ex.getMessage().startsWith("URISyntax exception"));
+      Assertions.assertTrue(ex.getMessage().startsWith("URISyntax exception"),
+          "Should get URISyntax Exception");
     }
   }
 }


### PR DESCRIPTION
### Description of PR

migrate ViewFileSystemBaseTest.java to Junit 5
This fixes the failures in the child class that have already been migrated

### How was this patch tested?

Run mvn test for the affected test classes.

Note that TestViewFileSystemHdfs.testTrashRootsAfterEncryptionZoneDeletion is failing, but that one
is not run on trunk, and is probably a pre-existing issue unrelated to the Junit 5 migration issues.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

