### PR TITLE
HDFS-17783. [ARR] Optimize the debug log of method asyncIpcClient to print concrete call info.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/protocolPB/AsyncRpcProtocolPBUtil.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hadoop.ipc.Client;
 import org.apache.hadoop.ipc.ProtobufRpcEngine2;
 import org.apache.hadoop.ipc.ProtobufRpcEngineCallback2;
+import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ipc.internal.ShadedProtobufHelper;
 import org.apache.hadoop.thirdparty.protobuf.Message;
 import org.apache.hadoop.util.concurrent.AsyncGet;
@@ -93,6 +94,8 @@ public final class AsyncRpcProtocolPBUtil {
       }
       try {
         T res = asyncReqMessage.get(-1, null);
+        LOG.debug("Async IPC Request, Call={}, CallerContext={}, Result={}",
+            Server.getCurCall().get(), CallerContext.getCurrent(), res);
         return response.apply(res);
       } catch (Exception ex) {
         throw warpCompletionException(ex);

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ThreadLocalContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/ThreadLocalContext.java
@@ -75,6 +75,7 @@ public class ThreadLocalContext {
    * that the task execution reflects the state of the original calling thread.
    */
   public void transfer() {
+    Server.getCurCall().set(null);
     if (call != null) {
       Server.getCurCall().set(call);
     }


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17783.
Currently, the debug log in method asyncIpcClient can not print the RpcCall information such as callId. clientIp, clientPort, callercontext. etc.

It print lambda expression object now which is not what we expected.

![image](https://github.com/user-attachments/assets/76c050ed-e92c-457a-a298-2b7959561b70)