### PR TITLE
HADOOP-19587. SSE-C integration changes

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1920,7 +1920,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withCallbacks(createInputStreamCallbacks(auditSpan))
         .withContext(readContext.build())
         .withObjectAttributes(createObjectAttributes(path, fileStatus))
-        .withStreamStatistics(inputStreamStats);
+        .withStreamStatistics(inputStreamStats)
+        .withEncryptionSecrets(getEncryptionSecrets());
     return new FSDataInputStream(getStore().readObject(parameters));
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -21,9 +21,13 @@ package org.apache.hadoop.fs.s3a.impl.streams;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Optional;
 
+import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecretOperations;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
+import software.amazon.s3.analyticsaccelerator.request.EncryptionSecrets;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.util.InputPolicy;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
@@ -203,6 +207,12 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()
           .contentLength(parameters.getObjectAttributes().getLen())
           .etag(parameters.getObjectAttributes().getETag()).build());
+    }
+
+    if(parameters.getEncryptionSecrets().getEncryptionMethod() == S3AEncryptionMethods.SSE_C) {
+      EncryptionSecretOperations.getSSECustomerKey(parameters.getEncryptionSecrets())
+              .ifPresent(base64customerKey -> openStreamInformationBuilder.encryptionSecrets(
+              EncryptionSecrets.builder().sseCustomerKey(Optional.of(base64customerKey)).build()));
     }
 
     return openStreamInformationBuilder.build();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
 
 import static java.util.Objects.requireNonNull;
@@ -68,6 +69,29 @@ public final class ObjectReadParameters {
    * Allocator of local FS storage.
    */
   private LocalDirAllocator directoryAllocator;
+
+  /**
+   * Encryption secrets for this stream
+   */
+  private EncryptionSecrets encryptionSecrets;
+
+  /**
+   * Getter.
+   * @return Encryption secrets.
+   */
+  public EncryptionSecrets getEncryptionSecrets() {
+    return encryptionSecrets;
+  }
+
+  /**
+   * Set encryption secrets.
+   * @param value new value
+   * @return the builder
+   */
+  public ObjectReadParameters withEncryptionSecrets(final EncryptionSecrets value) {
+    encryptionSecrets = value;
+    return this;
+  }
 
   /**
    * @return Read operation context.
@@ -185,6 +209,7 @@ public final class ObjectReadParameters {
     requireNonNull(directoryAllocator, "directoryAllocator");
     requireNonNull(objectAttributes, "objectAttributes");
     requireNonNull(streamStatistics, "streamStatistics");
+    requireNonNull(encryptionSecrets, "encryptionSecrets");
     return this;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -40,10 +40,10 @@ import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITH
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeStoreAwsHosted;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeSkipRootTests;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -96,8 +96,6 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
   @Override
   public void setup() throws Exception {
     super.setup();
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support SSE-C");
     assumeEnabled();
     // although not a root dir test, this confuses paths enough it shouldn't be run in
     // parallel with other jobs
@@ -325,6 +323,65 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     intercept(AccessDeniedException.class,
         SERVICE_AMAZON_S3_STATUS_CODE_403,
         () -> fsKeyB.getFileChecksum(path));
+  }
+
+
+  /**
+   * Tests the creation and reading of a file using a different encryption key
+   * when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndReadWithDifferentEncryptionKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testCreateFileAndReadWithDifferentEncryptionKey();
+  }
+
+  /**
+   * Tests the creation and movement of a file using a different SSE-C key
+   * when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileThenMoveWithDifferentSSECKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testCreateFileThenMoveWithDifferentSSECKey();
+  }
+
+  /**
+   * Tests create and file rename operation when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndRenameFileWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testRenameFile();
+  }
+
+  /**
+   * Tests the creation and listing of encrypted files when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndListStatusEncryptedFileWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testListStatusEncryptedFile();
+  }
+
+  /**
+   * Tests the creation and deletion of an encrypted object using a different key
+   * when Analytics Accelerator is enabled.t.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndDeleteEncryptedObjectWithDifferentKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testDeleteEncryptedObjectWithDifferentKey();
   }
 
   private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
@@ -31,7 +31,6 @@ import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionTestsDisabled;
 
 /**
@@ -55,8 +54,6 @@ public class ITestS3AHugeFilesSSECDiskBlocks
   public void setup() throws Exception {
     try {
       super.setup();
-      skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-          "Analytics Accelerator currently does not support SSE-C");
     } catch (AccessDeniedException | AWSUnsupportedFeatureException e) {
       skip("Bucket does not allow " + S3AEncryptionMethods.SSE_C + " encryption method");
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR is for the integration of S3A with SSE_C support introduced in Analytics Accelerator library.


### How was this patch tested?
Ran all the integrations tests in hadoop-aws on EC2 instance. 

Setup:
Created personal bucket in us-west-2 region. Ran the integrations tests in hadoop-aws with the configs mainly enabling Analytics stream and SSEC encryption.
```
<configuration>
    <property>
        <name>test.fs.s3a.name</name>
        <value>s3a://rajdchak-s3a-integration/</value>
    </property>

    <property>
        <name>fs.contract.test.fs.s3a</name>
        <value>${test.fs.s3a.name}</value>
    </property>

    <property>
        <name>fs.s3a.endpoint.region</name>
        <value>us-west-2</value>
    </property>

    <property>
        <name>fs.s3a.access.key</name>
        <description>AWS access key ID. Omit for IAM role-based authentication.</description>
        <value> </value>
    </property>

    <property>
        <name>fs.s3a.secret.key</name>
        <description>AWS secret key. Omit for IAM role-based authentication.</description>
        <value> </value>
    </property>

    <property>
        <name>fs.s3a.session.token</name>
        <value>
           
        </value>
    </property>

    <property>
        <name>fs.s3a.aws.credentials.provider</name>
        <value>
            org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider
        </value>
    </property>

    <property>
        <name>fs.s3a.scale.test.enabled</name>
        <value>true</value>
    </property>

    <property>
        <name>fs.s3a.input.stream.type</name>
        <value>analytics</value>
    </property>

    <property>
        <name>fs.s3a.encryption.algorithm</name>
        <description>Specify a server-side encryption or client-side
            encryption algorithm for s3a: file system. Unset by default. It supports the
            following values: 'AES256' (for SSE-S3), 'SSE-KMS', 'SSE-C', and 'CSE-KMS'
        </description>
        <value>SSE-C</value>
    </property>

    <property>
        <name>fs.s3a.encryption.key</name>
        <description>Specific encryption key to use if fs.s3a.encryption.algorithm
            has been set to 'SSE-KMS', 'SSE-C' or 'CSE-KMS'. In the case of SSE-C
            , the value of this property should be the Base64 encoded key. If you are
            using SSE-KMS and leave this property empty, you'll be using your default's
            S3 KMS key, otherwise you should set this property to the specific KMS key
            id. In case of 'CSE-KMS' this value needs to be the AWS-KMS Key ID
            generated from AWS console.
        </description>
        <value>AO8XKQXJgtIS9G+IrSWZ2eSNW1yJlvqElVoVcNlvDqE=</value>
    </property>


</configuration>
```

However unrelated to these changes whenever we enabled SSE_C there are multiple tests which fail with Bad Request exception as they are running on public buckets like ```noaa-cors-pds```. We should take an action item to disable those tests if SSE_C is enabled. Created an issue for this error https://issues.apache.org/jira/browse/HADOOP-19590 .

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

