### PR TITLE
HADOOP-19329. Remove direct usage of sun.misc.Signal

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
@@ -21,10 +21,9 @@ package org.apache.hadoop.service.launcher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.util.Preconditions;
+import org.apache.hadoop.util.SignalUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -39,7 +38,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 @SuppressWarnings("UseOfSunClasses")
-public final class IrqHandler implements SignalHandler {
+public final class IrqHandler implements SignalUtil.Handler {
   private static final Logger LOG = LoggerFactory.getLogger(IrqHandler.class);
   
   /**
@@ -68,7 +67,7 @@ public final class IrqHandler implements SignalHandler {
   /**
    * Stored signal.
    */
-  private Signal signal;
+  private SignalUtil.Signal signal;
 
   /**
    * Create an IRQ handler bound to the specific interrupt.
@@ -89,8 +88,8 @@ public final class IrqHandler implements SignalHandler {
   public void bind() {
     Preconditions.checkState(signal == null, "Handler already bound");
     try {
-      signal = new Signal(name);
-      Signal.handle(signal, this);
+      signal = new SignalUtil.Signal(name);
+      SignalUtil.handle(signal, this);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           "Could not set handler for signal \"" + name + "\"."
@@ -110,7 +109,7 @@ public final class IrqHandler implements SignalHandler {
    * Raise the signal.
    */
   public void raise() {
-    Signal.raise(signal);
+    SignalUtil.raise(signal);
   }
 
   @Override
@@ -123,7 +122,7 @@ public final class IrqHandler implements SignalHandler {
    * @param s signal raised
    */
   @Override
-  public void handle(Signal s) {
+  public void handle(SignalUtil.Signal s) {
     signalCount.incrementAndGet();
     InterruptData data = new InterruptData(s.getName(), s.getNumber());
     LOG.info("Interrupted: {}", data);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/service/launcher/IrqHandler.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.classification.InterfaceStability;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-@SuppressWarnings("UseOfSunClasses")
 public final class IrqHandler implements SignalUtil.Handler {
   private static final Logger LOG = LoggerFactory.getLogger(IrqHandler.class);
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
@@ -72,7 +72,7 @@ public enum SignalLogger {
     registered = true;
     StringBuilder bld = new StringBuilder();
     bld.append("registered UNIX signal handlers for [");
-    final String[] SIGNALS = { "TERM", "HUP", "INT" };
+    final String[] SIGNALS = {"TERM", "HUP", "INT"};
     String separator = "";
     for (String signalName : SIGNALS) {
       try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalLogger.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.util;
 
 import org.slf4j.Logger;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -41,13 +39,13 @@ public enum SignalLogger {
   /**
    * Our signal handler.
    */
-  private static class Handler implements SignalHandler {
+  private static class Handler implements SignalUtil.Handler {
     final private Logger log;
-    final private SignalHandler prevHandler;
+    final private SignalUtil.Handler prevHandler;
 
     Handler(String name, Logger log) {
       this.log = log;
-      prevHandler = Signal.handle(new Signal(name), this);
+      prevHandler = SignalUtil.handle(new SignalUtil.Signal(name), this);
     }
 
     /**
@@ -56,9 +54,8 @@ public enum SignalLogger {
      * @param signal    The incoming signal
      */
     @Override
-    public void handle(Signal signal) {
-      log.error("RECEIVED SIGNAL " + signal.getNumber() +
-          ": SIG" + signal.getName());
+    public void handle(SignalUtil.Signal signal) {
+      log.error("RECEIVED SIGNAL {}: SIG{}", signal.getNumber(), signal.getName());
       prevHandler.handle(signal);
     }
   }
@@ -75,7 +72,7 @@ public enum SignalLogger {
     registered = true;
     StringBuilder bld = new StringBuilder();
     bld.append("registered UNIX signal handlers for [");
-    final String SIGNALS[] = { "TERM", "HUP", "INT" };
+    final String[] SIGNALS = { "TERM", "HUP", "INT" };
     String separator = "";
     for (String signalName : SIGNALS) {
       try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.util.dynamic.BindingUtils;
 import org.apache.hadoop.util.dynamic.DynConstructors;
 import org.apache.hadoop.util.dynamic.DynMethods;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 @InterfaceAudience.Private
@@ -128,7 +129,8 @@ public class SignalUtil {
               handler.handle(new Signal(args[0]));
               return null;
             } else {
-              return method.invoke(proxyObj, args);
+              Method delegateMethod = Handler.class.getMethod(method.getName(), method.getParameterTypes());
+              return delegateMethod.invoke(handler, args);
             }
           }
       );

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+
+import org.apache.hadoop.util.dynamic.BindingUtils;
+import org.apache.hadoop.util.dynamic.DynConstructors;
+import org.apache.hadoop.util.dynamic.DynMethods;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+@InterfaceAudience.Private
+public class SignalUtil {
+
+  static final Class<?> jdkSignalClazz =
+      BindingUtils.loadClassSafely("sun.misc.Signal");
+  static final Class<?> jdkSignalHandlerClazz =
+      BindingUtils.loadClassSafely("sun.misc.SignalHandler");
+
+  static DynConstructors.Ctor<?> jdkSignalCtor =
+      new DynConstructors.Builder()
+          .impl(jdkSignalClazz, String.class)
+          .build();
+
+  static DynMethods.StaticMethod jdkSignalHandleStaticMethod =
+      new DynMethods.Builder("handle")
+          .impl(jdkSignalClazz, jdkSignalClazz, jdkSignalHandlerClazz)
+          .buildStatic();
+
+  static DynMethods.StaticMethod jdkSignalRaiseStaticMethod =
+      new DynMethods.Builder("raise")
+          .impl(jdkSignalClazz, jdkSignalClazz)
+          .buildStatic();
+
+  static DynMethods.UnboundMethod jdkSignalHandlerHandleMethod =
+      new DynMethods.Builder("handle")
+          .impl(jdkSignalHandlerClazz, jdkSignalClazz)
+          .build();
+
+  @InterfaceAudience.Private
+  public static class Signal {
+    private final static DynMethods.UnboundMethod getNumberMethod =
+        new DynMethods.Builder("getNumber").impl(jdkSignalClazz).build();
+
+    private final static DynMethods.UnboundMethod getNameMethod =
+        new DynMethods.Builder("getName").impl(jdkSignalClazz).build();
+
+    private final Object delegate;
+
+    public Signal(String name) {
+      this.delegate = jdkSignalCtor.newInstance(name);
+    }
+
+    public Signal(Object delegate) {
+      Preconditions.checkArgument(jdkSignalClazz.isInstance(delegate),
+          String.format("Expected class is '%s', but actual class is '%s'",
+              jdkSignalClazz.getName(), delegate.getClass().getName()));
+      this.delegate = delegate;
+    }
+
+    public int getNumber() {
+      return getNumberMethod.bind(delegate).invoke();
+    }
+
+    public String getName() {
+      return getNameMethod.bind(delegate).invoke();
+    }
+
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj instanceof Signal) {
+        return delegate.equals(((Signal)obj).delegate);
+      }
+      return false;
+    }
+
+    public int hashCode() {
+      return delegate.hashCode();
+    }
+
+    public String toString() {
+      return delegate.toString();
+    }
+  }
+
+  @InterfaceAudience.Private
+  public interface Handler {
+    void handle(Signal sig);
+  }
+
+  static class JdkSignalHandlerImpl implements Handler {
+
+    private final Object delegate;
+
+    JdkSignalHandlerImpl(Handler handler) {
+      this.delegate = Proxy.newProxyInstance(
+          getClass().getClassLoader(),
+          new Class<?>[] { jdkSignalHandlerClazz },
+          (proxyObj, method, args) -> {
+            if ("handle".equals(method.getName()) && args.length == 1 && jdkSignalClazz.isInstance(args[0])) {
+              handler.handle(new Signal(args[0]));
+              return null;
+            } else {
+              return InvocationHandler.invokeDefault(proxyObj, method, args);
+            }
+          }
+      );
+    }
+
+    JdkSignalHandlerImpl(Object delegate) {
+      Preconditions.checkArgument(jdkSignalHandlerClazz.isInstance(delegate),
+          String.format("Expected class is '%s', but actual class is '%s'",
+              jdkSignalHandlerClazz.getName(), delegate.getClass().getName()));
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void handle(Signal sig) {
+      jdkSignalHandlerHandleMethod.bind(delegate).invoke(sig.delegate);
+    }
+  }
+
+  public static Handler handle(Signal sig, Handler handler) {
+    Object preHandle = jdkSignalHandleStaticMethod.invoke(
+        sig.delegate, new JdkSignalHandlerImpl(handler).delegate);
+    return new JdkSignalHandlerImpl(preHandle);
+  }
+
+  public static void raise(Signal sig) throws IllegalArgumentException {
+    jdkSignalRaiseStaticMethod.invoke(sig.delegate);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.util.dynamic.BindingUtils;
 import org.apache.hadoop.util.dynamic.DynConstructors;
 import org.apache.hadoop.util.dynamic.DynMethods;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
 @InterfaceAudience.Private
@@ -50,23 +49,28 @@ public class SignalUtil {
           .impl(jdkSignalClazz, jdkSignalClazz)
           .buildStatic();
 
-  static DynMethods.UnboundMethod jdkSignalHandlerHandleMethod =
+  static DynMethods.UnboundMethod jdkSignalHandlerHandleUnboundMethod =
       new DynMethods.Builder("handle")
           .impl(jdkSignalHandlerClazz, jdkSignalClazz)
           .build();
 
   @InterfaceAudience.Private
   public static class Signal {
-    private final static DynMethods.UnboundMethod getNumberMethod =
+    private final DynMethods.UnboundMethod getNumberUnboundMethod =
         new DynMethods.Builder("getNumber").impl(jdkSignalClazz).build();
 
-    private final static DynMethods.UnboundMethod getNameMethod =
+    private final DynMethods.UnboundMethod getNameUnboundMethod =
         new DynMethods.Builder("getName").impl(jdkSignalClazz).build();
 
     private final Object delegate;
+    private final DynMethods.BoundMethod getNumberMethod;
+    private final DynMethods.BoundMethod getNameMethod;
 
     public Signal(String name) {
+      Preconditions.checkNotNull(name);
       this.delegate = jdkSignalCtor.newInstance(name);
+      this.getNumberMethod = getNumberUnboundMethod.bind(delegate);
+      this.getNameMethod = getNameUnboundMethod.bind(delegate);
     }
 
     public Signal(Object delegate) {
@@ -74,14 +78,16 @@ public class SignalUtil {
           String.format("Expected class is '%s', but actual class is '%s'",
               jdkSignalClazz.getName(), delegate.getClass().getName()));
       this.delegate = delegate;
+      this.getNumberMethod = getNumberUnboundMethod.bind(delegate);
+      this.getNameMethod = getNameUnboundMethod.bind(delegate);
     }
 
     public int getNumber() {
-      return getNumberMethod.bind(delegate).invoke();
+      return getNumberMethod.invoke();
     }
 
     public String getName() {
-      return getNameMethod.bind(delegate).invoke();
+      return getNameMethod.invoke();
     }
 
     public boolean equals(Object obj) {
@@ -111,6 +117,7 @@ public class SignalUtil {
   static class JdkSignalHandlerImpl implements Handler {
 
     private final Object delegate;
+    private final DynMethods.BoundMethod jdkSignalHandlerHandleMethod;
 
     JdkSignalHandlerImpl(Handler handler) {
       this.delegate = Proxy.newProxyInstance(
@@ -121,10 +128,11 @@ public class SignalUtil {
               handler.handle(new Signal(args[0]));
               return null;
             } else {
-              return InvocationHandler.invokeDefault(proxyObj, method, args);
+              return method.invoke(proxyObj, args);
             }
           }
       );
+      this.jdkSignalHandlerHandleMethod = jdkSignalHandlerHandleUnboundMethod.bind(delegate);
     }
 
     JdkSignalHandlerImpl(Object delegate) {
@@ -132,11 +140,12 @@ public class SignalUtil {
           String.format("Expected class is '%s', but actual class is '%s'",
               jdkSignalHandlerClazz.getName(), delegate.getClass().getName()));
       this.delegate = delegate;
+      this.jdkSignalHandlerHandleMethod = jdkSignalHandlerHandleUnboundMethod.bind(delegate);
     }
 
     @Override
     public void handle(Signal sig) {
-      jdkSignalHandlerHandleMethod.bind(delegate).invoke(sig.delegate);
+      jdkSignalHandlerHandleMethod.invoke(sig.delegate);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -130,7 +130,7 @@ public class SignalUtil {
               handler.handle(new Signal(args[0]));
               return null;
             } else {
-              Method delegateMethod = Handler.class.getMethod(
+              Method delegateMethod = handler.getClass().getMethod(
                   method.getName(), method.getParameterTypes());
               return delegateMethod.invoke(handler, args);
             }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -30,38 +30,38 @@ import java.lang.reflect.Proxy;
 @InterfaceAudience.Private
 public class SignalUtil {
 
-  static final Class<?> jdkSignalClazz =
+  static final Class<?> JDK_SIGNAL_CLAZZ =
       BindingUtils.loadClassSafely("sun.misc.Signal");
-  static final Class<?> jdkSignalHandlerClazz =
+  static final Class<?> JDK_SIGNAL_HANDLER_CLAZZ =
       BindingUtils.loadClassSafely("sun.misc.SignalHandler");
 
-  static DynConstructors.Ctor<?> jdkSignalCtor =
+  static final DynConstructors.Ctor<?> JDK_SIGNAL_CTOR =
       new DynConstructors.Builder()
-          .impl(jdkSignalClazz, String.class)
+          .impl(JDK_SIGNAL_CLAZZ, String.class)
           .build();
 
-  static DynMethods.StaticMethod jdkSignalHandleStaticMethod =
+  static final DynMethods.StaticMethod JDK_SIGNAL_HANDLE_STATIC_METHOD =
       new DynMethods.Builder("handle")
-          .impl(jdkSignalClazz, jdkSignalClazz, jdkSignalHandlerClazz)
+          .impl(JDK_SIGNAL_CLAZZ, JDK_SIGNAL_CLAZZ, JDK_SIGNAL_HANDLER_CLAZZ)
           .buildStatic();
 
-  static DynMethods.StaticMethod jdkSignalRaiseStaticMethod =
+  static final DynMethods.StaticMethod JDK_SIGNAL_RAISE_STATIC_METHOD =
       new DynMethods.Builder("raise")
-          .impl(jdkSignalClazz, jdkSignalClazz)
+          .impl(JDK_SIGNAL_CLAZZ, JDK_SIGNAL_CLAZZ)
           .buildStatic();
 
-  static DynMethods.UnboundMethod jdkSignalHandlerHandleUnboundMethod =
+  static final DynMethods.UnboundMethod JDK_SIGNAL_HANDLER_HANDLE_UNBOUND_METHOD =
       new DynMethods.Builder("handle")
-          .impl(jdkSignalHandlerClazz, jdkSignalClazz)
+          .impl(JDK_SIGNAL_HANDLER_CLAZZ, JDK_SIGNAL_CLAZZ)
           .build();
 
   @InterfaceAudience.Private
   public static class Signal {
-    private static final DynMethods.UnboundMethod getNumberUnboundMethod =
-        new DynMethods.Builder("getNumber").impl(jdkSignalClazz).build();
+    private static final DynMethods.UnboundMethod GET_NUMBER_UNBOUND_METHOD =
+        new DynMethods.Builder("getNumber").impl(JDK_SIGNAL_CLAZZ).build();
 
-    private static final DynMethods.UnboundMethod getNameUnboundMethod =
-        new DynMethods.Builder("getName").impl(jdkSignalClazz).build();
+    private static final DynMethods.UnboundMethod GET_NAME_UNBOUND_METHOD =
+        new DynMethods.Builder("getName").impl(JDK_SIGNAL_CLAZZ).build();
 
     private final Object delegate;
     private final DynMethods.BoundMethod getNumberMethod;
@@ -69,18 +69,18 @@ public class SignalUtil {
 
     public Signal(String name) {
       Preconditions.checkNotNull(name);
-      this.delegate = jdkSignalCtor.newInstance(name);
-      this.getNumberMethod = getNumberUnboundMethod.bind(delegate);
-      this.getNameMethod = getNameUnboundMethod.bind(delegate);
+      this.delegate = JDK_SIGNAL_CTOR.newInstance(name);
+      this.getNumberMethod = GET_NUMBER_UNBOUND_METHOD.bind(delegate);
+      this.getNameMethod = GET_NAME_UNBOUND_METHOD.bind(delegate);
     }
 
     public Signal(Object delegate) {
-      Preconditions.checkArgument(jdkSignalClazz.isInstance(delegate),
+      Preconditions.checkArgument(JDK_SIGNAL_CLAZZ.isInstance(delegate),
           String.format("Expected class is '%s', but actual class is '%s'",
-              jdkSignalClazz.getName(), delegate.getClass().getName()));
+              JDK_SIGNAL_CLAZZ.getName(), delegate.getClass().getName()));
       this.delegate = delegate;
-      this.getNumberMethod = getNumberUnboundMethod.bind(delegate);
-      this.getNameMethod = getNameUnboundMethod.bind(delegate);
+      this.getNumberMethod = GET_NUMBER_UNBOUND_METHOD.bind(delegate);
+      this.getNameMethod = GET_NAME_UNBOUND_METHOD.bind(delegate);
     }
 
     public int getNumber() {
@@ -123,26 +123,28 @@ public class SignalUtil {
     JdkSignalHandlerImpl(Handler handler) {
       this.delegate = Proxy.newProxyInstance(
           getClass().getClassLoader(),
-          new Class<?>[] { jdkSignalHandlerClazz },
+          new Class<?>[] {JDK_SIGNAL_HANDLER_CLAZZ},
           (proxyObj, method, args) -> {
-            if ("handle".equals(method.getName()) && args.length == 1 && jdkSignalClazz.isInstance(args[0])) {
+            if ("handle".equals(method.getName()) && args.length == 1
+                && JDK_SIGNAL_CLAZZ.isInstance(args[0])) {
               handler.handle(new Signal(args[0]));
               return null;
             } else {
-              Method delegateMethod = Handler.class.getMethod(method.getName(), method.getParameterTypes());
+              Method delegateMethod = Handler.class.getMethod(
+                  method.getName(), method.getParameterTypes());
               return delegateMethod.invoke(handler, args);
             }
           }
       );
-      this.jdkSignalHandlerHandleMethod = jdkSignalHandlerHandleUnboundMethod.bind(delegate);
+      this.jdkSignalHandlerHandleMethod = JDK_SIGNAL_HANDLER_HANDLE_UNBOUND_METHOD.bind(delegate);
     }
 
     JdkSignalHandlerImpl(Object delegate) {
-      Preconditions.checkArgument(jdkSignalHandlerClazz.isInstance(delegate),
+      Preconditions.checkArgument(JDK_SIGNAL_HANDLER_CLAZZ.isInstance(delegate),
           String.format("Expected class is '%s', but actual class is '%s'",
-              jdkSignalHandlerClazz.getName(), delegate.getClass().getName()));
+              JDK_SIGNAL_HANDLER_CLAZZ.getName(), delegate.getClass().getName()));
       this.delegate = delegate;
-      this.jdkSignalHandlerHandleMethod = jdkSignalHandlerHandleUnboundMethod.bind(delegate);
+      this.jdkSignalHandlerHandleMethod = JDK_SIGNAL_HANDLER_HANDLE_UNBOUND_METHOD.bind(delegate);
     }
 
     @Override
@@ -152,12 +154,12 @@ public class SignalUtil {
   }
 
   public static Handler handle(Signal sig, Handler handler) {
-    Object preHandle = jdkSignalHandleStaticMethod.invoke(
+    Object preHandle = JDK_SIGNAL_HANDLE_STATIC_METHOD.invoke(
         sig.delegate, new JdkSignalHandlerImpl(handler).delegate);
     return new JdkSignalHandlerImpl(preHandle);
   }
 
   public static void raise(Signal sig) throws IllegalArgumentException {
-    jdkSignalRaiseStaticMethod.invoke(sig.delegate);
+    JDK_SIGNAL_RAISE_STATIC_METHOD.invoke(sig.delegate);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -63,7 +63,7 @@ public class SignalUtil {
     private static final DynMethods.UnboundMethod GET_NAME_UNBOUND_METHOD =
         new DynMethods.Builder("getName").impl(JDK_SIGNAL_CLAZZ).build();
 
-    private final Object delegate;
+    private final Object/* sun.misc.SignalHandler */ delegate;
     private final DynMethods.BoundMethod getNumberMethod;
     private final DynMethods.BoundMethod getNameMethod;
 
@@ -117,7 +117,7 @@ public class SignalUtil {
 
   static class JdkSignalHandlerImpl implements Handler {
 
-    private final Object delegate;
+    private final Object/* sun.misc.Signal */ delegate;
     private final DynMethods.BoundMethod jdkSignalHandlerHandleMethod;
 
     JdkSignalHandlerImpl(Handler handler) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -57,10 +57,10 @@ public class SignalUtil {
 
   @InterfaceAudience.Private
   public static class Signal {
-    private final DynMethods.UnboundMethod getNumberUnboundMethod =
+    private static final DynMethods.UnboundMethod getNumberUnboundMethod =
         new DynMethods.Builder("getNumber").impl(jdkSignalClazz).build();
 
-    private final DynMethods.UnboundMethod getNameUnboundMethod =
+    private static final DynMethods.UnboundMethod getNameUnboundMethod =
         new DynMethods.Builder("getName").impl(jdkSignalClazz).build();
 
     private final Object delegate;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SignalUtil.java
@@ -63,7 +63,7 @@ public class SignalUtil {
     private static final DynMethods.UnboundMethod GET_NAME_UNBOUND_METHOD =
         new DynMethods.Builder("getName").impl(JDK_SIGNAL_CLAZZ).build();
 
-    private final Object/* sun.misc.SignalHandler */ delegate;
+    private final Object/* sun.misc.Signal */ delegate;
     private final DynMethods.BoundMethod getNumberMethod;
     private final DynMethods.BoundMethod getNameMethod;
 
@@ -91,6 +91,7 @@ public class SignalUtil {
       return getNameMethod.invoke();
     }
 
+    @Override
     public boolean equals(Object obj) {
       if (this == obj) {
         return true;
@@ -101,10 +102,12 @@ public class SignalUtil {
       return false;
     }
 
+    @Override
     public int hashCode() {
       return delegate.hashCode();
     }
 
+    @Override
     public String toString() {
       return delegate.toString();
     }
@@ -117,7 +120,7 @@ public class SignalUtil {
 
   static class JdkSignalHandlerImpl implements Handler {
 
-    private final Object/* sun.misc.Signal */ delegate;
+    private final Object/* sun.misc.SignalHandler */ delegate;
     private final DynMethods.BoundMethod jdkSignalHandlerHandleMethod;
 
     JdkSignalHandlerImpl(Handler handler) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19329. Remove direct usage of sun.misc.Signal.

Alternative of https://github.com/apache/hadoop/pull/7145

### How was this patch tested?

Pass existing UT:
- org.apache.hadoop.service.launcher.TestServiceInterruptHandling
- org.apache.hadoop.util.TestSignalLogger

with additional manual test to ensure `SignalLogger` works properly

<img width="1614" alt="Xnip2025-06-24_14-42-37" src="https://github.com/user-attachments/assets/7c8a46df-9cca-4d3b-97a0-34a8ea2eac02" />


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

