### PR TITLE
HADOOP-19532. Update commons-lang3 to 3.17.0 (#7591)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -301,7 +301,7 @@ org.apache.commons:commons-compress:1.26.1
 org.apache.commons:commons-configuration2:2.10.1
 org.apache.commons:commons-csv:1.9.0
 org.apache.commons:commons-digester:1.8.1
-org.apache.commons:commons-lang3:3.12.0
+org.apache.commons:commons-lang3:3.17.0
 org.apache.commons:commons-math3:3.6.1
 org.apache.commons:commons-text:1.10.0
 org.apache.commons:commons-validator:1.6

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -125,7 +125,7 @@
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-csv.version>1.9.0</commons-csv.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-logging.version>1.3.0</commons-logging.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.9.0</commons-net.version>


### PR DESCRIPTION
### Description of PR

Backports HADOOP-19532. Update commons-lang3 to 3.17.0 (#7591)

### How was this patch tested?

CI only

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

