### PR TITLE
HADOOP-19555. Fix testRenameFileWithFullQualifiedPath on Windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.fs.ftp;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
@@ -530,7 +530,7 @@ public class FTPFileSystem extends FileSystem {
       return new FileStatus(length, isDir, blockReplication, blockSize,
           modTime, this.makeQualified(root));
     }
-    String pathName = new File(parentPath.toUri().getPath()).getCanonicalPath();
+    String pathName = parentPath.toUri().getPath();
     FTPFile[] ftpFiles = client.listFiles(pathName);
     if (ftpFiles != null) {
       for (FTPFile ftpFile : ftpFiles) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ftp/FTPFileSystem.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.ftp;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -529,7 +530,7 @@ public class FTPFileSystem extends FileSystem {
       return new FileStatus(length, isDir, blockReplication, blockSize,
           modTime, this.makeQualified(root));
     }
-    String pathName = parentPath.toUri().getPath();
+    String pathName = new File(parentPath.toUri().getPath()).getCanonicalPath();
     FTPFile[] ftpFiles = client.listFiles(pathName);
     if (ftpFiles != null) {
       for (FTPFile ftpFile : ftpFiles) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -19,18 +19,10 @@ package org.apache.hadoop.fs.ftp;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Comparator;
 
-import org.apache.commons.net.PrintCommandListener;
-import org.apache.commons.net.ftp.FTPClientConfig;
-import org.apache.commons.net.ftp.FTPReply;
-import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
@@ -276,95 +268,11 @@ public class TestFTPFileSystem {
 
     FileSystem fs = FileSystem.get(configuration);
 
-    Path ftpDir = fs.makeQualified(new Path(testDir.toAbsolutePath().toString()));
+    Path ftpDir = fs.makeQualified(new Path("/"));
     Path file1 = fs.makeQualified(new Path(ftpDir, "renamefile" + "1"));
     Path file2 = fs.makeQualified(new Path(ftpDir, "renamefile" + "2"));
 
     touch(fs, file1);
-    FTPClient ftpClient = connect(configuration);
-    FTPFile[] files = ftpClient.listFiles("/D/projects/github/apache/hadoop/hadoop-common-project/hadoop-common/target/test/data");
-    FTPFile[] files1 = ftpClient.listFiles("D:/projects/github/apache/hadoop/hadoop-common-project/hadoop-common/target/test/data");
-    FTPFile[] files2 = ftpClient.listFiles("D:\\projects\\github\\apache\\hadoop\\hadoop-common-project\\hadoop-common\\target\\test\\data");
     assertTrue(fs.rename(file1, file2));
-  }
-
-  private FTPClient connect(Configuration conf) throws IOException {
-    FTPClient client = null;
-    String host = conf.get("fs.ftp.host");
-    int port = conf.getInt("fs.ftp.host.port", FTP.DEFAULT_PORT);
-    String user = conf.get("fs.ftp.user." + host);
-    String password = conf.get("fs.ftp.password." + host);
-    client = new FTPClient();
-    FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_NT);
-    client.configure(config);
-    client.connect(host, port);
-    int reply = client.getReplyCode();
-    if (!FTPReply.isPositiveCompletion(reply)) {
-      throw NetUtils.wrapException(host, port,
-          NetUtils.UNKNOWN_HOST, 0,
-          new ConnectException("Server response " + reply));
-    } else if (client.login(user, password)) {
-      client.setFileTransferMode(getTransferMode(conf));
-      client.setFileType(FTP.BINARY_FILE_TYPE);
-      client.setBufferSize(FTPFileSystem.DEFAULT_BUFFER_SIZE);
-      setTimeout(client, conf);
-      setDataConnectionMode(client, conf);
-    } else {
-      throw new IOException("Login failed on server - " + host + ", port - "
-          + port + " as user '" + user + "'");
-    }
-
-    client.enterLocalActiveMode();
-    client.initiateListParsing();
-
-    client.addProtocolCommandListener(new PrintCommandListener(new PrintWriter(System.out), true));
-    return client;
-  }
-
-  private
-  int getTransferMode(Configuration conf) {
-    final String mode = conf.get(FTPFileSystem.FS_FTP_TRANSFER_MODE);
-    // FTP default is STREAM_TRANSFER_MODE, but Hadoop FTPFS's default is
-    // FTP.BLOCK_TRANSFER_MODE historically.
-    int ret = FTP.BLOCK_TRANSFER_MODE;
-    if (mode == null) {
-      return ret;
-    }
-    final String upper = mode.toUpperCase();
-    if (upper.equals("STREAM_TRANSFER_MODE")) {
-      ret = FTP.STREAM_TRANSFER_MODE;
-    } else if (upper.equals("COMPRESSED_TRANSFER_MODE")) {
-      ret = FTP.COMPRESSED_TRANSFER_MODE;
-    } else {
-      if (!upper.equals("BLOCK_TRANSFER_MODE")) {
-        LOG.warn("Cannot parse the value for " + FTPFileSystem.FS_FTP_TRANSFER_MODE
-            + ": {}. Using default.", mode);
-      }
-    }
-    return ret;
-  }
-
-  private void setTimeout(FTPClient client, Configuration conf) {
-    long timeout = conf.getLong(FTPFileSystem.FS_FTP_TIMEOUT, FTPFileSystem.DEFAULT_TIMEOUT);
-    client.setControlKeepAliveTimeout(timeout);
-  }
-
-  private void setDataConnectionMode(FTPClient client, Configuration conf) throws IOException {
-    final String mode = conf.get(FTPFileSystem.FS_FTP_DATA_CONNECTION_MODE);
-    if (mode == null) {
-      return;
-    }
-    final String upper = mode.toUpperCase();
-    if (upper.equals("PASSIVE_LOCAL_DATA_CONNECTION_MODE")) {
-      client.enterLocalPassiveMode();
-    } else if (upper.equals("PASSIVE_REMOTE_DATA_CONNECTION_MODE")) {
-      client.enterRemotePassiveMode();
-    } else {
-      if (!upper.equals("ACTIVE_LOCAL_DATA_CONNECTION_MODE")) {
-        LOG.warn(
-            "Cannot parse the value for " + FTPFileSystem.FS_FTP_DATA_CONNECTION_MODE + ": " + mode
-                + ". Using default.");
-      }
-    }
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -236,6 +236,7 @@ public class TestFTPFileSystem {
 
   private static void touch(FileSystem fs, Path filePath)
           throws IOException {
+    // Create a file with a single byte of data.
     touch(fs, filePath, new byte[] {1});
   }
 
@@ -266,6 +267,8 @@ public class TestFTPFileSystem {
 
     FileSystem fs = FileSystem.get(configuration);
 
+    // All the file operations will be relative to the root directory specified by the testDir
+    // member variable.
     Path ftpDir = fs.makeQualified(new Path("/"));
     Path file1 = fs.makeQualified(new Path(ftpDir, "renamefile" + "1"));
     Path file2 = fs.makeQualified(new Path(ftpDir, "renamefile" + "2"));

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,8 +53,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Timeout(180)
 public class TestFTPFileSystem {
-  public static final Logger LOG = LoggerFactory.getLogger(TestFTPFileSystem.class);
-
   private FtpTestServer server;
   private java.nio.file.Path testDir;
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -234,7 +234,8 @@ public class TestFTPFileSystem {
     assertEquals(client.getControlKeepAliveTimeout(), timeout);
   }
 
-  private static void touch(FileSystem fs, Path filePath) throws IOException {
+  private static void touch(FileSystem fs, Path filePath)
+          throws IOException {
     touch(fs, filePath, new byte[] {1});
   }
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Timeout(180)
 public class TestFTPFileSystem {
+
   private FtpTestServer server;
   private java.nio.file.Path testDir;
 
@@ -267,7 +268,6 @@ public class TestFTPFileSystem {
     Path ftpDir = fs.makeQualified(new Path("/"));
     Path file1 = fs.makeQualified(new Path(ftpDir, "renamefile" + "1"));
     Path file2 = fs.makeQualified(new Path(ftpDir, "renamefile" + "2"));
-
     touch(fs, file1);
     assertTrue(fs.rename(file1, file2));
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/ftp/TestFTPFileSystem.java
@@ -19,10 +19,18 @@ package org.apache.hadoop.fs.ftp;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Comparator;
 
+import org.apache.commons.net.PrintCommandListener;
+import org.apache.commons.net.ftp.FTPClientConfig;
+import org.apache.commons.net.ftp.FTPReply;
+import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
@@ -42,6 +50,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Timeout(180)
 public class TestFTPFileSystem {
+  public static final Logger LOG = LoggerFactory.getLogger(TestFTPFileSystem.class);
 
   private FtpTestServer server;
   private java.nio.file.Path testDir;
@@ -234,9 +245,8 @@ public class TestFTPFileSystem {
     assertEquals(client.getControlKeepAliveTimeout(), timeout);
   }
 
-  private static void touch(FileSystem fs, Path filePath)
-          throws IOException {
-    touch(fs, filePath, null);
+  private static void touch(FileSystem fs, Path filePath) throws IOException {
+    touch(fs, filePath, new byte[] {1});
   }
 
   private static void touch(FileSystem fs, Path path, byte[] data)
@@ -266,11 +276,95 @@ public class TestFTPFileSystem {
 
     FileSystem fs = FileSystem.get(configuration);
 
-
     Path ftpDir = fs.makeQualified(new Path(testDir.toAbsolutePath().toString()));
     Path file1 = fs.makeQualified(new Path(ftpDir, "renamefile" + "1"));
     Path file2 = fs.makeQualified(new Path(ftpDir, "renamefile" + "2"));
+
     touch(fs, file1);
+    FTPClient ftpClient = connect(configuration);
+    FTPFile[] files = ftpClient.listFiles("/D/projects/github/apache/hadoop/hadoop-common-project/hadoop-common/target/test/data");
+    FTPFile[] files1 = ftpClient.listFiles("D:/projects/github/apache/hadoop/hadoop-common-project/hadoop-common/target/test/data");
+    FTPFile[] files2 = ftpClient.listFiles("D:\\projects\\github\\apache\\hadoop\\hadoop-common-project\\hadoop-common\\target\\test\\data");
     assertTrue(fs.rename(file1, file2));
+  }
+
+  private FTPClient connect(Configuration conf) throws IOException {
+    FTPClient client = null;
+    String host = conf.get("fs.ftp.host");
+    int port = conf.getInt("fs.ftp.host.port", FTP.DEFAULT_PORT);
+    String user = conf.get("fs.ftp.user." + host);
+    String password = conf.get("fs.ftp.password." + host);
+    client = new FTPClient();
+    FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_NT);
+    client.configure(config);
+    client.connect(host, port);
+    int reply = client.getReplyCode();
+    if (!FTPReply.isPositiveCompletion(reply)) {
+      throw NetUtils.wrapException(host, port,
+          NetUtils.UNKNOWN_HOST, 0,
+          new ConnectException("Server response " + reply));
+    } else if (client.login(user, password)) {
+      client.setFileTransferMode(getTransferMode(conf));
+      client.setFileType(FTP.BINARY_FILE_TYPE);
+      client.setBufferSize(FTPFileSystem.DEFAULT_BUFFER_SIZE);
+      setTimeout(client, conf);
+      setDataConnectionMode(client, conf);
+    } else {
+      throw new IOException("Login failed on server - " + host + ", port - "
+          + port + " as user '" + user + "'");
+    }
+
+    client.enterLocalActiveMode();
+    client.initiateListParsing();
+
+    client.addProtocolCommandListener(new PrintCommandListener(new PrintWriter(System.out), true));
+    return client;
+  }
+
+  private
+  int getTransferMode(Configuration conf) {
+    final String mode = conf.get(FTPFileSystem.FS_FTP_TRANSFER_MODE);
+    // FTP default is STREAM_TRANSFER_MODE, but Hadoop FTPFS's default is
+    // FTP.BLOCK_TRANSFER_MODE historically.
+    int ret = FTP.BLOCK_TRANSFER_MODE;
+    if (mode == null) {
+      return ret;
+    }
+    final String upper = mode.toUpperCase();
+    if (upper.equals("STREAM_TRANSFER_MODE")) {
+      ret = FTP.STREAM_TRANSFER_MODE;
+    } else if (upper.equals("COMPRESSED_TRANSFER_MODE")) {
+      ret = FTP.COMPRESSED_TRANSFER_MODE;
+    } else {
+      if (!upper.equals("BLOCK_TRANSFER_MODE")) {
+        LOG.warn("Cannot parse the value for " + FTPFileSystem.FS_FTP_TRANSFER_MODE
+            + ": {}. Using default.", mode);
+      }
+    }
+    return ret;
+  }
+
+  private void setTimeout(FTPClient client, Configuration conf) {
+    long timeout = conf.getLong(FTPFileSystem.FS_FTP_TIMEOUT, FTPFileSystem.DEFAULT_TIMEOUT);
+    client.setControlKeepAliveTimeout(timeout);
+  }
+
+  private void setDataConnectionMode(FTPClient client, Configuration conf) throws IOException {
+    final String mode = conf.get(FTPFileSystem.FS_FTP_DATA_CONNECTION_MODE);
+    if (mode == null) {
+      return;
+    }
+    final String upper = mode.toUpperCase();
+    if (upper.equals("PASSIVE_LOCAL_DATA_CONNECTION_MODE")) {
+      client.enterLocalPassiveMode();
+    } else if (upper.equals("PASSIVE_REMOTE_DATA_CONNECTION_MODE")) {
+      client.enterRemotePassiveMode();
+    } else {
+      if (!upper.equals("ACTIVE_LOCAL_DATA_CONNECTION_MODE")) {
+        LOG.warn(
+            "Cannot parse the value for " + FTPFileSystem.FS_FTP_DATA_CONNECTION_MODE + ": " + mode
+                + ". Using default.");
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The Apache Commons Net FTP library is used for `FTPFileSystem`. In `TestFTPFileSystem#testRenameFileWithFullQualifiedPath()`, the FS operations (such as touch and rename) are made using absolute paths. However, the library expects relative paths.
This caused `FTPFileSystem#getFileStatus()` to throw `FileNotFoundException` since the library was trying to look for the absolute path under which the FileSystem was mounted.

This worked fine on Linux as it just appended the absolute path under the FileSystem's mount path -
![image](https://github.com/user-attachments/assets/7ebf1d96-76ca-4388-8549-ee5a4942394f)

However, this fails on Windows since suffixing the absolute path under the FileSystem's mount path doesn't yield a valid path due to the drive letter in the absolute path.

Consider the following illustration -
## On Linux
```
path1 => /mnt/d/a/b
path2 => /mnt/d/x/y
path1 + path2 yields a valid path => /mnt/d/a/b/mnt/d/x/y
```

## On Windows

```
path1 => C:\a\b
path2 => C:\x\y
path1 + path2 doesn't yield a valid path => C:\a\b\C:\x\y
```

So, to fix this, we need to treat the FS operations as purely relative.

### How was this patch tested?

- Ran the unit tests locally.
- Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

