### PR TITLE
YARN-11822. Fix flaky unit test in TestFederationProtocolRecords

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/records/TestFederationProtocolRecords.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/store/records/TestFederationProtocolRecords.java
@@ -425,16 +425,17 @@ public class TestFederationProtocolRecords extends BasePBImplRecordsTest {
     String scRmAdminAddress = "5.6.7.8:7";
     String scWebAppAddress = "127.0.0.1:8080";
     String capabilityJson = "-";
+    long currentTime = Time.now();
 
     SubClusterInfo sc1 =
         SubClusterInfo.newInstance(SubClusterId.newInstance("SC-1"),
         scAmRMAddress, scClientRMAddress, scRmAdminAddress, scWebAppAddress,
-        SubClusterState.SC_RUNNING, Time.now(), capabilityJson);
+        SubClusterState.SC_RUNNING, currentTime, capabilityJson);
 
     SubClusterInfo sc2 =
         SubClusterInfo.newInstance(SubClusterId.newInstance("SC-1"),
         scAmRMAddress, scClientRMAddress, scRmAdminAddress, scWebAppAddress,
-        SubClusterState.SC_RUNNING, Time.now(), capabilityJson);
+        SubClusterState.SC_RUNNING, currentTime, capabilityJson);
 
     assertEquals(sc1, sc2);
   }


### PR DESCRIPTION
Change-Id: Ibf2c52efe20304bf5089e1aab160b20fb7f657b0

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11822. Fix flaky unit test in TestFederationProtocolRecords

TestFederationProtocolRecords.testSubClusterInfoEqual unit test fails intermittently.

It looks like a test issue that can be easily fixed: the test compares the results of two sequentially called Time.now() method in the SubClusterInfo, and expects to be equal. Using a variable that stores the current time should solve this issue

### How was this patch tested?
Unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

