### PR TITLE
HADOOP-19578: Upgrade esdk-obs-java to resolve CVE-2023-3635

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -29,7 +29,11 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <esdk.version>3.20.4.2</esdk.version>
+    <esdk.version>3.25.5</esdk.version> <!-- NOTE: due to a dependency convergence error caused by esdk-obs-java,
+      the following artifacts needed to be managed in hadoop-project:
+        com.squareup.okio:okio:3.8.0
+        org.jetbrains.kotlin:kotlin-bom:1.9.21
+      Please align (or remove) them when updating esdk.version -->
   </properties>
 
   <profiles>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -138,7 +138,7 @@
     <derby.version>10.14.2.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp3.version>4.11.0</okhttp3.version>
-    <kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>
+    <kotlin.version>1.9.21</kotlin.version> <!-- upgraded to align with esdk-obs-java -->
     <jdom2.version>2.0.6.1</jdom2.version>
     <jna.version>5.2.0</jna.version>
     <gson.version>2.9.0</gson.version>
@@ -245,21 +245,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-bom</artifactId>
+        <version>${kotlin.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
         <version>${okhttp3.version}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin-stdlib.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -2152,6 +2147,14 @@
         <groupId>net.jodah</groupId>
         <artifactId>failsafe</artifactId>
         <version>2.4.4</version>
+      </dependency>
+
+      <dependency>
+        <!-- due to a dependency convergence error caused by esdk-obs-java,
+             referenced in hadoop-cloud-stroage-project/hadoop-huaweicloud. -->
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.8.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Upgrade esdk-obs-java (in hadoop-huaweicloud) to resolve CVE-2023-3635

### How was this patch tested?

Ran existing tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
