### PR TITLE
MAPREDUCE-7506. Fix Jobhistoryserver UI - WebAppException controller …

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryClientService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/HistoryClientService.java
@@ -168,7 +168,7 @@ public class HistoryClientService extends AbstractService {
         ClientRMProxy.createRMProxy(conf, ApplicationClientProtocol.class);
     // NOTE: there should be a .at(InetSocketAddress)
     WebApps
-        .$for("jobhistory", HistoryClientService.class, this, "ws")
+        .$for("jobhistory", HistoryClientService.class, this, "hs-ws")
         .with(conf)
         .withHttpSpnegoKeytabKey(
             JHAdminConfig.MR_WEBAPP_SPNEGO_KEYTAB_FILE_KEY)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebApp.java
@@ -44,6 +44,7 @@ public class HsWebApp extends WebApp implements AMParams {
     bind(HistoryContext.class).toInstance(history);
     route("/", HsController.class);
     route("/app", HsController.class);
+    route("/jobhistory", HsController.class);
     route(pajoin("/job", JOB_ID), HsController.class, "job");
     route(pajoin("/conf", JOB_ID), HsController.class, "conf");
     routeWithoutDefaultView(pajoin("/downloadconf", JOB_ID),


### PR DESCRIPTION
…for jobhistory not found

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: MAPREDUCE-7506. Fix Jobhistoryserver UI - WebAppException controller for jobhistory not found.

Fix Jobhistoryserver UI - WebAppException controller for jobhistory not found

### How was this patch tested?
Built hadoop-mapreduce-client-hs and validated the http://localhost:19888/ws/v1/history and http://localhost:19888/jobhistory pages

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

