### PR TITLE
HADOOP-8865. Log warning message when loading deprecated properties from resources

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -3433,6 +3433,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
           deprecations.getDeprecatedKeyMap().get(confName);
 
       if (keyInfo != null) {
+        logDeprecation(keyInfo.getWarningMessage(confName, wrapper.toString()));
         keyInfo.clearAccessed();
         for (String key : keyInfo.newKeys) {
           // update new keys with deprecated key's value


### PR DESCRIPTION
### Description of PR
The goal is to emit the warning message when deprecated properties are loaded from XML configuration files to inform users that obsolete properties are in use. Before this patch we only inform users when a set/get operation is performed on a deprecated property but this is not sufficient cause if the users/apps are using the new key to obtain the value they will never see the warning. As a result when the property is finally removed or stops taking effect the application will fail or showcase different behavior.

With this patch deprecated properties may be logged twice:
* when a deprecated prop is loaded from a resource
* when a deprecated prop is accessed via get/set; if the deprecated key is not accessed no additional log is generated

### How was this patch tested?
```
mvn -pl hadoop-common-project/hadoop-common test -Dtest=TestConf*
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

