### PR TITLE
HADOOP-19588. S3A support for S3 express access points

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -205,7 +205,7 @@
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
-    <aws-java-sdk-v2.version>2.29.52</aws-java-sdk-v2.version>
+    <aws-java-sdk-v2.version>2.31.12</aws-java-sdk-v2.version>
     <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
     <amazon-s3-analyticsaccelerator-s3.version>1.0.0</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
@@ -33,7 +33,6 @@ public final class ArnResource {
   private final static String S3_ACCESSPOINT_ENDPOINT_FORMAT = "s3-accesspoint.%s.amazonaws.com";
   private final static String S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT = "s3-outposts.%s.amazonaws.com";
   private final static String S3_EXPRESS_ACCESSPOINT_ENDPOINT_FORMAT = "s3express-%s.%s.amazonaws.com";
-  
   // bucket example: mybucket--usw2-az1--x-s3
   // access point example: myaccesspoint--usw2-az1--xa-s3
   public final static Pattern S3_EXPRESS_RESOURCE_FORMAT_REGEX = Pattern.compile(
@@ -180,7 +179,7 @@ public final class ArnResource {
         parsed.partition(), arn, parsed.service());
   }
 
-  private static Optional<String> getZoneIdFromResourceName(final String resourceName) {    
+  private static Optional<String> getZoneIdFromResourceName(final String resourceName) {   
     return Optional.ofNullable(resourceName)
         .map(name -> {
             Matcher matcher = S3_EXPRESS_RESOURCE_FORMAT_REGEX.matcher(name);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
@@ -22,12 +22,23 @@ import javax.annotation.Nonnull;
 
 import software.amazon.awssdk.arns.Arn;
 
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Represents an Arn Resource, this can be an accesspoint or bucket.
  */
 public final class ArnResource {
   private final static String S3_ACCESSPOINT_ENDPOINT_FORMAT = "s3-accesspoint.%s.amazonaws.com";
   private final static String S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT = "s3-outposts.%s.amazonaws.com";
+  private final static String S3_EXPRESS_ACCESSPOINT_ENDPOINT_FORMAT = "s3express-%s.%s.amazonaws.com";
+  
+  // bucket example: mybucket--usw2-az1--x-s3
+  // access point example: myaccesspoint--usw2-az1--xa-s3
+  public final static Pattern S3_EXPRESS_RESOURCE_FORMAT_REGEX = Pattern.compile(
+    String.format("^(?<apname>[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)--(?<zoneId>[a-z0-9\\-]+)--(?<resource>x|xa)-s3$")
+  );
 
   /**
    * Resource name.
@@ -55,23 +66,33 @@ public final class ArnResource {
   private final String partition;
 
   /**
+   * Service for the resource. Allowed services: s3, s3-outposts, s3express
+   */
+  private final String service;
+
+  /**
    * Because of the different ways an endpoint can be constructed depending on partition we're
    * relying on the AWS SDK to produce the endpoint. In this case we need a region key of the form
    * {@code String.format("accesspoint-%s", awsRegion)}
    */
   private final String accessPointRegionKey;
 
-  private ArnResource(String name, String owner, String region, String partition, String fullArn) {
+  private ArnResource(String name, String owner, String region, String partition, String fullArn, String service) {
     this.name = name;
     this.ownerAccountId = owner;
     this.region = region;
     this.partition = partition;
     this.fullArn = fullArn;
+    this.service = service;
     this.accessPointRegionKey = String.format("accesspoint-%s", region);
   }
 
   private boolean isOutposts(){
     return fullArn.contains("s3-outposts");
+  }
+
+  private boolean isExpress(){
+    return fullArn.contains("s3express");
   }
 
   /**
@@ -107,12 +128,34 @@ public final class ArnResource {
   }
 
   /**
+   * Service for resource.
+   * @return service for resource.
+   */
+  public String getService() {
+    return service;
+  }
+
+  /**
    * Formatted endpoint for the resource.
    * @return resource endpoint.
    */
   public String getEndpoint() {
-    String format = isOutposts() ? S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT : S3_ACCESSPOINT_ENDPOINT_FORMAT;
-    return String.format(format, region);
+    String format;
+    if(isExpress()) {
+      Optional<String> zoneId = getZoneIdFromResourceName(name);
+      if(zoneId.isEmpty()) {
+        throw new IllegalArgumentException("Zone ID could not be extracted from S3Express resource name: " + name);
+      }
+
+      format = S3_EXPRESS_ACCESSPOINT_ENDPOINT_FORMAT;
+      return String.format(format, zoneId.get(), region);
+    } else if (isOutposts()) {
+      format = S3_OUTPOSTS_ACCESSPOINT_ENDPOINT_FORMAT;
+      return String.format(format, region);
+    } else {
+      format = S3_ACCESSPOINT_ENDPOINT_FORMAT;
+      return String.format(format, region);
+    }
   }
 
   /**
@@ -134,6 +177,14 @@ public final class ArnResource {
 
     String resourceName = parsed.resource().resource();
     return new ArnResource(resourceName, parsed.accountId().get(), parsed.region().get(),
-        parsed.partition(), arn);
+        parsed.partition(), arn, parsed.service());
+  }
+
+  private static Optional<String> getZoneIdFromResourceName(final String resourceName) {    
+    return Optional.ofNullable(resourceName)
+        .map(name -> {
+            Matcher matcher = S3_EXPRESS_RESOURCE_FORMAT_REGEX.matcher(name);
+            return matcher.matches() ? matcher.group("zoneId") : null;
+        });
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java
@@ -142,7 +142,7 @@ public final class ArnResource {
     String format;
     if(isExpress()) {
       Optional<String> zoneId = getZoneIdFromResourceName(name);
-      if(zoneId.isEmpty()) {
+      if(!zoneId.isPresent()) {
         throw new IllegalArgumentException("Zone ID could not be extracted from S3Express resource name: " + name);
       }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -598,7 +598,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       if (!configuredArn.isEmpty()) {
         accessPoint = ArnResource.accessPointFromArn(configuredArn);
         LOG.info("Using AccessPoint ARN \"{}\" for bucket {}", configuredArn, bucket);
-        bucket = accessPoint.getFullArn();
+
+        // s3express does not support ARNs in requests, but instead takes in access point name as bucket paramater
+        if(accessPoint.getService().equals("s3express")) {
+          bucket = accessPoint.getName();
+        } else {
+          bucket = accessPoint.getFullArn();
+        }
       } else if (conf.getBoolean(AWS_S3_ACCESSPOINT_REQUIRED, false)) {
         LOG.warn("Access Point usage is required because \"{}\" is enabled," +
             " but not configured for the bucket: {}", AWS_S3_ACCESSPOINT_REQUIRED, bucket);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
@@ -58,10 +58,10 @@ public class TestArnResource extends HadoopTestBase {
       String partition = testPair[1];
 
       ArnResource resource = getArnResourceFrom(partition, "s3", region, MOCK_ACCOUNT, accessPoint);
-      // assertEquals(accessPoint, resource.getName(), "Access Point name does not match");
-      // assertEquals(MOCK_ACCOUNT, resource.getOwnerAccountId(), "Account Id does not match");
-      // assertEquals(region, resource.getRegion(), "Region does not match");
-      // assertEquals("s3", resource.getService(), "Service does not match");
+      assertEquals(accessPoint, resource.getName(), "Access Point name does not match");
+      assertEquals(MOCK_ACCOUNT, resource.getOwnerAccountId(), "Account Id does not match");
+      assertEquals(region, resource.getRegion(), "Region does not match");
+      assertEquals("s3", resource.getService(), "Service does not match");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
@@ -49,7 +49,7 @@ public class TestArnResource extends HadoopTestBase {
     String accessPoint = "testAp";
     String[][] regionPartitionEndpoints = new String[][] {
         {Region.EU_WEST_1.id(), "aws"},
-        {Region.US_GOV_EAST_1.id(), "aws-us-gov"},
+        {Region.US_GOV_EAST_1.id(), "aws-us-gov"},  
         {Region.CN_NORTH_1.id(), "aws-cn"},
     };
 
@@ -58,9 +58,10 @@ public class TestArnResource extends HadoopTestBase {
       String partition = testPair[1];
 
       ArnResource resource = getArnResourceFrom(partition, "s3", region, MOCK_ACCOUNT, accessPoint);
-      assertEquals(accessPoint, resource.getName(), "Access Point name does not match");
-      assertEquals(MOCK_ACCOUNT, resource.getOwnerAccountId(), "Account Id does not match");
-      assertEquals(region, resource.getRegion(), "Region does not match");
+      // assertEquals(accessPoint, resource.getName(), "Access Point name does not match");
+      // assertEquals(MOCK_ACCOUNT, resource.getOwnerAccountId(), "Account Id does not match");
+      // assertEquals(region, resource.getRegion(), "Region does not match");
+      // assertEquals("s3", resource.getService(), "Service does not match");
     }
   }
 
@@ -88,6 +89,27 @@ public class TestArnResource extends HadoopTestBase {
     assertThat(accessPoint.getEndpoint())
         .describedAs("Endpoint has invalid format. Access Point requests will not work")
         .isEqualTo(expected);
+  }
+
+  @Test
+  public void makeSureS3ExpressEndpointHasTheCorrectFormat() {
+    ArnResource accessPoint = getArnResourceFrom("aws", "s3express", "us-west-2", MOCK_ACCOUNT,
+        "test--usw2-az1--xa-s3");
+    String expected = "s3express-usw2-az1.us-west-2.amazonaws.com";
+
+    assertThat(accessPoint.getEndpoint())
+        .describedAs("Endpoint has invalid format. Access Point requests will not work")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void getEndpointFromInvalidS3ExpressAccessPointNameMustThrow() throws Exception {
+    ArnResource accessPoint = getArnResourceFrom("aws", "s3express", "us-west-2", MOCK_ACCOUNT,
+        "test");
+    describe("Using an invalid access point name format must throw when getting an endpoint.");
+
+    intercept(IllegalArgumentException.class, () -> 
+        accessPoint.getEndpoint());
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestArnResource.java
@@ -49,7 +49,7 @@ public class TestArnResource extends HadoopTestBase {
     String accessPoint = "testAp";
     String[][] regionPartitionEndpoints = new String[][] {
         {Region.EU_WEST_1.id(), "aws"},
-        {Region.US_GOV_EAST_1.id(), "aws-us-gov"},  
+        {Region.US_GOV_EAST_1.id(), "aws-us-gov"},
         {Region.CN_NORTH_1.id(), "aws-cn"},
     };
 
@@ -108,7 +108,7 @@ public class TestArnResource extends HadoopTestBase {
         "test");
     describe("Using an invalid access point name format must throw when getting an endpoint.");
 
-    intercept(IllegalArgumentException.class, () -> 
+    intercept(IllegalArgumentException.class, () ->
         accessPoint.getEndpoint());
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

- Currently, the endpoint for using S3 accesspoint is resolved for S3 and S3 on outposts: https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/ArnResource.java#L29-L30. However, for s3express, the endpoint is `s3express-<zoneId>.<region>.amazonaws.com`. (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-az-networking.html). PR adds support for this.

- Additionally, for accessing objects using s3express in the `S3AFileSystem`, we need to parse the access point ARN for an S3express access point into the access point name, since ARNs aren't supported on S3express other than in IAM policies. (https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-directory-buckets-restrictions-limitations-naming-rules.html). This PR also addresses this change.

- Update the SDK version used by the changes to `2.31.12`, which is the version (at minimum) needed to use s3express access points. It does not do the SDK upgrade, but only the version of the dependency.


### How was this patch tested?
1. Make sure changes compile by running `mvn clean install -DskipTests`
2. Running newly added unit tests in `TestArnResource`: 
```
$ mvn -pl hadoop-tools/hadoop-aws test -Dtest=TestArnResource`

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.s3a.TestArnResource
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.098 s - in org.apache.hadoop.fs.s3a.TestArnResource
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.590 s
[INFO] Finished at: 2025-06-16T14:53:52-04:00
[INFO] ------------------------------------------------------------------------
```

3. Tried running integ test for S3ABucket existence using the following:
```
➜  hadoop git:(trunk) ✗ mvn clean test -Dit.test=ITestS3ABucketExistence -Dtest=none -Dsurefire.failIfNoSpecifiedTests=false

[INFO] Reactor Summary for Apache Hadoop Main 3.5.0-SNAPSHOT:
[INFO]
[INFO] Apache Hadoop Main ................................. SUCCESS [  0.175 s]
[INFO] Apache Hadoop Build Tools .......................... SUCCESS [  1.683 s]
[INFO] Apache Hadoop Project POM .......................... SUCCESS [  0.346 s]
[INFO] Apache Hadoop Annotations .......................... SUCCESS [  0.509 s]
[INFO] Apache Hadoop Project Dist POM ..................... SUCCESS [  0.034 s]
[INFO] Apache Hadoop Assemblies ........................... SUCCESS [  0.057 s]
[INFO] Apache Hadoop Maven Plugins ........................ SUCCESS [  1.460 s]
[INFO] Apache Hadoop MiniKDC .............................. SUCCESS [  0.495 s]
[INFO] Apache Hadoop Auth ................................. SUCCESS [  2.244 s]
[INFO] Apache Hadoop Auth Examples ........................ SUCCESS [  0.262 s]
[INFO] Apache Hadoop Common ............................... SUCCESS [01:34 min]
[INFO] Apache Hadoop NFS .................................. SUCCESS [  1.452 s]
[INFO] Apache Hadoop KMS .................................. SUCCESS [  1.350 s]
[INFO] Apache Hadoop Registry ............................. SUCCESS [  1.603 s]
[INFO] Apache Hadoop Common Project ....................... SUCCESS [  0.028 s]
[INFO] Apache Hadoop HDFS Client .......................... SUCCESS [  9.651 s]
[INFO] Apache Hadoop HDFS ................................. SUCCESS [ 20.707 s]
[INFO] Apache Hadoop HDFS Native Client ................... SUCCESS [  0.493 s]
[INFO] Apache Hadoop HttpFS ............................... SUCCESS [  2.054 s]
[INFO] Apache Hadoop HDFS-NFS ............................. SUCCESS [  1.420 s]
[INFO] Apache Hadoop YARN ................................. SUCCESS [  0.023 s]
[INFO] Apache Hadoop YARN API ............................. SUCCESS [  7.008 s]
[INFO] Apache Hadoop YARN Common .......................... SUCCESS [  6.862 s]
[INFO] Apache Hadoop YARN Server .......................... SUCCESS [  0.037 s]
[INFO] Apache Hadoop YARN Server Common ................... SUCCESS [  5.781 s]
[INFO] Apache Hadoop YARN ApplicationHistoryService ....... SUCCESS [  3.034 s]
[INFO] Apache Hadoop YARN Timeline Service ................ SUCCESS [  1.759 s]
[INFO] Apache Hadoop YARN Web Proxy ....................... SUCCESS [  1.493 s]
[INFO] Apache Hadoop YARN ResourceManager ................. SUCCESS [ 13.510 s]
[INFO] Apache Hadoop YARN NodeManager ..................... SUCCESS [  7.194 s]
[INFO] Apache Hadoop YARN Server Tests .................... SUCCESS [  2.439 s]
[INFO] Apache Hadoop YARN Client .......................... SUCCESS [  3.432 s]
[INFO] Apache Hadoop MapReduce Client ..................... SUCCESS [  0.650 s]
[INFO] Apache Hadoop MapReduce Core ....................... SUCCESS [  5.310 s]
[INFO] Apache Hadoop MapReduce Common ..................... SUCCESS [  3.321 s]
[INFO] Apache Hadoop MapReduce Shuffle .................... SUCCESS [  2.688 s]
[INFO] Apache Hadoop MapReduce App ........................ SUCCESS [  3.829 s]
[INFO] Apache Hadoop MapReduce HistoryServer .............. SUCCESS [  2.530 s]
[INFO] Apache Hadoop MapReduce JobClient .................. SUCCESS [  4.421 s]
[INFO] Apache Hadoop Distributed Copy ..................... SUCCESS [  2.416 s]
[INFO] Apache Hadoop Mini-Cluster ......................... SUCCESS [  1.433 s]
[INFO] Apache Hadoop Federation Balance ................... SUCCESS [  1.624 s]
[INFO] Apache Hadoop HDFS-RBF ............................. SUCCESS [  7.600 s]
[INFO] Apache Hadoop HDFS Project ......................... SUCCESS [  0.022 s]
[INFO] Apache Hadoop YARN SharedCacheManager .............. SUCCESS [  1.353 s]
[INFO] Apache Hadoop YARN Timeline Plugin Storage ......... SUCCESS [  1.326 s]
[INFO] Apache Hadoop YARN TimelineService HBase Backend ... SUCCESS [  0.020 s]
[INFO] Apache Hadoop YARN TimelineService HBase Common .... SUCCESS [  1.626 s]
[INFO] Apache Hadoop YARN TimelineService HBase Client .... SUCCESS [  3.227 s]
[INFO] Apache Hadoop YARN TimelineService HBase Servers ... SUCCESS [  0.028 s]
[INFO] Apache Hadoop YARN TimelineService HBase Server 2.5  SUCCESS [  1.450 s]
[INFO] Apache Hadoop YARN TimelineService HBase tests ..... SUCCESS [  2.108 s]
[INFO] Apache Hadoop YARN Router .......................... SUCCESS [  2.412 s]
[INFO] Apache Hadoop YARN TimelineService DocumentStore ... SUCCESS [  1.498 s]
[INFO] Apache Hadoop YARN GlobalPolicyGenerator ........... SUCCESS [  1.676 s]
[INFO] Apache Hadoop YARN Applications .................... SUCCESS [  0.021 s]
[INFO] Apache Hadoop YARN DistributedShell ................ SUCCESS [  1.667 s]
[INFO] Apache Hadoop YARN Unmanaged Am Launcher ........... SUCCESS [  1.003 s]
[INFO] Apache Hadoop YARN Services ........................ SUCCESS [  0.018 s]
[INFO] Apache Hadoop YARN Services Core ................... SUCCESS [  4.002 s]
[INFO] Apache Hadoop YARN Services API .................... SUCCESS [  2.181 s]
[INFO] Apache Hadoop YARN Application Catalog ............. SUCCESS [  0.022 s]
[INFO] Apache Hadoop YARN Application Catalog Webapp ...... SUCCESS [ 17.720 s]
[INFO] Apache Hadoop YARN Application Catalog Docker Image  SUCCESS [  0.042 s]
[INFO] Apache Hadoop YARN Application MaWo ................ SUCCESS [  0.022 s]
[INFO] Apache Hadoop YARN Application MaWo Core ........... SUCCESS [  1.074 s]
[INFO] Apache Hadoop YARN Site ............................ SUCCESS [  0.021 s]
[INFO] Apache Hadoop YARN Registry ........................ SUCCESS [  0.540 s]
[INFO] Apache Hadoop YARN UI .............................. SUCCESS [  0.135 s]
[INFO] Apache Hadoop YARN CSI ............................. SUCCESS [  4.102 s]
[INFO] Apache Hadoop YARN Project ......................... SUCCESS [  1.254 s]
[INFO] Apache Hadoop MapReduce HistoryServer Plugins ...... SUCCESS [  1.167 s]
[INFO] Apache Hadoop MapReduce NativeTask ................. SUCCESS [  1.709 s]
[INFO] Apache Hadoop MapReduce Uploader ................... SUCCESS [  1.088 s]
[INFO] Apache Hadoop MapReduce Examples ................... SUCCESS [  1.816 s]
[INFO] Apache Hadoop MapReduce ............................ SUCCESS [  1.271 s]
[INFO] Apache Hadoop MapReduce Streaming .................. SUCCESS [  2.025 s]
[INFO] Apache Hadoop Client Aggregator .................... SUCCESS [  0.839 s]
[INFO] Apache Hadoop Dynamometer Workload Simulator ....... SUCCESS [  1.458 s]
[INFO] Apache Hadoop Dynamometer Cluster Simulator ........ SUCCESS [  1.960 s]
[INFO] Apache Hadoop Dynamometer Block Listing Generator .. SUCCESS [  1.264 s]
[INFO] Apache Hadoop Dynamometer Dist ..................... SUCCESS [  1.259 s]
[INFO] Apache Hadoop Dynamometer .......................... SUCCESS [  0.019 s]
[INFO] Apache Hadoop Archives ............................. SUCCESS [  1.405 s]
[INFO] Apache Hadoop Archive Logs ......................... SUCCESS [  1.731 s]
[INFO] Apache Hadoop Rumen ................................ SUCCESS [  1.915 s]
[INFO] Apache Hadoop Gridmix .............................. SUCCESS [  1.984 s]
[INFO] Apache Hadoop Data Join ............................ SUCCESS [  1.413 s]
[INFO] Apache Hadoop Extras ............................... SUCCESS [  1.455 s]
[INFO] Apache Hadoop Pipes ................................ SUCCESS [  0.019 s]
[INFO] Apache Hadoop Amazon Web Services support .......... SUCCESS [  4.972 s]
[INFO] Apache Hadoop Kafka Library support ................ SUCCESS [  1.001 s]
[INFO] Apache Hadoop Azure support ........................ SUCCESS [  4.480 s]
[INFO] Apache Hadoop Aliyun OSS support ................... SUCCESS [  1.260 s]
[INFO] Apache Hadoop Scheduler Load Simulator ............. SUCCESS [  1.571 s]
[INFO] Apache Hadoop Resource Estimator Service ........... SUCCESS [  1.254 s]
[INFO] Apache Hadoop Azure Data Lake support .............. SUCCESS [  1.256 s]
[INFO] Apache Hadoop Image Generation Tool ................ SUCCESS [  1.259 s]
[INFO] Apache Hadoop Tools Dist ........................... SUCCESS [  0.711 s]
[INFO] Apache Hadoop OpenStack support .................... SUCCESS [  0.029 s]
[INFO] Apache Hadoop Common Benchmark ..................... SUCCESS [  0.619 s]
[INFO] Apache Hadoop Compatibility Benchmark .............. SUCCESS [  0.835 s]
[INFO] Apache Hadoop Tools ................................ SUCCESS [  0.022 s]
[INFO] Apache Hadoop Client API ........................... SUCCESS [  0.844 s]
[INFO] Apache Hadoop Client Runtime ....................... SUCCESS [  0.877 s]
[INFO] Apache Hadoop Client Packaging Invariants .......... SUCCESS [  0.156 s]
[INFO] Apache Hadoop Client Test Minicluster .............. SUCCESS [  0.705 s]
[INFO] Apache Hadoop Client Packaging Invariants for Test . SUCCESS [  0.047 s]
[INFO] Apache Hadoop Client Packaging Integration Tests ... SUCCESS [  0.053 s]
[INFO] Apache Hadoop Distribution ......................... SUCCESS [  0.528 s]
[INFO] Apache Hadoop Client Modules ....................... SUCCESS [  0.020 s]
[INFO] Apache Hadoop Tencent COS Support .................. SUCCESS [  0.875 s]
[INFO] Apache Hadoop OBS support .......................... SUCCESS [  1.395 s]
[INFO] Apache Hadoop Volcano Engine Services support ...... SUCCESS [  1.658 s]
[INFO] Apache Hadoop Cloud Storage ........................ SUCCESS [  0.370 s]
[INFO] Apache Hadoop Cloud Storage Project ................ SUCCESS [  0.018 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:32 min
[INFO] Finished at: 2025-06-16T18:04:59-04:00
[INFO] ------------------------------------------------------------------------
```

4. Tried running the same test from within the `hadoop-aws` folder since I didn't see it run in the above:
Additional info:

I set up `auth-keys.xml` as explained in https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/testing.html#Running_the_tests, and used bucket name as an S3express access point to test against it. But running into some JUnit version errors (pasted some sample errors below), which I believe is related to JUnit upgrade.
```
➜  hadoop-aws git:(trunk) ✗ pwd
...../hadoop/hadoop-tools/hadoop-aws
➜  hadoop-aws git:(trunk) ✗ mvn clean test -Dtest=none -Dit.test=ITestS3ABucketExistence

[ERROR] /hadoop/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFilesystem.java:[266,5] no suitable method found for assertEquals(java.lang.String,org.apache.hadoop.security.token.Token<org.apache.hadoop.fs.s3a.auth.delegation.AbstractS3ATokenIdentifier>,org.apache.hadoop.security.token.Token<capture#1 of ? extends org.apache.hadoop.security.token.TokenIdentifier>)
    method org.junit.jupiter.api.Assertions.assertEquals(short,short,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to short)
    method org.junit.jupiter.api.Assertions.assertEquals(short,java.lang.Short,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to short)
    method org.junit.jupiter.api.Assertions.assertEquals(java.lang.Short,short,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to java.lang.Short)
    method org.junit.jupiter.api.Assertions.assertEquals(java.lang.Short,java.lang.Short,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to java.lang.Short)
    method org.junit.jupiter.api.Assertions.assertEquals(short,short,java.util.function.Supplier<java.lang.String>) is not applicable
      (argument mismatch; java.lang.String cannot be converted to short)
    method org.junit.jupiter.api.Assertions.assertEquals(short,java.lang.Short,java.util.function.Supplier<java.lang.String>) is not applicable
      (argument mismatch; java.lang.String cannot be converted to short)
    method org.junit.jupiter.api.Assertions.assertEquals(java.lang.Short,short,java.util.function.Supplier<java.lang.String>) is not applicable
      (argument mismatch; java.lang.String cannot be converted to java.lang.Short)
    method org.junit.jupiter.api.Assertions.assertEquals(java.lang.Short,java.lang.Short,java.util.function.Supplier<java.lang.String>) is not applicable
      (argument mismatch; java.lang.String cannot be converted to java.lang.Short)
    method org.junit.jupiter.api.Assertions.assertEquals(byte,byte,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to byte)
    method org.junit.jupiter.api.Assertions.assertEquals(byte,java.lang.Byte,java.lang.String) is not applicable
      (argument mismatch; java.lang.String cannot be converted to byte)
    method org.junit.jupiter.api.Assertions.assertEquals(java.lang.Byte,byte,java.lang.String) is not applicable
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation? PENDING integ test and docs.
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

