### PR TITLE
YARN-11825. Yarn-ui2 build fails with java17

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/pom.xml
@@ -270,6 +270,13 @@
             <groupId>ro.isdc.wro4j</groupId>
             <artifactId>wro4j-maven-plugin</artifactId>
             <version>1.8.0</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>4.11.0</version>
+              </dependency>
+            </dependencies>
             <executions>
               <execution>
                 <phase>prepare-package</phase>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
YARN-11825. Yarn-ui2 build fails with java17
ro.isdc.wro4j:wro4j-maven-plugin:maven-plugin:1.8.0 has a dependency on org.mockito:mockito-core:jar:2.0.42-beta, which is causing build issues with java 17

### How was this patch tested?
Upgrade mockito-core dependency to 4.11.0
Export JAVA_HOME to java 17 and build using 
mvn clean install -DskipTests -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/ -am -Pyarn-ui -Pjdk17+
Build is successful

Export JAVA_HOME to java8 and build using 
mvn clean install -DskipTests -pl hadoop-yarn-project/hadoop-yarn/hadoop-yarn-ui/ -am -Pyarn-ui
Build is successful

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

