### PR TITLE
HADOOP-19562. Fix TestTextCommand on Windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestTextCommand.java
@@ -64,7 +64,7 @@ public class TestTextCommand {
       + "{\"station\":\"012650-99999\",\"time\":-655509600000,\"temp\":78}" + SEPARATOR;
 
   private static final String SEQUENCE_FILE_EXPECTED_OUTPUT =
-      "Key1\tValue1" + SEPARATOR + "Key2\tValue2" + SEPARATOR;
+      "Key1\tValue1\nKey2\tValue2\n";
 
   @Rule
   public final Timeout testTimeout = new Timeout(30000);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The following 2 tests are failing in `TestTextCommand` -
1. `testDisplayForNonWritableSequenceFile`
2. `testDisplayForSequenceFileSmallMultiByteReads`

These tests create a file and flush a string ending with `\n`. However, for verification, the test expects `\r\n` as the line ending on Windows. Thus, the test fails.

This PR fixes the same by checking for `\n` as the line ending on Windows.

### How was this patch tested?

1. Ran the fixed unit tests locally.
2. Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

