### PR TITLE
HADOOP-19554. LocalDirAllocator still doesn't always recover from directory deletion

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
@@ -65,7 +65,10 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})
 @InterfaceStability.Unstable
 public class LocalDirAllocator {
-  
+
+  static final String E_NO_SPACE_AVAILABLE =
+      "No space available in any of the local directories";
+
   //A Map from the config item names like "mapred.local.dir"
   //to the instance of the AllocatorPerContext. This
   //is a static object to make sure there exists exactly one instance per JVM
@@ -393,6 +396,8 @@ public class LocalDirAllocator {
      */
     public Path getLocalPathForWrite(String pathStr, long size,
         Configuration conf, boolean checkWrite) throws IOException {
+      LOG.debug("searchng for directory for file at {}, size = {}; checkWrite={}",
+          pathStr, size, checkWrite);
       Context ctx = confChanged(conf);
       int numDirs = ctx.localDirs.length;
       int numDirsSearched = 0;
@@ -406,27 +411,40 @@ public class LocalDirAllocator {
         pathStr = pathStr.substring(1);
       }
       Path returnPath = null;
-      
-      if(size == SIZE_UNKNOWN) {  //do roulette selection: pick dir with probability 
-                    //proportional to available size
-        long[] availableOnDisk = new long[ctx.dirDF.length];
-        long totalAvailable = 0;
-        
-            //build the "roulette wheel"
-        for(int i =0; i < ctx.dirDF.length; ++i) {
-          final DF target = ctx.dirDF[i];
-          // attempt to recreate the dir so that getAvailable() is valid
-          // if it fails, getAvailable() will return 0, so the dir will
-          // be declared unavailable.
-          // return value is logged at debug to keep spotbugs quiet.
-          final boolean b = new File(target.getDirPath()).mkdirs();
-          LOG.debug("mkdirs of {}={}", target, b);
-          availableOnDisk[i] = target.getAvailable();
-          totalAvailable += availableOnDisk[i];
-        }
 
-        if (totalAvailable == 0){
-          throw new DiskErrorException("No space available in any of the local directories.");
+      final int dirCount = ctx.dirDF.length;
+      long[] availableOnDisk = new long[dirCount];
+      long totalAvailable = 0;
+
+      StringBuilder pathNames = new StringBuilder();
+
+      //build the "roulette wheel"
+      for (int i =0; i < dirCount; ++i) {
+        final DF target = ctx.dirDF[i];
+        // attempt to recreate the dir so that getAvailable() is valid
+        // if it fails, getAvailable() will return 0, so the dir will
+        // be declared unavailable.
+        // return value is logged at debug to keep spotbugs quiet.
+        final String name = target.getDirPath();
+        pathNames.append(" ").append(name);
+        final File dirPath = new File(name);
+        if (!dirPath.exists()) {
+          LOG.debug("creating buffer dir {}}", name);
+          dirPath.mkdirs();
+        }
+        availableOnDisk[i] = target.getAvailable();
+        totalAvailable += availableOnDisk[i];
+      }
+
+      LOG.debug("Directory count is {}; total available capacity is {}",
+          dirCount, totalAvailable);
+
+      if (size == SIZE_UNKNOWN) {  //do roulette selection: pick dir with probability
+                    //proportional to available size
+        LOG.debug("Size not specified, so picking at random");
+
+        if (totalAvailable == 0) {
+          throw new DiskErrorException(E_NO_SPACE_AVAILABLE + pathNames);
         }
 
         // Keep rolling the wheel till we get a valid path
@@ -439,14 +457,19 @@ public class LocalDirAllocator {
             dir++;
           }
           ctx.dirNumLastAccessed.set(dir);
-          returnPath = createPath(ctx.localDirs[dir], pathStr, checkWrite);
+          final Path localDir = ctx.localDirs[dir];
+          returnPath = createPath(localDir, pathStr, checkWrite);
           if (returnPath == null) {
             totalAvailable -= availableOnDisk[dir];
             availableOnDisk[dir] = 0; // skip this disk
             numDirsSearched++;
+            LOG.debug("No capacity in {}", localDir);
+          } else {
+            LOG.debug("Allocated file {} in {}", returnPath, localDir);
           }
         }
       } else {
+        LOG.debug("Size is {}; searching", size);
         // Start linear search with random increment if possible
         int randomInc = 1;
         if (numDirs > 2) {
@@ -459,17 +482,20 @@ public class LocalDirAllocator {
             maxCapacity = capacity;
           }
           if (capacity > size) {
+            final Path localDir = ctx.localDirs[dirNum];
             try {
-              returnPath = createPath(ctx.localDirs[dirNum], pathStr,
-                  checkWrite);
+              returnPath = createPath(localDir, pathStr, checkWrite);
             } catch (IOException e) {
               errorText = e.getMessage();
               diskException = e;
-              LOG.debug("DiskException caught for dir {}", ctx.localDirs[dirNum], e);
+              LOG.debug("DiskException caught for dir {}", localDir, e);
             }
             if (returnPath != null) {
               ctx.getAndIncrDirNumLastAccessed(numDirsSearched);
+              LOG.debug("Allocated file {} in {}", returnPath, localDir);
               break;
+            } else {
+              LOG.debug("No capacity in {}", localDir);
             }
           }
           dirNum++;
@@ -484,7 +510,9 @@ public class LocalDirAllocator {
       //no path found
       String newErrorText = "Could not find any valid local directory for " +
           pathStr + " with requested size " + size +
-          " as the max capacity in any directory is " + maxCapacity;
+          " as the max capacity in any directory"
+          + " (" + pathNames + " )"
+          + " is " + maxCapacity;
       if (errorText != null) {
         newErrorText = newErrorText + " due to " + errorText;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
@@ -387,6 +387,24 @@ public class LocalDirAllocator {
       return currentContext.get().dirNumLastAccessed.get();
     }
 
+    /**
+     * Format a string, log at debug and append it to the history as a new line.
+     *
+     * @param history history to fill in
+     * @param fmt format string
+     * @param args varags
+     */
+    private void note(StringBuilder history, String fmt, Object... args) {
+      try {
+        final String s = String.format(fmt, args);
+        history.append(s).append("\n");
+        LOG.debug(s);
+      } catch (Exception e) {
+        // some resilience in case the format string is wrong
+        LOG.debug(fmt, e);
+      }
+    }
+
     /** Get a path from the local FS. If size is known, we go
      *  round-robin over the set of disks (via the configured dirs) and return
      *  the first complete path which has enough space.
@@ -396,7 +414,11 @@ public class LocalDirAllocator {
      */
     public Path getLocalPathForWrite(String pathStr, long size,
         Configuration conf, boolean checkWrite) throws IOException {
-      LOG.debug("searchng for directory for file at {}, size = {}; checkWrite={}",
+
+      // history is built up and logged at error if the alloc
+      StringBuilder history = new StringBuilder();
+
+      note(history, "Searchng for a directory for file at %s, size = %,d; checkWrite=%s",
           pathStr, size, checkWrite);
       Context ctx = confChanged(conf);
       int numDirs = ctx.localDirs.length;
@@ -428,23 +450,39 @@ public class LocalDirAllocator {
         final String name = target.getDirPath();
         pathNames.append(" ").append(name);
         final File dirPath = new File(name);
+
+        // existence probe
         if (!dirPath.exists()) {
-          LOG.debug("creating buffer dir {}}", name);
-          dirPath.mkdirs();
+          LOG.debug("creating buffer dir {}", name);
+          if (dirPath.mkdirs()) {
+            note(history, "Created buffer dir %s", name);
+          } else {
+            note(history, "Failed to create buffer dir %s", name);
+          }
         }
-        availableOnDisk[i] = target.getAvailable();
-        totalAvailable += availableOnDisk[i];
+
+        // path already existed or the mkdir call had an outcome
+        // make sure the path is present and a dir, and if so add its availability
+        if (dirPath.isDirectory()) {
+          final long available = target.getAvailable();
+          availableOnDisk[i] = available;
+          note(history, "%s available under path %s",  pathStr, available);
+          totalAvailable += availableOnDisk[i];
+        } else {
+          note(history, "%s does not exist/is not a directory",  pathStr);
+        }
       }
 
-      LOG.debug("Directory count is {}; total available capacity is {}",
+      note(history, "Directory count is %d; total available capacity is %,d{}",
           dirCount, totalAvailable);
 
-      if (size == SIZE_UNKNOWN) {  //do roulette selection: pick dir with probability
-                    //proportional to available size
-        LOG.debug("Size not specified, so picking at random");
+      if (size == SIZE_UNKNOWN) {
+        //do roulette selection: pick dir with probability
+        // proportional to available size
+        note(history, "Size not specified, so picking at random.");
 
         if (totalAvailable == 0) {
-          throw new DiskErrorException(E_NO_SPACE_AVAILABLE + pathNames);
+          throw new DiskErrorException(E_NO_SPACE_AVAILABLE + pathNames + "; history=" + history);
         }
 
         // Keep rolling the wheel till we get a valid path
@@ -463,13 +501,13 @@ public class LocalDirAllocator {
             totalAvailable -= availableOnDisk[dir];
             availableOnDisk[dir] = 0; // skip this disk
             numDirsSearched++;
-            LOG.debug("No capacity in {}", localDir);
+            note(history, "No capacity in %s", localDir);
           } else {
-            LOG.debug("Allocated file {} in {}", returnPath, localDir);
+            note(history, "Allocated file %s in %s", returnPath, localDir);
           }
         }
       } else {
-        LOG.debug("Size is {}; searching", size);
+        note(history, "Size is %,d; searching", size);
         // Start linear search with random increment if possible
         int randomInc = 1;
         if (numDirs > 2) {
@@ -488,14 +526,16 @@ public class LocalDirAllocator {
             } catch (IOException e) {
               errorText = e.getMessage();
               diskException = e;
+              note(history, "Exception while creating path %s: %s", localDir, errorText);
               LOG.debug("DiskException caught for dir {}", localDir, e);
             }
             if (returnPath != null) {
+              // success
               ctx.getAndIncrDirNumLastAccessed(numDirsSearched);
-              LOG.debug("Allocated file {} in {}", returnPath, localDir);
+              note(history, "Allocated file %s in %s", returnPath, localDir);
               break;
             } else {
-              LOG.debug("No capacity in {}", localDir);
+              note(history, "No capacity in %s", localDir);
             }
           }
           dirNum++;
@@ -516,6 +556,8 @@ public class LocalDirAllocator {
       if (errorText != null) {
         newErrorText = newErrorText + " due to " + errorText;
       }
+      LOG.error(newErrorText);
+      LOG.error(history.toString());
       throw new DiskErrorException(newErrorText, diskException);
     }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/LocalDirAllocator.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.net.NetUtils.getHostname;
+
 /** An implementation of a round-robin scheme for disk allocation for creating
  * files. The way it works is that it is kept track what disk was last
  * allocated for a file write. For the current request, the next disk from
@@ -418,7 +420,7 @@ public class LocalDirAllocator {
       // history is built up and logged at error if the alloc
       StringBuilder history = new StringBuilder();
 
-      note(history, "Searchng for a directory for file at %s, size = %,d; checkWrite=%s",
+      note(history, "Searching for a directory for file \"%s\", size = %,d; checkWrite=%s",
           pathStr, size, checkWrite);
       Context ctx = confChanged(conf);
       int numDirs = ctx.localDirs.length;
@@ -451,9 +453,9 @@ public class LocalDirAllocator {
         pathNames.append(" ").append(name);
         final File dirPath = new File(name);
 
-        // existence probe
+        // existence probe with directory recreation
         if (!dirPath.exists()) {
-          LOG.debug("creating buffer dir {}", name);
+          LOG.debug("Creating buffer dir {}", name);
           if (dirPath.mkdirs()) {
             note(history, "Created buffer dir %s", name);
           } else {
@@ -466,23 +468,29 @@ public class LocalDirAllocator {
         if (dirPath.isDirectory()) {
           final long available = target.getAvailable();
           availableOnDisk[i] = available;
-          note(history, "%s available under path %s",  pathStr, available);
+          note(history, "%,d bytes available under path %s",  available, name);
           totalAvailable += availableOnDisk[i];
         } else {
-          note(history, "%s does not exist/is not a directory",  pathStr);
+          note(history, "%s does not exist/is not a directory", name);
         }
       }
 
-      note(history, "Directory count is %d; total available capacity is %,d{}",
+      note(history, "Directory count is %d; total available capacity is %,d",
           dirCount, totalAvailable);
 
       if (size == SIZE_UNKNOWN) {
         //do roulette selection: pick dir with probability
         // proportional to available size
-        note(history, "Size not specified, so picking at random.");
+        note(history, "Size not specified, so picking directories at random.");
 
         if (totalAvailable == 0) {
-          throw new DiskErrorException(E_NO_SPACE_AVAILABLE + pathNames + "; history=" + history);
+          // log error and history
+          String newErrorText = E_NO_SPACE_AVAILABLE + pathNames
+              + " on host" + getHostname();
+          LOG.error(newErrorText);
+          LOG.error(history.toString());
+          // then raise the exception
+          throw new DiskErrorException(newErrorText);
         }
 
         // Keep rolling the wheel till we get a valid path
@@ -507,7 +515,8 @@ public class LocalDirAllocator {
           }
         }
       } else {
-        note(history, "Size is %,d; searching", size);
+        note(history, "Requested file size is %,d; searching for a suitable directory",
+            size);
         // Start linear search with random increment if possible
         int randomInc = 1;
         if (numDirs > 2) {
@@ -548,9 +557,11 @@ public class LocalDirAllocator {
       }
       
       //no path found
-      String newErrorText = "Could not find any valid local directory for " +
-          pathStr + " with requested size " + size +
-          " as the max capacity in any directory"
+      String hostname = getHostname();
+      String newErrorText = "Could not find any valid local directory for "
+          + pathStr + " with requested size " + size
+          + " on host " + hostname
+          + " as the max capacity in any directory"
           + " (" + pathNames + " )"
           + " is " + maxCapacity;
       if (errorText != null) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestLocalDirAllocator.java
@@ -615,7 +615,6 @@ public class TestLocalDirAllocator {
     dirAllocator.getLocalPathForWrite("file2", -1, conf);
   }
 
-
   /**
    * Test for HADOOP-19554. LocalDirAllocator still doesn't always recover
    * from directory tree deletion.


### PR DESCRIPTION
### Description of PR

#7651 with one final commit.


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

