### PR TITLE
HADOOP-19585. Upgrade commons-beanutils to 1.11.0 due to CVE-2025-48734.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -243,7 +243,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.microsoft.azure:azure-storage:7.0.0
 com.nimbusds:nimbus-jose-jwt:9.31
 com.zaxxer:HikariCP:4.0.3
-commons-beanutils:commons-beanutils:1.9.4
+commons-beanutils:commons-beanutils:1.11.0
 commons-cli:commons-cli:1.5.0
 commons-codec:commons-codec:1.11
 commons-collections:commons-collections:3.2.2

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -118,7 +118,7 @@
     <ldap-api.version>2.0.0</ldap-api.version>
 
     <!-- Apache Commons dependencies -->
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
+    <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION
JIRA: HADOOP-19585. Upgrade commons-beanutils to 1.11.0 due to CVE-2025-48734.

Upgrade commons-beanutils to 1.11.0 due to CVE-2025-48734.