### PR TITLE
YARN-11829. Make test directory unique to avoid locking after test cleanup

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigConverterTestCommons.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigConverterTestCommons.java
@@ -58,9 +58,32 @@ public class FSConfigConverterTestCommons {
 
   public void setUp() throws IOException {
     File d = new File(TEST_DIR, "conversion-output");
+
     if (d.exists()) {
-      FileUtils.deleteDirectory(d);
+      // Retry mechanism to ensure file handles are released
+      int maxRetries = 3;
+      int attempts = 0;
+      boolean deleted = false;
+
+      while (attempts < maxRetries && !deleted) {
+        try {
+          FileUtils.deleteDirectory(d);
+          deleted = true;
+        } catch (IOException e) {
+          attempts++;
+          System.gc(); // Hint JVM to run GC to close any unreferenced file streams
+          try {
+            Thread.sleep(100); // Wait a bit before retrying
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+          }
+          if (attempts == maxRetries) {
+            throw new IOException("Failed to delete directory after retries: " + d.getAbsolutePath(), e);
+          }
+        }
+      }
     }
+
     boolean success = d.mkdirs();
     assertTrue(success, "Can't create directory: " + d.getAbsolutePath());
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigConverterTestCommons.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fair/converter/FSConfigConverterTestCommons.java
@@ -27,6 +27,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,8 +44,7 @@ public class FSConfigConverterTestCommons {
       new File(TEST_DIR, "test-yarn-site.xml").getAbsolutePath();
   public final static String CONVERSION_RULES_FILE =
       new File(TEST_DIR, "test-conversion-rules.properties").getAbsolutePath();
-  public final static String OUTPUT_DIR =
-      new File(TEST_DIR, "conversion-output").getAbsolutePath();
+  public static String OUTPUT_DIR;
 
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
@@ -57,33 +57,14 @@ public class FSConfigConverterTestCommons {
   }
 
   public void setUp() throws IOException {
-    File d = new File(TEST_DIR, "conversion-output");
+    String uuid = UUID.randomUUID().toString().trim();
+    OUTPUT_DIR =
+            new File(TEST_DIR, "conversion-output" + uuid).getAbsolutePath();
+    File d = new File(TEST_DIR, "conversion-output" + uuid);
 
     if (d.exists()) {
-      // Retry mechanism to ensure file handles are released
-      int maxRetries = 3;
-      int attempts = 0;
-      boolean deleted = false;
-
-      while (attempts < maxRetries && !deleted) {
-        try {
-          FileUtils.deleteDirectory(d);
-          deleted = true;
-        } catch (IOException e) {
-          attempts++;
-          System.gc(); // Hint JVM to run GC to close any unreferenced file streams
-          try {
-            Thread.sleep(100); // Wait a bit before retrying
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-          }
-          if (attempts == maxRetries) {
-            throw new IOException("Failed to delete directory after retries: " + d.getAbsolutePath(), e);
-          }
-        }
-      }
+      FileUtils.deleteDirectory(d);
     }
-
     boolean success = d.mkdirs();
     assertTrue(success, "Can't create directory: " + d.getAbsolutePath());
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
UTs in yarn-resourcemanager is failing with below error: 

```
Caused by: org.apache.commons.io.IOIndexedException: IOException #0: Cannot delete file: C:\hadoop\hadoop-yarn-project\hadoop-yarn\hadoop-yarn-server\hadoop-yarn-server-resourcemanager\target\test-dir\conversion-output\capacity-scheduler.xml
    at org.apache.commons.io.function.IOStream.lambda$forAll$11(IOStream.java:354)
    at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
    at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
    at org.apache.commons.io.function.IOStream.forAll(IOStream.java:345)
    ... 79 more
Caused by: java.io.IOException: Cannot delete file: C:\hadoop\hadoop-yarn-project\hadoop-yarn\hadoop-yarn-server\hadoop-yarn-server-resourcemanager\target\test-dir\conversion-output\capacity-scheduler.xml
    at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1390)
    at org.apache.commons.io.function.IOStream.lambda$forAll$11(IOStream.java:347)
    ... 82 more
Caused by: java.nio.file.FileSystemException: C:\hadoop\hadoop-yarn-project\hadoop-yarn\hadoop-yarn-server\hadoop-yarn-server-resourcemanager\target\test-dir\conversion-output\capacity-scheduler.xml: The process cannot access the file because it is being used by another process.
```

The above error shows up when all the UTs for class `TestFSConfigToCSConfigConverter` runs together as we are using same folder structure which is being created/deleted after every test case.
The issue happens when the file handlers are not closed properly resulting in unsuccessful deletion of test directory.

### How was this patch tested?
The patch was tested by running UTs in local.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

