### PR TITLE
YARN-11818. Fix "submitted by user jenkins to unknown queue: default error " in hadoop-yarn-client tests.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestSchedConfCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestSchedConfCLI.java
@@ -23,7 +23,7 @@ import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -156,7 +156,7 @@ public class TestSchedConfCLI extends JerseyTest {
     config.setMaximumCapacity(a, 100f);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws Exception {
     if (rm != null) {
       rm.stop();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11818. Fix "submitted by user jenkins to unknown queue: default error " in hadoop-yarn-client tests.

The following error frequently occurs in integration tests:

```
[ERROR] org.apache.hadoop.yarn.client.api.impl.TestOpportunisticContainerAllocationE2E.testDemotionFromAcquired Time elapsed: 0.025 s <<< ERROR!org.apache.hadoop.yarn.exceptions.YarnException: Failed to submit application_1744044026935_0003 to YARN: Application application_1744044026935_0003 submitted by user jenkins to unknown queue: default
..... 
```

This issue is caused by the failure of TestSchedConfCLI#cleanup to run properly, and this JIRA will address and resolve the problem.

The tests were conducted locally and the results are as expected. The test results are as follows:

```

[INFO] --- maven-surefire-plugin:3.0.0-M4:test (default-test) @ hadoop-yarn-client ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.client.TestResourceTrackerOnHA
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.942 s - in org.apache.hadoop.yarn.client.TestResourceTrackerOnHA
[INFO] Running org.apache.hadoop.yarn.client.TestMemoryPageUtils
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in org.apache.hadoop.yarn.client.TestMemoryPageUtils
[INFO] Running org.apache.hadoop.yarn.client.TestApplicationMasterServiceProtocolForTimelineV2
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.254 s - in org.apache.hadoop.yarn.client.TestApplicationMasterServiceProtocolForTimelineV2
[INFO] Running org.apache.hadoop.yarn.client.util.TestYarnClientUtils
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.3 s - in org.apache.hadoop.yarn.client.util.TestYarnClientUtils
[INFO] Running org.apache.hadoop.yarn.client.util.TestFormattingCLIUtils
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.04 s - in org.apache.hadoop.yarn.client.util.TestFormattingCLIUtils
[INFO] Running org.apache.hadoop.yarn.client.TestRMFailoverProxyProvider
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.925 s - in org.apache.hadoop.yarn.client.TestRMFailoverProxyProvider
[INFO] Running org.apache.hadoop.yarn.client.TestRMFailover
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.8 s - in org.apache.hadoop.yarn.client.TestRMFailover
[INFO] Running org.apache.hadoop.yarn.client.TestGetGroups
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.936 s - in org.apache.hadoop.yarn.client.TestGetGroups
[INFO] Running org.apache.hadoop.yarn.client.cli.TestNodeAttributesCLI
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.216 s - in org.apache.hadoop.yarn.client.cli.TestNodeAttributesCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestSchedConfCLI
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.73 s - in org.apache.hadoop.yarn.client.cli.TestSchedConfCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestTopCLI
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.41 s - in org.apache.hadoop.yarn.client.cli.TestTopCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestLogsCLI
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.586 s - in org.apache.hadoop.yarn.client.cli.TestLogsCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestYarnCLI
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.451 s - in org.apache.hadoop.yarn.client.cli.TestYarnCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestGpgCLI
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 s - in org.apache.hadoop.yarn.client.cli.TestGpgCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestRouterCLI
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.215 s - in org.apache.hadoop.yarn.client.cli.TestRouterCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestClusterCLI
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.258 s - in org.apache.hadoop.yarn.client.cli.TestClusterCLI
[INFO] Running org.apache.hadoop.yarn.client.cli.TestRMAdminCLI
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.734 s - in org.apache.hadoop.yarn.client.cli.TestRMAdminCLI
[INFO] Running org.apache.hadoop.yarn.client.TestResourceManagerAdministrationProtocolPBClientImpl
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.548 s - in org.apache.hadoop.yarn.client.TestResourceManagerAdministrationProtocolPBClientImpl
[INFO] Running org.apache.hadoop.yarn.client.TestFederationRMFailoverProxyProvider
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.649 s - in org.apache.hadoop.yarn.client.TestFederationRMFailoverProxyProvider
[INFO] Running org.apache.hadoop.yarn.client.TestHedgingRequestRMFailoverProxyProvider
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.906 s - in org.apache.hadoop.yarn.client.TestHedgingRequestRMFailoverProxyProvider
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAMRMProxy
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 98.272 s - in org.apache.hadoop.yarn.client.api.impl.TestAMRMProxy
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAMRMClientOnRMRestart
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.05 s - in org.apache.hadoop.yarn.client.api.impl.TestAMRMClientOnRMRestart
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAHSClient
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.303 s - in org.apache.hadoop.yarn.client.api.impl.TestAHSClient
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestYarnClientWithReservation
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.58 s - in org.apache.hadoop.yarn.client.api.impl.TestYarnClientWithReservation
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestNMClient
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 119.793 s - in org.apache.hadoop.yarn.client.api.impl.TestNMClient
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAMRMClientContainerRequest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.317 s - in org.apache.hadoop.yarn.client.api.impl.TestAMRMClientContainerRequest
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestSharedCacheClientImpl
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.249 s - in org.apache.hadoop.yarn.client.api.impl.TestSharedCacheClientImpl
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAMRMClient
[WARNING] Tests run: 57, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 392.824 s - in org.apache.hadoop.yarn.client.api.impl.TestAMRMClient
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAMRMClientPlacementConstraints
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.337 s - in org.apache.hadoop.yarn.client.api.impl.TestAMRMClientPlacementConstraints
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestYarnClientImpl
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.08 s - in org.apache.hadoop.yarn.client.api.impl.TestYarnClientImpl
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestAHSv2ClientImpl
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.246 s - in org.apache.hadoop.yarn.client.api.impl.TestAHSv2ClientImpl
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestOpportunisticContainerAllocationE2E
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.345 s - in org.apache.hadoop.yarn.client.api.impl.TestOpportunisticContainerAllocationE2E
[INFO] Running org.apache.hadoop.yarn.client.api.impl.TestYarnClient
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.038 s - in org.apache.hadoop.yarn.client.api.impl.TestYarnClient
[INFO] Running org.apache.hadoop.yarn.client.api.async.impl.TestAMRMClientAsync
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.524 s - in org.apache.hadoop.yarn.client.api.async.impl.TestAMRMClientAsync
[INFO] Running org.apache.hadoop.yarn.client.api.async.impl.TestNMClientAsync
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.178 s - in org.apache.hadoop.yarn.client.api.async.impl.TestNMClientAsync
[INFO] Running org.apache.hadoop.yarn.client.TestNoHaRMFailoverProxyProvider
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.26 s - in org.apache.hadoop.yarn.client.TestNoHaRMFailoverProxyProvider
[INFO] Running org.apache.hadoop.yarn.client.TestYarnApiClasses
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.191 s - in org.apache.hadoop.yarn.client.TestYarnApiClasses
[INFO] Running org.apache.hadoop.yarn.client.TestApplicationClientProtocolOnHA
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 535.258 s - in org.apache.hadoop.yarn.client.TestApplicationClientProtocolOnHA
[INFO] Running org.apache.hadoop.yarn.client.TestApplicationMasterServiceProtocolOnHA
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.911 s - in org.apache.hadoop.yarn.client.TestApplicationMasterServiceProtocolOnHA
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 371, Failures: 0, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
```

### How was this patch tested?

Junit Test & mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

