### PR TITLE
HADOOP-19583. JDK8: RawLocalFileSystem calls ByteBuffer.flip

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/RawLocalFileSystem.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.FileDescriptor;
 import java.net.URI;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.CompletionHandler;
@@ -425,7 +426,7 @@ public class RawLocalFileSystem extends FileSystem {
           channel.read(buffer, range.getOffset() + buffer.position(), rangeIndex, this);
         } else {
           // Flip the buffer and declare success.
-          buffer.flip();
+          ((Buffer)(buffer)).flip();
           range.getData().complete(buffer);
         }
       }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
@@ -1029,7 +1030,7 @@ public class S3AInputStream extends ObjectInputStream implements CanSetReadahead
     LOG.debug("Start reading {} from {} ", range, getPathStr());
     if (range.getLength() == 0) {
       // a zero byte read.
-      buffer.flip();
+      ((Buffer)(buffer)).flip();
       range.getData().complete(buffer);
       return;
     }
@@ -1092,7 +1093,7 @@ public class S3AInputStream extends ObjectInputStream implements CanSetReadahead
             readByteArray(objectContent, range, tmp, offset, currentLength);
             return null;
           });
-      buffer.flip();
+      ((Buffer)(buffer)).flip();
     } else {
       // there is no use of a temp byte buffer, or buffer.put() calls,
       // so flip() is not needed.


### PR DESCRIPTION

Fixes the issues in the readVectored code of raw local and s3a by casting to the superclass first.

But it is used in many other places.


### How was this patch tested?

waiting for yetus


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

