### PR TITLE
YARN-11801: NPE in FifoCandidatesSelector.selectCandidates when prempting resources for an auto-created queue without child queues

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractParentQueue.java
@@ -552,6 +552,15 @@ public abstract class AbstractParentQueue extends AbstractCSQueue {
     return isDynamicQueue() || queueContext.getConfiguration().
         isAutoQueueCreationV2Enabled(getQueuePath());
   }
+  /**
+   * Check whether this queue supports legacy(v1) dynamic child queue creation.
+   * @return true if queue is eligible to create child queues dynamically using
+   * the legacy system, false otherwise
+   */
+  public boolean isEligibleForLegacyAutoQueueCreation() {
+    return isDynamicQueue() || queueContext.getConfiguration().
+        isAutoCreateChildQueueEnabled(getQueuePath());
+  }
 
   @Override
   public void reinitialize(CSQueue newlyParsedQueue,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
@@ -229,7 +229,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // A will preempt guaranteed-allocated.
     verify(mDisp, times(10)).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
-
+  
   @Test
   public void testMaxCap() {
     int[][] qData = new int[][]{
@@ -249,7 +249,7 @@ public class TestProportionalCapacityPreemptionPolicy {
       verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
 
-
+  
   @Test
   public void testPreemptCycle() {
     int[][] qData = new int[][]{
@@ -385,10 +385,10 @@ public class TestProportionalCapacityPreemptionPolicy {
     };
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-    // verify capacity taken from queueB (appA), not queueE (appC) despite
+    // verify capacity taken from queueB (appA), not queueE (appC) despite 
     // queueE being far over its absolute capacity because queueA (queueB's
     // parent) is over capacity and queueD (queueE's parent) is not.
-    ApplicationAttemptId expectedAttemptOnQueueB =
+    ApplicationAttemptId expectedAttemptOnQueueB = 
         ApplicationAttemptId.newInstance(
             appA.getApplicationId(), appA.getAttemptId());
     assertTrue("appA should be running on queueB",
@@ -401,10 +401,10 @@ public class TestProportionalCapacityPreemptionPolicy {
     conf.setPreemptionDisabled("root.queueA.queueB", true);
     ProportionalCapacityPreemptionPolicy policy2 = buildPolicy(qData);
     policy2.editSchedule();
-    ApplicationAttemptId expectedAttemptOnQueueC =
+    ApplicationAttemptId expectedAttemptOnQueueC = 
         ApplicationAttemptId.newInstance(
             appB.getApplicationId(), appB.getAttemptId());
-    ApplicationAttemptId expectedAttemptOnQueueE =
+    ApplicationAttemptId expectedAttemptOnQueueE = 
         ApplicationAttemptId.newInstance(
             appC.getApplicationId(), appC.getAttemptId());
     // Now, all of queueB's (appA) over capacity is not preemptable, so neither
@@ -422,7 +422,7 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionBroadHierarchical() {
     int[][] qData = new int[][] {
-        //  /    A              D              G
+        //  /    A              D              G    
         //            B    C         E    F         H    I
         {1000, 350, 150, 200, 400, 200, 200, 250, 100, 150 },  // abs
         {1000,1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
@@ -473,15 +473,15 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionInheritParent() {
     int[][] qData = new int[][] {
-        //  /    A                   E
+        //  /    A                   E        
         //            B    C    D         F    G    H
         {1000, 500, 200, 200, 100, 500, 200, 200, 100 },  // abs (guar)
         {1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
-        {1000, 700,   0, 350, 350, 300,   0, 200, 100 },  // used
+        {1000, 700,   0, 350, 350, 300,   0, 200, 100 },  // used 
         { 200,   0,   0,   0,   0, 200, 200,   0,   0 },  // pending
         {   0,   0,   0,   0,   0,   0,   0,   0,   0 },  // reserved
-        //               appA appB      appC appD appE
-        {   5,   2,   0,   1,   1,   3,   1,   1,   1 },  // apps
+        //               appA appB      appC appD appE 
+        {   5,   2,   0,   1,   1,   3,   1,   1,   1 },  // apps 
         {  -1,  -1,   1,   1,   1,  -1,   1,   1,   1 },  // req granulrity
         {   2,   3,   0,   0,   0,   3,   0,   0,   0 },  // subqueues
       };
@@ -532,7 +532,7 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionRootDisablesAll() {
     int[][] qData = new int[][] {
-        //  /    A              D              G
+        //  /    A              D              G    
         //            B    C         E    F         H    I
         {1000, 500, 250, 250, 250, 100, 150, 250, 100, 150 },  // abs
         {1000,1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
@@ -704,7 +704,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // its absolute guaranteed capacity
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
-
+  
   @Test
   public void testZeroGuarOverCap() {
     int[][] qData = new int[][] {
@@ -727,11 +727,11 @@ public class TestProportionalCapacityPreemptionPolicy {
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appC)));
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appD)));
   }
-
+  
   @Test
   public void testHierarchicalLarge() {
     int[][] qData = new int[][] {
-      //  /    A              D              G
+      //  /    A              D              G        
       //            B    C         E    F         H    I
       { 400, 200,  60, 140, 100,  70,  30, 100,  10,  90 },  // abs
       { 400, 400, 400, 400, 400, 400, 400, 400, 400, 400 },  // maxCap
@@ -788,7 +788,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     assert containers.get(4).equals(rm5);
 
   }
-
+  
   @Test
   public void testPolicyInitializeAfterSchedulerInitialized() {
     @SuppressWarnings("resource")
@@ -796,9 +796,9 @@ public class TestProportionalCapacityPreemptionPolicy {
     rm.init(conf);
 
     // ProportionalCapacityPreemptionPolicy should be initialized after
-    // CapacityScheduler initialized. We will
-    // 1) find SchedulingMonitor from RMActiveService's service list,
-    // 2) check if ResourceCalculator in policy is null or not.
+    // CapacityScheduler initialized. We will 
+    // 1) find SchedulingMonitor from RMActiveService's service list, 
+    // 2) check if ResourceCalculator in policy is null or not. 
     // If it's not null, we can come to a conclusion that policy initialized
     // after scheduler got initialized
     // Get SchedulingMonitor from SchedulingMonitorManager instead
@@ -812,10 +812,10 @@ public class TestProportionalCapacityPreemptionPolicy {
       assertNotNull(policy.getResourceCalculator());
       return;
     }
-
+    
     fail("Failed to find SchedulingMonitor service, please check what happened");
   }
-
+  
   @Test
   public void testSkipAMContainer() {
     int[][] qData = new int[][] {
@@ -832,7 +832,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMContainer = true;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-
+    
     // By skipping AM Container, all other 24 containers of appD will be
     // preempted
     verify(mDisp, times(24)).handle(argThat(new IsPreemptionRequestFor(appD)));
@@ -863,13 +863,13 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMContainer = true;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-
+    
     // All 5 containers of appD will be preempted including AM container.
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appD)));
 
     // All 5 containers of appC will be preempted including AM container.
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appC)));
-
+    
     // By skipping AM Container, all other 4 containers of appB will be
     // preempted
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appB)));
@@ -879,7 +879,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appA)));
     setAMContainer = false;
   }
-
+  
   @Test
   public void testAMResourcePercentForSkippedAMContainers() {
     int[][] qData = new int[][] {
@@ -897,7 +897,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMResourcePercent = 0.5f;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-
+    
     // AMResoucePercent is 50% of cluster and maxAMCapacity will be 5Gb.
     // Total used AM container size is 20GB, hence 2 AM container has
     // to be preempted as Queue Capacity is 10Gb.
@@ -906,7 +906,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // Including AM Container, all other 4 containers of appC will be
     // preempted
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appC)));
-
+    
     // By skipping AM Container, all other 4 containers of appB will be
     // preempted
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appB)));
@@ -1395,7 +1395,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     when(mCS.getQueue(queuePath)).thenReturn(lq);
 
     ResourceCalculator rc = mCS.getResourceCalculator();
-    List<ApplicationAttemptId> appAttemptIdList =
+    List<ApplicationAttemptId> appAttemptIdList = 
         new ArrayList<ApplicationAttemptId>();
     when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
         isA(String.class), eq(false))).thenReturn(pending[i]);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
@@ -229,7 +229,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // A will preempt guaranteed-allocated.
     verify(mDisp, times(10)).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
-  
+
   @Test
   public void testMaxCap() {
     int[][] qData = new int[][]{
@@ -249,7 +249,7 @@ public class TestProportionalCapacityPreemptionPolicy {
       verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
 
-  
+
   @Test
   public void testPreemptCycle() {
     int[][] qData = new int[][]{
@@ -385,10 +385,10 @@ public class TestProportionalCapacityPreemptionPolicy {
     };
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-    // verify capacity taken from queueB (appA), not queueE (appC) despite 
+    // verify capacity taken from queueB (appA), not queueE (appC) despite
     // queueE being far over its absolute capacity because queueA (queueB's
     // parent) is over capacity and queueD (queueE's parent) is not.
-    ApplicationAttemptId expectedAttemptOnQueueB = 
+    ApplicationAttemptId expectedAttemptOnQueueB =
         ApplicationAttemptId.newInstance(
             appA.getApplicationId(), appA.getAttemptId());
     assertTrue("appA should be running on queueB",
@@ -401,10 +401,10 @@ public class TestProportionalCapacityPreemptionPolicy {
     conf.setPreemptionDisabled("root.queueA.queueB", true);
     ProportionalCapacityPreemptionPolicy policy2 = buildPolicy(qData);
     policy2.editSchedule();
-    ApplicationAttemptId expectedAttemptOnQueueC = 
+    ApplicationAttemptId expectedAttemptOnQueueC =
         ApplicationAttemptId.newInstance(
             appB.getApplicationId(), appB.getAttemptId());
-    ApplicationAttemptId expectedAttemptOnQueueE = 
+    ApplicationAttemptId expectedAttemptOnQueueE =
         ApplicationAttemptId.newInstance(
             appC.getApplicationId(), appC.getAttemptId());
     // Now, all of queueB's (appA) over capacity is not preemptable, so neither
@@ -422,7 +422,7 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionBroadHierarchical() {
     int[][] qData = new int[][] {
-        //  /    A              D              G    
+        //  /    A              D              G
         //            B    C         E    F         H    I
         {1000, 350, 150, 200, 400, 200, 200, 250, 100, 150 },  // abs
         {1000,1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
@@ -473,15 +473,15 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionInheritParent() {
     int[][] qData = new int[][] {
-        //  /    A                   E          
+        //  /    A                   E
         //            B    C    D         F    G    H
         {1000, 500, 200, 200, 100, 500, 200, 200, 100 },  // abs (guar)
         {1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
-        {1000, 700,   0, 350, 350, 300,   0, 200, 100 },  // used 
+        {1000, 700,   0, 350, 350, 300,   0, 200, 100 },  // used
         { 200,   0,   0,   0,   0, 200, 200,   0,   0 },  // pending
         {   0,   0,   0,   0,   0,   0,   0,   0,   0 },  // reserved
-        //               appA appB      appC appD appE 
-        {   5,   2,   0,   1,   1,   3,   1,   1,   1 },  // apps 
+        //               appA appB      appC appD appE
+        {   5,   2,   0,   1,   1,   3,   1,   1,   1 },  // apps
         {  -1,  -1,   1,   1,   1,  -1,   1,   1,   1 },  // req granulrity
         {   2,   3,   0,   0,   0,   3,   0,   0,   0 },  // subqueues
       };
@@ -532,7 +532,7 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionRootDisablesAll() {
     int[][] qData = new int[][] {
-        //  /    A              D              G    
+        //  /    A              D              G
         //            B    C         E    F         H    I
         {1000, 500, 250, 250, 250, 100, 150, 250, 100, 150 },  // abs
         {1000,1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap
@@ -704,7 +704,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // its absolute guaranteed capacity
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appA)));
   }
-  
+
   @Test
   public void testZeroGuarOverCap() {
     int[][] qData = new int[][] {
@@ -727,11 +727,11 @@ public class TestProportionalCapacityPreemptionPolicy {
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appC)));
     verify(mDisp, never()).handle(argThat(new IsPreemptionRequestFor(appD)));
   }
-  
+
   @Test
   public void testHierarchicalLarge() {
     int[][] qData = new int[][] {
-      //  /    A              D              G        
+      //  /    A              D              G
       //            B    C         E    F         H    I
       { 400, 200,  60, 140, 100,  70,  30, 100,  10,  90 },  // abs
       { 400, 400, 400, 400, 400, 400, 400, 400, 400, 400 },  // maxCap
@@ -788,7 +788,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     assert containers.get(4).equals(rm5);
 
   }
-  
+
   @Test
   public void testPolicyInitializeAfterSchedulerInitialized() {
     @SuppressWarnings("resource")
@@ -796,9 +796,9 @@ public class TestProportionalCapacityPreemptionPolicy {
     rm.init(conf);
 
     // ProportionalCapacityPreemptionPolicy should be initialized after
-    // CapacityScheduler initialized. We will 
-    // 1) find SchedulingMonitor from RMActiveService's service list, 
-    // 2) check if ResourceCalculator in policy is null or not. 
+    // CapacityScheduler initialized. We will
+    // 1) find SchedulingMonitor from RMActiveService's service list,
+    // 2) check if ResourceCalculator in policy is null or not.
     // If it's not null, we can come to a conclusion that policy initialized
     // after scheduler got initialized
     // Get SchedulingMonitor from SchedulingMonitorManager instead
@@ -812,10 +812,10 @@ public class TestProportionalCapacityPreemptionPolicy {
       assertNotNull(policy.getResourceCalculator());
       return;
     }
-    
+
     fail("Failed to find SchedulingMonitor service, please check what happened");
   }
-  
+
   @Test
   public void testSkipAMContainer() {
     int[][] qData = new int[][] {
@@ -832,7 +832,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMContainer = true;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-    
+
     // By skipping AM Container, all other 24 containers of appD will be
     // preempted
     verify(mDisp, times(24)).handle(argThat(new IsPreemptionRequestFor(appD)));
@@ -863,13 +863,13 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMContainer = true;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-    
+
     // All 5 containers of appD will be preempted including AM container.
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appD)));
 
     // All 5 containers of appC will be preempted including AM container.
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appC)));
-    
+
     // By skipping AM Container, all other 4 containers of appB will be
     // preempted
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appB)));
@@ -879,7 +879,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appA)));
     setAMContainer = false;
   }
-  
+
   @Test
   public void testAMResourcePercentForSkippedAMContainers() {
     int[][] qData = new int[][] {
@@ -897,7 +897,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     setAMResourcePercent = 0.5f;
     ProportionalCapacityPreemptionPolicy policy = buildPolicy(qData);
     policy.editSchedule();
-    
+
     // AMResoucePercent is 50% of cluster and maxAMCapacity will be 5Gb.
     // Total used AM container size is 20GB, hence 2 AM container has
     // to be preempted as Queue Capacity is 10Gb.
@@ -906,7 +906,7 @@ public class TestProportionalCapacityPreemptionPolicy {
     // Including AM Container, all other 4 containers of appC will be
     // preempted
     verify(mDisp, times(5)).handle(argThat(new IsPreemptionRequestFor(appC)));
-    
+
     // By skipping AM Container, all other 4 containers of appB will be
     // preempted
     verify(mDisp, times(4)).handle(argThat(new IsPreemptionRequestFor(appB)));
@@ -1073,44 +1073,75 @@ public class TestProportionalCapacityPreemptionPolicy {
   }
 
   @Test
-  public void testLeafQueueNameExtraction() throws Exception {
-    ProportionalCapacityPreemptionPolicy policy =
-        buildPolicy(Q_DATA_FOR_IGNORE);
+  public void testLeafQueueNameExtractionWithFlexibleAQC() throws Exception {
+    ProportionalCapacityPreemptionPolicy policy = buildPolicy(Q_DATA_FOR_IGNORE);
     ParentQueue root = (ParentQueue) mCS.getRootQueue();
+
     root.addDynamicParentQueue("childlessFlexible");
-    List<CSQueue> queues = root.getChildQueues();
-    ArrayList<CSQueue> extendedQueues = new ArrayList<>();
-    LinkedList<ParentQueue> pqs = new LinkedList<>();
-    ParentQueue dynamicParent = mockParentQueue(
-        null, 0, pqs);
-    when(dynamicParent.getQueuePath()).thenReturn("root.dynamicParent");
-    when(dynamicParent.getQueueCapacities()).thenReturn(
-        new QueueCapacities(false));
-    QueueResourceQuotas dynamicParentQr = new QueueResourceQuotas();
-    dynamicParentQr.setEffectiveMaxResource(Resource.newInstance(1, 1));
-    dynamicParentQr.setEffectiveMinResource(Resources.createResource(1));
-    dynamicParentQr.setEffectiveMaxResource(RMNodeLabelsManager.NO_LABEL,
-        Resource.newInstance(1, 1));
-    dynamicParentQr.setEffectiveMinResource(RMNodeLabelsManager.NO_LABEL,
-        Resources.createResource(1));
-    when(dynamicParent.getQueueResourceQuotas()).thenReturn(dynamicParentQr);
-    when(dynamicParent.getEffectiveCapacity(RMNodeLabelsManager.NO_LABEL))
-        .thenReturn(Resources.createResource(1));
-    when(dynamicParent.getEffectiveMaxCapacity(RMNodeLabelsManager.NO_LABEL))
-        .thenReturn(Resource.newInstance(1, 1));
-    ResourceUsage resUsage = new ResourceUsage();
-    resUsage.setUsed(Resources.createResource(1024));
-    resUsage.setReserved(Resources.createResource(1024));
-    when(dynamicParent.getQueueResourceUsage()).thenReturn(resUsage);
-    when(dynamicParent.isEligibleForAutoQueueCreation()).thenReturn(true);
-    extendedQueues.add(dynamicParent);
-    extendedQueues.addAll(queues);
-    when(root.getChildQueues()).thenReturn(extendedQueues);
+    ParentQueue dynamicParent = setupDynamicParentQueue("root.dynamicParent", true);
+    extendRootQueueWithMock(root, dynamicParent);
 
     policy.editSchedule();
+    assertFalse(
+            "root.dynamicLegacyParent" + " should not be a LeafQueue candidate",
+            policy.getLeafQueueNames().contains( "root.dynamicParent"));
+  }
 
-    assertFalse("dynamicParent should not be a LeafQueue " +
-        "candidate", policy.getLeafQueueNames().contains("root.dynamicParent"));
+  @Test
+  public void testLeafQueueNameExtractionWithLegacyAQC() throws Exception {
+    ProportionalCapacityPreemptionPolicy policy = buildPolicy(Q_DATA_FOR_IGNORE);
+    ParentQueue root = (ParentQueue) mCS.getRootQueue();
+
+    root.addDynamicParentQueue("childlessLegacy");
+    ParentQueue dynamicParent = setupDynamicParentQueue("root.dynamicLegacyParent", false);
+    extendRootQueueWithMock(root, dynamicParent);
+
+    policy.editSchedule();
+    assertFalse("root.dynamicLegacyParent" + " should not be a LeafQueue candidate",
+            policy.getLeafQueueNames().contains( "root.dynamicLegacyParent"));
+  }
+
+  private ParentQueue setupDynamicParentQueue(String queuePath, boolean isFlexible) {
+    ParentQueue dynamicParent = mockParentQueue(null, 0, new LinkedList<>());
+    mockQueueFields(dynamicParent, queuePath);
+
+    if (isFlexible) {
+      when(dynamicParent.isEligibleForAutoQueueCreation()).thenReturn(true);
+    } else {
+      when(dynamicParent.isEligibleForLegacyAutoQueueCreation()).thenReturn(true);
+    }
+
+    return dynamicParent;
+  }
+
+  private void extendRootQueueWithMock(ParentQueue root, ParentQueue mockQueue) {
+    List<CSQueue> queues = root.getChildQueues();
+    ArrayList<CSQueue> extendedQueues = new ArrayList<>();
+    extendedQueues.add(mockQueue);
+    extendedQueues.addAll(queues);
+    when(root.getChildQueues()).thenReturn(extendedQueues);
+  }
+
+  private void mockQueueFields(ParentQueue queue, String queuePath) {
+    when(queue.getQueuePath()).thenReturn(queuePath);
+    when(queue.getQueueCapacities()).thenReturn(new QueueCapacities(false));
+
+    QueueResourceQuotas qrq = new QueueResourceQuotas();
+    qrq.setEffectiveMaxResource(Resource.newInstance(1, 1));
+    qrq.setEffectiveMinResource(Resources.createResource(1));
+    qrq.setEffectiveMaxResource(RMNodeLabelsManager.NO_LABEL, Resource.newInstance(1, 1));
+    qrq.setEffectiveMinResource(RMNodeLabelsManager.NO_LABEL, Resources.createResource(1));
+
+    when(queue.getQueueResourceQuotas()).thenReturn(qrq);
+    when(queue.getEffectiveCapacity(RMNodeLabelsManager.NO_LABEL))
+        .thenReturn(Resources.createResource(1));
+    when(queue.getEffectiveMaxCapacity(RMNodeLabelsManager.NO_LABEL))
+        .thenReturn(Resource.newInstance(1, 1));
+
+    ResourceUsage usage = new ResourceUsage();
+    usage.setUsed(Resources.createResource(1024));
+    usage.setReserved(Resources.createResource(1024));
+    when(queue.getQueueResourceUsage()).thenReturn(usage);
   }
 
   static class IsPreemptionRequestFor
@@ -1359,8 +1390,12 @@ public class TestProportionalCapacityPreemptionPolicy {
       Resource[] used, Resource[] pending, Resource[] reserved, int[] apps,
       Resource[] gran) {
     LeafQueue lq = mock(LeafQueue.class);
+
+    String queuePath = p.getQueuePath() + ".queue" + (char)('A' + i - 1);
+    when(mCS.getQueue(queuePath)).thenReturn(lq);
+
     ResourceCalculator rc = mCS.getResourceCalculator();
-    List<ApplicationAttemptId> appAttemptIdList = 
+    List<ApplicationAttemptId> appAttemptIdList =
         new ArrayList<ApplicationAttemptId>();
     when(lq.getTotalPendingResourcesConsideringUserLimit(isA(Resource.class),
         isA(String.class), eq(false))).thenReturn(pending[i]);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/monitor/capacity/TestProportionalCapacityPreemptionPolicy.java
@@ -473,7 +473,7 @@ public class TestProportionalCapacityPreemptionPolicy {
   @Test
   public void testPerQueueDisablePreemptionInheritParent() {
     int[][] qData = new int[][] {
-        //  /    A                   E        
+        //  /    A                   E          
         //            B    C    D         F    G    H
         {1000, 500, 200, 200, 100, 500, 200, 200, 100 },  // abs (guar)
         {1000,1000,1000,1000,1000,1000,1000,1000,1000 },  // maxCap


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11801: NPE in FifoCandidatesSelector.selectCandidates when prempting resources for an auto-created queue without child queues.

### How was this patch tested?


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

