### PR TITLE
HADOOP-19575. ABFS: [FNSOverBlob] Add Distinct String In User Agent to Get Telemetry for FNS-Blob

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.Permissions;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.ApiVersion;
+import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.HttpOperationType;
@@ -152,6 +153,7 @@ public abstract class AbfsClient implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   public static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
   public static final String ABFS_CLIENT_TIMER_THREAD_NAME = "abfs-timer-client";
+  public static final String FNS_BLOB_USER_AGENT_IDENTIFIER = "FNS";
 
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
@@ -1318,6 +1320,12 @@ public abstract class AbfsClient implements Closeable {
     sb.append(abfsConfiguration.getClusterName());
     sb.append(FORWARD_SLASH);
     sb.append(abfsConfiguration.getClusterType());
+
+    // Add a unique identifier in FNS-Blob user agent string
+    if(!getIsNamespaceEnabled() && abfsConfiguration.getFsConfiguredServiceType() == AbfsServiceType.BLOB){
+      sb.append(SEMICOLON).append(SINGLE_WHITE_SPACE);
+      sb.append(FNS_BLOB_USER_AGENT_IDENTIFIER);
+    }
 
     sb.append(")");
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1322,7 +1322,7 @@ public abstract class AbfsClient implements Closeable {
     sb.append(abfsConfiguration.getClusterType());
 
     // Add a unique identifier in FNS-Blob user agent string
-    if(!getIsNamespaceEnabled() && abfsConfiguration.getFsConfiguredServiceType() == AbfsServiceType.BLOB){
+    if (!getIsNamespaceEnabled() && abfsConfiguration.getFsConfiguredServiceType() == AbfsServiceType.BLOB){
       sb.append(SEMICOLON).append(SINGLE_WHITE_SPACE);
       sb.append(FNS_BLOB_USER_AGENT_IDENTIFIER);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.Permissions;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.ApiVersion;
-import org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.HttpOperationType;
@@ -128,6 +127,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.PLUS_ENC
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SEMICOLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.UTF_8;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType.BLOB;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_IDENTITY_TRANSFORM_CLASS;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DEFAULT_DELETE_CONSIDERED_IDEMPOTENT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
@@ -1322,9 +1322,11 @@ public abstract class AbfsClient implements Closeable {
     sb.append(abfsConfiguration.getClusterType());
 
     // Add a unique identifier in FNS-Blob user agent string
-    if (!getIsNamespaceEnabled() && abfsConfiguration.getFsConfiguredServiceType() == AbfsServiceType.BLOB){
-      sb.append(SEMICOLON).append(SINGLE_WHITE_SPACE);
-      sb.append(FNS_BLOB_USER_AGENT_IDENTIFIER);
+    if (!getIsNamespaceEnabled()
+        && abfsConfiguration.getFsConfiguredServiceType() == BLOB) {
+      sb.append(SEMICOLON)
+          .append(SINGLE_WHITE_SPACE)
+          .append(FNS_BLOB_USER_AGENT_IDENTIFIER);
     }
 
     sb.append(")");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -106,6 +106,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
 
   private static final String ACCOUNT_NAME = "bogusAccountName.dfs.core.windows.net";
   private static final String FS_AZURE_USER_AGENT_PREFIX = "Partner Service";
+  private static final String FNS_BLOB_USER_AGENT_IDENTIFIER = "FNS";
   private static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
   private static final String TEST_PATH = "/testfile";
   public static final int REDUCED_RETRY_COUNT = 2;
@@ -353,6 +354,25 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
       .doesNotContain(clusterType)
       .describedAs("User-Agent string should contain UNKNOWN as cluster type config is absent")
       .contains(DEFAULT_VALUE_UNKNOWN);
+  }
+
+  @Test
+  // Test to verify that the user agent string for FNS-Blob accounts
+  public void verifyUserAgentForFNSBlob() throws Exception {
+    Assume.assumeTrue(JDK_HTTP_URL_CONNECTION == httpOperationType);
+    assumeHnsDisabled();
+    Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.BLOB);
+    final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
+    final AbfsConfiguration configuration = fs.getAbfsStore()
+        .getAbfsConfiguration();
+
+    String userAgentStr = getUserAgentString(configuration, false);
+    verifyBasicInfo(userAgentStr);
+    Assertions.assertThat(userAgentStr)
+        .describedAs(
+            "User-Agent string for FNS accounts on Blob endpoint should contain "
+                + FNS_BLOB_USER_AGENT_IDENTIFIER)
+        .contains(FNS_BLOB_USER_AGENT_IDENTIFIER);
   }
 
   public static AbfsClient createTestClientFromCurrentContext(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -359,7 +359,6 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   @Test
   // Test to verify the unique identifier in user agent string for FNS-Blob accounts
   public void verifyUserAgentForFNSBlob() throws Exception {
-    Assume.assumeTrue(JDK_HTTP_URL_CONNECTION == httpOperationType);
     assumeHnsDisabled();
     Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.BLOB);
     final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
@@ -379,7 +378,6 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   // Test to verify that the user agent string for non-FNS-Blob accounts
   // does not contain the FNS identifier.
   public void verifyUserAgentForDFS() throws Exception {
-    Assume.assumeTrue(JDK_HTTP_URL_CONNECTION == httpOperationType);
     Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.DFS);
     final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
     final AbfsConfiguration configuration = fs.getAbfsStore()

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -360,8 +360,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   // Test to verify the unique identifier in user agent string for FNS-Blob accounts
   public void verifyUserAgentForFNSBlob() throws Exception {
     assumeHnsDisabled();
-    Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.BLOB);
-    final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
+    assumeBlobServiceType();
+    final AzureBlobFileSystem fs = getFileSystem();
     final AbfsConfiguration configuration = fs.getAbfsStore()
         .getAbfsConfiguration();
 
@@ -378,8 +378,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   // Test to verify that the user agent string for non-FNS-Blob accounts
   // does not contain the FNS identifier.
   public void verifyUserAgentForDFS() throws Exception {
-    Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.DFS);
-    final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
+    assumeDfsServiceType();
+    final AzureBlobFileSystem fs = getFileSystem();
     final AbfsConfiguration configuration = fs.getAbfsStore()
         .getAbfsConfiguration();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -357,7 +357,7 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  // Test to verify that the user agent string for FNS-Blob accounts
+  // Test to verify the unique identifier in user agent string for FNS-Blob accounts
   public void verifyUserAgentForFNSBlob() throws Exception {
     Assume.assumeTrue(JDK_HTTP_URL_CONNECTION == httpOperationType);
     assumeHnsDisabled();
@@ -373,6 +373,25 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
             "User-Agent string for FNS accounts on Blob endpoint should contain "
                 + FNS_BLOB_USER_AGENT_IDENTIFIER)
         .contains(FNS_BLOB_USER_AGENT_IDENTIFIER);
+  }
+
+  @Test
+  // Test to verify that the user agent string for non-FNS-Blob accounts
+  // does not contain the FNS identifier.
+  public void verifyUserAgentForDFS() throws Exception {
+    Assume.assumeTrue(JDK_HTTP_URL_CONNECTION == httpOperationType);
+    Assume.assumeTrue(getAbfsServiceType() == AbfsServiceType.DFS);
+    final AzureBlobFileSystem fs = getFileSystem(getRawConfiguration());
+    final AbfsConfiguration configuration = fs.getAbfsStore()
+        .getAbfsConfiguration();
+
+    String userAgentStr = getUserAgentString(configuration, false);
+    verifyBasicInfo(userAgentStr);
+    Assertions.assertThat(userAgentStr)
+        .describedAs(
+            "User-Agent string for non-FNS-Blob accounts should not contain"
+                + FNS_BLOB_USER_AGENT_IDENTIFIER)
+        .doesNotContain(FNS_BLOB_USER_AGENT_IDENTIFIER);
   }
 
   public static AbfsClient createTestClientFromCurrentContext(


### PR DESCRIPTION
## Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19575
Adding a unique identifier in the user agent for FNS-Blob case for telemetry purposes.

## How was this patch tested?
Test suite was run- the results of which are added in the comments below

