### PR TITLE
HADOOP-19567. S3A: error stack traces printed on analytics stream factory close

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs.s3a.impl.streams;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
@@ -40,6 +42,8 @@ import static org.apache.hadoop.fs.s3a.impl.streams.StreamIntegration.populateVe
  *  {@code S3AStore}, if fs.s3a.input.stream.type is set to Analytics.
  */
 public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(AnalyticsStreamFactory.class);
 
   private S3SeekableInputStreamConfiguration seekableInputStreamConfiguration;
   private LazyAutoCloseableReference<S3SeekableInputStreamFactory>  s3SeekableInputStreamFactory;
@@ -98,7 +102,11 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
 
   @Override
   protected void serviceStop() throws Exception {
-    this.s3SeekableInputStreamFactory.close();
+    try {
+      s3SeekableInputStreamFactory.close();
+    } catch (Exception ignored) {
+      LOG.debug("Ignored exception while closing stream factory", ignored);
+    }
     callbacks().incrementFactoryStatistic(ANALYTICS_STREAM_FACTORY_CLOSED);
     super.serviceStop();
   }


### PR DESCRIPTION

HADOOP-19567.

catch all exception raised in stream close; log at debug

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### How was this patch tested?

Surfaced during a cloudstore bandwidth test; manual testing can check.

Hard to write an ITest as it probably depends on the stream state at the time...will have to explore.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

