### PR TITLE
YARN-11815: Fix NodeQueueLoadMonitor scheduler running on standby RMs

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
@@ -375,10 +375,10 @@ public class OpportunisticContainerAllocatorAMService
 
   @Override
   protected void serviceStart() throws Exception {
-    super.serviceStart();
     if (this.nodeMonitor != null) {
       this.nodeMonitor.start();
     }
+    super.serviceStart();
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/OpportunisticContainerAllocatorAMService.java
@@ -374,6 +374,14 @@ public class OpportunisticContainerAllocatorAMService
   }
 
   @Override
+  protected void serviceStart() throws Exception {
+    super.serviceStart();
+    if (this.nodeMonitor != null) {
+      this.nodeMonitor.start();
+    }
+  }
+
+  @Override
   protected void serviceStop() throws Exception {
     if (nodeMonitor != null) {
       nodeMonitor.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/distributed/NodeQueueLoadMonitor.java
@@ -245,6 +245,7 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
   protected ReentrantReadWriteLock sortedNodesLock = new ReentrantReadWriteLock();
   protected ReentrantReadWriteLock clusterNodesLock =
       new ReentrantReadWriteLock();
+  private long nodeComputationInterval;
 
   Runnable computeTask = new Runnable() {
     @Override
@@ -278,10 +279,13 @@ public class NodeQueueLoadMonitor implements ClusterMonitor {
     this.sortedNodes = new ArrayList<>();
     this.scheduledExecutor = Executors.newScheduledThreadPool(1);
     this.comparator = comparator;
-    this.scheduledExecutor.scheduleAtFixedRate(computeTask,
-        nodeComputationInterval, nodeComputationInterval,
-        TimeUnit.MILLISECONDS);
+    this.nodeComputationInterval = nodeComputationInterval;
     numNodesForAnyAllocation = numNodes;
+  }
+
+  public void start() {
+    this.scheduledExecutor.scheduleAtFixedRate(computeTask, nodeComputationInterval,
+        nodeComputationInterval, TimeUnit.MILLISECONDS);
   }
 
   protected void updateSortedNodes() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRM.java
@@ -750,17 +750,7 @@ public class MockRM extends ResourceManager {
         YarnConfiguration.OPPORTUNISTIC_CONTAINER_ALLOCATION_ENABLED,
         YarnConfiguration.DEFAULT_OPPORTUNISTIC_CONTAINER_ALLOCATION_ENABLED)) {
       return new OpportunisticContainerAllocatorAMService(getRMContext(),
-          scheduler) {
-        @Override
-        protected void serviceStart() {
-          // override to not start rpc handler
-        }
-
-        @Override
-        protected void serviceStop() {
-          // don't do anything
-        }
-      };
+          scheduler);
     }
     return new ApplicationMasterService(getRMContext(), scheduler) {
       @Override


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

`NodeQueueLoadMonitor` runs as an active service via `OpportunisticContainerAllocatorAMService` in YARN Resource Manager. However, its scheduler thread is started in the constructor itself.

This would cause the scheduler to run on standby RM too, which shouldn't be the case since it is an active service. 

### How was this patch tested?

Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

