### PR TITLE
HDFS-17801. EC supports createBlockReader retry when IOException occurs

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -72,6 +72,8 @@ public class DFSClientFaultInjector {
   public void onCreateBlockReader(LocatedBlock block, int chunkIndex, long offset, long length) {}
 
   public void failCreateBlockReader() throws InvalidBlockTokenException {}
+  
+  public void failWhenReadWithStrategy(boolean isRetryRead) throws IOException {}
 
-  public void failWhenReadWithStrategy(boolean isRetryRead) throws IOException {};
+  public void failCreateBlockReader(int curRetryCounts) throws IOException {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedInputStream.java
@@ -234,12 +234,12 @@ public class DFSStripedInputStream extends DFSInputStream {
 
   boolean createBlockReader(LocatedBlock block, long offsetInBlock,
       LocatedBlock[] targetBlocks, BlockReaderInfo[] readerInfos,
-      int chunkIndex, long readTo) throws IOException {
+      int chunkIndex, long readTo, int readDNMaxRetryCounts) throws IOException {
     BlockReader reader = null;
     final ReaderRetryPolicy retry = new ReaderRetryPolicy();
     DFSInputStream.DNAddrPair dnInfo =
         new DFSInputStream.DNAddrPair(null, null, null, null);
-
+    int curRetryCounts = 0;
     while (true) {
       try {
         // the cached block location might have been re-fetched, so always
@@ -255,6 +255,7 @@ public class DFSStripedInputStream extends DFSInputStream {
         if (readTo < 0 || readTo > block.getBlockSize()) {
           readTo = block.getBlockSize();
         }
+        DFSClientFaultInjector.get().failCreateBlockReader(curRetryCounts);
         reader = getBlockReader(block, offsetInBlock,
             readTo - offsetInBlock,
             dnInfo.addr, dnInfo.storageType, dnInfo.info);
@@ -273,10 +274,17 @@ public class DFSStripedInputStream extends DFSInputStream {
           fetchBlockAt(block.getStartOffset());
           retry.refetchToken();
         } else {
+          if (curRetryCounts++ < readDNMaxRetryCounts) {
+            DFSClient.LOG.info("Try to reconnect to {} for block {} for {} time.", dnInfo.addr,
+                block.getBlock(), curRetryCounts);
+            // Re-fetch the block in case the block has been moved.
+            fetchBlockAt(block.getStartOffset());
+            continue;
+          }
           //TODO: handles connection issues
-          DFSClient.LOG.warn("Failed to connect to " + dnInfo.addr + " for " +
-              "block" + block.getBlock(), e);
-          // re-fetch the block in case the block has been moved
+          DFSClient.LOG.warn("Failed to connect to {} for block {} after retrying {} time.",
+              dnInfo.addr, block.getBlock(), curRetryCounts, e);
+          // Re-fetch the block in case the block has been moved
           fetchBlockAt(block.getStartOffset());
           addToLocalDeadNodes(dnInfo.info);
         }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/StripeReader.java
@@ -120,6 +120,7 @@ abstract class StripeReader {
   protected final RawErasureDecoder decoder;
   protected final DFSStripedInputStream dfsStripedInputStream;
   private long readTo = -1;
+  private final int readDNMaxRetryCounts;
 
   protected ECChunk[] decodeInputs;
 
@@ -138,6 +139,8 @@ abstract class StripeReader {
     this.corruptedBlocks = corruptedBlocks;
     this.decoder = decoder;
     this.dfsStripedInputStream = dfsStripedInputStream;
+    this.readDNMaxRetryCounts = dfsStripedInputStream.getDFSClient()
+        .getConf().getStripedReadDnMaxRetryCounts();
 
     service = new ExecutorCompletionService<>(
             dfsStripedInputStream.getStripedReadsThreadPool());
@@ -309,7 +312,7 @@ abstract class StripeReader {
     if (readerInfos[chunkIndex] == null) {
       if (!dfsStripedInputStream.createBlockReader(block,
           alignedStripe.getOffsetInBlock(), targetBlocks,
-          readerInfos, chunkIndex, readTo)) {
+          readerInfos, chunkIndex, readTo, readDNMaxRetryCounts)) {
         chunk.state = StripingChunk.MISSING;
         return false;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -532,6 +532,14 @@ public interface HdfsClientConfigKeys {
      * span 6 DNs, so this default value accommodates 3 read streams
      */
     int     THREADPOOL_SIZE_DEFAULT = 18;
+
+    /**
+     * The max retry counts of reconnecting to DN
+     * during the striped read process, Default is 1.
+     */
+    String DATANODE_MAX_RETRY_COUNT = PREFIX +
+        "datanode.max.retry.count";
+    int DATANODE_MAX_RETRY_COUNT_DEFAULT = 1;
   }
 
   /** dfs.http.client configuration properties */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -167,6 +167,7 @@ public class DfsClientConf {
   private final boolean deadNodeDetectionEnabled;
   private final long leaseHardLimitPeriod;
   private final boolean recoverLeaseOnCloseException;
+  private final int stripedReadDnMaxRetryCounts;
 
   public DfsClientConf(Configuration conf) {
     // The hdfsTimeout is currently the same as the ipc timeout
@@ -296,6 +297,13 @@ public class DfsClientConf {
     Preconditions.checkArgument(stripedReadThreadpoolSize > 0, "The value of " +
         HdfsClientConfigKeys.StripedRead.THREADPOOL_SIZE_KEY +
         " must be greater than 0.");
+    stripedReadDnMaxRetryCounts =
+        conf.getInt(
+            HdfsClientConfigKeys.StripedRead.DATANODE_MAX_RETRY_COUNT,
+            HdfsClientConfigKeys.StripedRead.DATANODE_MAX_RETRY_COUNT_DEFAULT);
+    Preconditions.checkArgument(stripedReadDnMaxRetryCounts >= 0, "The value of " +
+        HdfsClientConfigKeys.StripedRead.DATANODE_MAX_RETRY_COUNT +
+        " must be greater than or equal to 0.");
     replicaAccessorBuilderClasses = loadReplicaAccessorBuilderClasses(conf);
 
     leaseHardLimitPeriod =
@@ -708,6 +716,13 @@ public class DfsClientConf {
    */
   public long getleaseHardLimitPeriod() {
     return leaseHardLimitPeriod;
+  }
+
+  /**
+   * @return the stripedReadDnMaxRetryCounts
+   */
+  public int getStripedReadDnMaxRetryCounts() {
+    return stripedReadDnMaxRetryCounts;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4626,6 +4626,15 @@
 </property>
 
 <property>
+  <name>dfs.client.read.striped.datanode.max.retry.count</name>
+  <value>1</value>
+  <description>
+    The max retry counts of reconnecting to DN during
+    the striped read process, Default is 1.
+  </description>
+</property>
+
+<property>
   <name>dfs.client.replica.accessor.builder.classes</name>
   <value></value>
   <description>


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17801.

Currently , there is no retry policy If we meet IOExcetion when creating block reader to read EC file. Suppose below case (using RS-6-3-1024k):

The first 4 to 6 data blocks' datanodes are very busy at the same time, createBlockReader will timeout. This will cause read failure, we should make EC support retry mechanism to mitigate read failure.

### How was this patch tested?
Add an unit test to reproduce.