### PR TITLE
HADOOP-19559: S3A Analytics-Accelerator Add IoStatistics support

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -132,10 +132,10 @@ public final class StreamStatisticNames {
   public static final String STREAM_READ_OPERATIONS =
       "stream_read_operations";
 
-  /** Analytics GET requests made by stream. */
+  /** GET requests made by the analytics stream. */
   public static final String STREAM_READ_ANALYTICS_GET_REQUESTS = "stream_read_analytics_get_requests";
 
-  /** Analytics HEAD requests made by stream. */
+  /** HEAD requests made by the analytics stream. */
   public static final String STREAM_READ_ANALYTICS_HEAD_REQUESTS = "stream_read_analytics_head_requests";
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -132,6 +132,12 @@ public final class StreamStatisticNames {
   public static final String STREAM_READ_OPERATIONS =
       "stream_read_operations";
 
+  /** Analytics GET requests made by stream. */
+  public static final String STREAM_READ_ANALYTICS_GET_REQUESTS = "stream_read_analytics_get_requests";
+
+  /** Analytics HEAD requests made by stream. */
+  public static final String STREAM_READ_ANALYTICS_HEAD_REQUESTS = "stream_read_analytics_head_requests";
+
   /**
    * Count of readVectored() operations in an input stream.
    * Value: {@value}.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -133,10 +133,12 @@ public final class StreamStatisticNames {
       "stream_read_operations";
 
   /** GET requests made by the analytics stream. */
-  public static final String STREAM_READ_ANALYTICS_GET_REQUESTS = "stream_read_analytics_get_requests";
+  public static final String STREAM_READ_ANALYTICS_GET_REQUESTS =
+          "stream_read_analytics_get_requests";
 
   /** HEAD requests made by the analytics stream. */
-  public static final String STREAM_READ_ANALYTICS_HEAD_REQUESTS = "stream_read_analytics_head_requests";
+  public static final String STREAM_READ_ANALYTICS_HEAD_REQUESTS =
+          "stream_read_analytics_head_requests";
 
   /**
    * Count of readVectored() operations in an input stream.

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -207,7 +207,7 @@
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.29.52</aws-java-sdk-v2.version>
     <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
-    <amazon-s3-analyticsaccelerator-s3.version>1.0.0</amazon-s3-analyticsaccelerator-s3.version>
+    <amazon-s3-analyticsaccelerator-s3.version>1.2.1</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -872,6 +872,8 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
               StreamStatisticNames.STREAM_READ_CLOSE_OPERATIONS,
               StreamStatisticNames.STREAM_READ_OPENED,
               StreamStatisticNames.STREAM_READ_BYTES,
+              StreamStatisticNames.STREAM_READ_ANALYTICS_GET_REQUESTS,
+              StreamStatisticNames.STREAM_READ_ANALYTICS_HEAD_REQUESTS,
               StreamStatisticNames.STREAM_READ_EXCEPTIONS,
               StreamStatisticNames.STREAM_READ_FULLY_OPERATIONS,
               StreamStatisticNames.STREAM_READ_OPERATIONS,
@@ -1126,6 +1128,15 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     @Override
     public void readVectoredBytesDiscarded(int discarded) {
       bytesDiscardedInVectoredIO.addAndGet(discarded);
+    }
+
+    @Override
+    public void incrementAnalyticsGetRequests() {
+      increment(StreamStatisticNames.STREAM_READ_ANALYTICS_GET_REQUESTS);
+    }
+    @Override
+    public void incrementAnalyticsHeadRequests() {
+      increment(StreamStatisticNames.STREAM_READ_ANALYTICS_HEAD_REQUESTS);
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -459,6 +459,14 @@ public enum Statistic {
       "Gauge of active memory in use",
       TYPE_GAUGE),
 
+  ANALYTICS_GET_REQUESTS(
+      StreamStatisticNames.STREAM_READ_ANALYTICS_GET_REQUESTS,
+      "GET requests made by analytics streams",
+      TYPE_COUNTER),
+  ANALYTICS_HEAD_REQUESTS(
+          StreamStatisticNames.STREAM_READ_ANALYTICS_HEAD_REQUESTS,
+          "HEAD requests made by analytics streams",
+          TYPE_COUNTER),
   /* Stream Write statistics */
 
   STREAM_WRITE_EXCEPTIONS(

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
@@ -26,27 +26,27 @@ import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
  * Implementation of AAL's RequestCallback interface that tracks analytics operations.
  */
 public class AnalyticsRequestCallback implements RequestCallback {
-    private final S3AInputStreamStatistics statistics;
+  private final S3AInputStreamStatistics statistics;
 
     /**
      * Create a new callback instance.
      * @param statistics the statistics to update
      */
-    public AnalyticsRequestCallback(S3AInputStreamStatistics statistics) {
-        this.statistics = statistics;
-    }
+  public AnalyticsRequestCallback(S3AInputStreamStatistics statistics) {
+    this.statistics = statistics;
+  }
 
-    @Override
+  @Override
     public void onGetRequest() {
-        statistics.incrementAnalyticsGetRequests();
-        // Update ACTION_HTTP_GET_REQUEST statistic
-        DurationTracker tracker = statistics.initiateGetRequest();
-        tracker.close();
-    }
+    statistics.incrementAnalyticsGetRequests();
+    // Update ACTION_HTTP_GET_REQUEST statistic
+    DurationTracker tracker = statistics.initiateGetRequest();
+    tracker.close();
+  }
 
-    @Override
+  @Override
     public void onHeadRequest() {
-        statistics.incrementAnalyticsHeadRequests();
-    }
+    statistics.incrementAnalyticsHeadRequests();
+  }
 }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
@@ -1,0 +1,30 @@
+package org.apache.hadoop.fs.s3a.impl.streams;
+
+import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
+import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
+
+/**
+ * Implementation of AAL's RequestCallback interface that tracks analytics operations.
+ */
+public class AnalyticsRequestCallback implements RequestCallback {
+    private final S3AInputStreamStatistics statistics;
+
+    /**
+     * Create a new callback instance.
+     * @param statistics the statistics to update
+     */
+    public AnalyticsRequestCallback(S3AInputStreamStatistics statistics) {
+        this.statistics = statistics;
+    }
+
+    @Override
+    public void onGetRequest() {
+        statistics.incrementAnalyticsGetRequests();
+    }
+
+    @Override
+    public void onHeadRequest() {
+        statistics.incrementAnalyticsHeadRequests();
+    }
+}
+

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
@@ -1,6 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.s3a.impl.streams;
 
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
+import org.apache.hadoop.fs.statistics.DurationTracker;
 import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
 
 /**
@@ -20,6 +39,9 @@ public class AnalyticsRequestCallback implements RequestCallback {
     @Override
     public void onGetRequest() {
         statistics.incrementAnalyticsGetRequests();
+        // Update ACTION_HTTP_GET_REQUEST statistic
+        DurationTracker tracker = statistics.initiateGetRequest();
+        tracker.close();
     }
 
     @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -28,6 +28,7 @@ import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.util.InputPolicy;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
+import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   @Override
   public int read() throws IOException {
     throwIfClosed();
+    getS3AStreamStatistics().readOperationStarted(getPos(), 1);
+
     int bytesRead;
     try {
       bytesRead = inputStream.read();
@@ -70,6 +73,11 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead != -1) {
+      getS3AStreamStatistics().bytesRead(1);
+    }
+
     return bytesRead;
   }
 
@@ -105,6 +113,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
    */
   public int readTail(byte[] buf, int off, int len) throws IOException {
     throwIfClosed();
+    getS3AStreamStatistics().readOperationStarted(getPos(), len);
+
     int bytesRead;
     try {
       bytesRead = inputStream.readTail(buf, off, len);
@@ -112,12 +122,19 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead > 0) {
+      getS3AStreamStatistics().bytesRead(bytesRead);
+    }
+
     return bytesRead;
   }
 
   @Override
   public int read(byte[] buf, int off, int len) throws IOException {
     throwIfClosed();
+    getS3AStreamStatistics().readOperationStarted(getPos(), len);
+
     int bytesRead;
     try {
       bytesRead = inputStream.read(buf, off, len);
@@ -125,6 +142,11 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead > 0) {
+      getS3AStreamStatistics().bytesRead(bytesRead);
+    }
+
     return bytesRead;
   }
 
@@ -194,10 +216,13 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   }
 
   private OpenStreamInformation buildOpenStreamInformation(ObjectReadParameters parameters) {
+
+    final RequestCallback requestCallback = new AnalyticsRequestCallback(getS3AStreamStatistics());
+
     OpenStreamInformation.OpenStreamInformationBuilder openStreamInformationBuilder =
         OpenStreamInformation.builder()
             .inputPolicy(mapS3AInputPolicyToAAL(parameters.getContext()
-            .getInputPolicy()));
+            .getInputPolicy())).requestCallback(requestCallback);
 
     if (parameters.getObjectAttributes().getETag() != null) {
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -144,7 +144,6 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
     if (pos >= lengthLimit) {
       return -1; // EOF reached due to length limit
     }
-    
     // Limit read length to not exceed the length limit
     int maxRead = (int) Math.min(len, lengthLimit - pos);
     getS3AStreamStatistics().readOperationStarted(pos, maxRead);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -49,6 +49,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   private S3SeekableInputStream inputStream;
   private long lastReadCurrentPos = 0;
   private volatile boolean closed;
+  private final long contentLength;
+  private final long lengthLimit;
 
   public static final Logger LOG = LoggerFactory.getLogger(AnalyticsStream.class);
 
@@ -56,6 +58,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       final S3SeekableInputStreamFactory s3SeekableInputStreamFactory) throws IOException {
     super(InputStreamType.Analytics, parameters);
     S3ObjectAttributes s3Attributes = parameters.getObjectAttributes();
+    this.contentLength = s3Attributes.getLen();
+    this.lengthLimit = s3Attributes.getLen();
     this.inputStream = s3SeekableInputStreamFactory.createStream(S3URI.of(s3Attributes.getBucket(),
         s3Attributes.getKey()), buildOpenStreamInformation(parameters));
     getS3AStreamStatistics().streamOpened(InputStreamType.Analytics);
@@ -64,6 +68,9 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   @Override
   public int read() throws IOException {
     throwIfClosed();
+    if (getPos() >= lengthLimit) {
+      return -1; // EOF reached due to length limit
+    }
     getS3AStreamStatistics().readOperationStarted(getPos(), 1);
 
     int bytesRead;
@@ -75,7 +82,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
     }
 
     if (bytesRead != -1) {
-      getS3AStreamStatistics().bytesRead(1);
+      incrementBytesRead(1);
     }
 
     return bytesRead;
@@ -124,7 +131,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
     }
 
     if (bytesRead > 0) {
-      getS3AStreamStatistics().bytesRead(bytesRead);
+      incrementBytesRead(bytesRead);
     }
 
     return bytesRead;
@@ -133,18 +140,25 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   @Override
   public int read(byte[] buf, int off, int len) throws IOException {
     throwIfClosed();
-    getS3AStreamStatistics().readOperationStarted(getPos(), len);
+    long pos = getPos();
+    if (pos >= lengthLimit) {
+      return -1; // EOF reached due to length limit
+    }
+    
+    // Limit read length to not exceed the length limit
+    int maxRead = (int) Math.min(len, lengthLimit - pos);
+    getS3AStreamStatistics().readOperationStarted(pos, maxRead);
 
     int bytesRead;
     try {
-      bytesRead = inputStream.read(buf, off, len);
+      bytesRead = inputStream.read(buf, off, maxRead);
     } catch (IOException ioe) {
       onReadFailure(ioe);
       throw ioe;
     }
 
     if (bytesRead > 0) {
-      getS3AStreamStatistics().bytesRead(bytesRead);
+      incrementBytesRead(bytesRead);
     }
 
     return bytesRead;
@@ -258,6 +272,18 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   protected void throwIfClosed() throws IOException {
     if (closed) {
       throw new IOException(getKey() + ": " + FSExceptionMessages.STREAM_IS_CLOSED);
+    }
+  }
+
+  /**
+   * Increment the bytes read counter if there is a stats instance
+   * and the number of bytes read is more than zero.
+   * @param bytesRead number of bytes read
+   */
+  private void incrementBytesRead(long bytesRead) {
+    getS3AStreamStatistics().bytesRead(bytesRead);
+    if (getContext().getStats() != null && bytesRead > 0) {
+      getContext().getStats().incrementBytesRead(bytesRead);
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
@@ -190,7 +190,14 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
   long getVersionMismatches();
 
   long getInputPolicy();
-
+  /**
+   * Increment the counter for GET requests made by Analytics Accelerator Library.
+   */
+  void incrementAnalyticsGetRequests();
+  /**
+   * Increment the counter for HEAD requests made by Analytics Accelerator Library.
+   */
+  void incrementAnalyticsHeadRequests();
   /**
    * Get the value of a counter.
    * @param name counter name

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
@@ -159,7 +159,12 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
         final long bytesReadInSeek) {
 
     }
-
+    @Override
+    public void incrementAnalyticsGetRequests() {
+    }
+    @Override
+    public void incrementAnalyticsHeadRequests() {
+    }
     @Override
     public long streamOpened() {
       return 0;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -47,6 +47,11 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
+
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_GET_REQUESTS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_HEAD_REQUESTS;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.ANALYTICS_STREAM_FACTORY_CLOSED;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -104,6 +109,12 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       Assertions.assertThat(objectInputStream.streamType()).isEqualTo(InputStreamType.Analytics);
       Assertions.assertThat(objectInputStream.getInputPolicy())
           .isEqualTo(S3AInputPolicy.Sequential);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_BYTES, 500);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
+
+      long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read").isEqualTo(500);
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
@@ -129,11 +140,17 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
     byte[] buffer = new byte[500];
     IOStatistics ioStats;
+    int bytesRead;
 
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
       ioStats = inputStream.getIOStatistics();
       inputStream.seek(5);
-      inputStream.read(buffer, 0, 500);
+      bytesRead = inputStream.read(buffer, 0, 500);
+
+      ObjectInputStream objectInputStream = (ObjectInputStream) inputStream.getWrappedStream();
+      long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read").isEqualTo(bytesRead);
+
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
@@ -166,15 +183,19 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
-
+    verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
     try (FSDataInputStream inputStream = getFileSystem().openFile(dest)
         .must(FS_OPTION_OPENFILE_READ_POLICY, FS_OPTION_OPENFILE_READ_POLICY_PARQUET)
         .build().get()) {
       ioStats = inputStream.getIOStatistics();
       inputStream.readFully(buffer, 0, (int) fileStatus.getLen());
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_BYTES, (int) fileStatus.getLen());
+      verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
   }
 
   @Test
@@ -194,4 +215,127 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
         () -> S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration));
   }
 
+  @Test
+  public void testLargeFileMultipleGets() throws Throwable {
+    describe("Large file should trigger multiple GET requests");
+
+    Path dest = writeThenReadFile("large-test-file.txt", 10 * 1024 * 1024); // 10MB
+
+
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      IOStatistics ioStats = inputStream.getIOStatistics();
+      inputStream.readFully(new byte[(int) getFileSystem().getFileStatus(dest).getLen()]);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 2);
+    }
+  }
+
+  @Test
+  public void testSmallFileSingleGet() throws Throwable {
+    describe("Small file should trigger only one GET request");
+
+    Path dest = writeThenReadFile("small-test-file.txt", 1 * 1024 * 1024); // 1KB
+
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      IOStatistics ioStats = inputStream.getIOStatistics();
+      inputStream.readFully(new byte[(int) getFileSystem().getFileStatus(dest).getLen()]);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+    }
+  }
+
+
+  @Test
+  public void testRandomSeekPatternGets() throws Throwable {
+    describe("Random seek pattern should optimize GET requests");
+
+    Path dest = writeThenReadFile("seek-test.txt", 100 * 1024);
+
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      IOStatistics ioStats = inputStream.getIOStatistics();
+
+      inputStream.seek(1000);
+      inputStream.read(new byte[100]);
+
+      inputStream.seek(50000);
+      inputStream.read(new byte[100]);
+
+      inputStream.seek(90000);
+      inputStream.read(new byte[100]);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+    }
+}
+
+  @Test
+  public void testAALNeverMakesHeadRequests() throws Throwable {
+    describe("Prove AAL never makes HEAD requests - S3A provides all metadata");
+
+    Path dest = writeThenReadFile("no-head-test.txt", 1024 * 1024); // 1MB
+
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      IOStatistics ioStats = inputStream.getIOStatistics();
+      inputStream.read(new byte[1024]);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+
+      ObjectInputStream objectInputStream = (ObjectInputStream) inputStream.getWrappedStream();
+      Assertions.assertThat(objectInputStream.streamType()).isEqualTo(InputStreamType.Analytics);
+
+    }
+  }
+
+
+  @Test
+  public void testParquetReadingNoHeadRequests() throws Throwable {
+    describe("Parquet-optimized reading should not trigger AAL HEAD requests");
+
+    Path dest = path("parquet-head-test.parquet");
+    File file = new File("src/test/resources/multi_row_group.parquet");
+    Path sourcePath = new Path(file.toURI().getPath());
+    getFileSystem().copyFromLocalFile(false, true, sourcePath, dest);
+
+    try (FSDataInputStream stream = getFileSystem().openFile(dest)
+            .must(FS_OPTION_OPENFILE_READ_POLICY, FS_OPTION_OPENFILE_READ_POLICY_PARQUET)
+            .build().get()) {
+
+      FileStatus fileStatus = getFileSystem().getFileStatus(dest);
+      stream.readFully(new byte[(int) fileStatus.getLen()]);
+
+      IOStatistics stats = stream.getIOStatistics();
+
+      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
+      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_OPENED, 1);
+
+      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+    }
+  }
+
+
+  @Test
+  public void testConcurrentStreamsNoDuplicateGets() throws Throwable {
+    describe("Concurrent streams reading same object should not duplicate GETs");
+
+    Path dest = writeThenReadFile("concurrent-test.txt", 1 * 1024 * 1024);
+
+    try (FSDataInputStream stream1 = getFileSystem().open(dest);
+         FSDataInputStream stream2 = getFileSystem().open(dest)) {
+
+      byte[] buffer1 = new byte[1024];
+      byte[] buffer2 = new byte[1024];
+
+      stream1.read(buffer1);
+      stream2.read(buffer2);
+
+      IOStatistics stats1 = stream1.getIOStatistics();
+      IOStatistics stats2 = stream2.getIOStatistics();
+
+      long totalGets = stats1.counters().getOrDefault(
+              STREAM_READ_ANALYTICS_GET_REQUESTS, 0L) +
+              stats2.counters().getOrDefault(
+                      STREAM_READ_ANALYTICS_GET_REQUESTS, 0L);
+      Assertions.assertThat(totalGets).isEqualTo(1);
+    }
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -118,7 +118,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
 
       long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
-      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read").isEqualTo(500);
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read")
+              .isEqualTo(500);
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
@@ -153,7 +154,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
       ObjectInputStream objectInputStream = (ObjectInputStream) inputStream.getWrappedStream();
       long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
-      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read").isEqualTo(bytesRead);
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read")
+              .isEqualTo(bytesRead);
 
     }
 
@@ -200,9 +202,9 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       verifyStatisticCounterValue(ioStats, STREAM_READ_BYTES, (int) fileStatus.getLen());
       verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
     }
-
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
-    // S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
+    // S3A passes in the meta-data(content length) on file open,
+    // we expect AAL to make no HEAD requests
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
   }
 
@@ -224,8 +226,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
   }
 
   /**
-   *
-   * TXT files are classified as SEQUENTIAL format and use SequentialPrefetcher(requests the entire 10MB file)
+   * TXT files(SEQUENTIAL format) use SequentialPrefetcher(requests the entire 10MB file).
    * RangeOptimiser splits ranges larger than maxRangeSizeBytes (8MB) using partSizeBytes (8MB)
    * The 10MB range gets split into: [0-8MB) and [8MB-10MB)
    * Each split range becomes a separate Block, resulting in 2 GET requests:
@@ -244,7 +245,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       inputStream.readFully(buffer);
 
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 2);
-      // Because S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
+      // Because S3A passes in the meta-data(content length) on file open,
+      // we expect AAL to make no HEAD requests
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
     }
   }
@@ -263,7 +265,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       inputStream.readFully(buffer);
 
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
-      // Because S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
+      // Because S3A passes in the meta-data(content length) on file open,
+      // we expect AAL to make no HEAD requests
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -42,6 +42,8 @@ import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_PARQUET;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
@@ -54,6 +56,8 @@ import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_A
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_HEAD_REQUESTS;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.ANALYTICS_STREAM_FACTORY_CLOSED;
+import static org.apache.hadoop.io.Sizes.S_1K;
+import static org.apache.hadoop.io.Sizes.S_1M;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -154,6 +158,9 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+    // S3A passes in the meta data on file open, we expect AAL to make no HEAD requests
+    verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
   }
 
   /**
@@ -195,6 +202,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    // S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
   }
 
@@ -215,18 +223,29 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
         () -> S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration));
   }
 
+  /**
+   *
+   * TXT files are classified as SEQUENTIAL format and use SequentialPrefetcher(requests the entire 10MB file)
+   * RangeOptimiser splits ranges larger than maxRangeSizeBytes (8MB) using partSizeBytes (8MB)
+   * The 10MB range gets split into: [0-8MB) and [8MB-10MB)
+   * Each split range becomes a separate Block, resulting in 2 GET requests:
+   */
   @Test
   public void testLargeFileMultipleGets() throws Throwable {
     describe("Large file should trigger multiple GET requests");
 
-    Path dest = writeThenReadFile("large-test-file.txt", 10 * 1024 * 1024); // 10MB
+    Path dest = path("large-test-file.txt");
+    byte[] data = dataset(10 * S_1M, 256, 255);
+    writeDataset(getFileSystem(), dest, data, 10 * S_1M, 1024, true);
 
-
+    byte[] buffer = new byte[S_1M * 10];
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
       IOStatistics ioStats = inputStream.getIOStatistics();
-      inputStream.readFully(new byte[(int) getFileSystem().getFileStatus(dest).getLen()]);
+      inputStream.readFully(buffer);
 
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 2);
+      // Because S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
     }
   }
 
@@ -234,13 +253,18 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
   public void testSmallFileSingleGet() throws Throwable {
     describe("Small file should trigger only one GET request");
 
-    Path dest = writeThenReadFile("small-test-file.txt", 1 * 1024 * 1024); // 1KB
+    Path dest = path("small-test-file.txt");
+    byte[] data = dataset(S_1M, 256, 255);
+    writeDataset(getFileSystem(), dest, data, S_1M, 1024, true);
 
+    byte[] buffer = new byte[S_1M];
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
       IOStatistics ioStats = inputStream.getIOStatistics();
-      inputStream.readFully(new byte[(int) getFileSystem().getFileStatus(dest).getLen()]);
+      inputStream.readFully(buffer);
 
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+      // Because S3A passes in the meta-data(content length) on file open, we expect AAL to make no HEAD requests
+      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
     }
   }
 
@@ -249,93 +273,46 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
   public void testRandomSeekPatternGets() throws Throwable {
     describe("Random seek pattern should optimize GET requests");
 
-    Path dest = writeThenReadFile("seek-test.txt", 100 * 1024);
+    Path dest = path("seek-test.txt");
+    byte[] data = dataset(5 * S_1M, 256, 255);
+    writeDataset(getFileSystem(), dest, data, 5 * S_1M, 1024, true);
 
+    byte[] buffer = new byte[S_1M];
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
       IOStatistics ioStats = inputStream.getIOStatistics();
 
-      inputStream.seek(1000);
-      inputStream.read(new byte[100]);
-
-      inputStream.seek(50000);
-      inputStream.read(new byte[100]);
-
-      inputStream.seek(90000);
-      inputStream.read(new byte[100]);
+      inputStream.read(buffer);
+      inputStream.seek(2 * S_1M);
+      inputStream.read(new byte[512 * S_1K]);
+      inputStream.seek(3 * S_1M);
+      inputStream.read(new byte[512 * S_1K]);
 
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
-    }
-}
-
-  @Test
-  public void testAALNeverMakesHeadRequests() throws Throwable {
-    describe("Prove AAL never makes HEAD requests - S3A provides all metadata");
-
-    Path dest = writeThenReadFile("no-head-test.txt", 1024 * 1024); // 1MB
-
-    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
-      IOStatistics ioStats = inputStream.getIOStatistics();
-      inputStream.read(new byte[1024]);
-
       verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
-      verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
-
-      ObjectInputStream objectInputStream = (ObjectInputStream) inputStream.getWrappedStream();
-      Assertions.assertThat(objectInputStream.streamType()).isEqualTo(InputStreamType.Analytics);
-
     }
   }
 
 
   @Test
-  public void testParquetReadingNoHeadRequests() throws Throwable {
-    describe("Parquet-optimized reading should not trigger AAL HEAD requests");
+  public void testSequentialStreamsNoDuplicateGets() throws Throwable {
+    describe("Sequential streams reading same object should not duplicate GETs");
 
-    Path dest = path("parquet-head-test.parquet");
-    File file = new File("src/test/resources/multi_row_group.parquet");
-    Path sourcePath = new Path(file.toURI().getPath());
-    getFileSystem().copyFromLocalFile(false, true, sourcePath, dest);
+    Path dest = path("sequential-test.txt");
+    byte[] data = dataset(S_1M, 256, 255);
+    writeDataset(getFileSystem(), dest, data, S_1M, 1024, true);
 
-    try (FSDataInputStream stream = getFileSystem().openFile(dest)
-            .must(FS_OPTION_OPENFILE_READ_POLICY, FS_OPTION_OPENFILE_READ_POLICY_PARQUET)
-            .build().get()) {
-
-      FileStatus fileStatus = getFileSystem().getFileStatus(dest);
-      stream.readFully(new byte[(int) fileStatus.getLen()]);
-
-      IOStatistics stats = stream.getIOStatistics();
-
-      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_HEAD_REQUESTS, 0);
-      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_OPENED, 1);
-
-      verifyStatisticCounterValue(stats, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
-    }
-  }
-
-
-  @Test
-  public void testConcurrentStreamsNoDuplicateGets() throws Throwable {
-    describe("Concurrent streams reading same object should not duplicate GETs");
-
-    Path dest = writeThenReadFile("concurrent-test.txt", 1 * 1024 * 1024);
-
+    byte[] buffer = new byte[1024];
     try (FSDataInputStream stream1 = getFileSystem().open(dest);
          FSDataInputStream stream2 = getFileSystem().open(dest)) {
 
-      byte[] buffer1 = new byte[1024];
-      byte[] buffer2 = new byte[1024];
-
-      stream1.read(buffer1);
-      stream2.read(buffer2);
+      stream1.read(buffer);
+      stream2.read(buffer);
 
       IOStatistics stats1 = stream1.getIOStatistics();
       IOStatistics stats2 = stream2.getIOStatistics();
 
-      long totalGets = stats1.counters().getOrDefault(
-              STREAM_READ_ANALYTICS_GET_REQUESTS, 0L) +
-              stats2.counters().getOrDefault(
-                      STREAM_READ_ANALYTICS_GET_REQUESTS, 0L);
-      Assertions.assertThat(totalGets).isEqualTo(1);
+      verifyStatisticCounterValue(stats1, STREAM_READ_ANALYTICS_GET_REQUESTS, 1);
+      verifyStatisticCounterValue(stats2, STREAM_READ_ANALYTICS_GET_REQUESTS, 0);
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -45,7 +45,6 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.assertCapabilities
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disablePrefetching;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -81,10 +81,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
   public void setup() throws Exception {
     super.setup();
     executor = HadoopExecutors.newFixedThreadPool(SMALL_THREADS);
-    // Analytics accelerator currently does not support IOStatisticsContext, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support IOStatisticsContext");
+
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsSourceToString;
 
 /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
@@ -52,10 +52,6 @@ public class ITestS3AMetrics extends AbstractS3ATestBase {
 
   @Test
   public void testStreamStatistics() throws IOException {
-     // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
 
     S3AFileSystem fs = getFileSystem();
     Path file = path("testStreamStatistics");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
@@ -174,10 +174,7 @@ public class ITestCommitOperationCost extends AbstractS3ACostTest {
   public void testCostOfCreatingMagicFile() throws Throwable {
     describe("Files created under magic paths skip existence checks and marker deletes");
 
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
+
     S3AFileSystem fs = getFileSystem();
     Path destFile = methodSubPath("file.txt");
     fs.delete(destFile.getParent(), true);
@@ -255,10 +252,6 @@ public class ITestCommitOperationCost extends AbstractS3ACostTest {
   public void testCostOfSavingLoadingPendingFile() throws Throwable {
     describe("Verify costs of saving .pending file under a magic path");
 
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
     S3AFileSystem fs = getFileSystem();
     Path partDir = methodSubPath("file.pending");
     Path destFile = new Path(partDir, "file.pending");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.fs.s3a.commit.impl.CommitOperations;
 import org.apache.hadoop.fs.s3a.performance.AbstractS3ACostTest;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.Statistic.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.s3a.Statistic.COMMITTER_MAGIC_FILES_CREATED;
 import static org.apache.hadoop.fs.s3a.Statistic.COMMITTER_MAGIC_MARKER_PUT;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
@@ -46,10 +46,6 @@ public class ITestS3AFileContextStatistics extends FCStatisticsBaseTest {
   @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(conf,
-        "Analytics Accelerator currently does not support stream statistics");
     fc = S3ATestUtils.createTestFileContext(conf);
     testRootPath = fileContextTestHelper.getTestRootPath(fc, "test");
     fc.mkdir(testRootPath,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.s3a.auth.STSClientFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
@@ -113,10 +113,7 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
   @Override
   public void setup() throws Exception {
     super.setup();
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
+
     S3AFileSystem fs = getFileSystem();
     testFile = methodPath();
 
@@ -177,6 +174,11 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
 
     // if prefetching is enabled, skip this test
     assumeNoPrefetching();
+    // Skip for Analytics streams - checksum validation only exists in S3AInputStream.
+    // AnalyticsStream handles data integrity through AWS Analytics Accelerator internally.
+    if (isAnalyticsStream()) {
+      skip("Analytics stream doesn't use checksums");
+    }
     S3AFileSystem fs = getFileSystem();
 
     // open the file
@@ -261,10 +263,13 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       }
     },
         always(),
-        // two GET calls were made, one for readFully,
-        // the second on the read() past the EOF
-        // the operation has got as far as S3
-        probe(!prefetching(), STREAM_READ_OPENED, 1 + 1));
+        // Analytics stream: 1 open (persistent connection)
+        // S3AInputStream: 2 opens (reopen on EOF)
+            // two GET calls were made, one for readFully,
+            // the second on the read() past the EOF
+            // the operation has got as far as S3
+        probe(!prefetching() && !isAnalyticsStream(), STREAM_READ_OPENED, 2),
+        probe(!prefetching() && isAnalyticsStream(), STREAM_READ_OPENED, 1));
 
     // now on a new stream, try a full read from after the EOF
     verifyMetrics(() -> {
@@ -348,7 +353,9 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       }
     },
         always(),
-        probe(!prefetching, Statistic.ACTION_HTTP_GET_REQUEST, extra));
+        // Analytics streams don't make HTTP requests when reading past EOF
+        probe(!prefetching && !isAnalyticsStream(), Statistic.ACTION_HTTP_GET_REQUEST, extra),
+        probe(!prefetching && isAnalyticsStream(), Statistic.ACTION_HTTP_GET_REQUEST, 0));
   }
 
   /**
@@ -459,6 +466,14 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
    */
   private boolean prefetching()  {
     return InputStreamType.Prefetch == streamType(getFileSystem());
+  }
+
+  /**
+   * Is the current stream type Analytics?
+   * @return true if Analytics stream is enabled.
+   */
+  private boolean isAnalyticsStream() {
+    return streamType(getFileSystem()) == InputStreamType.Analytics;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
@@ -58,7 +58,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.assertStreamIsNotChecksummed
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getS3AInputStream;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.streamType;
 import static org.apache.hadoop.fs.s3a.Statistic.STREAM_READ_BYTES_READ_CLOSE;
 import static org.apache.hadoop.fs.s3a.Statistic.STREAM_READ_OPENED;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 
 /**
@@ -77,14 +76,5 @@ public class ITestS3AContractStreamIOStatistics extends
     return Arrays.asList(STREAM_WRITE_BYTES,
         STREAM_WRITE_BLOCK_UPLOADS,
         STREAM_WRITE_EXCEPTIONS);
-  }
-
-  @Override
-  public void testInputStreamStatisticRead() throws Throwable {
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getContract().getConf(),
-        "Analytics Accelerator currently does not support stream statistics");
-    super.testInputStreamStatisticRead();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
@@ -44,10 +44,6 @@ public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
    */
   @Test
   public void testBytesReadWithStream() throws IOException {
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
     S3AFileSystem fs = getFileSystem();
     Path filePath = path(getMethodName());
     byte[] oneKbBuf = new byte[ONE_KB];

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 
 public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Add analytics stream statistics for S3A

This PR enhances the S3A, by adding proper tracking of analytics stream statistics:

1. Tracks GET requests made by the analytics stream
2. Ensures bytes read are properly counted
3. Tracks read operations performed by the stream

Public Jira: https://issues.apache.org/jira/browse/HADOOP-19364

Opening this PR as draft while I am working to extend it to add tests and modify existing tests to assert on these new stats we are adding

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

