### PR TITLE
HADOOP-18562: Correct compilation error after S3A custom S3/STS header changes

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestAwsClientConfig.java
@@ -218,26 +218,26 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
     final Configuration conf = new Configuration();
     conf.set(CUSTOM_HEADERS_STS, "header1=value1;value2,header2=value3");
 
-    Assertions.assertThat(conf.get(CUSTOM_HEADERS_S3))
+    assertThat(conf.get(CUSTOM_HEADERS_S3))
             .describedAs("Custom client headers for s3 %s", CUSTOM_HEADERS_S3)
             .isNull();
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
             .headers().size())
         .describedAs("Count of S3 client headers")
         .isEqualTo(0);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
             .headers().size())
         .describedAs("Count of STS client headers")
         .isEqualTo(2);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
             .headers().get("header1"))
         .describedAs("STS client 'header1' header value")
         .isEqualTo(Lists.newArrayList("value1", "value2"));
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
             .headers().get("header2"))
         .describedAs("STS client 'header2' header value")
         .isEqualTo(Lists.newArrayList("value3"));
@@ -252,26 +252,26 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
     final Configuration conf = new Configuration();
     conf.set(CUSTOM_HEADERS_S3, "header1=value1;value2,header2=value3");
 
-    Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
+    assertThat(conf.get(CUSTOM_HEADERS_STS))
             .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
             .isNull();
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
             .headers().size())
         .describedAs("Count of STS client headers")
         .isEqualTo(0);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
             .headers().size())
         .describedAs("Count of S3 client headers")
         .isEqualTo(2);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
             .headers().get("header1"))
         .describedAs("S3 client 'header1' header value")
         .isEqualTo(Lists.newArrayList("value1", "value2"));
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
             .headers().get("header2"))
         .describedAs("S3 client 'header2' header value")
         .isEqualTo(Lists.newArrayList("value3"));
@@ -287,26 +287,26 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
     final Configuration conf = new Configuration();
     conf.set(CUSTOM_HEADERS_S3, "  header1 =  value1 ;  value2 ,   header2= value3  ");
 
-    Assertions.assertThat(conf.get(CUSTOM_HEADERS_STS))
+    assertThat(conf.get(CUSTOM_HEADERS_STS))
             .describedAs("Custom client headers for STS %s", CUSTOM_HEADERS_STS)
             .isNull();
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_STS)
                     .headers().size())
             .describedAs("Count of STS client headers")
             .isEqualTo(0);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
                     .headers().size())
             .describedAs("Count of S3 client headers")
             .isEqualTo(2);
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
                     .headers().get("header1"))
             .describedAs("S3 client 'header1' header value")
             .isEqualTo(Lists.newArrayList("value1", "value2"));
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
                     .headers().get("header2"))
             .describedAs("S3 client 'header2' header value")
             .isEqualTo(Lists.newArrayList("value3"));
@@ -321,7 +321,7 @@ public class TestAwsClientConfig extends AbstractHadoopTestBase {
     Configuration conf = new Configuration();
     conf.set(CUSTOM_HEADERS_S3, "header1=duplicate;duplicate");
 
-    Assertions.assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
+    assertThat(createClientConfigBuilder(conf, AWS_SERVICE_IDENTIFIER_S3)
                     .headers().get("header1"))
             .describedAs("S3 client 'header1' header value")
             .isEqualTo(Lists.newArrayList("duplicate", "duplicate"));


### PR DESCRIPTION
### Description of PR

It looks like changes in #7379 introduced a compilation error in the tests. This patch fixes the compilation error.

### How was this patch tested?

```
./start-build-env.sh
mvn clean test -Dtest=TestAwsClientConfig
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

