### PR TITLE
YARN-11827. Fix the bug of 'Removing extra containers' when autoCorrectContainerAllocation is enabled.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -692,8 +692,8 @@ public abstract class AbstractYarnScheduler
               request.getCapability());
       int numContainerAllocated = allocatedContainerMap.getOrDefault(containerObjectType,
           Collections.emptyList()).size();
-      if (numContainerAllocated > 0) {
-        int numContainerAsk = request.getNumContainers();
+      int numContainerAsk = request.getNumContainers();
+      if (numContainerAllocated > 0 && numContainerAsk > 0) {
         int updatedContainerRequest = numContainerAsk - numContainerAllocated;
         if (updatedContainerRequest < 0) {
           // add an entry to extra allocated map


### PR DESCRIPTION
When a ResourceRequest in the AM’s AskList has its container count set to 0, it causes the `autoCorrectContainerAllocation` to erroneously remove already allocated containers.