### PR TITLE
HADOOP-19424. [S3A] Upgrade JUnit from 4 to 5 in hadoop-aws.

### DIFF
--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -500,11 +500,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
@@ -616,11 +611,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
@@ -28,8 +28,8 @@ import java.net.URI;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
@@ -56,7 +56,7 @@ public abstract class AbstractS3AMockTest {
   protected S3Client s3;
   protected Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = createConfiguration();
     fs = new S3AFileSystem();
@@ -97,7 +97,7 @@ public abstract class AbstractS3AMockTest {
     return s3;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (fs != null) {
       fs.close();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3AMockTest.java
@@ -30,8 +30,6 @@ import org.apache.hadoop.conf.Configuration;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 
 /**
@@ -48,9 +46,6 @@ public abstract class AbstractS3AMockTest {
               .errorCode("")
               .build())
           .build();
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   protected S3AFileSystem fs;
   protected S3Client s3;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestBlockingThreadPoolExecutorService.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestBlockingThreadPoolExecutorService.java
@@ -22,10 +22,9 @@ import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.hadoop.util.SemaphoredDelegatingExecutor;
 import org.apache.hadoop.util.StopWatch;
 
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,11 +34,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Basic test for S3A's blocking executor service.
  */
+@Timeout(60)
 public class ITestBlockingThreadPoolExecutorService {
 
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -56,10 +56,7 @@ public class ITestBlockingThreadPoolExecutorService {
 
   private static BlockingThreadPoolExecutorService tpe;
 
-  @Rule
-  public Timeout testTimeout = new Timeout(60, TimeUnit.SECONDS);
-
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     ensureDestroyed();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestEMRFSCompatibility.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.s3a;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
@@ -29,10 +29,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.impl.InstantiationIOException;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Timeout;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -46,18 +45,17 @@ import static org.apache.hadoop.fs.s3a.impl.InstantiationIOException.CONSTRUCTOR
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.isUsingDefaultExternalDataFile;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration tests for {@link Constants#AWS_CREDENTIALS_PROVIDER} logic
  * through the S3A Filesystem instantiation process.
  */
+@Timeout(60)
 public class ITestS3AAWSCredentialsProvider {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3AAWSCredentialsProvider.class);
-
-  @Rule
-  public Timeout testTimeout = new Timeout(60_1000, TimeUnit.MILLISECONDS);
 
   /**
    * Expecting a wrapped ClassNotFoundException.
@@ -219,9 +217,8 @@ public class ITestS3AAWSCredentialsProvider {
           .describedAs("Filesystem")
           .isNotNull();
       FileStatus stat = fs.getFileStatus(testFile);
-      assertEquals(
-          "The qualified path returned by getFileStatus should be same as the original file",
-          testFile, stat.getPath());
+      assertEquals(testFile, stat.getPath(),
+          "The qualified path returned by getFileStatus should be same as the original file");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.assertj.core.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
@@ -67,7 +67,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
   private Path externalTestFile;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setup();
     skipIfClientSideEncryption();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AChecksum.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AChecksum.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.s3a;
 import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADSSEEncryptionWithDefaultS3Settings.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADSSEEncryptionWithDefaultS3Settings.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.apache.commons.lang3.StringUtils;
@@ -96,13 +96,13 @@ public class ITestS3ADSSEEncryptionWithDefaultS3Settings extends
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void testEncryptionSettingPropagation() throws Throwable {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void testEncryption() throws Throwable {
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATestUtils.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,12 +31,12 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
  * Test the test utils. Why an integration test? it's needed to
  * verify property pushdown.
  */
-public class ITestS3ATestUtils extends Assert {
+public class ITestS3ATestUtils extends Assertions {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3ATestUtils.class);
   public static final String KEY = "undefined.property";
 
-  @Before
+  @BeforeEach
   public void clear() {
     System.clearProperty(KEY);
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MultipartTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MultipartTestUtils.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +45,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.assertFileHasLengt
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.MAGIC_PATH_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Utilities for S3A multipart upload tests.
@@ -80,8 +81,7 @@ public final class MultipartTestUtils {
         anyFailure = true;
       }
     }
-    Assert.assertFalse("Failure aborting multipart upload(s), see log.",
-        anyFailure);
+    assertFalse(anyFailure, "Failure aborting multipart upload(s), see log.");
   }
 
   public static IdKey createPartUpload(S3AFileSystem fs, String key, int len,
@@ -116,7 +116,7 @@ public final class MultipartTestUtils {
     RemoteIterator<MultipartUpload> uploads = fs.listUploads(key);
     while (uploads.hasNext()) {
       MultipartUpload upload = uploads.next();
-      Assert.fail("Found unexpected upload " + upload.key() + " " +
+      Assertions.fail("Found unexpected upload " + upload.key() + " " +
           truncatedUploadId(upload.uploadId()));
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -70,7 +70,6 @@ import org.apache.hadoop.util.functional.FutureIO;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
@@ -126,7 +125,10 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.util.functional.FunctionalIO.uncheckIOExceptions;
 import static org.apache.hadoop.util.functional.RemoteIterators.mappingRemoteIterator;
 import static org.apache.hadoop.util.functional.RemoteIterators.toList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Utilities for the S3A tests.
@@ -1264,8 +1266,7 @@ public final class S3ATestUtils {
         // Log in error ensures that the details appear in the test output
         LOG.error(text + " expected {}, actual {}", expected, diff);
       }
-      Assert.assertEquals(text,
-          expected, diff);
+      assertEquals(expected, diff, text);
     }
 
     /**
@@ -1282,8 +1283,8 @@ public final class S3ATestUtils {
      * @param that the other metric diff instance.
      */
     public void assertDiffEquals(MetricDiff that) {
-      Assert.assertEquals(this.toString() + " != " + that,
-          this.diff(), that.diff());
+      assertEquals(this.diff(), that.diff(),
+          this.toString() + " != " + that);
     }
 
     /**
@@ -1337,9 +1338,9 @@ public final class S3ATestUtils {
    * @param obj object to check
    */
   public static void assertInstanceOf(Class<?> expectedClass, Object obj) {
-    Assert.assertTrue(String.format("Expected instance of class %s, but is %s.",
-        expectedClass, obj.getClass()),
-        expectedClass.isAssignableFrom(obj.getClass()));
+    assertTrue(expectedClass.isAssignableFrom(obj.getClass()),
+        String.format("Expected instance of class %s, but is %s.",
+        expectedClass, obj.getClass()));
   }
 
   /**
@@ -1399,17 +1400,17 @@ public final class S3ATestUtils {
       String group,
       FsPermission permission) {
     String details = status.toString();
-    assertFalse("Not a dir: " + details, status.isDirectory());
-    assertEquals("Mod time: " + details, modTime, status.getModificationTime());
-    assertEquals("File size: " + details, size, status.getLen());
-    assertEquals("Block size: " + details, blockSize, status.getBlockSize());
+    assertFalse(status.isDirectory(), "Not a dir: " + details);
+    assertEquals(modTime, status.getModificationTime(), "Mod time: " + details);
+    assertEquals(size, status.getLen(), "File size: " + details);
+    assertEquals(blockSize, status.getBlockSize(), "Block size: " + details);
     if (replication > 0) {
-      assertEquals("Replication value: " + details, replication,
-          status.getReplication());
+      assertEquals(replication, status.getReplication(),
+          "Replication value: " + details);
     }
     if (accessTime != 0) {
-      assertEquals("Access time: " + details, accessTime,
-          status.getAccessTime());
+      assertEquals(accessTime, status.getAccessTime(),
+          "Access time: " + details);
     }
     if (owner != null) {
       assertEquals("Owner: " + details, owner, status.getOwner());
@@ -1418,8 +1419,8 @@ public final class S3ATestUtils {
       assertEquals("Group: " + details, group, status.getGroup());
     }
     if (permission != null) {
-      assertEquals("Permission: " + details, permission,
-          status.getPermission());
+      assertEquals(permission, status.getPermission(),
+          "Permission: " + details);
     }
   }
 
@@ -1433,19 +1434,20 @@ public final class S3ATestUtils {
       int replication,
       String owner) {
     String details = status.toString();
-    assertTrue("Is a dir: " + details, status.isDirectory());
-    assertEquals("zero length: " + details, 0, status.getLen());
+    assertTrue(status.isDirectory(), "Is a dir: " + details);
+    assertEquals(0, status.getLen(), "zero length: " + details);
     // S3AFileStatus always assigns modTime = System.currentTimeMillis()
-    assertTrue("Mod time: " + details, status.getModificationTime() > 0);
-    assertEquals("Replication value: " + details, replication,
-        status.getReplication());
-    assertEquals("Access time: " + details, 0, status.getAccessTime());
+    assertTrue(status.getModificationTime() > 0, "Mod time: " + details);
+    assertEquals(replication, status.getReplication(),
+        "Replication value: " + details);
+    assertEquals(0, status.getAccessTime(),
+        "Access time: " + details);
     assertEquals("Owner: " + details, owner, status.getOwner());
     // S3AFileStatus always assigns group=owner
     assertEquals("Group: " + details, owner, status.getGroup());
     // S3AFileStatus always assigns permission = default
-    assertEquals("Permission: " + details,
-        FsPermission.getDefault(), status.getPermission());
+    assertEquals(FsPermission.getDefault(), status.getPermission(),
+        "Permission: " + details);
   }
 
   /**
@@ -1590,15 +1592,15 @@ public final class S3ATestUtils {
         fs.listFiles(filePath.getParent(), false);
     while (listIter.hasNext()) {
       final LocatedFileStatus lfs = listIter.next();
-      assertNotEquals("Listing was not supposed to include " + filePath,
-            filePath, lfs.getPath());
+      assertNotEquals(filePath, lfs.getPath(),
+          "Listing was not supposed to include " + filePath);
     }
     LOG.info("{}; file omitted from listFiles listing as expected.", filePath);
 
     final FileStatus[] fileStatuses = fs.listStatus(filePath.getParent());
     for (FileStatus fileStatus : fileStatuses) {
-      assertNotEquals("Listing was not supposed to include " + filePath,
-            filePath, fileStatus.getPath());
+      assertNotEquals(filePath, fileStatus.getPath(),
+          "Listing was not supposed to include " + filePath);
     }
     LOG.info("{}; file omitted from listStatus as expected.", filePath);
   }
@@ -1626,10 +1628,10 @@ public final class S3ATestUtils {
         listStatusHasIt = true;
       }
     }
-    assertTrue("fs.listFiles didn't include " + filePath,
-          listFilesHasIt);
-    assertTrue("fs.listStatus didn't include " + filePath,
-          listStatusHasIt);
+    assertTrue(listFilesHasIt,
+        "fs.listFiles didn't include " + filePath);
+    assertTrue(listStatusHasIt,
+        "fs.listStatus didn't include " + filePath);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestListing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestListing.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.fs.s3a;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -45,10 +45,10 @@ public class TestListing extends AbstractS3AMockTest {
     RemoteIterator<S3AFileStatus> it = Listing.toProvidedFileStatusIterator(
         statuses);
 
-    Assert.assertTrue("hasNext() should return true first time", it.hasNext());
-    Assert.assertEquals("first element from iterator",
-        s3aStatus, it.next());
-    Assert.assertFalse("hasNext() should now be false", it.hasNext());
+    Assertions.assertTrue(it.hasNext(), "hasNext() should return true first time");
+    Assertions.assertEquals(s3aStatus, it.next(),
+        "first element from iterator");
+    Assertions.assertFalse(it.hasNext(), "hasNext() should now be false");
     intercept(NoSuchElementException.class, it::next);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -644,10 +644,10 @@ public class TestS3AAWSCredentialsProvider extends AbstractS3ATestBase {
 
       for (Future<AwsCredentials> result : results) {
         AwsCredentials credentials = result.get();
-        assertEquals("Access key from credential provider",
-            "expectedAccessKey", credentials.accessKeyId());
-        assertEquals("Secret key from credential provider",
-            "expectedSecret", credentials.secretAccessKey());
+        assertEquals("expectedAccessKey", credentials.accessKeyId(),
+            "Access key from credential provider");
+        assertEquals("expectedSecret", credentials.secretAccessKey(),
+            "Secret key from credential provider");
       }
     } finally {
       pool.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.SECONDS);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ABlockOutputStream.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.fs.s3a.statistics.impl.EmptyS3AStatisticsContext;
 import org.apache.hadoop.fs.s3a.test.MinimalWriteOperationHelperCallbacks;
 import org.apache.hadoop.fs.statistics.IOStatisticsContext;
 import org.apache.hadoop.util.Progressable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 
@@ -76,7 +76,7 @@ public class TestS3ABlockOutputStream extends AbstractS3AMockTest {
     return builder;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final S3ABlockOutputStream.BlockOutputStreamBuilder
         builder = mockS3ABuilder();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ADeleteOnExit.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3ADeleteOnExit.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AEndpointParsing.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.s3a;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
 
 public class TestS3AEndpointParsing extends AbstractS3AMockTest {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
@@ -131,16 +131,17 @@ public class TestS3AGetFileStatus extends AbstractS3AMockTest {
 
   @Test
   public void testNotFound() throws Exception {
-    Path path = new Path("/dir");
-    String key = path.toUri().getPath().substring(1);
-    when(s3.headObject(argThat(correctGetMetadataRequest(BUCKET, key))))
-      .thenThrow(NOT_FOUND);
-    when(s3.headObject(argThat(
-      correctGetMetadataRequest(BUCKET, key + "/")
-    ))).thenThrow(NOT_FOUND);
-    setupListMocks(Collections.emptyList(), Collections.emptyList());
-    exception.expect(FileNotFoundException.class);
-    fs.getFileStatus(path);
+    assertThrows(FileNotFoundException.class, () -> {
+      Path path = new Path("/dir");
+      String key = path.toUri().getPath().substring(1);
+      when(s3.headObject(argThat(correctGetMetadataRequest(BUCKET, key))))
+          .thenThrow(NOT_FOUND);
+      when(s3.headObject(argThat(
+          correctGetMetadataRequest(BUCKET, key + "/")
+      ))).thenThrow(NOT_FOUND);
+      setupListMocks(Collections.emptyList(), Collections.emptyList());
+      fs.getFileStatus(path);
+    });
   }
 
   private void setupListMocks(List<CommonPrefix> prefixes,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -42,7 +42,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 
 
@@ -66,9 +66,9 @@ public class TestS3AGetFileStatus extends AbstractS3AMockTest {
     assertEquals(objectMetadata.contentLength().longValue(), stat.getLen());
     assertEquals(Date.from(objectMetadata.lastModified()).getTime(), stat.getModificationTime());
     ContractTestUtils.assertNotErasureCoded(fs, path);
-    assertTrue(path + " should have erasure coding unset in " +
-            "FileStatus#toString(): " + stat,
-        stat.toString().contains("isErasureCoded=false"));
+    assertTrue(stat.toString().contains("isErasureCoded=false"),
+        path + " should have erasure coding unset in " +
+        "FileStatus#toString(): " + stat);
   }
 
   @Test
@@ -107,9 +107,9 @@ public class TestS3AGetFileStatus extends AbstractS3AMockTest {
     assertEquals(fs.makeQualified(path), stat.getPath());
     assertTrue(stat.isDirectory());
     ContractTestUtils.assertNotErasureCoded(fs, path);
-    assertTrue(path + " should have erasure coding unset in " +
-            "FileStatus#toString(): " + stat,
-        stat.toString().contains("isErasureCoded=false"));
+    assertTrue(stat.toString().contains("isErasureCoded=false"),
+        path + " should have erasure coding unset in " +
+        "FileStatus#toString(): " + stat);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -81,11 +81,11 @@ public class TestS3AInputPolicies {
 
   @Test
   public void testInputPolicies() throws Throwable {
-    Assert.assertEquals(
-        String.format("calculateRequestLimit(%s, %d, %d, %d, %d)",
-            policy, targetPos, length, contentLength, readahead),
+    Assertions.assertEquals(
         expectedLimit,
         S3AInputStream.calculateRequestLimit(policy, targetPos,
-            length, contentLength, readahead));
+            length, contentLength, readahead),
+        String.format("calculateRequestLimit(%s, %d, %d, %d, %d)",
+            policy, targetPos, length, contentLength, readahead));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
@@ -19,9 +19,8 @@
 package org.apache.hadoop.fs.s3a;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,7 +28,6 @@ import java.util.Collection;
 /**
  * Unit test of the input policy logic, without making any S3 calls.
  */
-@RunWith(Parameterized.class)
 public class TestS3AInputPolicies {
 
   private S3AInputPolicy policy;
@@ -45,7 +43,7 @@ public class TestS3AInputPolicies {
   public static final long _1MB = 1024L * 1024;
   public static final long _10MB = _1MB * 10;
 
-  public TestS3AInputPolicies(S3AInputPolicy policy,
+  public void initTestS3AInputPolicies(S3AInputPolicy policy,
       long targetPos,
       long length,
       long contentLength,
@@ -59,7 +57,6 @@ public class TestS3AInputPolicies {
     this.expectedLimit = expectedLimit;
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {S3AInputPolicy.Normal, 0, -1, 0, _64K, 0},
@@ -79,8 +76,12 @@ public class TestS3AInputPolicies {
     });
   }
 
-  @Test
-  public void testInputPolicies() throws Throwable {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testInputPolicies(S3AInputPolicy policy,
+      long targetPos, long length, long contentLength,
+      long readahead, long expectedLimit) throws Throwable {
+    initTestS3AInputPolicies(policy, targetPos, length, contentLength, readahead, expectedLimit);
     Assertions.assertEquals(
         expectedLimit,
         S3AInputStream.calculateRequestLimit(policy, targetPos,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputPolicies.java
@@ -43,18 +43,18 @@ public class TestS3AInputPolicies {
   public static final long _1MB = 1024L * 1024;
   public static final long _10MB = _1MB * 10;
 
-  public void initTestS3AInputPolicies(S3AInputPolicy policy,
-      long targetPos,
-      long length,
-      long contentLength,
-      long readahead,
-      long expectedLimit) {
-    this.policy = policy;
-    this.targetPos = targetPos;
-    this.length = length;
-    this.contentLength = contentLength;
-    this.readahead = readahead;
-    this.expectedLimit = expectedLimit;
+  public void initTestS3AInputPolicies(S3AInputPolicy pPolicy,
+      long pTargetPos,
+      long pLength,
+      long pContentLength,
+      long pReadahead,
+      long pExpectedLimit) {
+    this.policy = pPolicy;
+    this.targetPos = pTargetPos;
+    this.length = pLength;
+    this.contentLength = pContentLength;
+    this.readahead = pReadahead;
+    this.expectedLimit = pExpectedLimit;
   }
 
   public static Collection<Object[]> data() {
@@ -78,10 +78,11 @@ public class TestS3AInputPolicies {
 
   @MethodSource("data")
   @ParameterizedTest
-  public void testInputPolicies(S3AInputPolicy policy,
-      long targetPos, long length, long contentLength,
-      long readahead, long expectedLimit) throws Throwable {
-    initTestS3AInputPolicies(policy, targetPos, length, contentLength, readahead, expectedLimit);
+  public void testInputPolicies(S3AInputPolicy pPolicy,
+      long pTargetPos, long pLength, long pContentLength,
+      long pReadahead, long pExpectedLimit) throws Throwable {
+    initTestS3AInputPolicies(pPolicy, pTargetPos, pLength, pContentLength,
+        pReadahead, pExpectedLimit);
     Assertions.assertEquals(
         expectedLimit,
         S3AInputStream.calculateRequestLimit(policy, targetPos,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -49,8 +49,8 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.requestRange;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.sdkClientException;
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_416_RANGE_NOT_SATISFIABLE;
 import static org.apache.hadoop.util.functional.FutureIO.eval;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests S3AInputStream retry behavior on read failure.
@@ -78,10 +78,12 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   public void testInputStreamReadRetryForException() throws IOException {
     S3AInputStream s3AInputStream = getMockedS3AInputStream(failingInputStreamCallbacks(
         awsServiceException(STATUS)));
-    assertEquals("'0' from the test input stream should be the first " +
-        "character being read", INPUT.charAt(0), s3AInputStream.read());
-    assertEquals("'1' from the test input stream should be the second " +
-        "character being read", INPUT.charAt(1), s3AInputStream.read());
+    assertEquals(INPUT.charAt(0), s3AInputStream.read(),
+        "'0' from the test input stream should be the first " +
+        "character being read");
+    assertEquals(INPUT.charAt(1), s3AInputStream.read(),
+        "'1' from the test input stream should be the second " +
+         "character being read");
   }
 
   @Test
@@ -92,8 +94,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
     s3AInputStream.read(result, 0, INPUT.length());
 
     assertArrayEquals(
-        "The read result should equals to the test input stream content",
-        INPUT.getBytes(), result);
+        INPUT.getBytes(), result,
+        "The read result should equals to the test input stream content");
   }
 
   @Test
@@ -104,8 +106,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
     s3AInputStream.readFully(0, result);
 
     assertArrayEquals(
-        "The read result should equals to the test input stream content",
-        INPUT.getBytes(), result);
+        INPUT.getBytes(), result,
+        "The read result should equals to the test input stream content");
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AUnbuffer.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AUnbuffer.java
@@ -28,14 +28,14 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/adapter/TestV1CredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/adapter/TestV1CredentialsProvider.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -47,8 +47,8 @@ import static org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.EC2_CO
 import static org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.ENVIRONMENT_CREDENTIALS_V1;
 import static org.apache.hadoop.fs.s3a.auth.CredentialProviderListFactory.createAWSCredentialProviderList;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for v1 to v2 credential provider logic.
@@ -150,13 +150,12 @@ public class TestV1CredentialsProvider {
       Class<?> expectedClass =
           expectedClasses.get(i);
       AwsCredentialsProvider provider = providers.get(i);
-      assertNotNull(
+      assertNotNull(provider,
           String.format("At position %d, expected class is %s, but found null.",
-              i, expectedClass), provider);
-      assertTrue(
+          i, expectedClass));
+      assertTrue(expectedClass.isAssignableFrom(provider.getClass()),
           String.format("At position %d, expected class is %s, but found %s.",
-              i, expectedClass, provider.getClass()),
-          expectedClass.isAssignableFrom(provider.getClass()));
+          i, expectedClass, provider.getClass()));
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ProgressCounter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ProgressCounter.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.util.Progressable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A progress callback for testing.
@@ -40,6 +40,6 @@ public class ProgressCounter implements Progressable {
   }
 
   public void assertCount(String message, int expected) {
-    assertEquals(message, expected, getCount());
+    assertEquals(expected, getCount(), message);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
@@ -46,8 +46,8 @@ import static org.apache.hadoop.fs.s3a.auth.RoleModel.*;
 import static org.apache.hadoop.fs.s3a.auth.RolePolicies.*;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_BINDING;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper class for testing roles.
@@ -229,15 +229,14 @@ public final class RoleTestUtils {
       final MarshalledCredentials actual) {
     // DO NOT use assertEquals() here, as that could print a secret to
     // the test report.
-    assertEquals(message + ": access key",
-        expected.getAccessKey(),
-        actual.getAccessKey());
-    assertTrue(message + ": secret key",
-        expected.getSecretKey().equals(actual.getSecretKey()));
-    assertEquals(message + ": session token",
-        expected.getSessionToken(),
-        actual.getSessionToken());
-
+    assertEquals(expected.getAccessKey(),
+        actual.getAccessKey(),
+        message + ": access key");
+    assertTrue(expected.getSecretKey().equals(actual.getSecretKey()),
+        message + ": secret key");
+    assertEquals(expected.getSessionToken(),
+        actual.getSessionToken(),
+        message + ": session token");
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/MiniKerberizedHadoopCluster.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/MiniKerberizedHadoopCluster.java
@@ -49,7 +49,7 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DATA_TRANSF
 import static org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig.DEFAULT_MR_HISTORY_PORT;
 import static org.apache.hadoop.security.UserGroupInformation.loginUserFromKeytabAndReturnUGI;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.*;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is intended to support setting up an mini-secure Hadoop + YARN + MR
@@ -350,8 +350,8 @@ public class MiniKerberizedHadoopCluster extends CompositeService {
    * General assertion that security is turred on for a cluster.
    */
   public static void assertSecurityEnabled() {
-    assertTrue("Security is needed for this test",
-        UserGroupInformation.isSecurityEnabled());
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Security is needed for this test");
   }
 
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
@@ -37,9 +37,9 @@ import org.apache.hadoop.security.token.Token;
 
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.FULL_TOKEN_KIND;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.SESSION_TOKEN_KIND;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests related to S3A DT support.
@@ -48,7 +48,7 @@ public class TestS3ADelegationTokenSupport {
 
   private static URI externalUri;
 
-  @BeforeClass
+  @BeforeAll
   public static void classSetup() throws Exception {
     externalUri = new URI(PublicDatasetTestUtils.DEFAULT_EXTERNAL_FILE);
   }
@@ -65,7 +65,7 @@ public class TestS3ADelegationTokenSupport {
     AbstractS3ATokenIdentifier identifier
         = new SessionTokenIdentifier();
     assertEquals(SESSION_TOKEN_KIND, identifier.getKind());
-    assertTrue("issue date is not set", identifier.getIssueDate() > 0L);
+    assertTrue(identifier.getIssueDate() > 0L, "issue date is not set");
   }
 
   @Test
@@ -91,21 +91,20 @@ public class TestS3ADelegationTokenSupport {
     decoded.validate();
     MarshalledCredentials creds
         = ((SessionTokenIdentifier) decoded).getMarshalledCredentials();
-    assertNotNull("credentials",
-        MarshalledCredentialBinding.toAWSCredentials(creds,
-        MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty, ""));
+    assertNotNull(MarshalledCredentialBinding.toAWSCredentials(creds,
+        MarshalledCredentials.CredentialTypeRequired.AnyNonEmpty, ""),
+        "credentials");
     assertEquals(alice, decoded.getOwner());
     UserGroupInformation decodedUser = decoded.getUser();
-    assertEquals("name of " + decodedUser,
-        "alice",
-        decodedUser.getUserName());
-    assertEquals("renewer", renewer, decoded.getRenewer());
-    assertEquals("Authentication method of " + decodedUser,
-        UserGroupInformation.AuthenticationMethod.TOKEN,
-        decodedUser.getAuthenticationMethod());
+    assertEquals("alice",
+        decodedUser.getUserName(), "name of " + decodedUser);
+    assertEquals(renewer, decoded.getRenewer(), "renewer");
+    assertEquals(UserGroupInformation.AuthenticationMethod.TOKEN,
+        decodedUser.getAuthenticationMethod(),
+        "Authentication method of " + decodedUser);
     assertEquals("origin", decoded.getOrigin());
-    assertEquals("issue date", identifier.getIssueDate(),
-        decoded.getIssueDate());
+    assertEquals(identifier.getIssueDate(),
+        decoded.getIssueDate(), "issue date");
     EncryptionSecrets encryptionSecrets = decoded.getEncryptionSecrets();
     assertEquals(S3AEncryptionMethods.SSE_S3, encryptionSecrets.getEncryptionMethod());
     assertEquals(encryptionKey, encryptionSecrets.getEncryptionKey());
@@ -138,11 +137,11 @@ public class TestS3ADelegationTokenSupport {
 
     SessionTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
-    assertEquals("URI in " + ids, id.getUri(), result.getUri());
-    assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
-    assertEquals("renewer in " + ids, renewer, id.getRenewer());
+    assertEquals(id.getUri(), result.getUri(),"URI in " + ids);
+    assertEquals(id.getMarshalledCredentials(),
+        result.getMarshalledCredentials(),
+        "credentials in " + ids);
+    assertEquals(renewer, id.getRenewer(), "renewer in " + ids);
     EncryptionSecrets encryptionSecrets = result.getEncryptionSecrets();
     assertEquals(S3AEncryptionMethods.DSSE_KMS, encryptionSecrets.getEncryptionMethod());
     assertEquals(encryptionKey, encryptionSecrets.getEncryptionKey());
@@ -161,11 +160,11 @@ public class TestS3ADelegationTokenSupport {
 
     SessionTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
-    assertEquals("URI in " + ids, id.getUri(), result.getUri());
-    assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
-    assertEquals("renewer in " + ids, new Text(), id.getRenewer());
+    assertEquals(id.getUri(), result.getUri(), "URI in " + ids);
+    assertEquals(id.getMarshalledCredentials(),
+        result.getMarshalledCredentials(),
+        "credentials in " + ids);
+    assertEquals(new Text(), id.getRenewer(), "renewer in " + ids);
   }
 
   @Test
@@ -179,11 +178,11 @@ public class TestS3ADelegationTokenSupport {
 
     RoleTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
-    assertEquals("URI in " + ids, id.getUri(), result.getUri());
-    assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
-    assertEquals("renewer in " + ids, new Text(), id.getRenewer());
+    assertEquals(id.getUri(), result.getUri(), "URI in " + ids);
+    assertEquals(id.getMarshalledCredentials(),
+        result.getMarshalledCredentials(),
+        "credentials in " + ids);
+    assertEquals(new Text(), id.getRenewer(), "renewer in " + ids);
   }
 
   @Test
@@ -198,11 +197,11 @@ public class TestS3ADelegationTokenSupport {
 
     FullCredentialsTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
-    assertEquals("URI in " + ids, id.getUri(), result.getUri());
-    assertEquals("credentials in " + ids,
-        id.getMarshalledCredentials(),
-        result.getMarshalledCredentials());
-    assertEquals("renewer in " + ids, renewer, result.getRenewer());
+    assertEquals(id.getUri(), result.getUri(), "URI in " + ids);
+    assertEquals(id.getMarshalledCredentials(),
+        result.getMarshalledCredentials(),
+        "credentials in " + ids);
+    assertEquals(renewer, result.getRenewer(), "renewer in " + ids);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/TestS3ADelegationTokenSupport.java
@@ -137,7 +137,7 @@ public class TestS3ADelegationTokenSupport {
 
     SessionTokenIdentifier result = S3ATestUtils.roundTrip(id, null);
     String ids = id.toString();
-    assertEquals(id.getUri(), result.getUri(),"URI in " + ids);
+    assertEquals(id.getUri(), result.getUri(), "URI in " + ids);
     assertEquals(id.getMarshalledCredentials(),
         result.getMarshalledCredentials(),
         "credentials in " + ids);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractITCommitProtocol.java
@@ -733,8 +733,8 @@ public abstract class AbstractITCommitProtocol extends AbstractCommitITest {
     expectedOutput.append(KEY_1).append("\n");
     expectedOutput.append(KEY_2).append('\t').append(VAL_2).append("\n");
     String output = readFile(expectedFile);
-    assertEquals("Content of " + expectedFile,
-        expectedOutput.toString(), output);
+    assertEquals(expectedOutput.toString(), output,
+        "Content of " + expectedFile);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitPaths.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitPaths.java
@@ -178,9 +178,9 @@ public class TestMagicCommitPaths extends Assertions {
 
   @Test
   public void testFinalDestinationMagicNoChild() {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-          finalDestination(l(MAGIC_PATH_PREFIX));
-      });
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      finalDestination(l(MAGIC_PATH_PREFIX));
+    });
   }
 
   @Test
@@ -190,9 +190,9 @@ public class TestMagicCommitPaths extends Assertions {
 
   @Test
   public void testFinalDestinationBaseNoChild() {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-          assertEquals(l(), finalDestination(l(MAGIC_PATH_PREFIX, BASE)));
-      });
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      assertEquals(l(), finalDestination(l(MAGIC_PATH_PREFIX, BASE)));
+    });
   }
 
   @Test
@@ -239,8 +239,8 @@ public class TestMagicCommitPaths extends Assertions {
 
   private void assertPathSplits(String pathString, String[] expected) {
     Path path = new Path(pathString);
-    assertArrayEquals(expected
-,         splitPathToElements(path).toArray(), "From path " + path);
+    assertArrayEquals(expected,
+        splitPathToElements(path).toArray(), "From path " + path);
   }
 
   private void assertListEquals(String[] expected, List<String> actual) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitPaths.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitPaths.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.util.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.fs.Path;
 
@@ -35,7 +35,7 @@ import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
 /**
  * Tests for {@link MagicCommitPaths} path operations.
  */
-public class TestMagicCommitPaths extends Assert {
+public class TestMagicCommitPaths extends Assertions {
 
   private static final List<String> MAGIC_AT_ROOT =
       list(MAGIC_PATH_PREFIX);
@@ -176,9 +176,11 @@ public class TestMagicCommitPaths extends Assert {
         finalDestination(l(MAGIC_PATH_PREFIX, "2", "3.txt")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFinalDestinationMagicNoChild() {
-    finalDestination(l(MAGIC_PATH_PREFIX));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          finalDestination(l(MAGIC_PATH_PREFIX));
+      });
   }
 
   @Test
@@ -186,9 +188,11 @@ public class TestMagicCommitPaths extends Assert {
     finalDestination(l(MAGIC_PATH_PREFIX, BASE, "3.txt"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFinalDestinationBaseNoChild() {
-    assertEquals(l(), finalDestination(l(MAGIC_PATH_PREFIX, BASE)));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          assertEquals(l(), finalDestination(l(MAGIC_PATH_PREFIX, BASE)));
+      });
   }
 
   @Test
@@ -235,8 +239,8 @@ public class TestMagicCommitPaths extends Assert {
 
   private void assertPathSplits(String pathString, String[] expected) {
     Path path = new Path(pathString);
-    assertArrayEquals("From path " + path, expected,
-        splitPathToElements(path).toArray());
+    assertArrayEquals(expected
+,         splitPathToElements(path).toArray(), "From path " + path);
   }
 
   private void assertListEquals(String[] expected, List<String> actual) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitTrackerUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitTrackerUtils.java
@@ -57,8 +57,9 @@ public final class TestMagicCommitTrackerUtils {
         taskAttemptId);
     Path path = CommitUtilsWithMR
         .getBaseMagicTaskAttemptPath(taskAttemptContext, "00001", DEST_PATH);
-    assertEquals(attemptId
-,         MagicCommitTrackerUtils.extractTaskAttemptIdFromPath(path), "TaskAttemptId didn't match");
+    assertEquals(attemptId,
+        MagicCommitTrackerUtils.extractTaskAttemptIdFromPath(path),
+        "TaskAttemptId didn't match");
 
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitTrackerUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/TestMagicCommitTrackerUtils.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.fs.s3a.commit.magic.MagicCommitTrackerUtils;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.fs.s3a.commit.AbstractCommitITest.randomJobId;
 
 /**
@@ -43,7 +43,7 @@ public final class TestMagicCommitTrackerUtils {
   private static final Path DEST_PATH = new Path("s3://dummyBucket/dummyTable");
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     jobId = randomJobId();
     attemptId = "attempt_" + jobId + "_m_000000_0";
@@ -57,8 +57,8 @@ public final class TestMagicCommitTrackerUtils {
         taskAttemptId);
     Path path = CommitUtilsWithMR
         .getBaseMagicTaskAttemptPath(taskAttemptContext, "00001", DEST_PATH);
-    assertEquals("TaskAttemptId didn't match", attemptId,
-        MagicCommitTrackerUtils.extractTaskAttemptIdFromPath(path));
+    assertEquals(attemptId
+,         MagicCommitTrackerUtils.extractTaskAttemptIdFromPath(path), "TaskAttemptId didn't match");
 
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestMagicCommitProtocol.java
@@ -170,9 +170,9 @@ public class ITestMagicCommitProtocol extends AbstractITCommitProtocol {
       final AbstractS3ACommitter committer,
       final TaskAttemptContext context) throws IOException {
     URI wd = committer.getWorkPath().toUri();
-    assertEquals("Wrong schema for working dir " + wd
-        + " with committer " + committer,
-        "s3a", wd.getScheme());
+    assertEquals("s3a", wd.getScheme(),
+        "Wrong schema for working dir " + wd
+        + " with committer " + committer);
     Assertions.assertThat(wd.getPath())
         .contains("/" + MAGIC_PATH_PREFIX + committer.getUUID() + "/");
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContext.java
@@ -16,7 +16,7 @@ package org.apache.hadoop.fs.s3a.fileContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TestFileContext;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Implementation of TestFileContext for S3a.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3AConditionalCreateBehavior.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3AConditionalCreateBehavior.java
@@ -22,8 +22,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -110,7 +110,7 @@ public class ITestS3AConditionalCreateBehavior extends AbstractS3ATestBase {
     return conf;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setup();
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import org.apache.commons.io.IOUtils;
@@ -552,7 +552,7 @@ public class ITestS3APutIfMatchAndIfNoneMatch extends AbstractS3ATestBase {
     assertS3ExceptionStatusCode(SC_412_PRECONDITION_FAILED, exception);
   }
 
-  @Ignore("conditional_write statistics not yet fully implemented")
+  @Disabled("conditional_write statistics not yet fully implemented")
   @Test
   public void testConditionalWriteStatisticsWithoutIfNoneMatch() throws Throwable {
     FileSystem fs = getFileSystem();
@@ -598,7 +598,7 @@ public class ITestS3APutIfMatchAndIfNoneMatch extends AbstractS3ATestBase {
     verifyStatisticCounterValue(statistics.getIOStatistics(), Statistic.CONDITIONAL_CREATE_FAILED.getSymbol(), 0);
   }
 
-  @Ignore("conditional_write statistics not yet fully implemented")
+  @Disabled("conditional_write statistics not yet fully implemented")
   @Test
   public void testConditionalWriteStatisticsWithIfNoneMatch() throws Throwable {
     FileSystem fs = getFileSystem();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestS3AEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestS3AEncryption.java
@@ -24,8 +24,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
@@ -43,7 +43,7 @@ public class TestS3AEncryption {
     configuration.set("fs.s3a.bucket.bucket1.encryption.context", BUCKET_CONTEXT);
     configuration.set(S3_ENCRYPTION_CONTEXT, GLOBAL_CONTEXT);
     final String result = S3AEncryption.getS3EncryptionContext("bucket1", configuration);
-    Assert.assertEquals(BUCKET_CONTEXT, result);
+    Assertions.assertEquals(BUCKET_CONTEXT, result);
   }
 
   @Test
@@ -52,14 +52,14 @@ public class TestS3AEncryption {
     configuration.set("fs.s3a.bucket.bucket1.encryption.context", BUCKET_CONTEXT);
     configuration.set(S3_ENCRYPTION_CONTEXT, GLOBAL_CONTEXT);
     final String result = S3AEncryption.getS3EncryptionContext("bucket2", configuration);
-    Assert.assertEquals(GLOBAL_CONTEXT.trim(), result);
+    Assertions.assertEquals(GLOBAL_CONTEXT.trim(), result);
   }
 
   @Test
   public void testGetS3EncryptionContextNoSet() throws IOException {
     Configuration configuration = new Configuration(false);
     final String result = S3AEncryption.getS3EncryptionContext("bucket1", configuration);
-    Assert.assertEquals("", result);
+    Assertions.assertEquals("", result);
   }
 
   @Test
@@ -71,7 +71,7 @@ public class TestS3AEncryption {
     final String decoded = new String(Base64.decodeBase64(result), StandardCharsets.UTF_8);
     final TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
     final Map<String, String> resultMap = new ObjectMapper().readValue(decoded, typeRef);
-    Assert.assertEquals("hadoop", resultMap.get("project"));
-    Assert.assertEquals("HADOOP-19197", resultMap.get("jira"));
+    Assertions.assertEquals("hadoop", resultMap.get("project"));
+    Assertions.assertEquals("HADOOP-19197", resultMap.get("jira"));
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardToolTestHelper.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/S3GuardToolTestHelper.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.util.ExitCodeProvider;
 import org.apache.hadoop.util.ExitUtil;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Helper class for tests which make CLI invocations of the S3Guard tools.
@@ -128,7 +128,7 @@ public final class S3GuardToolTestHelper {
     if (expectedResult != r) {
       String message = errorText.isEmpty() ? "" : (errorText + ": ")
           + "Command " + cmd + " failed\n" + buf;
-      assertEquals(message, expectedResult, r);
+      assertEquals(expectedResult, r, message);
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3GuardCLI.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/s3guard/TestS3GuardCLI.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.fs.s3a.s3guard;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -30,7 +30,7 @@ import static org.apache.hadoop.fs.s3a.s3guard.S3GuardTool.*;
 /**
  * Test the S3Guard CLI entry point.
  */
-public class TestS3GuardCLI extends Assert {
+public class TestS3GuardCLI extends Assertions {
 
   /**
    * Run a S3GuardTool command from a varags list.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/ExtraAssertions.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +36,7 @@ import org.apache.hadoop.fs.s3a.AWSServiceIOException;
 import org.apache.hadoop.util.DurationInfo;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.applyLocatedFiles;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Some extra assertions for tests.
@@ -73,7 +72,7 @@ public final class ExtraAssertions {
     long actual = files.size();
     if (actual != expected) {
       String ls = files.stream().collect(Collectors.joining("\n"));
-      Assert.fail(message + ": expected " + expected + " files in " + path
+      Assertions.fail(message + ": expected " + expected + " files in " + path
           + " but got " + actual + "\n" + ls);
     }
   }
@@ -84,8 +83,8 @@ public final class ExtraAssertions {
    * @param contained text to look for.
    */
   public static void assertTextContains(String text, String contained) {
-    assertTrue("string \"" + contained + "\" not found in \"" + text + "\"",
-        text != null && text.contains(contained));
+    assertTrue(text != null && text.contains(contained),
+        "string \"" + contained + "\" not found in \"" + text + "\"");
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19424. [S3A] Upgrade JUnit from 4 to 5 in hadoop-aws.

### How was this patch tested?

mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

