### PR TITLE
HADOOP-19599. Fix file permission errors as per the platform

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/ChecksumFileSystem.java
@@ -205,13 +205,29 @@ public abstract class ChecksumFileSystem extends FilterFileSystem {
       } catch (IOException e) {
         // mincing the message is terrible, but java throws permission
         // exceptions as FNF because that's all the method signatures allow!
-        if (!(e instanceof FileNotFoundException) ||
-            e.getMessage().endsWith(" (Permission denied)")) {
+        if (!(e instanceof FileNotFoundException) || isPermissionDenied(e)) {
           LOG.warn("Problem opening checksum file: "+ file +
               ".  Ignoring exception: " , e);
         }
         set(fs.verifyChecksum, null, 1, 0);
       }
+    }
+
+    /**
+     * Check if the exception is a permission denied error.
+     * This is used to differentiate between a missing checksum file
+     * and a permission denied error when trying to read it.
+     *
+     * @param e the IOException to check
+     * @return true if the exception indicates a permission denied error
+     */
+    private static boolean isPermissionDenied(IOException e) {
+      String errorMessage = e.getMessage();
+      if (Path.WINDOWS) {
+        return errorMessage.endsWith(" (Access is denied)");
+      }
+
+      return errorMessage.endsWith(" (Permission denied)");
     }
 
     private long getChecksumFilePos( long dataPos ) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellCopy.java
@@ -676,11 +676,26 @@ public class TestFsShellCopy {
       System.setErr(new PrintStream(err));
       shellRun(1, "-put", src.toString(), dst.toString());
       System.setErr(oldErr);
-      System.err.print(err.toString());
-      assertTrue(err.toString().contains("(Permission denied)"));
+      System.err.print(err);
+      assertPermissionDenied(err);
     } finally {
       // make sure the test file can be deleted
       lfs.setPermission(src, new FsPermission((short)0755));
+    }
+  }
+
+  /**
+   * Assert that the error message contains the expected permission denied
+   * message, which varies by platform.
+   *
+   * @param err the ByteArrayOutputStream containing the error output
+   */
+  private static void assertPermissionDenied(ByteArrayOutputStream err) {
+    String errorMessage = err.toString();
+    if (Path.WINDOWS) {
+      assertTrue(errorMessage.contains("(Access is denied)"));
+    } else {
+      assertTrue(errorMessage.contains("(Permission denied)"));
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* The file permission denial error message in Linux systems end with `(Permission denied)` particularly.
* However, an error message in the same scenario on Windows ends with an `(Access is denied)` error.
* This PR fixes the resulting bug in `org.apache.hadoop.fs.ChecksumFileSystem.ChecksumFSInputChecker` and also fixes the unit test failure `org.apache.hadoop.fs.TestFsShellCopy#testPutSrcFileNoPerm` by making the appropriate check in accordance with the platform.

### How was this patch tested?

1. Ran the unit test locally (for Windows).
2. CI validation (for Windows and Linux).

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

