### PR TITLE
HADOOP-19564: delete configuration io.compression.codec.lzo.buffersize in core-default.xml

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -946,14 +946,6 @@
 </property>
 
 <property>
-  <name>io.compression.codec.lzo.buffersize</name>
-  <value>65536</value>
-  <description>
-    Internal buffer size for Lzo compressor/decompressors.
-  </description>
-</property>
-
-<property>
   <name>io.compression.codec.lzo.class</name>
   <value>org.apache.hadoop.io.compress.LzoCodec</value>
   <description>


### PR DESCRIPTION
### Description of PR

PR for [HADOOP-19564](https://issues.apache.org/jira/browse/HADOOP-19564)


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

