### PR TITLE
HDFS-17781.Fix webImageViewer getContentSummary return wrong result when inode is a ec file

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageLoader.java
@@ -246,10 +246,11 @@ class FSImageLoader {
     for (int i = 0; i < s.getPoliciesCount(); ++i) {
       ecPolicies.add(PBHelperClient.convertErasureCodingPolicyInfo(s.getPolicies(i)));
     }
-
+    Configuration conf = new Configuration();
     ErasureCodingPolicyManager erasureCodingPolicyManager =
         ErasureCodingPolicyManager.getInstance();
-    erasureCodingPolicyManager.loadPolicies(ecPolicies, new Configuration());
+    erasureCodingPolicyManager.init(conf);
+    erasureCodingPolicyManager.loadPolicies(ecPolicies, conf);
     return erasureCodingPolicyManager;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/FSImageLoader.java
@@ -37,16 +37,22 @@ import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.permission.PermissionStatus;
 import org.apache.hadoop.hdfs.XAttrHelper;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
 import org.apache.hadoop.hdfs.protocol.XAttrNotFoundException;
 import org.apache.hadoop.hdfs.protocol.proto.HdfsProtos;
+import org.apache.hadoop.hdfs.protocolPB.PBHelperClient;
+import org.apache.hadoop.hdfs.server.namenode.ErasureCodingPolicyManager;
 import org.apache.hadoop.hdfs.server.namenode.FSImageFormatPBINode;
 import org.apache.hadoop.hdfs.server.namenode.FSImageFormatProtobuf;
 import org.apache.hadoop.hdfs.server.namenode.FSImageUtil;
 import org.apache.hadoop.hdfs.server.namenode.FsImageProto;
+import org.apache.hadoop.hdfs.server.namenode.FsImageProto.ErasureCodingSection;
 import org.apache.hadoop.hdfs.server.namenode.FsImageProto.INodeSection.INode;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.INodeId;
 import org.apache.hadoop.hdfs.server.namenode.SerialNumberManager;
+import org.apache.hadoop.hdfs.util.StripedBlockUtil;
 import org.apache.hadoop.hdfs.web.JsonUtil;
 import org.apache.hadoop.hdfs.web.resources.XAttrEncodingParam;
 import org.apache.hadoop.io.IOUtils;
@@ -232,6 +238,21 @@ class FSImageLoader {
     return builder.build();
   }
 
+  static ErasureCodingPolicyManager loadErasureCodingSection(InputStream in) throws IOException {
+    ErasureCodingSection s = ErasureCodingSection.parseDelimitedFrom(in);
+    List<ErasureCodingPolicyInfo> ecPolicies =
+        org.apache.hadoop.thirdparty.com.google.common.collect.Lists.newArrayListWithCapacity(
+            s.getPoliciesCount());
+    for (int i = 0; i < s.getPoliciesCount(); ++i) {
+      ecPolicies.add(PBHelperClient.convertErasureCodingPolicyInfo(s.getPolicies(i)));
+    }
+
+    ErasureCodingPolicyManager erasureCodingPolicyManager =
+        ErasureCodingPolicyManager.getInstance();
+    erasureCodingPolicyManager.loadPolicies(ecPolicies, new Configuration());
+    return erasureCodingPolicyManager;
+  }
+
   private static byte[][] loadINodeSection(InputStream in)
           throws IOException {
     FsImageProto.INodeSection s = FsImageProto.INodeSection
@@ -344,7 +365,7 @@ class FSImageLoader {
       data[1] = 1;
       data[2] = getFileSize(f);
       nsQuota = -1;
-      data[3] = data[2] * f.getReplication();
+      data[3] = getStorageSpaceConsumed(f);
       spaceQuota = -1;
       return fillSummaryMap(spaceQuota, nsQuota, data);
     case DIRECTORY:
@@ -396,7 +417,7 @@ class FSImageLoader {
         long curLength = getFileSize(f);
         data[1]++;
         data[2] += curLength;
-        data[3] += (curLength) * (f.getReplication());
+        data[3] += getStorageSpaceConsumed(f);
         break;
       case SYMLINK:
         data[1]++;
@@ -658,6 +679,26 @@ class FSImageLoader {
     long size = 0;
     for (HdfsProtos.BlockProto p : f.getBlocksList()) {
       size += p.getNumBytes();
+    }
+    return size;
+  }
+
+  static long getStorageSpaceConsumed(FsImageProto.INodeSection.INodeFile f) {
+    long size = 0;
+    boolean isStriped = f.hasErasureCodingPolicyID();
+    ErasureCodingPolicy ecPolicy = null;
+    if (isStriped) {
+      ecPolicy =
+          ErasureCodingPolicyManager.getInstance().getByID((byte) f.getErasureCodingPolicyID());
+    }
+
+    for (HdfsProtos.BlockProto p : f.getBlocksList()) {
+      if (isStriped) {
+        size += StripedBlockUtil.spaceConsumedByStripedBlock(p.getNumBytes(),
+            ecPolicy.getNumDataUnits(), ecPolicy.getNumParityUnits(), ecPolicy.getCellSize());
+      } else {
+        size += p.getNumBytes() * f.getReplication();
+      }
     }
     return size;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageTextWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/PBImageTextWriter.java
@@ -643,6 +643,10 @@ abstract class PBImageTextWriter implements Closeable {
           LOG.info("Loading inode references");
           refIdList = FSImageLoader.loadINodeReferenceSection(is);
           break;
+        case ERASURE_CODING:
+          LOG.info("Loading erasure coding");
+          FSImageLoader.loadErasureCodingSection(is);
+          break;
         default:
           break;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerWithStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/TestOfflineImageViewerWithStripedBlocks.java
@@ -22,24 +22,31 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeModeAction;
-import org.apache.hadoop.fs.UnresolvedLinkException;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.StripedFileTestUtil;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
-import org.apache.hadoop.hdfs.protocol.SnapshotAccessControlException;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoStriped;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSImageTestUtil;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
+import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
+import org.apache.hadoop.net.NetUtils;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,18 +105,18 @@ public class TestOfflineImageViewerWithStripedBlocks {
   }
 
   @Test(timeout = 60000)
-  public void testFileLargerThanABlockGroup1() throws IOException {
+  public void testFileLargerThanABlockGroup1() throws Exception {
     testFileSize(blockSize * dataBlocks + cellSize + 123);
   }
 
   @Test(timeout = 60000)
-  public void testFileLargerThanABlockGroup2() throws IOException {
+  public void testFileLargerThanABlockGroup2() throws Exception {
     testFileSize(blockSize * dataBlocks * 3 + cellSize * dataBlocks + cellSize
         + 123);
   }
 
   @Test(timeout = 60000)
-  public void testFileFullBlockGroup() throws IOException {
+  public void testFileFullBlockGroup() throws Exception {
     testFileSize(blockSize * dataBlocks);
   }
 
@@ -119,8 +126,7 @@ public class TestOfflineImageViewerWithStripedBlocks {
     testFileSize(numBytes);
   }
 
-  private void testFileSize(int numBytes) throws IOException,
-      UnresolvedLinkException, SnapshotAccessControlException {
+  private void testFileSize(int numBytes) throws Exception{
     fs.setSafeMode(SafeModeAction.LEAVE);
     File orgFsimage = null;
     Path file = new Path("/eczone/striped");
@@ -166,5 +172,37 @@ public class TestOfflineImageViewerWithStripedBlocks {
         "Wrongly computed file size contains striped blocks, file status:"
             + fileStatus + ". Expected file size is : " + EXPECTED_FILE_SIZE,
         fileStatus.contains(EXPECTED_FILE_SIZE));
+
+    testGetContentSummaryForFile(orgFsimage, file);
+  }
+
+  public void testGetContentSummaryForFile(File orgFsimage, Path file)
+      throws IOException, InterruptedException, URISyntaxException {
+    ContentSummary contentSummary = fs.getContentSummary(file);
+    try (WebImageViewer viewer = new WebImageViewer(NetUtils.createSocketAddr("localhost:0"))) {
+      viewer.initServer(orgFsimage.getAbsolutePath());
+      int port = viewer.getPort();
+      URL url =
+          new URL("http://localhost:" + port + "/webhdfs/v1" + file + "?op=GETCONTENTSUMMARY");
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestMethod("GET");
+      connection.connect();
+      assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
+      // create a WebHdfsFileSystem instance
+      URI uri = new URI("webhdfs://localhost:" + port);
+      Configuration conf = new Configuration();
+      WebHdfsFileSystem webfs = (WebHdfsFileSystem) FileSystem.get(uri, conf);
+      ContentSummary summary = webfs.getContentSummary(file);
+      verifyContentSummary(contentSummary, summary);
+    }
+  }
+
+  private void verifyContentSummary(ContentSummary expected, ContentSummary actual) {
+    assertEquals(expected.getDirectoryCount(), actual.getDirectoryCount());
+    assertEquals(expected.getFileCount(), actual.getFileCount());
+    assertEquals(expected.getLength(), actual.getLength());
+    assertEquals(expected.getSpaceConsumed(), actual.getSpaceConsumed());
+    assertEquals(expected.getQuota(), actual.getQuota());
+    assertEquals(expected.getSpaceQuota(), actual.getSpaceQuota());
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

As described [HDFS-17781](https://issues.apache.org/jira/browse/HDFS-17781)

Now when  use hdfs oiv Web  mode for offline analysis , the ec file's getContentSummary is wrong.  It  supports replicated file only.  
`data[3] += (curLength) * (f.getReplication()); `

 

This PR is to fix this.

