### PR TITLE
YARN-11830. Normalise path to fix file uri in windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
@@ -258,7 +258,14 @@ public class Path
   private void initialize(String scheme, String authority, String path,
       String fragment) {
     try {
-      this.uri = new URI(scheme, authority, normalizePath(scheme, path), null, fragment)
+      // Normalize the path
+      String normalizedPath = normalizePath(scheme, path);
+
+      // Windows-specific fix: file URIs must start with "/"
+      if ("file".equalsIgnoreCase(scheme) && normalizedPath.matches("^[A-Za-z]:.*")) {
+        normalizedPath = "/" + normalizedPath.replace("\\", "/");
+      }
+      this.uri = new URI(scheme, authority, normalizedPath, null, fragment)
         .normalize();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
UTs in yarn-resourcemanager is failing with below error

```
[ERROR] Tests run: 19, Failures: 0, Errors: 19, Skipped: 0, Time elapsed: 2.262 s <<< FAILURE! - in org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.TestFSQueueConverter
[ERROR] org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.converter.TestFSQueueConverter.testQueueMaxAMShare  Time elapsed: 1.65 s  <<< ERROR!
java.lang.IllegalArgumentException: java.net.URISyntaxException: Relative path in absolute URI: [file:C:/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/fair-scheduler-conversion.xml](file:///C:/hadoop/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/resources/fair-scheduler-conversion.xml)
    at org.apache.hadoop.fs.Path.initialize(Path.java:264)
    at org.apache.hadoop.fs.Path.<init>(Path.java:222)
```

The URISyntaxException shows up in windows as file uri is different from linux system.

### How was this patch tested?
The fix was tested by running UTs locally.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

