### PR TITLE
HADOOP-19605. Upgrade Protobuf 3.25.5 for docker images

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -84,7 +84,7 @@ Refer to  dev-support/docker/Dockerfile):
   $ tar -zxvf protobuf-3.25.5.tar.gz
   $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
   $ cd protobuf-3.25.5
-  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF
   $ cmake --build build --parallel $(nproc)
   $ sudo cmake --install build
 * Boost
@@ -441,7 +441,7 @@ you may optionally install zlib, lz4, etc.
   $ tar -zxvf protobuf-3.25.5.tar.gz
   $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
   $ cd protobuf-3.25.5
-  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF
   $ cmake --build build --parallel $(nproc)
   $ cmake --install build
   $ protoc --version
@@ -481,7 +481,7 @@ Building on Rocky Linux 8
   $ tar -zxvf protobuf-3.25.5.tar.gz
   $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
   $ cd protobuf-3.25.5
-  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF
   $ cmake --build build --parallel $(nproc)
   $ sudo cmake --install build --prefix /usr/local
   $ cd ..

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -7,7 +7,7 @@ Requirements:
 * JDK 1.8
 * Maven 3.3 or later
 * Boost 1.86.0 (if compiling native code)
-* Protocol Buffers 3.21.12 (if compiling native code)
+* Protocol Buffers 3.25.5 (if compiling native code)
 * CMake 3.19 or newer (if compiling native code)
 * Zlib devel (if compiling native code)
 * Cyrus SASL devel (if compiling native code)
@@ -78,13 +78,15 @@ Refer to  dev-support/docker/Dockerfile):
   $ ./bootstrap
   $ make -j$(nproc)
   $ sudo make install
-* Protocol Buffers 3.21.12 (required to build native code)
-  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz > protobuf-3.21.12.tar.gz
-  $ tar -zxvf protobuf-3.21.12.tar.gz && cd protobuf-3.21.12
-  $ ./autogen.sh
-  $ ./configure
-  $ make -j$(nproc)
-  $ sudo make install
+* Protocol Buffers 3.25.5 (required to build native code)
+  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.25.5.tar.gz > protobuf-3.25.5.tar.gz
+  $ curl -L https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz > abseil-cpp-20230802.1.tar.gz
+  $ tar -zxvf protobuf-3.25.5.tar.gz
+  $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
+  $ cd protobuf-3.25.5
+  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake --build build --parallel $(nproc)
+  $ sudo cmake --install build
 * Boost
   $ curl -L https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download > boost_1_86_0.tar.bz2
   $ tar --bzip2 -xf boost_1_86_0.tar.bz2 && cd boost_1_86_0
@@ -433,14 +435,15 @@ Installing required dependencies for clean install of macOS 10.14:
 * Install native libraries, only openssl is required to compile native code,
 you may optionally install zlib, lz4, etc.
   $ brew install openssl
-* Protocol Buffers 3.21.12 (required to compile native code)
-  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz > protobuf-3.21.12.tar.gz
-  $ tar -zxvf protobuf-3.21.12.tar.gz && cd protobuf-3.21.12
-  $ ./autogen.sh
-  $ ./configure
-  $ make
-  $ make check
-  $ make install
+* Protocol Buffers 3.25.5 (required to build native code)
+  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.25.5.tar.gz > protobuf-3.25.5.tar.gz
+  $ curl -L https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz > abseil-cpp-20230802.1.tar.gz
+  $ tar -zxvf protobuf-3.25.5.tar.gz
+  $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
+  $ cd protobuf-3.25.5
+  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake --build build --parallel $(nproc)
+  $ cmake --install build
   $ protoc --version
 
 Note that building Hadoop 3.1.1/3.1.2/3.2.0 native code from source is broken
@@ -472,13 +475,15 @@ Building on Rocky Linux 8
 * Install python2 for building documentation.
   $ sudo dnf install python2
 
-* Install Protocol Buffers v3.21.12.
-  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz > protobuf-3.21.12.tar.gz
-  $ tar -zxvf protobuf-3.21.12.tar.gz && cd protobuf-3.21.12
-  $ ./autogen.sh
-  $ ./configure --prefix=/usr/local
-  $ make
-  $ sudo make install
+* Protocol Buffers 3.25.5 (required to build native code)
+  $ curl -L https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.25.5.tar.gz > protobuf-3.25.5.tar.gz
+  $ curl -L https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz > abseil-cpp-20230802.1.tar.gz
+  $ tar -zxvf protobuf-3.25.5.tar.gz
+  $ tar -zxvf abseil-cpp-20230802.1.tar.gz --strip-components 1 -C protobuf-3.25.5/third_party/abseil-cpp
+  $ cd protobuf-3.25.5
+  $ cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF
+  $ cmake --build build --parallel $(nproc)
+  $ sudo cmake --install build --prefix /usr/local
   $ cd ..
 
 * Install libraries provided by Rocky Linux 8.
@@ -530,7 +535,7 @@ Requirements:
 * JDK 1.8
 * Maven 3.3 or later (maven.apache.org)
 * Boost 1.86.0 (boost.org)
-* Protocol Buffers 3.21.12 (https://github.com/protocolbuffers/protobuf/tags)
+* Protocol Buffers 3.25.5 (https://github.com/protocolbuffers/protobuf/tags)
 * CMake 3.19 or newer (cmake.org)
 * Visual Studio 2019 (visualstudio.com)
 * Windows SDK 8.1 (optional, if building CPU rate control for the container executor. Get this from

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -72,7 +72,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV SPOTBUGS_HOME /opt/spotbugs
 
 #######
-# Set env vars for Google Protobuf 3.21.12
+# Set env vars for Google Protobuf 3.25.5
 #######
 ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -73,7 +73,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-arm64
 ENV SPOTBUGS_HOME /opt/spotbugs
 
 #######
-# Set env vars for Google Protobuf 3.21.12
+# Set env vars for Google Protobuf 3.25.5
 #######
 ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"

--- a/dev-support/docker/Dockerfile_debian_11
+++ b/dev-support/docker/Dockerfile_debian_11
@@ -65,7 +65,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
-# Set env vars for Google Protobuf 3.21.12
+# Set env vars for Google Protobuf 3.25.5
 #######
 ENV PROTOBUF_HOME=/opt/protobuf
 ENV PATH="${PATH}:/opt/protobuf/bin"

--- a/dev-support/docker/Dockerfile_rockylinux_8
+++ b/dev-support/docker/Dockerfile_rockylinux_8
@@ -94,7 +94,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
 ENV SPOTBUGS_HOME=/opt/spotbugs
 
 #######
-# Set env vars for Google Protobuf 3.21.12
+# Set env vars for Google Protobuf 3.25.5
 #######
 ENV PROTOBUF_HOME=/opt/protobuf
 ENV PATH="${PATH}:${PROTOBUF_HOME}/bin"

--- a/dev-support/docker/Dockerfile_ubuntu_24
+++ b/dev-support/docker/Dockerfile_ubuntu_24
@@ -72,7 +72,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV SPOTBUGS_HOME /opt/spotbugs
 
 #######
-# Set env vars for Google Protobuf 3.21.12
+# Set env vars for Google Protobuf 3.25.5
 #######
 ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"

--- a/dev-support/docker/pkg-resolver/install-protobuf.sh
+++ b/dev-support/docker/pkg-resolver/install-protobuf.sh
@@ -45,13 +45,12 @@ if [ "$version_to_install" == "3.25.5" ]; then
       https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.25.5.tar.gz \
       -o /opt/protobuf.tar.gz &&
     tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src &&
-    mkdir -p /opt/abseil-cpp-src &&
     curl -L -s -S \
       https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz \
       -o /opt/abseil-cpp.tar.gz &&
     tar xzf /opt/abseil-cpp.tar.gz --strip-components 1 -C /opt/protobuf-src/third_party/abseil-cpp &&
     cd /opt/protobuf-src &&
-    cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF &&
+    cmake -S . -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF &&
     cmake --build build --parallel $(nproc) &&
     cmake --install build --prefix /opt/protobuf &&
     cd /root &&

--- a/dev-support/docker/pkg-resolver/install-protobuf.sh
+++ b/dev-support/docker/pkg-resolver/install-protobuf.sh
@@ -27,29 +27,33 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-default_version="3.21.12"
+default_version="3.25.5"
 version_to_install=$default_version
 if [ -n "$2" ]; then
   version_to_install="$2"
 fi
 
-if [ "$version_to_install" != "3.21.12" ]; then
+if [ "$version_to_install" != "3.25.5" ]; then
   echo "WARN: Don't know how to install version $version_to_install, installing the default version $default_version instead"
   version_to_install=$default_version
 fi
 
-if [ "$version_to_install" == "3.21.12" ]; then
+if [ "$version_to_install" == "3.25.5" ]; then
   # hadolint ignore=DL3003
   mkdir -p /opt/protobuf-src &&
     curl -L -s -S \
-      https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz \
+      https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.25.5.tar.gz \
       -o /opt/protobuf.tar.gz &&
     tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src &&
+    mkdir -p /opt/abseil-cpp-src &&
+    curl -L -s -S \
+      https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz \
+      -o /opt/abseil-cpp.tar.gz &&
+    tar xzf /opt/abseil-cpp.tar.gz --strip-components 1 -C /opt/protobuf-src/third_party/abseil-cpp &&
     cd /opt/protobuf-src &&
-    ./autogen.sh &&
-    ./configure --prefix=/opt/protobuf &&
-    make "-j$(nproc)" &&
-    make install &&
+    cmake -S . -B build -Dprotobuf_BUILD_TESTS=OFF &&
+    cmake --build build --parallel $(nproc) &&
+    cmake --install build --prefix /opt/protobuf &&
     cd /root &&
     rm -rf /opt/protobuf-src
 else

--- a/dev-support/docker/vcpkg/vcpkg.json
+++ b/dev-support/docker/vcpkg/vcpkg.json
@@ -10,7 +10,7 @@
   "overrides": [
     {
       "name": "protobuf",
-      "version": "3.21.12"
+      "version": "3.25.5"
     }
   ]
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/CMakeLists.txt
@@ -43,9 +43,70 @@ SET(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CYRUS_SASL_DIR};${GSASL_DIR};$ENV{
 # Specify PROTOBUF_HOME so that find_package picks up the correct version
 SET(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$ENV{PROTOBUF_HOME}")
 
+if (BUILD_SHARED_LIBS AND MSVC)
+  # On MSVC Abseil is bundled into a single DLL.
+  # This condition is necessary as of abseil 20230125.3 when abseil is consumed via add_subdirectory,
+  # the abseil_dll target  is named abseil_dll, while if abseil is consumed via find_package, the target
+  # is called absl::abseil_dll
+  # Once https://github.com/abseil/abseil-cpp/pull/1466 is merged and released in the minimum version of
+  # abseil required by protobuf, it is possible to always link absl::abseil_dll and absl::abseil_test_dll
+  # and remove the if
+  if(protobuf_ABSL_PROVIDER STREQUAL "package")
+    set(protobuf_ABSL_USED_TARGETS absl::abseil_dll)
+    set(protobuf_ABSL_USED_TEST_TARGETS absl::abseil_test_dll)
+  else()
+    set(protobuf_ABSL_USED_TARGETS abseil_dll)
+    set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+  endif()
+else()
+  set(protobuf_ABSL_USED_TARGETS
+    absl::absl_check
+    absl::absl_log
+    absl::algorithm
+    absl::base
+    absl::bind_front
+    absl::bits
+    absl::btree
+    absl::cleanup
+    absl::cord
+    absl::core_headers
+    absl::debugging
+    absl::die_if_null
+    absl::dynamic_annotations
+    absl::flags
+    absl::flat_hash_map
+    absl::flat_hash_set
+    absl::function_ref
+    absl::hash
+    absl::layout
+    absl::log_initialize
+    absl::log_severity
+    absl::memory
+    absl::node_hash_map
+    absl::node_hash_set
+    absl::optional
+    absl::span
+    absl::status
+    absl::statusor
+    absl::strings
+    absl::synchronization
+    absl::time
+    absl::type_traits
+    absl::utility
+    absl::variant
+    utf8_range::utf8_validity
+    utf8_range::utf8_range
+  )
+  set(protobuf_ABSL_USED_TEST_TARGETS
+    absl::scoped_mock_log
+  )
+endif ()
+
 find_package(Doxygen)
 find_package(OpenSSL REQUIRED)
 find_package(Protobuf REQUIRED)
+find_package(absl REQUIRED)
+find_package(utf8_range REQUIRED)
 find_package(CyrusSASL)
 find_package(GSasl)
 find_package(Threads)
@@ -89,7 +150,10 @@ endif (NOT THREAD_LOCAL_SUPPORTED)
 # to compile some dummy code
 unset (PROTOC_IS_COMPATIBLE CACHE)
 set (CMAKE_REQUIRED_INCLUDES ${PROTOBUF_INCLUDE_DIRS})
-set (CMAKE_REQUIRED_LIBRARIES ${PROTOBUF_LIBRARY} ${PROTOBUF_PROTOC_LIBRARY})
+set (CMAKE_REQUIRED_LIBRARIES
+  ${PROTOBUF_LIBRARY}
+  ${PROTOBUF_PROTOC_LIBRARY}
+  ${protobuf_ABSL_USED_TARGETS})
 check_cxx_source_compiles(
     "#include <google/protobuf/io/printer.h>
     #include <string>
@@ -280,6 +344,7 @@ if (HADOOP_BUILD AND NOT MSVC)
   hadoop_target_link_dual_libraries(hdfspp
     ${LIB_DL}
     ${PROTOBUF_LIBRARY}
+    ${protobuf_ABSL_USED_TARGETS}
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
@@ -291,6 +356,7 @@ else (HADOOP_BUILD AND NOT MSVC)
   target_link_libraries(hdfspp_static PUBLIC
     ${LIB_DL}
     ${PROTOBUF_LIBRARY}
+    ${protobuf_ABSL_USED_TARGETS}
     ${OPENSSL_LIBRARIES}
     ${SASL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/CMakeLists.txt
@@ -38,7 +38,10 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
 )
 
 add_executable(protoc-gen-hrpc protoc_gen_hrpc.cc)
-target_link_libraries(protoc-gen-hrpc ${PROTOBUF_PROTOC_LIBRARY} ${PROTOBUF_LIBRARY})
+target_link_libraries(protoc-gen-hrpc
+  ${PROTOBUF_PROTOC_LIBRARY}
+  ${PROTOBUF_LIBRARY}
+  ${protobuf_ABSL_USED_TARGETS})
 
 function(GEN_HRPC SRCS)
   if(NOT ARGN)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/protoc_gen_hrpc.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/lib/proto/protoc_gen_hrpc.cc
@@ -48,7 +48,6 @@ private:
 
 bool StubGenerator::Generate(const FileDescriptor *file, const std::string &,
                              GeneratorContext *ctx, std::string *) const {
-  namespace pb = ::google::protobuf;
   std::unique_ptr<ZeroCopyOutputStream> os(
       ctx->Open(StripProto(file->name()) + ".hrpc.inl"));
   Printer out(os.get(), '$');

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/CMakeLists.txt
@@ -90,11 +90,11 @@ target_link_libraries(get_jni_test
 add_memcheck_test(get_jni get_jni_test)
 
 add_executable(remote_block_reader_test remote_block_reader_test.cc)
-target_link_libraries(remote_block_reader_test test_common reader proto common connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(remote_block_reader_test test_common reader proto common connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(remote_block_reader remote_block_reader_test)
 
 add_executable(sasl_digest_md5_test sasl_digest_md5_test.cc)
-target_link_libraries(sasl_digest_md5_test common ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(sasl_digest_md5_test common ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(sasl_digest_md5 sasl_digest_md5_test)
 
 add_executable(retry_policy_test retry_policy_test.cc)
@@ -103,15 +103,15 @@ add_memcheck_test(retry_policy retry_policy_test)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_executable(rpc_engine_test rpc_engine_test.cc ${PROTO_TEST_SRCS} ${PROTO_TEST_HDRS})
-target_link_libraries(rpc_engine_test test_common rpc proto common ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
+target_link_libraries(rpc_engine_test test_common rpc proto common ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
 add_memcheck_test(rpc_engine rpc_engine_test)
 
 add_executable(bad_datanode_test bad_datanode_test.cc)
-target_link_libraries(bad_datanode_test rpc reader proto fs bindings_c rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(bad_datanode_test rpc reader proto fs bindings_c rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(bad_datanode bad_datanode_test)
 
 add_executable(node_exclusion_test node_exclusion_test.cc)
-target_link_libraries(node_exclusion_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(node_exclusion_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(node_exclusion node_exclusion_test)
 
 add_executable(configuration_test $<TARGET_OBJECTS:test_utils> configuration_test.cc)
@@ -125,30 +125,30 @@ target_link_libraries(hdfs_configuration_test common gmock_main ${CMAKE_THREAD_L
 add_memcheck_test(hdfs_configuration hdfs_configuration_test)
 
 add_executable(hdfspp_errors_test hdfspp_errors.cc)
-target_link_libraries(hdfspp_errors_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(hdfspp_errors_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(hdfspp_errors hdfspp_errors_test)
 
 add_executable(hdfs_builder_test $<TARGET_OBJECTS:test_utils> hdfs_builder_test.cc)
 target_include_directories(hdfs_builder_test PRIVATE ../lib)
-target_link_libraries(hdfs_builder_test test_common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(hdfs_builder_test test_common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(hdfs_builder_test hdfs_builder_test)
 
 add_executable(logging_test logging_test.cc $<TARGET_OBJECTS:x_platform_obj>)
 target_include_directories(logging_test PRIVATE ../lib)
-target_link_libraries(logging_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(logging_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} gmock_main ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(logging_test logging_test)
 
 add_executable(hdfs_ioservice_test hdfs_ioservice_test.cc)
-target_link_libraries(hdfs_ioservice_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(hdfs_ioservice_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(hdfs_ioservice hdfs_ioservice_test)
 
 add_executable(user_lock_test user_lock_test.cc)
-target_link_libraries(user_lock_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(user_lock_test fs gmock_main common ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(user_lock user_lock_test)
 
 add_executable(hdfs_config_connect_bugs_test $<TARGET_OBJECTS:test_utils> hdfs_config_connect_bugs.cc)
 target_include_directories(hdfs_config_connect_bugs_test PRIVATE ../lib)
-target_link_libraries(hdfs_config_connect_bugs_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(hdfs_config_connect_bugs_test common gmock_main bindings_c fs rpc proto common reader connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} ${SASL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_memcheck_test(hdfs_config_connect_bugs hdfs_config_connect_bugs_test)
 
 
@@ -178,22 +178,22 @@ add_dependencies(hdfspp_test_static proto)
 #TODO: Link against full library rather than just parts
 
 build_libhdfs_test(libhdfs_threaded hdfspp_test_shim_static expect.c test_libhdfs_threaded.c ${OS_DIR}/thread.c)
-link_libhdfs_test(libhdfs_threaded hdfspp_test_shim_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES} )
+link_libhdfs_test(libhdfs_threaded hdfspp_test_shim_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES} )
 add_libhdfs_test  (libhdfs_threaded hdfspp_test_shim_static)
 
 build_libhdfs_test(hdfspp_mini_dfs_smoke hdfspp_test_shim_static ${CMAKE_CURRENT_LIST_DIR}/hdfspp_mini_dfs_smoke.cc)
-link_libhdfs_test (hdfspp_mini_dfs_smoke hdfspp_test_shim_static fs reader rpc proto common connection gmock_main ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
+link_libhdfs_test (hdfspp_mini_dfs_smoke hdfspp_test_shim_static fs reader rpc proto common connection gmock_main ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
 add_libhdfs_test  (hdfspp_mini_dfs_smoke hdfspp_test_shim_static)
 
 if (NOT MSVC)
   build_libhdfs_test(libhdfs_mini_stress_valgrind hdfspp_test_static expect.c test_libhdfs_mini_stress.c ${OS_DIR}/thread.c)
-  link_libhdfs_test(libhdfs_mini_stress_valgrind hdfspp_test_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
+  link_libhdfs_test(libhdfs_mini_stress_valgrind hdfspp_test_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
   add_memcheck_test(libhdfs_mini_stress_valgrind_hdfspp_test_static libhdfs_mini_stress_valgrind_hdfspp_test_static)
   set_target_properties(libhdfs_mini_stress_valgrind_hdfspp_test_static PROPERTIES COMPILE_DEFINITIONS "VALGRIND")
 endif (NOT MSVC)
 
 build_libhdfs_test(libhdfs_mini_stress hdfspp_test_shim_static expect.c test_libhdfs_mini_stress.c ${OS_DIR}/thread.c)
-link_libhdfs_test(libhdfs_mini_stress hdfspp_test_shim_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
+link_libhdfs_test(libhdfs_mini_stress hdfspp_test_shim_static fs reader rpc proto common connection ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS} ${OPENSSL_LIBRARIES} native_mini_dfs ${JAVA_JVM_LIBRARY} ${SASL_LIBRARIES})
 add_libhdfs_test(libhdfs_mini_stress hdfspp_test_shim_static)
 
 build_libhdfs_test(hdfs_ext hdfspp_test_shim_static ${CMAKE_CURRENT_LIST_DIR}/hdfs_ext_test.cc)

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/remote_block_reader_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/remote_block_reader_test.cc
@@ -58,8 +58,7 @@ using ::testing::Return;
 using std::make_pair;
 using std::string;
 
-namespace pb = ::google::protobuf;
-namespace pbio = pb::io;
+namespace pbio = ::google::protobuf::io;
 
 namespace hdfs {
 
@@ -114,7 +113,7 @@ public:
 
 }
 
-static inline string ToDelimitedString(const pb::MessageLite *msg) {
+static inline string ToDelimitedString(const google::protobuf::MessageLite *msg) {
   string res;
   res.reserve(hdfs::DelimitedPBMessageSize(msg));
   pbio::StringOutputStream os(&res);

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/rpc_engine_test.cc
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfspp/tests/rpc_engine_test.cc
@@ -48,7 +48,6 @@ using ::testing::Return;
 using ::std::make_pair;
 using ::std::string;
 
-namespace pb = ::google::protobuf;
 namespace pbio = ::google::protobuf::io;
 
 namespace hdfs {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

HADOOP-19605. Upgrade Protobuf 3.25.5 for docker images.

[HADOOP-19289](https://issues.apache.org/jira/browse/HADOOP-19289) upgraded protobuf-java 3.25.5, we should use same version for protobuf installed in docker images.

### How was this patch tested?

Changes are covered by CI, also manually tested in local

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

