### PR TITLE
HDFS-17006 : Compute correct checksum type when file is empty

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
@@ -240,17 +240,35 @@ final class FileChecksumHelper {
        * magic entry that matches what previous hdfs versions return.
        */
       if (locatedBlocks == null || locatedBlocks.isEmpty()) {
-        // Explicitly specified here in case the default DataOutputBuffer
-        // buffer length value is changed in future. This matters because the
-        // fixed value 32 has to be used to repeat the magic value for previous
-        // HDFS version.
-        final int lenOfZeroBytes = 32;
-        byte[] emptyBlockMd5 = new byte[lenOfZeroBytes];
-        MD5Hash fileMD5 = MD5Hash.digest(emptyBlockMd5);
-        fileChecksum =  new MD5MD5CRC32GzipFileChecksum(0, 0, fileMD5);
+        fileChecksum = makeEmptyBlockResult();
       } else {
         checksumBlocks();
         fileChecksum = makeFinalResult();
+      }
+    }
+
+    /**
+     * Returns a zero byte checksum based on the combine mode and CRC type
+     */
+    FileChecksum makeEmptyBlockResult() {
+      // Explicitly specified here in case the default DataOutputBuffer
+      // buffer length value is changed in future. This matters because the
+      // fixed value 32 has to be used to repeat the magic value for previous
+      // HDFS version.
+      final int lenOfZeroBytes = 32;
+      byte[] emptyBlockMd5 = new byte[lenOfZeroBytes];
+      MD5Hash fileMD5 = MD5Hash.digest(emptyBlockMd5);
+
+      switch (combineMode) {
+        case MD5MD5CRC:
+          if (crcType == DataChecksum.Type.CRC32C) {
+            return new MD5MD5CRC32CastagnoliFileChecksum(0, 0, fileMD5);
+          }
+          return new MD5MD5CRC32GzipFileChecksum(0, 0, fileMD5);
+        case COMPOSITE_CRC:
+          return new CompositeCrcFileChecksum(0, getCrcType(), bytesPerCRC);
+        default:
+          return new MD5MD5CRC32GzipFileChecksum(0, 0, fileMD5);
       }
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/TestFileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/TestFileChecksumHelper.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdfs;
 
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/TestFileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/test/java/org/apache/hadoop/hdfs/TestFileChecksumHelper.java
@@ -1,0 +1,75 @@
+package org.apache.hadoop.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.MD5MD5CRC32CastagnoliFileChecksum;
+import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
+import org.apache.hadoop.fs.CompositeCrcFileChecksum;
+import org.apache.hadoop.fs.Options.ChecksumCombineMode;
+import org.apache.hadoop.hdfs.protocol.ClientProtocol;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+
+import org.apache.hadoop.util.DataChecksum;
+
+@RunWith(Parameterized.class)
+public class TestFileChecksumHelper {
+
+    private final ChecksumCombineMode combineMode;
+    private final DataChecksum.Type crcType;
+    private final Class<? extends FileChecksum> expectedChecksumClass;
+
+    public TestFileChecksumHelper(ChecksumCombineMode combineMode,
+                                  DataChecksum.Type crcType,
+                                  Class<? extends FileChecksum> expectedChecksumClass) {
+        this.combineMode = combineMode;
+        this.crcType = crcType;
+        this.expectedChecksumClass = expectedChecksumClass;
+    }
+
+    @Parameterized.Parameters(name = "{index}: Mode={0}, CRC={1}, Expect={2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {ChecksumCombineMode.MD5MD5CRC, DataChecksum.Type.CRC32,  MD5MD5CRC32GzipFileChecksum.class},
+                {ChecksumCombineMode.MD5MD5CRC, DataChecksum.Type.CRC32C, MD5MD5CRC32CastagnoliFileChecksum.class},
+                {ChecksumCombineMode.COMPOSITE_CRC, DataChecksum.Type.CRC32, CompositeCrcFileChecksum.class},
+                {ChecksumCombineMode.COMPOSITE_CRC, DataChecksum.Type.CRC32C, CompositeCrcFileChecksum.class},
+        });
+    }
+
+    @Test
+    public void testComputeReturnsCorrectChecksumForEmptyBlocks() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set("dfs.checksum.combine.mode", combineMode.toString());
+        conf.set("dfs.checksum.type", crcType.toString());
+
+        LocatedBlocks emptyBlocks = new LocatedBlocks(); // No blocks
+
+        DFSClient mockClient = mock(DFSClient.class);
+        ClientProtocol mockNamenode = mock(ClientProtocol.class);
+
+        FileChecksumHelper.ReplicatedFileChecksumComputer checker =
+                new FileChecksumHelper.ReplicatedFileChecksumComputer(
+                        "/empty-file", 0L, emptyBlocks,
+                        mockNamenode, mockClient, combineMode
+                );
+
+        checker.setCrcType(crcType);
+        checker.setBytesPerCRC(512);
+        checker.compute();
+        FileChecksum checksum = checker.getFileChecksum();
+
+        assertNotNull("Checksum must not be null", checksum);
+        assertEquals("Unexpected checksum class", expectedChecksumClass, checksum.getClass());
+    }
+}


### PR DESCRIPTION
### Description of PR
When the file is empty or the file size is 0, the checksum returned is always MD5MD5CRC type even when the selected checksum type is COMPOSITE_CRC.

This is misleading and can create confusion while debugging.


### How was this patch tested?
Unit tests added

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

