### PR TITLE
HADOOP-19573. S3A: ITestS3AConfiguration.testDirectoryAllocatorDefval() failing

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -57,6 +57,7 @@ import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
@@ -287,10 +288,11 @@ public class S3AStoreImpl
    * Initialize dir allocator if not already initialized.
    */
   private void initLocalDirAllocator() {
-    String bufferDir = getConfig().get(BUFFER_DIR) != null
-        ? BUFFER_DIR
-        : HADOOP_TMP_DIR;
-    directoryAllocator = new LocalDirAllocator(bufferDir);
+    String key = BUFFER_DIR;
+    if (StringUtils.isEmpty(getConfig().getTrimmed(key))) {
+      key = HADOOP_TMP_DIR;
+    }
+    directoryAllocator = new LocalDirAllocator(key);
   }
 
   /** Acquire write capacity for rate limiting {@inheritDoc}. */


### PR DESCRIPTION


* trim the buffer dir string before the probe (more robust code anyway)
* tests to set this, and remove any instantiated context mappers


### How was this patch tested?

in the ide until eventually the stack trace went away

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

