### PR TITLE
HDFS-17791: Fix libhdfs client that needlessly outputs full stack trace for common "file not found" errors

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
@@ -189,12 +189,25 @@ int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
         if (!rootCause) {
             fprintf(stderr, "(unable to get root cause for %s)\n", className);
         } else {
-            fprintf(stderr, "%s", rootCause);
+	    // Trim overly long rootCause message after new-line.
+	    const char *newlnIndex = strchr(rootCause, '\n');
+	    int displayLen = 80;
+	    if (newlnIndex != NULL) {
+	        int newLen = (int) (newlnIndex - rootCause);
+		if (newLen > 10 && newLen < 200) {
+		    // Keep message a reasonable length.
+		    displayLen = newLen;
+		}
+	    }
+            fprintf(stderr, "%.*s\n", displayLen, rootCause);
         }
-        if (!stackTrace) {
-            fprintf(stderr, "(unable to get stack trace for %s)\n", className);
-        } else {
-            fprintf(stderr, "%s", stackTrace);
+        if (!(noPrintFlags & NOSTACK_FILE_NOT_FOUND)) {
+        // Do not print stack for file not found
+            if (!stackTrace) {
+                fprintf(stderr, "(unable to get stack trace for %s)\n", className);
+            } else {
+                fprintf(stderr, "%s", stackTrace);
+            }
         }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
@@ -189,16 +189,16 @@ int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
         if (!rootCause) {
             fprintf(stderr, "(unable to get root cause for %s)\n", className);
         } else {
-	    // Trim overly long rootCause message after new-line.
-	    const char *newlnIndex = strchr(rootCause, '\n');
-	    int displayLen = 80;
-	    if (newlnIndex != NULL) {
-	        int newLen = (int) (newlnIndex - rootCause);
-		if (newLen > 10 && newLen < 200) {
-		    // Keep message a reasonable length.
-		    displayLen = newLen;
-		}
-	    }
+            // Trim overly long rootCause message after new-line.
+            const char *newlnIndex = strchr(rootCause, '\n');
+            int displayLen = 80;
+            if (newlnIndex != NULL) {
+                int newLen = (int) (newlnIndex - rootCause);
+                if (newLen > 10 && newLen < 200) {
+                    // Keep message a reasonable length.
+                    displayLen = newLen;
+                }
+            }
             fprintf(stderr, "%.*s\n", displayLen, rootCause);
         }
         if (!(noPrintFlags & NOSTACK_FILE_NOT_FOUND)) {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.h
@@ -65,6 +65,7 @@
  */
 #define PRINT_EXC_ALL                           0x00
 #define NOPRINT_EXC_FILE_NOT_FOUND              0x01
+#define NOSTACK_FILE_NOT_FOUND                 0x100
 #define NOPRINT_EXC_ACCESS_CONTROL              0x02
 #define NOPRINT_EXC_UNRESOLVED_LINK             0x04
 #define NOPRINT_EXC_PARENT_NOT_DIRECTORY        0x08

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -1247,7 +1247,7 @@ static hdfsFile hdfsOpenFileImpl(hdfsFS fs, const char *path, int flags,
                 jReplication, jBlockSize);
     }
     if (jthr) {
-        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+        ret = printExceptionAndFree(env, jthr, NOSTACK_FILE_NOT_FOUND,
             "hdfsOpenFile(%s): FileSystem#%s(%s)", path, method, signature);
         goto done;
     }


### PR DESCRIPTION
This PR fixes issue [HDFS-17791](https://issues.apache.org/jira/browse/HDFS-17791).

The `libhdfs` client outputs a full Java stack trace in its error message for a "file not found" error. Our HDFS application processes numerous queries checking for the presence of files, so "file not found" errors are frequent. Each such error generates a very lengthy and useless Java stack trace. These traces have no diagnostic value, since the cause of the error is that the file doesn't exist.

See the comment below for an example of the error with stack trace.

This PR eliminates the stack trace in the case of a "file not found" error. The stack trace will still be output for other kinds of errors.

### How was this patch tested?
This patch was tested by loading it into our HDFS application and sending it queries for non-existent files. Concise and useful error messages resulted in the error log that no longer had the lengthy stack traces.

This patch only changes the `libhdfs` C API library.There's no change to HDFS itself. The effect of the change can only be seen in an application that uses `libhdfs` to open files.