### PR TITLE
HADOOP-19365. AAL support for auditing.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1920,7 +1920,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withContext(readContext.build())
         .withObjectAttributes(createObjectAttributes(path, fileStatus))
         .withStreamStatistics(inputStreamStats)
-        .withEncryptionSecrets(getEncryptionSecrets());
+        .withEncryptionSecrets(getEncryptionSecrets())
+        .withAuditSpan(auditSpan);
+
     return new FSDataInputStream(getStore().readObject(parameters));
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.audit;
 import java.util.List;
 
 import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
@@ -50,6 +51,8 @@ import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_DELETE_
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_LIST_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_PUT_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.STORE_EXISTS_PROBE;
+import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.OPERATION_NAME;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.SPAN_ID;
 
 /**
  * Extract information from a request.
@@ -191,6 +194,18 @@ public class AWSRequestAnalyzer {
         || request instanceof CompleteMultipartUploadRequest
         || request instanceof GetBucketLocationRequest
         || request instanceof CreateSessionRequest;
+  }
+
+  /**
+   * If spanId and operation name are set by dependencies such as AAL, then this returns true. Allows for auditing
+   * of requests which are made outside S3A's requestFactory.
+   *
+   * @param executionAttributes request execution attributes
+   * @return true if request is audited outside of current span
+   */
+  public static boolean isRequestAuditedOutsideOfCurrentSpan(ExecutionAttributes executionAttributes) {
+   return executionAttributes.getAttribute(SPAN_ID) != null
+            && executionAttributes.getAttribute(OPERATION_NAME) != null;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
@@ -51,7 +51,7 @@ import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_DELETE_
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_LIST_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_PUT_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.STORE_EXISTS_PROBE;
-import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.OPERATION_NAME;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.OPERATION_NAME;
 import static software.amazon.s3.analyticsaccelerator.request.Constants.SPAN_ID;
 
 /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
@@ -61,6 +61,7 @@ import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MULTIPART_UPLOAD_ENABLE
 import static org.apache.hadoop.fs.s3a.Constants.MULTIPART_UPLOADS_ENABLED;
 import static org.apache.hadoop.fs.s3a.audit.AWSRequestAnalyzer.isRequestMultipartIO;
 import static org.apache.hadoop.fs.s3a.audit.AWSRequestAnalyzer.isRequestNotAlwaysInSpan;
+import static org.apache.hadoop.fs.s3a.audit.AWSRequestAnalyzer.isRequestAuditedOutsideOfCurrentSpan;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.OUTSIDE_SPAN;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.REFERRER_HEADER_ENABLED;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.REFERRER_HEADER_ENABLED_DEFAULT;
@@ -69,6 +70,8 @@ import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.UNAUDITED_OPERATI
 import static org.apache.hadoop.fs.s3a.commit.CommitUtils.extractJobID;
 import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.HEADER_REFERRER;
 import static org.apache.hadoop.fs.s3a.statistics.impl.StatisticsFromAwsSdkImpl.mapErrorStatusCodeToStatisticName;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.OPERATION_NAME;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.SPAN_ID;
 
 /**
  * The LoggingAuditor logs operations at DEBUG (in SDK Request) and
@@ -84,7 +87,6 @@ public class LoggingAuditor
    */
   private static final Logger LOG =
       LoggerFactory.getLogger(LoggingAuditor.class);
-
 
   /**
    * Some basic analysis for the logs.
@@ -267,8 +269,9 @@ public class LoggingAuditor
    */
   private class LoggingAuditSpan extends AbstractAuditSpanImpl {
 
-    private final HttpReferrerAuditHeader referrer;
+    private HttpReferrerAuditHeader referrer;
 
+    private final HttpReferrerAuditHeader.Builder headerBuilder;
     /**
      * Attach Range of data for GetObject Request.
      * @param request the sdk request to be modified
@@ -300,7 +303,7 @@ public class LoggingAuditor
         final String path2) {
       super(spanId, operationName);
 
-      this.referrer = HttpReferrerAuditHeader.builder()
+      this.headerBuilder = HttpReferrerAuditHeader.builder()
           .withContextId(getAuditorId())
           .withSpanId(spanId)
           .withOperationName(operationName)
@@ -312,8 +315,9 @@ public class LoggingAuditor
               currentThreadID())
           .withAttribute(PARAM_TIMESTAMP, Long.toString(getTimestamp()))
           .withEvaluated(context.getEvaluatedEntries())
-          .withFilter(filters)
-          .build();
+          .withFilter(filters);
+
+      this.referrer = this.headerBuilder.build();
 
       this.description = referrer.buildHttpReferrer();
     }
@@ -384,11 +388,32 @@ public class LoggingAuditor
       SdkHttpRequest httpRequest = context.httpRequest();
       SdkRequest sdkRequest = context.request();
 
+      // If spanId and operationName are set in execution attributes, then use these values,
+      // instead of the ones in the current span. This is useful when requests are happening in dependencies such as
+      // the analytics accelerator library (AAL), where they cannot be attached to the correct span. In which case, AAL
+      // will attach the current spanId and operationName via execution attributes during it's request creation. These
+      // can then used to update the values in the logger and referrer header. Without this overwriting, the operation
+      // name and corresponding span will be whichever is active on the thread the request is getting executed on.
+      boolean isRequestAuditedOutsideCurrentSpan = isRequestAuditedOutsideOfCurrentSpan(executionAttributes);
+
+      String spanId = isRequestAuditedOutsideCurrentSpan ?
+              executionAttributes.getAttribute(SPAN_ID) : getSpanId();
+
+      String operationName = isRequestAuditedOutsideCurrentSpan ?
+              executionAttributes.getAttribute(OPERATION_NAME) : getOperationName();
+
+      if (isRequestAuditedOutsideCurrentSpan) {
+        this.headerBuilder.withSpanId(spanId);
+        this.headerBuilder.withOperationName(operationName);
+        this.referrer = this.headerBuilder.build();
+      }
+
       // attach range for GetObject requests
       attachRangeFromRequest(httpRequest, executionAttributes);
 
       // for delete op, attach the number of files to delete
       attachDeleteKeySizeAttribute(sdkRequest);
+
 
       // build the referrer header
       final String header = referrer.buildHttpReferrer();
@@ -400,11 +425,12 @@ public class LoggingAuditor
             .appendHeader(HEADER_REFERRER, header)
             .build();
       }
+
       if (LOG.isDebugEnabled()) {
         LOG.debug("[{}] {} Executing {} with {}; {}",
             currentThreadID(),
-            getSpanId(),
-            getOperationName(),
+            spanId,
+            operationName,
             analyzer.analyze(context.request()),
             header);
       }
@@ -533,10 +559,12 @@ public class LoggingAuditor
           + analyzer.analyze(context.request());
       final String unaudited = getSpanId() + " "
           + UNAUDITED_OPERATION + " " + error;
+      // If request is attached to a span in the modifyHttpRequest, as is the case for requests made by AAL, treat it
+      // as an audited request.
       if (isRequestNotAlwaysInSpan(context.request())) {
-        // can get by auditing during a copy, so don't overreact
+        // can get by auditing during a copy, so don't overreact.
         LOG.debug(unaudited);
-      } else {
+      } else if (!isRequestAuditedOutsideOfCurrentSpan(executionAttributes)) {
         final RuntimeException ex = new AuditFailureException(unaudited);
         LOG.debug(unaudited, ex);
         if (isRejectOutOfSpan()) {
@@ -547,5 +575,4 @@ public class LoggingAuditor
       super.beforeExecution(context, executionAttributes);
     }
   }
-
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
@@ -271,7 +271,13 @@ public class LoggingAuditor
 
     private HttpReferrerAuditHeader referrer;
 
+    /**
+     * Builder for the referrer header. Requests that execute outside S3A, such as in AAL, will initially have SpanId
+     * of  the outside-span operation. For such requests, the spanId and operation name in this builder is overwritten
+     * in the modifyHttpRequest execution interceptor.
+     */
     private final HttpReferrerAuditHeader.Builder headerBuilder;
+
     /**
      * Attach Range of data for GetObject Request.
      * @param request the sdk request to be modified
@@ -413,7 +419,6 @@ public class LoggingAuditor
 
       // for delete op, attach the number of files to delete
       attachDeleteKeySizeAttribute(sdkRequest);
-
 
       // build the referrer header
       final String header = referrer.buildHttpReferrer();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/S3AStoreImpl.java
@@ -994,8 +994,7 @@ public class S3AStoreImpl
 
     @Override
     public S3Client getOrCreateSyncClient() throws IOException {
-      // Needs support of the CRT before the requireCRT can be used
-      LOG.debug("Stream factory requested async client");
+      LOG.debug("Stream factory requested sync client");
       return clientManager().getOrCreateS3Client();
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -36,6 +36,7 @@ import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 import software.amazon.s3.analyticsaccelerator.common.ObjectRange;
 import software.amazon.s3.analyticsaccelerator.request.EncryptionSecrets;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
+import software.amazon.s3.analyticsaccelerator.request.StreamAuditContext;
 import software.amazon.s3.analyticsaccelerator.util.InputPolicy;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
@@ -257,11 +258,17 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
           .etag(parameters.getObjectAttributes().getETag()).build());
     }
 
+
     if (parameters.getEncryptionSecrets().getEncryptionMethod() == S3AEncryptionMethods.SSE_C) {
       EncryptionSecretOperations.getSSECustomerKey(parameters.getEncryptionSecrets())
               .ifPresent(base64customerKey -> openStreamInformationBuilder.encryptionSecrets(
               EncryptionSecrets.builder().sseCustomerKey(Optional.of(base64customerKey)).build()));
     }
+
+    openStreamInformationBuilder.streamAuditContext(StreamAuditContext.builder()
+                    .operationName(parameters.getAuditSpan().getOperationName())
+                    .spanId(parameters.getAuditSpan().getSpanId())
+                    .build());
 
     return openStreamInformationBuilder.build();
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
@@ -97,8 +97,7 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
     vectorContext.setMinSeekForVectoredReads(0);
 
     return new StreamFactoryRequirements(0,
-            0, vectorContext,
-            StreamFactoryRequirements.Requirements.ExpectUnauditedGetRequests);
+            0, vectorContext);
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
 
 import static java.util.Objects.requireNonNull;
 
@@ -74,6 +75,11 @@ public final class ObjectReadParameters {
    * Encryption secrets for this stream.
    */
   private EncryptionSecrets encryptionSecrets;
+
+  /**
+   * Span for which this stream is being created.
+   */
+  private AuditSpan auditSpan;
 
   /**
    * Getter.
@@ -197,6 +203,24 @@ public final class ObjectReadParameters {
   }
 
   /**
+   * Getter.
+   * @return Audit span.
+   */
+  public AuditSpan getAuditSpan() {
+    return auditSpan;
+  }
+
+  /**
+   * Set audit span.
+   * @param value new value
+   * @return the builder
+   */
+  public ObjectReadParameters withAuditSpan(final AuditSpan value) {
+    auditSpan = value;
+    return this;
+  }
+
+  /**
    * Validate that all attributes are as expected.
    * Mock tests can skip this if required.
    * @return the object.
@@ -210,6 +234,7 @@ public final class ObjectReadParameters {
     requireNonNull(objectAttributes, "objectAttributes");
     requireNonNull(streamStatistics, "streamStatistics");
     requireNonNull(encryptionSecrets, "encryptionSecrets");
+    requireNonNull(auditSpan, "auditSpan");
     return this;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -42,6 +42,7 @@ import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_PARQUET;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
+import static org.apache.hadoop.fs.audit.AuditStatisticNames.AUDIT_REQUEST_EXECUTION;
 import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
@@ -109,6 +110,12 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
     fs.close();
     verifyStatisticCounterValue(fs.getIOStatistics(), ANALYTICS_STREAM_FACTORY_CLOSED, 1);
+
+    // Expect 4 audited requests. One HEAD, and 3 GETs. The 3 GETs are because the read policy is WHOLE_FILE,
+    // in which case, AAL will start prefetching till EoF on file open in 8MB chunks. The file read here
+    // s3://noaa-cors-pds/raw/2023/017/ohfh/OHFH017d.23_.gz, has a size of ~21MB, resulting in 3 GETS:
+    // [5-8388612, 8388613-16777220, 16777221-21511173].
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 4);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -114,7 +114,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // Expect 4 audited requests. One HEAD, and 3 GETs. The 3 GETs are because the read policy is WHOLE_FILE,
     // in which case, AAL will start prefetching till EoF on file open in 8MB chunks. The file read here
     // s3://noaa-cors-pds/raw/2023/017/ohfh/OHFH017d.23_.gz, has a size of ~21MB, resulting in 3 GETS:
-    // [5-8388612, 8388613-16777220, 16777221-21511173].
+    // [0-8388607, 8388608-16777215, 16777216-21511173].
     verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 4);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -182,6 +182,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), AUDIT_REQUEST_EXECUTION, 4);
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Relevant AAL PR: https://github.com/awslabs/analytics-accelerator-s3/pull/280

* S3A will pass in the span_id and operation_name when opening the stream with AAL. 
* AAL will attach these per request as executionAttributes.
* When the `modifyHttpRequest` executionInterceptor in the LoggingAuditor called, these are now available in the `ExecutionAttributes` and can be used for logging. 
* Referrer header is updated by updating the spanId and operation in the builder. 

Example logs:

```
// FIRST HEAD
2025-06-04 16:04:16,414 [s3a-transfer-noaa-cors-pds-unbounded-pool5-t1] DEBUG impl.LoggingAuditor (LoggingAuditor.java:modifyHttpRequest(429)) - [33] ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009 Executing op_open with {action_http_head_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=0, mutating=false}; https://audit.example.org/hadoop/1/op_open/ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009/?op=op_open&p1=raw/2023/017/ohfh/OHFH017d.23_.gz&pr=ahmarsu&ps=6d6c1b1f-5677-4ed6-9706-10b4d5bf8284&id=ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009&t0=33&fs=ad10d217-5092-4323-ba27-d24ca0e8a0f7&t1=33&ts=1749049456399


// FIRST GET
2025-06-04 16:04:18,335 [setup] DEBUG impl.LoggingAuditor (LoggingAuditor.java:modifyHttpRequest(429)) - [15] ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009 Executing op_open with {action_http_get_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=8388607, mutating=false}; https://audit.example.org/hadoop/1/op_open/ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009/?op=op_open&p1=noaa-cors-pds&pr=ahmarsu&ps=6d6c1b1f-5677-4ed6-9706-10b4d5bf8284&rg=5-8388612&id=ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009&t0=15&fs=ad10d217-5092-4323-ba27-d24ca0e8a0f7&t1=15&ts=1749049456389

// SECOND GET
2025-06-04 16:04:18,359 [setup] DEBUG impl.LoggingAuditor (LoggingAuditor.java:modifyHttpRequest(429)) - [15] ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009 Executing op_open with {action_http_get_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=8388607, mutating=false}; https://audit.example.org/hadoop/1/op_open/ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009/?op=op_open&p1=noaa-cors-pds&pr=ahmarsu&ps=6d6c1b1f-5677-4ed6-9706-10b4d5bf8284&rg=8388613-16777220&id=ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009&t0=15&fs=ad10d217-5092-4323-ba27-d24ca0e8a0f7&t1=15&ts=1749049456389

// THIRD GET
2025-06-04 16:04:18,361 [setup] DEBUG impl.LoggingAuditor (LoggingAuditor.java:modifyHttpRequest(429)) - [15] ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009 Executing op_open with {action_http_get_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=4733952, mutating=false}; https://audit.example.org/hadoop/1/op_open/ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009/?op=op_open&p1=noaa-cors-pds&pr=ahmarsu&ps=6d6c1b1f-5677-4ed6-9706-10b4d5bf8284&rg=16777221-21511173&id=ad10d217-5092-4323-ba27-d24ca0e8a0f7-00000009&t0=15&fs=ad10d217-5092-4323-ba27-d24ca0e8a0f7&t1=15&ts=1749049456389
```



### How was this patch tested?

Tested in eu-west-1, `mvn -Dparallel-tests -DtestsThreadCount=16 clean verify`

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

