### PR TITLE
HADOOP-19558. Skip testRenameFileBeingAppended on Windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
@@ -135,17 +135,21 @@ public abstract class AbstractContractAppendTest extends AbstractFSContractTestB
     touch(getFileSystem(), target);
     assertPathExists("original file does not exist", target);
     byte[] dataset = dataset(256, 'a', 'z');
-    FSDataOutputStream outputStream = getFileSystem().append(target);
-    if (isSupported(CREATE_VISIBILITY_DELAYED)) {
-      // Some filesystems like WebHDFS doesn't assure sequential consistency.
-      // In such a case, delay is needed. Given that we can not check the lease
-      // because here is closed in client side package, simply add a sleep.
-      Thread.sleep(100);
+    try (FSDataOutputStream outputStream = getFileSystem().append(target)) {
+      if (isSupported(CREATE_VISIBILITY_DELAYED)) {
+        // Some filesystems like WebHDFS doesn't assure sequential consistency.
+        // In such a case, delay is needed. Given that we can not check the lease
+        // because here is closed in client side package, simply add a sleep.
+        Thread.sleep(100);
+      }
+      outputStream.write(dataset);
     }
-    outputStream.write(dataset);
+
     Path renamed = new Path(testPath, "renamed");
+    // Renaming must be done after the "target" file is closed. Renaming will fail
+    // on Windows otherwise. The 'try' block above ensures that the "target" file gets
+    // closed.
     rename(target, renamed);
-    outputStream.close();
     String listing = ls(testPath);
 
     //expected: the stream goes to the file that was being renamed, not

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractAppendTest.java
@@ -135,21 +135,17 @@ public abstract class AbstractContractAppendTest extends AbstractFSContractTestB
     touch(getFileSystem(), target);
     assertPathExists("original file does not exist", target);
     byte[] dataset = dataset(256, 'a', 'z');
-    try (FSDataOutputStream outputStream = getFileSystem().append(target)) {
-      if (isSupported(CREATE_VISIBILITY_DELAYED)) {
-        // Some filesystems like WebHDFS doesn't assure sequential consistency.
-        // In such a case, delay is needed. Given that we can not check the lease
-        // because here is closed in client side package, simply add a sleep.
-        Thread.sleep(100);
-      }
-      outputStream.write(dataset);
+    FSDataOutputStream outputStream = getFileSystem().append(target);
+    if (isSupported(CREATE_VISIBILITY_DELAYED)) {
+      // Some filesystems like WebHDFS doesn't assure sequential consistency.
+      // In such a case, delay is needed. Given that we can not check the lease
+      // because here is closed in client side package, simply add a sleep.
+      Thread.sleep(100);
     }
-
+    outputStream.write(dataset);
     Path renamed = new Path(testPath, "renamed");
-    // Renaming must be done after the "target" file is closed. Renaming will fail
-    // on Windows otherwise. The 'try' block above ensures that the "target" file gets
-    // closed.
     rename(target, renamed);
+    outputStream.close();
     String listing = ls(testPath);
 
     //expected: the stream goes to the file that was being renamed, not

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractAppend.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractAppend.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.fs.contract.rawlocal;
 
+import org.junit.Assume;
+
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractAppendTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 
@@ -29,4 +32,12 @@ public class TestRawlocalContractAppend extends AbstractContractAppendTest {
     return new RawlocalFSContract(conf);
   }
 
+  @Override
+  public void testRenameFileBeingAppended() throws Throwable {
+    // Renaming a file while its handle is open is not supported on Windows.
+    // Thus, this test should be skipped on Windows.
+    Assume.assumeFalse(Path.WINDOWS);
+
+    super.testRenameFileBeingAppended();
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* The `AbstractContractAppendTest#testRenameFileBeingAppended()`
   tries to rename the file while the handle
   to the file is open.
* This isn't allowed on Windows, and thus the
   call to rename fails.
* Thus, we need to skip this test on Windows.

### How was this patch tested?

* Verified by running the failing unit test locally
   and ensured that it skipped.
* Jenkins CI validation for Windows.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?