### PR TITLE
HADOOP-19603. Fix TestFsShellList.testList on Windows

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellList.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestFsShellList.java
@@ -66,9 +66,12 @@ public class TestFsShellList {
     String[] lsArgv = new String[]{"-ls", testRootDir.toString()};
     assertThat(shell.run(lsArgv)).isEqualTo(0);
 
-    createFile(new Path(testRootDir, "abc\bd\tef"));
+    if (!Path.WINDOWS) {
+      createFile(new Path(testRootDir, "abc\bd\tef"));
+      createFile(new Path(testRootDir, "qq\r123"));
+    }
+
     createFile(new Path(testRootDir, "ghi"));
-    createFile(new Path(testRootDir, "qq\r123"));
     lsArgv = new String[]{"-ls", testRootDir.toString()};
     assertThat(shell.run(lsArgv)).isEqualTo(0);
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

* The test `org.apache.hadoop.fs.TestFsShellList#testList` creates files with special characters and tries to list them using `ls`.
* Filenames with special characters aren't allowed on Windows.
* Thus, this PR modifies the test to only test for non-special characters on Windows and include the filenames with special characters on non-Windows environments.

### How was this patch tested?

1. Ran the unit tests locally on Windows.
2. Jenkins CI validation.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

