### PR TITLE
HDFS-17785. DFSAdmin supports setting the bandwidth for DataNode.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2481,8 +2481,9 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
 
   /**
    * Requests the namenode to tell all datanodes to use a new bandwidth value.
-   * See {@link ClientProtocol#setDataNodeBandwidth(long, String)}
-   * for more details.
+   * @param bandwidth Bandwidth in bytes per second for this datanode.
+   * @param type DataNode bandwidth type.
+   * @throws IOException If an I/O error occurred
    *
    * @see ClientProtocol#setDataNodeBandwidth(long, String)
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2480,6 +2480,20 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
   }
 
   /**
+   * Requests the namenode to tell all datanodes to use a new bandwidth value.
+   * See {@link ClientProtocol#setDataNodeBandwidth(long, String)}
+   * for more details.
+   *
+   * @see ClientProtocol#setDataNodeBandwidth(long, String)
+   */
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    checkOpen();
+    try (TraceScope ignored = tracer.newScope("setDataNodeBandwidth-" + type)) {
+      namenode.setDataNodeBandwidth(bandwidth, type);
+    }
+  }
+
+  /**
    * @see ClientProtocol#finalizeUpgrade()
    */
   public void finalizeUpgrade() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -2088,7 +2088,7 @@ public class DistributedFileSystem extends FileSystem
    * bandwidth to be used by a datanode during balancing.
    *
    * @param bandwidth Balancer bandwidth in bytes per second for all datanodes.
-   * @throws IOException
+   * @throws IOException If an I/O error occurred
    */
   public void setBalancerBandwidth(long bandwidth) throws IOException {
     dfs.setBalancerBandwidth(bandwidth);

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -2095,6 +2095,17 @@ public class DistributedFileSystem extends FileSystem
   }
 
   /**
+   * Requests the namenode to tell all datanodes to reset the bandwidth of the specified type.
+   *
+   * @param bandwidth Bandwidth in bytes per second for all datanodes.
+   * @param type DataNode bandwidth type.
+   * @throws IOException
+   */
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    dfs.setDataNodeBandwidth(bandwidth, type);
+  }
+
+  /**
    * Get a canonical service name for this file system. If the URI is logical,
    * the hostname part of the URI will be returned.
    * @return a service string that uniquely identifies this file system.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/ViewDistributedFileSystem.java
@@ -1058,6 +1058,16 @@ public class ViewDistributedFileSystem extends DistributedFileSystem {
   }
 
   @Override
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    if (this.vfs == null) {
+      super.setDataNodeBandwidth(bandwidth, type);
+      return;
+    }
+    checkDefaultDFS(defaultDFS, "setDataNodeBandwidth");
+    defaultDFS.setDataNodeBandwidth(bandwidth, type);
+  }
+
+  @Override
   public String getCanonicalServiceName() {
     if (this.vfs == null) {
       return super.getCanonicalServiceName();

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -1051,6 +1051,16 @@ public interface ClientProtocol {
   void setBalancerBandwidth(long bandwidth) throws IOException;
 
   /**
+   * Tell all datanodes to reset the bandwidth of the specified type.
+   *
+   * @param bandwidth Bandwidth in bytes per second for this datanode.
+   * @param type DataNode bandwidth type.
+   * @throws IOException
+   */
+  @Idempotent
+  void setDataNodeBandwidth(long bandwidth, String type) throws IOException;
+
+  /**
    * Get the file info for a specific file or directory.
    * @param src The string representation of the path to the file
    *

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -1055,7 +1055,7 @@ public interface ClientProtocol {
    *
    * @param bandwidth Bandwidth in bytes per second for this datanode.
    * @param type DataNode bandwidth type.
-   * @throws IOException
+   * @throws IOException If an I/O error occurred
    */
   @Idempotent
   void setDataNodeBandwidth(long bandwidth, String type) throws IOException;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -189,6 +189,7 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.Rollin
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.RollingUpgradeResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SaveNamespaceRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetBalancerBandwidthRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetDataNodeBandwidthRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetOwnerRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetPermissionRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetQuotaRequestProto;
@@ -974,6 +975,16 @@ public class ClientNamenodeProtocolTranslatorPB implements
             .setBandwidth(bandwidth)
             .build();
     ipc(() -> rpcProxy.setBalancerBandwidth(null, req));
+  }
+
+  @Override
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    SetDataNodeBandwidthRequestProto req =
+        SetDataNodeBandwidthRequestProto.newBuilder()
+            .setBandwidth(bandwidth)
+            .setType(type)
+            .build();
+    ipc(() -> rpcProxy.setDataNodeBandwidth(null, req));
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/ClientNamenodeProtocol.proto
@@ -772,7 +772,15 @@ message SetBalancerBandwidthRequestProto {
   required int64 bandwidth = 1;
 }
 
+message SetDataNodeBandwidthRequestProto {
+  required int64 bandwidth = 1;
+  required string type = 2;
+}
+
 message SetBalancerBandwidthResponseProto { // void response
+}
+
+message SetDataNodeBandwidthResponseProto { // void response
 }
 
 message GetDataEncryptionKeyRequestProto { // no parameters
@@ -999,6 +1007,8 @@ service ClientNamenodeProtocol {
       returns(hadoop.common.CancelDelegationTokenResponseProto);
   rpc setBalancerBandwidth(SetBalancerBandwidthRequestProto)
       returns(SetBalancerBandwidthResponseProto);
+  rpc setDataNodeBandwidth(SetDataNodeBandwidthRequestProto)
+      returns(SetDataNodeBandwidthResponseProto);
   rpc getDataEncryptionKey(GetDataEncryptionKeyRequestProto)
       returns(GetDataEncryptionKeyResponseProto);
   rpc createSnapshot(CreateSnapshotRequestProto)

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterClientProtocol.java
@@ -1314,6 +1314,16 @@ public class RouterClientProtocol implements ClientProtocol {
     rpcClient.invokeConcurrent(nss, method, true, false);
   }
 
+  @Override
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    rpcServer.checkOperation(NameNode.OperationCategory.UNCHECKED);
+
+    RemoteMethod method = new RemoteMethod("setDataNodeBandwidth",
+        new Class<?>[] {long.class, String.class}, bandwidth, type);
+    final Set<FederationNamespaceInfo> nss = namenodeResolver.getNamespaces();
+    rpcClient.invokeConcurrent(nss, method, true, false);
+  }
+
   /**
    * Recursively get all the locations for the path.
    * For example, there are some mount points:

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -1640,6 +1640,11 @@ public class RouterRpcServer extends AbstractService implements ClientProtocol,
   }
 
   @Override // ClientProtocol
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    clientProto.setDataNodeBandwidth(bandwidth, type);
+  }
+
+  @Override // ClientProtocol
   public ContentSummary getContentSummary(String path) throws IOException {
     return clientProto.getContentSummary(path);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/router/TestRouterRpc.java
@@ -2206,6 +2206,15 @@ public class TestRouterRpc {
   }
 
   @Test
+  public void testSetDataNodeBandwidth() throws Exception {
+    routerProtocol.setDataNodeBandwidth(1000L, "transfer");
+    ArrayList<DataNode> datanodes = cluster.getCluster().getDataNodes();
+    GenericTestUtils.waitFor(() ->  {
+      return datanodes.get(0).getTransferBandwidth() == 1000L;
+    }, 100, 60 * 1000);
+  }
+
+  @Test
   public void testAddClientIpPortToCallerContext() throws IOException {
     GenericTestUtils.LogCapturer auditLog =
         GenericTestUtils.LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -225,6 +225,8 @@ import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SaveNa
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SaveNamespaceResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetBalancerBandwidthRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetBalancerBandwidthResponseProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetDataNodeBandwidthRequestProto;
+import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetDataNodeBandwidthResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetOwnerRequestProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetOwnerResponseProto;
 import org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos.SetPermissionRequestProto;
@@ -414,6 +416,9 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
 
   protected static final SetBalancerBandwidthResponseProto VOID_SETBALANCERBANDWIDTH_RESPONSE =
       SetBalancerBandwidthResponseProto.newBuilder().build();
+
+  protected static final SetDataNodeBandwidthResponseProto VOID_SETDATANODEBANDWIDTH_RESPONSE =
+      SetDataNodeBandwidthResponseProto.newBuilder().build();
 
   protected static final SetAclResponseProto VOID_SETACL_RESPONSE =
       SetAclResponseProto.getDefaultInstance();
@@ -1249,6 +1254,18 @@ public class ClientNamenodeProtocolServerSideTranslatorPB implements
     try {
       server.setBalancerBandwidth(req.getBandwidth());
       return VOID_SETBALANCERBANDWIDTH_RESPONSE;
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  @Override
+  public SetDataNodeBandwidthResponseProto setDataNodeBandwidth(
+      RpcController controller, SetDataNodeBandwidthRequestProto req)
+      throws ServiceException {
+    try {
+      server.setDataNodeBandwidth(req.getBandwidth(), req.getType());
+      return VOID_SETDATANODEBANDWIDTH_RESPONSE;
     } catch (IOException e) {
       throw new ServiceException(e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelper.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.ProvidedStorageLocation;
 import org.apache.hadoop.hdfs.protocol.proto.AliasMapProtocolProtos.KeyValueProto;
 import org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos.BalancerBandwidthCommandProto;
+import org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos.DataNodeBandwidthCommandProto;
 import org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos.BlockCommandProto;
 import org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos.BlockECReconstructionCommandProto;
 import org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos.BlockIdCommandProto;
@@ -90,6 +91,7 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.ReplicaState;
 import org.apache.hadoop.hdfs.server.common.StorageInfo;
 import org.apache.hadoop.hdfs.server.namenode.CheckpointSignature;
 import org.apache.hadoop.hdfs.server.protocol.BalancerBandwidthCommand;
+import org.apache.hadoop.hdfs.server.protocol.DataNodeBandwidthCommand;
 import org.apache.hadoop.hdfs.server.protocol.BlockCommand;
 import org.apache.hadoop.hdfs.server.protocol.BlockECReconstructionCommand;
 import org.apache.hadoop.hdfs.server.protocol.BlockIdCommand;
@@ -458,6 +460,8 @@ public class PBHelper {
     switch (proto.getCmdType()) {
     case BalancerBandwidthCommand:
       return PBHelper.convert(proto.getBalancerCmd());
+    case DataNodeBandwidthCommand:
+      return PBHelper.convert(proto.getBandwidthCmd());
     case BlockCommand:
       return PBHelper.convert(proto.getBlkCmd());
     case BlockRecoveryCommand:
@@ -481,6 +485,13 @@ public class PBHelper {
       BalancerBandwidthCommand bbCmd) {
     return BalancerBandwidthCommandProto.newBuilder()
         .setBandwidth(bbCmd.getBalancerBandwidthValue()).build();
+  }
+
+  public static DataNodeBandwidthCommandProto convert(
+      DataNodeBandwidthCommand bbCmd) {
+    return DataNodeBandwidthCommandProto.newBuilder()
+        .setBandwidth(bbCmd.getDataNodeBandwidthValue())
+        .setType(bbCmd.getDataNodeBandwidthType()).build();
   }
 
   public static KeyUpdateCommandProto convert(KeyUpdateCommand cmd) {
@@ -571,6 +582,11 @@ public class PBHelper {
       builder.setCmdType(DatanodeCommandProto.Type.BalancerBandwidthCommand)
           .setBalancerCmd(
               PBHelper.convert((BalancerBandwidthCommand) datanodeCommand));
+      break;
+    case DatanodeProtocol.DNA_DATANODEBANDWIDTHUPDATE:
+      builder.setCmdType(DatanodeCommandProto.Type.DataNodeBandwidthCommand)
+          .setBandwidthCmd(
+              PBHelper.convert((DataNodeBandwidthCommand) datanodeCommand));
       break;
     case DatanodeProtocol.DNA_ACCESSKEYUPDATE:
       builder
@@ -707,6 +723,12 @@ public class PBHelper {
   public static BalancerBandwidthCommand convert(
       BalancerBandwidthCommandProto balancerCmd) {
     return new BalancerBandwidthCommand(balancerCmd.getBandwidth());
+  }
+
+  public static DataNodeBandwidthCommand convert(
+      DataNodeBandwidthCommandProto bandwidthCmd) {
+    return new DataNodeBandwidthCommand(bandwidthCmd.getBandwidth(),
+        bandwidthCmd.getType());
   }
 
   public static ReceivedDeletedBlockInfoProto convert(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -1037,11 +1037,11 @@ public class DatanodeDescriptor extends DatanodeInfo {
   }
 
   /**
-   * @param bandwidth Bandwidth in bytes per second for this datanode
+   * @param dnBandwidth Bandwidth in bytes per second for this datanode
    * @param type DataNode bandwidth type.
    */
-  public synchronized void setDataNodeBandwidth(long bandwidth, String type) {
-    this.throttlers.put(type, bandwidth);
+  public synchronized void setDataNodeBandwidth(long dnBandwidth, String type) {
+    this.throttlers.put(type, dnBandwidth);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -193,6 +193,8 @@ public class DatanodeDescriptor extends DatanodeInfo {
   // specified datanode, this value will be set back to 0.
   private long bandwidth;
 
+  private Map<String, Long> throttlers = new HashMap<>();
+
   /** A queue of blocks to be replicated by this datanode */
   private final BlockQueue<BlockTargetPair> replicateBlocks =
       new BlockQueue<>();
@@ -1025,6 +1027,21 @@ public class DatanodeDescriptor extends DatanodeInfo {
    */
   public synchronized void setBalancerBandwidth(long bandwidth) {
     this.bandwidth = bandwidth;
+  }
+
+  /**
+   * @return bandwidth throttlers for this datanode
+   */
+  public synchronized Map<String, Long> getDataNodeBandwidth() {
+    return this.throttlers;
+  }
+
+  /**
+   * @param bandwidth Bandwidth in bytes per second for this datanode
+   * @param type DataNode bandwidth type.
+   */
+  public synchronized void setDataNodeBandwidth(long bandwidth, String type) {
+    this.throttlers.put(type, bandwidth);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1974,6 +1974,14 @@ public class DatanodeManager {
       nodeinfo.setBalancerBandwidth(0);
     }
 
+    // check for datanode bandwidth update
+    if (!nodeinfo.getDataNodeBandwidth().isEmpty()) {
+      for (Map.Entry<String, Long> entry : nodeinfo.getDataNodeBandwidth().entrySet()){
+        cmds.add(new DataNodeBandwidthCommand(entry.getValue(), entry.getKey()));
+      }
+      nodeinfo.getDataNodeBandwidth().clear();
+    }
+
     Preconditions.checkNotNull(slowPeerTracker, "slowPeerTracker should not be un-assigned");
 
     if (slowPeerTracker.isSlowPeerTrackerEnabled()) {
@@ -2085,7 +2093,25 @@ public class DatanodeManager {
       }
     }
   }
-  
+
+  /**
+   * Tell all datanodes to reset the bandwidth of the specified type.
+   *
+   * A system administrator can tune the datanode bandwidth dynamically by calling
+   * "dfsadmin -setDataNodeBandwidth newbandwidth -type <transfer|write|read>"
+   *
+   * @param bandwidth Bandwidth in bytes per second for all datanodes.
+   * @param type DataNode bandwidth type.
+   * @throws IOException
+   */
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    synchronized(this) {
+      for (DatanodeDescriptor nodeInfo : datanodeMap.values()) {
+        nodeInfo.setDataNodeBandwidth(bandwidth, type);
+      }
+    }
+  }
+
   public void markAllDatanodesStaleAndSetKeyUpdateIfNeed() {
     LOG.info("Marking all datanodes as stale and schedule update block token if need.");
     synchronized (this) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -1930,8 +1930,7 @@ public class DatanodeManager {
       if (!pendingList.isEmpty()) {
         // If the block is deleted, the block size will become
         // BlockCommand.NO_ACK (LONG.MAX_VALUE) . This kind of block we don't
-        // need
-        // to send for replication or reconstruction
+        // need to send for replication or reconstruction
         Iterator<BlockTargetPair> iterator = pendingList.iterator();
         while (iterator.hasNext()) {
           BlockTargetPair cmd = iterator.next();
@@ -1962,9 +1961,7 @@ public class DatanodeManager {
       cmds.add(new BlockCommand(DatanodeProtocol.DNA_INVALIDATE, blockPoolId,
           blks));
     }
-    // cache commands
     addCacheCommands(blockPoolId, nodeinfo, cmds);
-    // key update command
     blockManager.addKeyUpdateCommand(cmds, nodeinfo);
 
     // check for balancer bandwidth update
@@ -1974,7 +1971,6 @@ public class DatanodeManager {
       nodeinfo.setBalancerBandwidth(0);
     }
 
-    // check for datanode bandwidth update
     if (!nodeinfo.getDataNodeBandwidth().isEmpty()) {
       for (Map.Entry<String, Long> entry : nodeinfo.getDataNodeBandwidth().entrySet()){
         cmds.add(new DataNodeBandwidthCommand(entry.getValue(), entry.getKey()));
@@ -2102,7 +2098,7 @@ public class DatanodeManager {
    *
    * @param bandwidth Bandwidth in bytes per second for all datanodes.
    * @param type DataNode bandwidth type.
-   * @throws IOException
+   * @throws IOException If an I/O error occurred
    */
   public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
     synchronized(this) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdfs.protocolPB.DatanodeProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdfs.server.protocol.*;
 import org.apache.hadoop.hdfs.server.protocol.BlockECReconstructionCommand.BlockECReconstructionInfo;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStatus;
+import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Sets;
@@ -804,6 +805,40 @@ class BPOfferService {
             + dxcs.balanceThrottler.getBandwidth() + " bytes/s "
             + "to: " + bandwidth + " bytes/s.");
         dxcs.balanceThrottler.setBandwidth(bandwidth);
+      }
+      break;
+    case DatanodeProtocol.DNA_DATANODEBANDWIDTHUPDATE:
+      LOG.info("DatanodeCommand action: DNA_DATANODEBANDWIDTHUPDATE");
+      long dnBandwidth =
+          ((DataNodeBandwidthCommand) cmd).getDataNodeBandwidthValue();
+      long oldBandwidth;
+      String type =
+          ((DataNodeBandwidthCommand) cmd).getDataNodeBandwidthType();
+      if (dnBandwidth >= 0) {
+        DataXceiverServer dxcs = dn.getXferServer();
+        if (type.equals("transfer")) {
+          oldBandwidth = dxcs.getTransferThrottler() == null ? 0 :
+              dxcs.getTransferThrottler().getBandwidth();
+          DataTransferThrottler transferThrottler = dnBandwidth == 0 ? null :
+              new DataTransferThrottler(dnBandwidth);
+          dxcs.setTransferThrottler(transferThrottler);
+        } else if (type.equals("write")) {
+          oldBandwidth = dxcs.getWriteThrottler() == null ? 0 :
+              dxcs.getWriteThrottler().getBandwidth();
+          DataTransferThrottler writeThrottler = dnBandwidth == 0 ? null :
+              new DataTransferThrottler(dnBandwidth);
+          dxcs.setWriteThrottler(writeThrottler);
+        } else if (type.equals("read")) {
+          oldBandwidth = dxcs.getReadThrottler() == null ? 0 :
+              dxcs.getReadThrottler().getBandwidth();
+          DataTransferThrottler readThrottler = dnBandwidth == 0 ? null :
+              new DataTransferThrottler(dnBandwidth);
+          dxcs.setReadThrottler(readThrottler);
+        } else {
+          break;
+        }
+        LOG.info("Updated " + type + " throttler bandwidth from "
+            + oldBandwidth + " bytes/s to: " + dnBandwidth + " bytes/s.");
       }
       break;
     case DatanodeProtocol.DNA_ERASURE_CODING_RECONSTRUCTION:

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataNode.java
@@ -4004,7 +4004,31 @@ public class DataNode extends ReconfigurableBase
                        (DataXceiverServer) this.dataXceiverServer.getRunnable();
     return dxcs.balanceThrottler.getBandwidth();
   }
-  
+
+  @VisibleForTesting
+  public long getTransferBandwidth() {
+    if (this.xserver.getTransferThrottler() != null) {
+      return this.xserver.getTransferThrottler().getBandwidth();
+    }
+    return 0;
+  }
+
+  @VisibleForTesting
+  public long getWriteBandwidth() {
+    if (this.xserver.getWriteThrottler() != null) {
+      return this.xserver.getWriteThrottler().getBandwidth();
+    }
+    return 0;
+  }
+
+  @VisibleForTesting
+  public long getReadBandwidth() {
+    if (this.xserver.getReadThrottler() != null) {
+      return this.xserver.getReadThrottler().getBandwidth();
+    }
+    return 0;
+  }
+
   public DNConf getDnConf() {
     return dnConf;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -5188,6 +5188,14 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     logAuditEvent(true, operationName, null);
   }
 
+  void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    String operationName = "setDataNodeBandwidth-" + type;
+    checkOperation(OperationCategory.WRITE);
+    checkSuperuserPrivilege(operationName);
+    getBlockManager().getDatanodeManager().setDataNodeBandwidth(bandwidth, type);
+    logAuditEvent(true, operationName, null);
+  }
+
   boolean setSafeMode(SafeModeAction action) throws IOException {
     String operationName = action.toString().toLowerCase();
     boolean error = false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1499,7 +1499,25 @@ public class NameNodeRpcServer implements NamenodeProtocols {
     checkNNStartup();
     namesystem.setBalancerBandwidth(bandwidth);
   }
-  
+
+  /**
+   * Tell all datanodes to reset the bandwidth of the specified type.
+   * @param bandwidth Bandwidth in bytes per second for all datanodes.
+   * @param type DataNode bandwidth type.
+   * @throws IOException
+   */
+  @Override // ClientProtocol
+  public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {
+    if (bandwidth > HdfsServerConstants.MAX_BANDWIDTH_PER_DATANODE) {
+      throw new IllegalArgumentException(
+          "Bandwidth should not exceed maximum limit "
+              + HdfsServerConstants.MAX_BANDWIDTH_PER_DATANODE
+              + " bytes per second");
+    }
+    checkNNStartup();
+    namesystem.setDataNodeBandwidth(bandwidth, type);
+  }
+
   @Override // ClientProtocol
   public ContentSummary getContentSummary(String path) throws IOException {
     checkNNStartup();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1504,7 +1504,7 @@ public class NameNodeRpcServer implements NamenodeProtocols {
    * Tell all datanodes to reset the bandwidth of the specified type.
    * @param bandwidth Bandwidth in bytes per second for all datanodes.
    * @param type DataNode bandwidth type.
-   * @throws IOException
+   * @throws IOException If an I/O error occurred
    */
   @Override // ClientProtocol
   public void setDataNodeBandwidth(long bandwidth, String type) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DataNodeBandwidthCommand.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DataNodeBandwidthCommand.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.protocol;
+
+/**
+ * DataNode bandwidth command instructs each datanode to change its value for
+ * the max amount of network bandwidth.
+ */
+public class DataNodeBandwidthCommand extends DatanodeCommand {
+  private final static long DBC_DEFAULTBANDWIDTH = 0L;
+
+  private final long bandwidth;
+  private final String type;
+
+  /**
+   * DataNode Bandwidth Command constructor. Sets bandwidth to 0.
+   */
+  DataNodeBandwidthCommand() {
+    this(DBC_DEFAULTBANDWIDTH, null);
+  }
+
+  /**
+   * DataNode Bandwidth Command constructor.
+   *
+   * @param bandwidth Bandwidth in bytes per second.
+   */
+  public DataNodeBandwidthCommand(long bandwidth, String type) {
+    super(DatanodeProtocol.DNA_DATANODEBANDWIDTHUPDATE);
+    this.bandwidth = bandwidth;
+    this.type = type;
+  }
+
+  /**
+   * Get current value of the max bandwidth in bytes per second.
+   *
+   * @return bandwidth DataNode bandwidth in bytes per second for this datanode.
+   */
+  public long getDataNodeBandwidthValue() {
+    return this.bandwidth;
+  }
+
+  /**
+   * Get current value of bandwidth type.
+   *
+   * @return datanode bandwidth type.
+   */
+  public String getDataNodeBandwidthType() {
+    return this.type;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
@@ -81,7 +81,7 @@ public interface DatanodeProtocol {
   final static int DNA_ERASURE_CODING_RECONSTRUCTION = 11; // erasure coding reconstruction command
   int DNA_BLOCK_STORAGE_MOVEMENT = 12; // block storage movement command
   int DNA_DROP_SPS_WORK_COMMAND = 13; // drop sps work command
-  final static int DNA_DATANODEBANDWIDTHUPDATE = 14; // update datanode bandwidth
+  int DNA_DATANODEBANDWIDTHUPDATE = 14; // update datanode bandwidth
 
   /** 
    * Register Datanode.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
@@ -81,6 +81,7 @@ public interface DatanodeProtocol {
   final static int DNA_ERASURE_CODING_RECONSTRUCTION = 11; // erasure coding reconstruction command
   int DNA_BLOCK_STORAGE_MOVEMENT = 12; // block storage movement command
   int DNA_DROP_SPS_WORK_COMMAND = 13; // drop sps work command
+  final static int DNA_DATANODEBANDWIDTHUPDATE = 14; // update datanode bandwidth
 
   /** 
    * Register Datanode.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -461,7 +461,7 @@ public class DFSAdmin extends FsShell {
       "\t[-getVolumeReport datanode_host:ipc_port]\n" +
     "\t[-deleteBlockPool datanode_host:ipc_port blockpoolId [force]]\n"+
     "\t[-setBalancerBandwidth <bandwidth in bytes per second>]\n" +
-    "\t[-setDataNodeBandwidth <bandwidth in bytes per second> -type <transfer|write|read>]\n" +
+      "\t[-setDataNodeBandwidth <bandwidth in bytes per second> -type <transfer|write|read>]\n" +
     "\t[-getBalancerBandwidth <datanode_host:ipc_port>]\n" +
     "\t[-fetchImage <local directory>]\n" +
     "\t[-allowSnapshot <snapshotDir>]\n" +
@@ -1137,7 +1137,7 @@ public class DFSAdmin extends FsShell {
    * Usage: hdfs dfsadmin -setDataNodeBandwidth bandwidth -type <transfer|write|read>
    * @param argv List of of command line parameters.
    * @param idx The index of the command that is being processed.
-   * @exception IOException
+   * @exception IOException If an I/O error occurred
    */
   public int setDataNodeBandwidth(String[] argv, int idx) throws IOException {
 
@@ -1148,12 +1148,13 @@ public class DFSAdmin extends FsShell {
 
     try {
       List<String> args = new ArrayList<>(Arrays.asList(argv));
-      type = StringUtils.popOptionWithArgument("-type", args);;
+      type = StringUtils.popOptionWithArgument("-type", args);
       bandwidth = StringUtils.TraditionalBinaryPrefix.string2long(argv[idx]);
     } catch (Exception e) {
       System.err.println("Exception: " + e.getMessage());
       System.err.println("Usage: hdfs dfsadmin"
-          + " [-setDataNodeBandwidth <bandwidth in bytes per second> [-type <transfer|write|read>]]");
+          + " [-setDataNodeBandwidth <bandwidth in bytes per second>"
+          + " [-type <transfer|write|read>]]");
       return exitCode;
     }
 
@@ -2411,7 +2412,8 @@ public class DFSAdmin extends FsShell {
                   + " [-setBalancerBandwidth <bandwidth in bytes per second>]");
     } else if ("-setDataNodeBandwidth".equals(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
-          + " [-setDataNodeBandwidth <bandwidth in bytes per second> [-type <transfer|write|read>]]");
+          + " [-setDataNodeBandwidth <bandwidth in bytes per second>"
+          + " [-type <transfer|write|read>]]");
     } else if ("-getBalancerBandwidth".equalsIgnoreCase(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
           + " [-getBalancerBandwidth <datanode_host:ipc_port>]");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSAdmin.java
@@ -461,6 +461,7 @@ public class DFSAdmin extends FsShell {
       "\t[-getVolumeReport datanode_host:ipc_port]\n" +
     "\t[-deleteBlockPool datanode_host:ipc_port blockpoolId [force]]\n"+
     "\t[-setBalancerBandwidth <bandwidth in bytes per second>]\n" +
+    "\t[-setDataNodeBandwidth <bandwidth in bytes per second> -type <transfer|write|read>]\n" +
     "\t[-getBalancerBandwidth <datanode_host:ipc_port>]\n" +
     "\t[-fetchImage <local directory>]\n" +
     "\t[-allowSnapshot <snapshotDir>]\n" +
@@ -1132,6 +1133,53 @@ public class DFSAdmin extends FsShell {
   }
 
   /**
+   * Command to ask the active namenode to set the datandoe bandwidth.
+   * Usage: hdfs dfsadmin -setDataNodeBandwidth bandwidth -type <transfer|write|read>
+   * @param argv List of of command line parameters.
+   * @param idx The index of the command that is being processed.
+   * @exception IOException
+   */
+  public int setDataNodeBandwidth(String[] argv, int idx) throws IOException {
+
+    long bandwidth;
+    int exitCode = -1;
+    String type;
+    List<String> types = Arrays.asList("transfer", "write", "read");
+
+    try {
+      List<String> args = new ArrayList<>(Arrays.asList(argv));
+      type = StringUtils.popOptionWithArgument("-type", args);;
+      bandwidth = StringUtils.TraditionalBinaryPrefix.string2long(argv[idx]);
+    } catch (Exception e) {
+      System.err.println("Exception: " + e.getMessage());
+      System.err.println("Usage: hdfs dfsadmin"
+          + " [-setDataNodeBandwidth <bandwidth in bytes per second> [-type <transfer|write|read>]]");
+      return exitCode;
+    }
+
+    if (bandwidth < 0) {
+      System.err.println("Bandwidth should be a non-negative integer");
+      return exitCode;
+    }
+
+    if (!types.contains(type)) {
+      System.err.println("Bandwidth type should be in <transfer|write|read>");
+      return exitCode;
+    }
+    DistributedFileSystem dfs = getDFS();
+    try{
+      dfs.setDataNodeBandwidth(bandwidth, type);
+      System.out.println("DataNode " + type + " bandwidth is set to " + bandwidth);
+    } catch (IOException ioe){
+      System.err.println("DataNode " + type + " bandwidth is set failed.");
+      throw ioe;
+    }
+    exitCode = 0;
+
+    return exitCode;
+  }
+
+  /**
    * Command to get balancer bandwidth for the given datanode. Usage: hdfs
    * dfsadmin -getBalancerBandwidth {@literal <datanode_host:ipc_port>}
    * @param argv List of of command line parameters.
@@ -1318,6 +1366,11 @@ public class DFSAdmin extends FsShell {
         "\tduring HDFS block balancing.\n\n" +
         "\t--- NOTE: This value is not persistent on the DataNode.---\n";
 
+    String setDataNodeBandwidth = "-setDataNodeBandwidth <bandwidth>:\n" +
+        "\tChanges the bandwidth of the throttler for each datanode.\n" +
+        "\tThe types of throttlers include transfer, write, and read.\n\n" +
+        "\t--- NOTE: The new value is not persistent on the DataNode.---\n";
+
     String fetchImage = "-fetchImage <local directory>:\n" +
       "\tDownloads the most recent fsimage from the Name Node and saves it in" +
       "\tthe specified local directory.\n";
@@ -1414,6 +1467,8 @@ public class DFSAdmin extends FsShell {
       System.out.println(deleteBlockPool);
     } else if ("setBalancerBandwidth".equals(cmd)) {
       System.out.println(setBalancerBandwidth);
+    } else if ("setDataNodeBandwidth".equals(cmd)) {
+      System.out.println(setDataNodeBandwidth);
     } else if ("getBalancerBandwidth".equals(cmd)) {
       System.out.println(getBalancerBandwidth);
     } else if ("fetchImage".equals(cmd)) {
@@ -1462,6 +1517,7 @@ public class DFSAdmin extends FsShell {
       System.out.println(refreshNamenodes);
       System.out.println(deleteBlockPool);
       System.out.println(setBalancerBandwidth);
+      System.out.println(setDataNodeBandwidth);
       System.out.println(getBalancerBandwidth);
       System.out.println(fetchImage);
       System.out.println(allowSnapshot);
@@ -2353,6 +2409,9 @@ public class DFSAdmin extends FsShell {
     } else if ("-setBalancerBandwidth".equals(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
                   + " [-setBalancerBandwidth <bandwidth in bytes per second>]");
+    } else if ("-setDataNodeBandwidth".equals(cmd)) {
+      System.err.println("Usage: hdfs dfsadmin"
+          + " [-setDataNodeBandwidth <bandwidth in bytes per second> [-type <transfer|write|read>]]");
     } else if ("-getBalancerBandwidth".equalsIgnoreCase(cmd)) {
       System.err.println("Usage: hdfs dfsadmin"
           + " [-getBalancerBandwidth <datanode_host:ipc_port>]");
@@ -2511,6 +2570,11 @@ public class DFSAdmin extends FsShell {
         printUsage(cmd);
         return exitCode;
       }
+    } else if ("-setDataNodeBandwidth".equals(cmd)) {
+      if (argv.length != 4) {
+        printUsage(cmd);
+        return exitCode;
+      }
     } else if ("-getBalancerBandwidth".equalsIgnoreCase(cmd)) {
       if (argv.length != 2) {
         printUsage(cmd);
@@ -2603,6 +2667,8 @@ public class DFSAdmin extends FsShell {
         exitCode = deleteBlockPool(argv, i);
       } else if ("-setBalancerBandwidth".equals(cmd)) {
         exitCode = setBalancerBandwidth(argv, i);
+      } else if ("-setDataNodeBandwidth".equals(cmd)) {
+        exitCode = setDataNodeBandwidth(argv, i);
       } else if ("-getBalancerBandwidth".equals(cmd)) {
         exitCode = getBalancerBandwidth(argv, i);
       } else if ("-fetchImage".equals(cmd)) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
@@ -60,6 +60,7 @@ message DatanodeCommandProto {
     NullDatanodeCommand = 7;
     BlockIdCommand = 8;
     BlockECReconstructionCommand = 9;
+    DataNodeBandwidthCommand = 10;
   }
 
   required Type cmdType = 1;    // Type of the command
@@ -74,6 +75,7 @@ message DatanodeCommandProto {
   optional RegisterCommandProto registerCmd = 7;
   optional BlockIdCommandProto blkIdCmd = 8;
   optional BlockECReconstructionCommandProto blkECReconstructionCmd = 9;
+  optional DataNodeBandwidthCommandProto bandwidthCmd = 10;
 }
 
 /**
@@ -84,6 +86,17 @@ message BalancerBandwidthCommandProto {
 
   // Maximum bandwidth to be used by datanode for balancing
   required uint64 bandwidth = 1;
+}
+
+/**
+ * Command sent from namenode to datanode to set the
+ * maximum bandwidth.
+ */
+message DataNodeBandwidthCommandProto {
+
+  // Maximum bandwidth to be used by datanode
+  required uint64 bandwidth = 1;
+  required string type = 2;
 }
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/HDFSCommands.md
@@ -388,6 +388,7 @@ Usage:
         hdfs dfsadmin [-getVolumeReport datanodehost:port]
         hdfs dfsadmin [-deleteBlockPool datanode-host:port blockpoolId [force]]
         hdfs dfsadmin [-setBalancerBandwidth <bandwidth in bytes per second>]
+        hdfs dfsadmin [-setDataNodeBandwidth <bandwidth in bytes per second> -type <transfer|write|read>]
         hdfs dfsadmin [-getBalancerBandwidth <datanode_host:ipc_port>]
         hdfs dfsadmin [-fetchImage <local directory>]
         hdfs dfsadmin [-allowSnapshot <snapshotDir>]
@@ -427,6 +428,7 @@ Usage:
 | `-getVolumeReport` datanodehost:port | For the given datanode, get the volume report. |
 | `-deleteBlockPool` datanode-host:port blockpoolId [force] | If force is passed, block pool directory for the given blockpool id on the given datanode is deleted along with its contents, otherwise the directory is deleted only if it is empty. The command will fail if datanode is still serving the block pool. Refer to refreshNamenodes to shutdown a block pool service on a datanode. |
 | `-setBalancerBandwidth` \<bandwidth in bytes per second\> | Changes the network bandwidth used by each datanode during HDFS block balancing. \<bandwidth\> is the maximum number of bytes per second that will be used by each datanode. This value overrides the dfs.datanode.balance.bandwidthPerSec parameter. NOTE: The new value is not persistent on the DataNode. |
+| `-setDataNodeBandwidth` \<bandwidth in bytes per second\> `-type` \<transfer\|write\|read\> | Changes the bandwidth of the throttler for each datanode. The types of throttlers include transfer, write, and read. |
 | `-getBalancerBandwidth` \<datanode\_host:ipc\_port\> | Get the network bandwidth(in bytes per second) for the given datanode. This is the maximum network bandwidth used by the datanode during HDFS block balancing.|
 | `-fetchImage` \<local directory\> | Downloads the most recent fsimage from the NameNode and saves it in the specified local directory. |
 | `-allowSnapshot` \<snapshotDir\> | Allowing snapshots of a directory to be created. If the operation completes successfully, the directory becomes snapshottable. See the [HDFS Snapshot Documentation](./HdfsSnapshots.html) for more information. |

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -339,6 +339,12 @@ public class TestDistributedFileSystem {
       GenericTestUtils.assertExceptionContains("Filesystem closed", ioe);
     }
     try {
+      dfsClient.setDataNodeBandwidth(1000L, "transfer");
+      fail("setDataNodeBandwidth using a closed filesystem!");
+    } catch (IOException ioe) {
+      GenericTestUtils.assertExceptionContains("Filesystem closed", ioe);
+    }
+    try {
       dfsClient.finalizeUpgrade();
       fail("finalizeUpgrade using a closed filesystem!");
     } catch (IOException ioe) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -1043,6 +1043,36 @@ public class TestAuditLoggerWithCommands {
   }
 
   @Test
+  public void testSetDataNodeBandwidth() throws Exception {
+    String auditLogString =
+        ".*allowed=true.*cmd=setDataNodeBandwidth.*";
+    FSNamesystem fsNamesystem = spy(cluster.getNamesystem());
+    when(fsNamesystem.isExternalInvocation()).thenReturn(true);
+    Server.Call call = spy(new Server.Call(
+        1, 1, null, null, RPC.RpcKind.RPC_BUILTIN, new byte[] {1, 2, 3}));
+    when(call.getRemoteUser()).thenReturn(
+        UserGroupInformation.createRemoteUser(System.getProperty("user.name")));
+    Server.getCurCall().set(call);
+    try {
+      fsNamesystem.setDataNodeBandwidth(10, "transfer");
+      verifyAuditLogs(auditLogString);
+    } catch (Exception e) {
+      fail("setDataNodeBandwidth threw exception!");
+    }
+    when(call.getRemoteUser()).thenReturn(
+        UserGroupInformation.createRemoteUser("theDoctor"));
+    try {
+      fsNamesystem.setDataNodeBandwidth(10, "transfer");
+      fail(
+          "setDataNodeBandwidth should have thrown AccessControlException!");
+    } catch (AccessControlException ace) {
+      auditLogString =
+          ".*allowed=false.*cmd=setDataNodeBandwidth.*";
+      verifyAuditLogs(auditLogString);
+    }
+  }
+
+  @Test
   public void testRefreshNodes() throws Exception {
     String auditLogString =
         ".*allowed=true.*cmd=refreshNodes.*";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdmin.java
@@ -1142,6 +1142,33 @@ public class TestDFSAdmin {
         new String[]{"-setBalancerBandwidth", "-10m"}));
   }
 
+  @Test
+  public void testSetDataNodeBandwidth() throws Exception {
+    final DFSAdmin dfsAdmin = new DFSAdmin(conf);
+
+    // Test basic case: 10000
+    assertEquals(0, ToolRunner.run(dfsAdmin,
+        new String[]{"-setDataNodeBandwidth", "10000", "-type", "transfer"}));
+    assertEquals(0, ToolRunner.run(dfsAdmin,
+        new String[]{"-setDataNodeBandwidth", "10000", "-type", "write"}));
+    assertEquals(0, ToolRunner.run(dfsAdmin,
+        new String[]{"-setDataNodeBandwidth", "10000", "-type", "read"}));
+
+    Thread.sleep(3 * 1000);
+
+    // verify bandwidth
+    assertEquals(10000, datanode.getTransferBandwidth());
+    assertEquals(10000, datanode.getWriteBandwidth());
+    assertEquals(10000, datanode.getReadBandwidth());
+
+    // Test negative numbers
+    assertEquals(-1, ToolRunner.run(dfsAdmin,
+        new String[]{"-setBalancerBandwidth", "-10000", "-type", "transfer"}));
+    // Test error type
+    assertEquals(-1, ToolRunner.run(dfsAdmin,
+        new String[]{"-setBalancerBandwidth", "10000", "-type", "errorType"}));
+  }
+
   @Test(timeout = 300000L)
   public void testCheckNumOfBlocksInReportCommand() throws Exception {
     DistributedFileSystem dfs = cluster.getFileSystem();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSAdminWithHA.java
@@ -426,6 +426,65 @@ public class TestDFSAdminWithHA {
   }
 
   @Test (timeout = 30000)
+  public void testSetDataNodeBandwidth() throws Exception {
+    setUpHaCluster(false);
+    cluster.getDfsCluster().transitionToActive(0);
+
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "10", "-type", "transfer"});
+    assertEquals(err.toString().trim(), 0, exitCode);
+    String message = "DataNode transfer bandwidth is set to 10";
+    assertOutputMatches(message + newLine);
+  }
+
+  @Test (timeout = 30000)
+  public void testSetDataNodeBandwidthNN1UpNN2Down() throws Exception {
+    setUpHaCluster(false);
+    cluster.getDfsCluster().shutdownNameNode(1);
+    cluster.getDfsCluster().transitionToActive(0);
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "10", "-type", "transfer"});
+    assertEquals(err.toString().trim(), 0, exitCode);
+    String message = "DataNode transfer bandwidth is set to 10";
+    assertOutputMatches(message + newLine);
+  }
+
+  @Test (timeout = 30000)
+  public void testSetDataNodeBandwidthNN1DownNN2Up() throws Exception {
+    setUpHaCluster(false);
+    cluster.getDfsCluster().shutdownNameNode(0);
+    cluster.getDfsCluster().transitionToActive(1);
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "10", "-type", "transfer"});
+    assertEquals(err.toString().trim(), 0, exitCode);
+    String message = "DataNode transfer bandwidth is set to 10";
+    assertOutputMatches(message + newLine);
+  }
+
+  @Test
+  public void testSetDataNodeBandwidthNN1DownNN2Down() throws Exception {
+    setUpHaCluster(false);
+    cluster.getDfsCluster().shutdownNameNode(0);
+    cluster.getDfsCluster().shutdownNameNode(1);
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "10", "-type", "transfer"});
+    assertNotEquals(err.toString().trim(), 0, exitCode);
+    String message = "DataNode transfer bandwidth is set failed." + newLine
+        + ".*" + newLine;
+    assertOutputMatches(message);
+  }
+
+  @Test (timeout = 30000)
+  public void testSetNegativeDataNodeBandwidth() throws Exception {
+    setUpHaCluster(false);
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "-10", "-type", "transfer"});
+    assertEquals("Negative bandwidth value must fail the command", -1, exitCode);
+  }
+
+  @Test (timeout = 30000)
+  public void testSetErrorTypeDataNodeBandwidth() throws Exception {
+    setUpHaCluster(false);
+    int exitCode = admin.run(new String[] {"-setDataNodeBandwidth", "10", "-type", "errortype"});
+    assertEquals("Bandwidth type should be in <transfer|write|read>", -1, exitCode);
+  }
+
+  @Test (timeout = 30000)
   public void testMetaSave() throws Exception {
     setUpHaCluster(false);
     cluster.getDfsCluster().transitionToActive(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestViewFileSystemOverloadSchemeWithDFSAdmin.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestViewFileSystemOverloadSchemeWithDFSAdmin.java
@@ -290,4 +290,24 @@ public class TestViewFileSystemOverloadSchemeWithDFSAdmin {
     assertOutMsg("Balancer bandwidth is set to 1000", 0);
     assertEquals(0, ret);
   }
+
+  /**
+   * Tests setDataNodeBandwidth with ViewFSOverloadScheme.
+   */
+  @Test
+  public void testSetDataNodeBandwidth() throws Exception {
+    final Path hdfsTargetPath = new Path(defaultFSURI + HDFS_USER_FOLDER);
+    addMountLinks(defaultFSURI.getHost(),
+        new String[] {HDFS_USER_FOLDER, LOCAL_FOLDER },
+        new String[] {hdfsTargetPath.toUri().toString(),
+            localTargetDir.toURI().toString() },
+        conf);
+    final DFSAdmin dfsAdmin = new DFSAdmin(conf);
+    redirectStream();
+    int ret = ToolRunner.run(dfsAdmin,
+        new String[] {"-fs", defaultFSURI.toString(), "-setDataNodeBandwidth",
+            "1000", "-type", "transfer"});
+    assertOutMsg("DataNode transfer bandwidth is set to 1000", 0);
+    assertEquals(0, ret);
+  }
 }


### PR DESCRIPTION
Currently, bandwidth can only be configured for individual DataNodes through the reconfig command. It is expected that bandwidth settings for all DataNodes could be managed centrally via dfsadmin.

`hdfs dfsadmin -setDataNodeBandwidth 100000000 -type <transfer|write|read>`
 
![image](https://github.com/user-attachments/assets/1881a8cd-627e-4b57-aa89-3022f5fbca42)




