### PR TITLE
[YARN-11819] Request a HDFS delegation token refresh even at DelegationTokenRenewerAppSubmitEvent

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/DelegationTokenRenewer.java
@@ -529,7 +529,7 @@ public class DelegationTokenRenewer extends AbstractService {
           } catch (IOException ioe) {
             if (ioe instanceof SecretManager.InvalidToken
                 && dttr.maxDate < Time.now()
-                && evt instanceof DelegationTokenRenewerAppRecoverEvent
+                && (evt instanceof DelegationTokenRenewerAppRecoverEvent || evt instanceof DelegationTokenRenewerAppSubmitEvent)
                 && token.getKind().equals(HDFS_DELEGATION_KIND)) {
               LOG.info("Failed to renew hdfs token " + dttr
                   + " on recovery as it expired, requesting new hdfs token for "


### PR DESCRIPTION
[YARN-11819](https://issues.apache.org/jira/browse/YARN-11819)
Request a HDFS delegation token refresh even at DelegationTokenRenewerAppSubmitEvent
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

