### PR TITLE
YARN-11713. yarn-ui build fails in ARM docker in MacOs phantomjs error.

### DIFF
--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -46,6 +46,7 @@ RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
     && apt-get -q install -y --no-install-recommends python3 \
+    && apt-get -q install -y --no-install-recommends phantomjs \
     && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
     && wget -q -O - https://packages.adoptium.net/artifactory/api/gpg/key/public > /etc/apt/trusted.gpg.d/adoptium.asc  \
     && apt-get -q update \


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YARN-11713

- phantomjs package is needed on arm64. The part of fix of HADOOP-17723 looks missing in the current Docker resources.
- Since the phantomjs package is not available in recent Ubuntu any more, we need another fix for upgrading the build environment.
- YARN-11712 must be addressed too for successful build of yarn-ui on arm64.
