### PR TITLE
HDFS-17800 Prevent observer node from returning partial block data for erasure coded files

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2252,11 +2252,20 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
             dir, pc, srcArg, offset, length, true);
         inode = res.getIIp().getLastINode();
         if (isInSafeMode()) {
+          int minBlocks = 1;
+
+          ErasureCodingPolicy ecPolicy = res.blocks.getErasureCodingPolicy();
           for (LocatedBlock b : res.blocks.getLocatedBlocks()) {
+            if (ecPolicy != null) {
+              // If the file is erasure coded, we need at least the number of data units of
+              // blocks available, unless the file is smaller than a full stripe of cells.
+              long numCells = (b.getBlockSize() - 1) / (long)ecPolicy.getCellSize() + 1;
+              minBlocks = (int)Math.min((long)ecPolicy.getNumDataUnits(), numCells);
+            }
             // if safemode & no block locations yet then throw safemodeException
-            if ((b.getLocations() == null) || (b.getLocations().length == 0)) {
+            if ((b.getLocations() == null) || (b.getLocations().length < minBlocks)) {
               SafeModeException se = newSafemodeException(
-                  "Zero blocklocations for " + srcArg);
+                  "Not enough blocklocations for " + srcArg);
               if (haEnabled && haContext != null &&
                   (haContext.getState().getServiceState() == ACTIVE ||
                       haContext.getState().getServiceState() == OBSERVER)) {
@@ -9267,9 +9276,18 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     }
     List<LocatedBlock> locatedBlockList = blocks.getLocatedBlocks();
     if (locatedBlockList != null) {
+      int minBlocks = 1;
+
+      ErasureCodingPolicy ecPolicy = blocks.getErasureCodingPolicy();
       for (LocatedBlock b : locatedBlockList) {
-        if (b.getLocations() == null || b.getLocations().length == 0) {
-          throw new ObserverRetryOnActiveException("Zero blocklocations for " + src);
+        if (ecPolicy != null) {
+          // If the file is erasure coded, we need at least the number of data units of
+          // blocks available, unless the file is smaller than a full stripe of cells.
+          long numCells = (b.getBlockSize() - 1) / (long)ecPolicy.getCellSize() + 1;
+          minBlocks = (int)Math.min((long)ecPolicy.getNumDataUnits(), numCells);
+        }
+        if (b.getLocations() == null || b.getLocations().length < minBlocks) {
+          throw new ObserverRetryOnActiveException("Not enough blocklocations for " + src);
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -9258,7 +9258,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       return false;
     }
 
-    if (ecPolicy != null) {
+    if (block.isStriped()) {
       LocatedStripedBlock stripedBlock = (LocatedStripedBlock) block;
       // For erasure coded files, require enough data units to reconstruct
       // the block, bounded by the number of cells in the block.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -3533,9 +3533,13 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       logAuditEvent(false, operationName, src);
       throw e;
     }
-    if (needLocation && isObserver() && stat instanceof HdfsLocatedFileStatus) {
+    if (needLocation && stat instanceof HdfsLocatedFileStatus) {
       LocatedBlocks lbs = ((HdfsLocatedFileStatus) stat).getLocatedBlocks();
-      checkBlockLocationsWhenObserver(lbs, src);
+      if (isInSafeMode()) {
+        checkBlockLocationsInSafeMode(lbs, src);
+      } else if (isObserver()) {
+        checkBlockLocationsWhenObserver(lbs, src);
+      }
     }
     logAuditEvent(true, operationName, src);
     return stat;
@@ -4265,11 +4269,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       logAuditEvent(false, operationName, src);
       throw e;
     }
-    if (dl != null && needLocation && isObserver()) {
+    if (dl != null && needLocation) {
       for (HdfsFileStatus fs : dl.getPartialListing()) {
         if (fs instanceof HdfsLocatedFileStatus) {
           LocatedBlocks lbs = ((HdfsLocatedFileStatus) fs).getLocatedBlocks();
-          checkBlockLocationsWhenObserver(lbs, fs.toString());
+          if (isInSafeMode()) {
+            checkBlockLocationsInSafeMode(lbs, fs.toString());
+          } else if (isObserver()) {
+            checkBlockLocationsWhenObserver(lbs, fs.toString());
+          }
         }
       }
     }
@@ -9251,7 +9259,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return haEnabled && haContext != null && haContext.getState().getServiceState() == OBSERVER;
   }
 
-  private boolean hasSufficientReplicas(LocatedBlock block,
+  private boolean hasSufficientBlockLocations(LocatedBlock block,
       ErasureCodingPolicy ecPolicy) {
     DatanodeInfo[] locations = block.getLocations();
     if (locations == null) {
@@ -9262,20 +9270,19 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       LocatedStripedBlock stripedBlock = (LocatedStripedBlock) block;
       // For erasure coded files, require enough data units to reconstruct
       // the block, bounded by the number of cells in the block.
-      long numCells =
-          (block.getBlockSize() - 1) / (long) ecPolicy.getCellSize() + 1;
-      int minBlocks = (int) Math.min((long) ecPolicy.getNumDataUnits(), numCells);
+      long numCells = (block.getBlockSize() - 1) / ecPolicy.getCellSize() + 1;
+      int minRequiredIndices = (int) Math.min(ecPolicy.getNumDataUnits(), numCells);
 
       // Units can be over-replicated, so need to account for unique indices
-      byte[] indices = stripedBlock.getBlockIndices();
-      boolean[] seen = new boolean[ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits()];
+      byte[] blockIndices = stripedBlock.getBlockIndices();
+      boolean[] seenIndices = new boolean[ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits()];
 
-      int count = 0;
-      for (byte idx : indices) {
-        int i = idx & 0xFF;
-        if (!seen[i]) {
-          seen[i] = true;
-          if (++count >= minBlocks) {
+      int uniqueIndexCount = 0;
+      for (byte idx : blockIndices) {
+        int index = idx & 0xFF;
+        if (!seenIndices[index]) {
+          seenIndices[index] = true;
+          if (++uniqueIndexCount >= minRequiredIndices) {
             return true;
           }
         }
@@ -9295,7 +9302,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     if (locatedBlockList != null) {
       ErasureCodingPolicy ecPolicy = blocks.getErasureCodingPolicy();
       for (LocatedBlock block : locatedBlockList) {
-        if (!hasSufficientReplicas(block, ecPolicy)) {
+        if (!hasSufficientBlockLocations(block, ecPolicy)) {
           SafeModeException se = newSafemodeException(
               "Not enough blocklocations for " + src);
           if (haEnabled && haContext != null &&
@@ -9318,7 +9325,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     if (locatedBlockList != null) {
       ErasureCodingPolicy ecPolicy = blocks.getErasureCodingPolicy();
       for (LocatedBlock block : locatedBlockList) {
-        if (!hasSufficientReplicas(block, ecPolicy)) {
+        if (!hasSufficientBlockLocations(block, ecPolicy)) {
           throw new ObserverRetryOnActiveException("Not enough blocklocations for " + src);
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -9258,15 +9258,32 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       return false;
     }
 
-    int minBlocks = 1;
     if (ecPolicy != null) {
+      LocatedStripedBlock stripedBlock = (LocatedStripedBlock) block;
       // For erasure coded files, require enough data units to reconstruct
       // the block, bounded by the number of cells in the block.
       long numCells =
           (block.getBlockSize() - 1) / (long) ecPolicy.getCellSize() + 1;
-      minBlocks = (int) Math.min((long) ecPolicy.getNumDataUnits(), numCells);
+      int minBlocks = (int) Math.min((long) ecPolicy.getNumDataUnits(), numCells);
+
+      // Units can be over-replicated, so need to account for unique indices
+      byte[] indices = stripedBlock.getBlockIndices();
+      boolean[] seen = new boolean[ecPolicy.getNumDataUnits() + ecPolicy.getNumParityUnits()];
+
+      int count = 0;
+      for (byte idx : indices) {
+        int i = idx & 0xFF;
+        if (!seen[i]) {
+          seen[i] = true;
+          if (++count >= minBlocks) {
+            return true;
+          }
+        }
+      }
+      return false;
+    } else {
+      return locations.length > 0;
     }
-    return locations.length >= minBlocks;
   }
 
   private void checkBlockLocationsInSafeMode(LocatedBlocks blocks, String src)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2252,29 +2252,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
             dir, pc, srcArg, offset, length, true);
         inode = res.getIIp().getLastINode();
         if (isInSafeMode()) {
-          int minBlocks = 1;
-
-          ErasureCodingPolicy ecPolicy = res.blocks.getErasureCodingPolicy();
-          for (LocatedBlock b : res.blocks.getLocatedBlocks()) {
-            if (ecPolicy != null) {
-              // If the file is erasure coded, we need at least the number of data units of
-              // blocks available, unless the file is smaller than a full stripe of cells.
-              long numCells = (b.getBlockSize() - 1) / (long)ecPolicy.getCellSize() + 1;
-              minBlocks = (int)Math.min((long)ecPolicy.getNumDataUnits(), numCells);
-            }
-            // if safemode & no block locations yet then throw safemodeException
-            if ((b.getLocations() == null) || (b.getLocations().length < minBlocks)) {
-              SafeModeException se = newSafemodeException(
-                  "Not enough blocklocations for " + srcArg);
-              if (haEnabled && haContext != null &&
-                  (haContext.getState().getServiceState() == ACTIVE ||
-                      haContext.getState().getServiceState() == OBSERVER)) {
-                throw new RetriableException(se);
-              } else {
-                throw se;
-              }
-            }
-          }
+          checkBlockLocationsInSafeMode(res.blocks, srcArg);
         } else if (isObserver()) {
           checkBlockLocationsWhenObserver(res.blocks, srcArg);
         }
@@ -4366,11 +4344,15 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
           if (dirListing == null) {
             throw new FileNotFoundException("Path " + src + " does not exist");
           }
-          if (needLocation && isObserver()) {
+          if (needLocation) {
             for (HdfsFileStatus fs : dirListing.getPartialListing()) {
               if (fs instanceof HdfsLocatedFileStatus) {
                 LocatedBlocks lbs = ((HdfsLocatedFileStatus) fs).getLocatedBlocks();
-                checkBlockLocationsWhenObserver(lbs, fs.toString());
+                if (isInSafeMode()) {
+                  checkBlockLocationsInSafeMode(lbs, fs.toString());
+                } else if (isObserver()) {
+                  checkBlockLocationsWhenObserver(lbs, fs.toString());
+                }
               }
             }
           }
@@ -9269,6 +9251,47 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     return haEnabled && haContext != null && haContext.getState().getServiceState() == OBSERVER;
   }
 
+  private boolean hasSufficientReplicas(LocatedBlock block,
+      ErasureCodingPolicy ecPolicy) {
+    DatanodeInfo[] locations = block.getLocations();
+    if (locations == null) {
+      return false;
+    }
+
+    int minBlocks = 1;
+    if (ecPolicy != null) {
+      // For erasure coded files, require enough data units to reconstruct
+      // the block, bounded by the number of cells in the block.
+      long numCells =
+          (block.getBlockSize() - 1) / (long) ecPolicy.getCellSize() + 1;
+      minBlocks = (int) Math.min((long) ecPolicy.getNumDataUnits(), numCells);
+    }
+    return locations.length >= minBlocks;
+  }
+
+  private void checkBlockLocationsInSafeMode(LocatedBlocks blocks, String src)
+      throws SafeModeException, RetriableException {
+    if (blocks == null) {
+      return;
+    }
+    List<LocatedBlock> locatedBlockList = blocks.getLocatedBlocks();
+    if (locatedBlockList != null) {
+      ErasureCodingPolicy ecPolicy = blocks.getErasureCodingPolicy();
+      for (LocatedBlock block : locatedBlockList) {
+        if (!hasSufficientReplicas(block, ecPolicy)) {
+          SafeModeException se = newSafemodeException(
+              "Not enough blocklocations for " + src);
+          if (haEnabled && haContext != null &&
+              (haContext.getState().getServiceState() == ACTIVE ||
+                  haContext.getState().getServiceState() == OBSERVER)) {
+            throw new RetriableException(se);
+          }
+          throw se;
+        }
+      }
+    }
+  }
+
   private void checkBlockLocationsWhenObserver(LocatedBlocks blocks, String src)
       throws ObserverRetryOnActiveException {
     if (blocks == null) {
@@ -9276,17 +9299,9 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     }
     List<LocatedBlock> locatedBlockList = blocks.getLocatedBlocks();
     if (locatedBlockList != null) {
-      int minBlocks = 1;
-
       ErasureCodingPolicy ecPolicy = blocks.getErasureCodingPolicy();
-      for (LocatedBlock b : locatedBlockList) {
-        if (ecPolicy != null) {
-          // If the file is erasure coded, we need at least the number of data units of
-          // blocks available, unless the file is smaller than a full stripe of cells.
-          long numCells = (b.getBlockSize() - 1) / (long)ecPolicy.getCellSize() + 1;
-          minBlocks = (int)Math.min((long)ecPolicy.getNumDataUnits(), numCells);
-        }
-        if (b.getLocations() == null || b.getLocations().length < minBlocks) {
+      for (LocatedBlock block : locatedBlockList) {
+        if (!hasSufficientReplicas(block, ecPolicy)) {
           throw new ObserverRetryOnActiveException("Not enough blocklocations for " + src);
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
@@ -69,6 +70,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapterMockitoUtil;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer;
 import org.apache.hadoop.hdfs.server.namenode.TestFsck;
 import org.apache.hadoop.hdfs.tools.GetGroups;
+import org.apache.hadoop.io.erasurecode.ECSchema;
 import org.apache.hadoop.ipc.ObserverRetryOnActiveException;
 import org.apache.hadoop.ipc.metrics.RpcMetrics;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -439,6 +441,43 @@ public class TestObserverNode {
     dfs.open(testPath).close();
     assertSentTo(0);
 
+    // Test erasure coded files
+    ErasureCodingPolicy ecPolicy = new ErasureCodingPolicy(new ECSchema("rs", 3, 2), 1024);
+
+    // Fake a small file that only needs 1 block
+    doAnswer((invocation) -> {
+      List<LocatedBlock> fakeBlocks = new ArrayList<>();
+      // Return a single location, which is enough for the small file but not for the large file
+      ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1, 0));
+      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
+      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      fakeBlocks.add(fakeBlock);
+      return new LocatedBlocks(1, false, fakeBlocks, null, true, null, ecPolicy);
+    }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
+        anyBoolean(), anyLong(), anyLong(), anyBoolean(), anyBoolean(),
+        Mockito.any(), Mockito.any());
+
+    // Small file should suceed with just the one block
+    dfs.open(testPath).close();
+    assertSentTo(2);
+
+    // Fake a larger file that needs all 3 data shards
+    doAnswer((invocation) -> {
+      List<LocatedBlock> fakeBlocks = new ArrayList<>();
+      // Return a single location, which is enough for the small file but not for the large file
+      ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1024 * 3, 0));
+      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
+      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      fakeBlocks.add(fakeBlock);
+      return new LocatedBlocks(1024 * 3, false, fakeBlocks, null, true, null, ecPolicy);
+    }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
+        anyBoolean(), anyLong(), anyLong(), anyBoolean(), anyBoolean(),
+        Mockito.any(), Mockito.any());
+
+    // Large file should failover to the active
+    dfs.open(testPath).close();
+    assertSentTo(0);
+
     Mockito.reset(bmSpy);
 
     // Remove safe mode on observer, request should still go to it.
@@ -473,7 +512,62 @@ public class TestObserverNode {
         anyBoolean(), anyLong(), anyLong(), anyBoolean(), anyBoolean(),
         Mockito.any(), Mockito.any());
 
-    dfs.open(testPath);
+    dfs.open(testPath).close();
+    assertSentTo(0);
+
+    dfs.getClient().listPaths("/", new byte[0], true);
+    assertSentTo(0);
+
+    dfs.getClient().getLocatedFileInfo(testPath.toString(), false);
+    assertSentTo(0);
+
+    dfs.getClient().batchedListPaths(new String[]{"/"}, new byte[0], true);
+    assertSentTo(0);
+
+    // Test erasure coded files
+    ErasureCodingPolicy ecPolicy = new ErasureCodingPolicy(new ECSchema("rs", 3, 2), 1024);
+
+    // Fake a small file that only needs 1 block
+    doAnswer((invocation) -> {
+      List<LocatedBlock> fakeBlocks = new ArrayList<>();
+      // Return a single location, which is enough for the small file but not for the large file
+      ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1, 0));
+      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
+      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      fakeBlocks.add(fakeBlock);
+      return new LocatedBlocks(1, false, fakeBlocks, null, true, null, ecPolicy);
+    }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
+        anyBoolean(), anyLong(), anyLong(), anyBoolean(), anyBoolean(),
+        Mockito.any(), Mockito.any());
+
+    // The small file should succeed on the observer, while the large file should not
+
+    dfs.open(testPath).close();
+    assertSentTo(2);
+
+    dfs.getClient().listPaths("/", new byte[0], true);
+    assertSentTo(2);
+
+    dfs.getClient().getLocatedFileInfo(testPath.toString(), false);
+    assertSentTo(2);
+
+    dfs.getClient().batchedListPaths(new String[]{"/"}, new byte[0], true);
+    assertSentTo(2);
+
+    // Fake a larger file that needs all 3 data shards
+    doAnswer((invocation) -> {
+      List<LocatedBlock> fakeBlocks = new ArrayList<>();
+      // Return a single location, which is enough for the small file but not for the large file
+      ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1024 * 3, 0));
+      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
+      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      fakeBlocks.add(fakeBlock);
+      return new LocatedBlocks(1024 * 3, false, fakeBlocks, null, true, null, ecPolicy);
+    }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
+        anyBoolean(), anyLong(), anyLong(), anyBoolean(), anyBoolean(),
+        Mockito.any(), Mockito.any());
+
+    dfs.open(testPath).close();
     assertSentTo(0);
 
     dfs.getClient().listPaths("/", new byte[0], true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -449,6 +449,12 @@ public class TestObserverNode {
     dfs.open(testPath).close();
     assertSentTo(0);
 
+    dfs.getClient().listPaths("/", new byte[0], true);
+    assertSentTo(0);
+
+    dfs.getClient().getLocatedFileInfo(testPath.toString(), false);
+    assertSentTo(0);
+
     // Test erasure coded files
     ErasureCodingPolicy ecPolicy = new ErasureCodingPolicy(new ECSchema("rs", 3, 2), 1024);
 
@@ -469,6 +475,12 @@ public class TestObserverNode {
     dfs.open(testPath).close();
     assertSentTo(2);
 
+    dfs.getClient().listPaths("/", new byte[0], true);
+    assertSentTo(2);
+
+    dfs.getClient().getLocatedFileInfo(testPath.toString(), false);
+    assertSentTo(2);
+
     // Fake a larger file that needs all 3 data shards
     doAnswer((invocation) -> {
       List<LocatedBlock> fakeBlocks = new ArrayList<>();
@@ -484,6 +496,12 @@ public class TestObserverNode {
 
     // Large file should failover to the active
     dfs.open(testPath).close();
+    assertSentTo(0);
+
+    dfs.getClient().listPaths("/", new byte[0], true);
+    assertSentTo(0);
+
+    dfs.getClient().getLocatedFileInfo(testPath.toString(), false);
     assertSentTo(0);
 
     Mockito.reset(bmSpy);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,11 +58,13 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.protocol.LocatedStripedBlock;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLog;
@@ -423,6 +426,11 @@ public class TestObserverNode {
     // Set observer to safe mode.
     dfsCluster.getFileSystem(2).setSafeMode(SafeModeAction.ENTER);
 
+    DatanodeInfo fakeDatanodeInfo = new DatanodeInfo.DatanodeInfoBuilder()
+      // Stiped blocks need a UUID to be hashed
+      .setNodeID(new DatanodeID(UUID.randomUUID().toString(), DatanodeID.EMPTY_DATANODE_ID))
+      .build();
+
     // Mock block manager for observer to generate some fake blocks which
     // will trigger the (retriable) safe mode exception.
     BlockManager bmSpy =
@@ -449,8 +457,8 @@ public class TestObserverNode {
       List<LocatedBlock> fakeBlocks = new ArrayList<>();
       // Return a single location, which is enough for the small file but not for the large file
       ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1, 0));
-      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
-      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      LocatedStripedBlock fakeBlock = new LocatedStripedBlock(b, new DatanodeInfo[] {fakeDatanodeInfo},
+        null, null, new byte[] {0}, 0, false, null);
       fakeBlocks.add(fakeBlock);
       return new LocatedBlocks(1, false, fakeBlocks, null, true, null, ecPolicy);
     }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
@@ -466,8 +474,8 @@ public class TestObserverNode {
       List<LocatedBlock> fakeBlocks = new ArrayList<>();
       // Return a single location, which is enough for the small file but not for the large file
       ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1024 * 3, 0));
-      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
-      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      LocatedStripedBlock fakeBlock = new LocatedStripedBlock(b, new DatanodeInfo[] {fakeDatanodeInfo},
+        null, null, new byte[] {0}, 0, false, null);
       fakeBlocks.add(fakeBlock);
       return new LocatedBlocks(1024 * 3, false, fakeBlocks, null, true, null, ecPolicy);
     }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
@@ -494,6 +502,11 @@ public class TestObserverNode {
     assertSentTo(0);
 
     dfsCluster.rollEditLogAndTail(0);
+
+    DatanodeInfo fakeDatanodeInfo = new DatanodeInfo.DatanodeInfoBuilder()
+      // Stiped blocks need a UUID to be hashed
+      .setNodeID(new DatanodeID(UUID.randomUUID().toString(), DatanodeID.EMPTY_DATANODE_ID))
+      .build();
 
     // Mock block manager for observer to generate some fake blocks which
     // will trigger the block missing exception.
@@ -532,8 +545,8 @@ public class TestObserverNode {
       List<LocatedBlock> fakeBlocks = new ArrayList<>();
       // Return a single location, which is enough for the small file but not for the large file
       ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1, 0));
-      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
-      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      LocatedStripedBlock fakeBlock = new LocatedStripedBlock(b, new DatanodeInfo[] {fakeDatanodeInfo},
+        null, null, new byte[] {0}, 0, false, null);
       fakeBlocks.add(fakeBlock);
       return new LocatedBlocks(1, false, fakeBlocks, null, true, null, ecPolicy);
     }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),
@@ -559,8 +572,8 @@ public class TestObserverNode {
       List<LocatedBlock> fakeBlocks = new ArrayList<>();
       // Return a single location, which is enough for the small file but not for the large file
       ExtendedBlock b = new ExtendedBlock("fake-pool", new Block(12345L, 1024 * 3, 0));
-      DatanodeInfo datanodeInfo = new DatanodeInfo.DatanodeInfoBuilder().build();
-      LocatedBlock fakeBlock = new LocatedBlock(b, new DatanodeInfo[] {datanodeInfo});
+      LocatedStripedBlock fakeBlock = new LocatedStripedBlock(b, new DatanodeInfo[] {fakeDatanodeInfo},
+        null, null, new byte[] {0}, 0, false, null);
       fakeBlocks.add(fakeBlock);
       return new LocatedBlocks(1024 * 3, false, fakeBlocks, null, true, null, ecPolicy);
     }).when(bmSpy).createLocatedBlocks(Mockito.any(), anyLong(),


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HDFS-17800](https://issues.apache.org/jira/browse/HDFS-17800)

Follow up to [HDFS-13924](https://issues.apache.org/jira/browse/HDFS-13924), [HDFS-16732](https://issues.apache.org/jira/browse/HDFS-16732), and [HDFS-17768](https://issues.apache.org/jira/browse/HDFS-17768), factor in erasure coding policy when determining if observer or safe mode nodes have enough blocks to successfully serve a request, as a single block may not be sufficient for an erasure coded block.

### How was this patch tested?
Updated existing UTs to factor in erasure coding policy.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

