### PR TITLE
HADOOP-19601. Fix Unit Test Failure in ITestAzureBlobFileSystemMainOperation.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMainOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMainOperation.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs.azurebfs;
 import org.apache.hadoop.fs.FSMainOperationsBaseTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.azurebfs.contract.ABFSContractTestBinding;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 
 /**
@@ -41,12 +43,14 @@ public class ITestAzureBlobFileSystemMainOperation extends FSMainOperationsBaseT
     binding = new ABFSContractTestBinding(false);
   }
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     binding.setup();
     fSys = binding.getFileSystem();
   }
 
+  @AfterEach
   @Override
   public void tearDown() throws Exception {
     // Note: Because "tearDown()" is called during the testing,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19601. Fix Unit Test Failure in ITestAzureBlobFileSystemMainOperation.

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

