### PR TITLE
YARN-11831 Remove bash parent process of containers

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -1308,7 +1308,7 @@ public class ContainerLaunch implements Callable<Integer> {
 
     @Override
     public void command(List<String> command) {
-      line("exec /bin/bash -c \"", StringUtils.join(" ", command), "\"");
+      line("exec /bin/bash -c \"exec ", StringUtils.join(" ", command), "\"");
     }
 
     @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -46,6 +46,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
@@ -1475,6 +1476,76 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
   @Timeout(value = 30)
   public void testImmediateKill() throws Exception {
     internalKillTest(false);
+  }
+
+  @Test
+  @Timeout(value = 30)
+  public void testNoBashParentProcess() throws Exception {
+    assumeNotWindows();
+    containerManager.start();
+
+    // Construct the Container-id
+    ApplicationId appId = ApplicationId.newInstance(1, 1);
+    ApplicationAttemptId appAttemptId =
+        ApplicationAttemptId.newInstance(appId, 1);
+    ContainerId cId = ContainerId.newContainerId(appAttemptId, 0);
+
+    ContainerLaunchContext containerLaunchContext =
+        recordFactory.newRecordInstance(ContainerLaunchContext.class);
+
+    // set up the rest of the container
+    List<String> commands = Arrays.asList(new String[] {"sleep 30 1>/dev/null 2>/dev/null"});
+    containerLaunchContext.setCommands(commands);
+    Priority priority = Priority.newInstance(10);
+    long createTime = 1234;
+    Token containerToken = createContainerToken(cId, priority, createTime);
+
+    StartContainerRequest scRequest =
+        StartContainerRequest.newInstance(containerLaunchContext,
+          containerToken);
+    List<StartContainerRequest> list = new ArrayList<StartContainerRequest>();
+    list.add(scRequest);
+    StartContainersRequest allRequests =
+        StartContainersRequest.newInstance(list);
+    containerManager.startContainers(allRequests);
+
+    NMContainerStatus nmContainerStatus =
+        containerManager.getContext().getContainers().get(cId)
+          .getNMContainerStatus();
+    assertEquals(priority, nmContainerStatus.getPriority());
+
+    int timeoutSecs = 0;
+    String pid = containerManager.getContext().getContainerExecutor().getProcessId(cId);
+    while (pid == null && timeoutSecs++ < 20) {
+      Thread.sleep(1000);
+      pid = containerManager.getContext().getContainerExecutor().getProcessId(cId);
+      LOG.info("Waiting for process start-file to be created");
+    }
+    assertNotNull(pid);
+
+    Process proc = Runtime.getRuntime().exec(new String[] {"ps", "-o", "command=", pid});
+    assertEquals(proc.waitFor(), 0);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+
+    assertEquals(reader.readLine(), "sleep 30");
+
+    List<ContainerId> containerIds = new ArrayList<ContainerId>();
+    containerIds.add(cId);
+    StopContainersRequest stopRequest =
+        StopContainersRequest.newInstance(containerIds);
+    containerManager.stopContainers(stopRequest);
+
+    BaseContainerManagerTest.waitForContainerState(containerManager, cId,
+        ContainerState.COMPLETE);
+
+    GetContainerStatusesRequest gcsRequest =
+        GetContainerStatusesRequest.newInstance(containerIds);
+
+    ContainerStatus containerStatus =
+        containerManager.getContainerStatuses(gcsRequest)
+          .getContainerStatuses().get(0);
+    assertEquals(ContainerExitStatus.KILLED_BY_APPMASTER,
+        containerStatus.getExitStatus());
   }
 
   @SuppressWarnings("rawtypes")


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
YARN-11831

When using the Docker runtime, signals sent by `docker kill` do not get forwarded to applications because the parent `bash -c` process that runs swallows all signals and doesn't forward them. Non-docker runtimes don't have this issue because signals are sent to the process group, not just the parent process, so all child processes receive the signal even if the parent process doesn't forward it.

The launch_container.sh script is already running in bash, so I don't think there is a need for another bash process.

### How was this patch tested?
UT showing that there is no bash parent process for a running container.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

