### PR TITLE
HADOOP-19606. Delete the UID in the dev container that is the same as the host user

### DIFF
--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -89,6 +89,7 @@ DOCKER_HOME_DIR=${DOCKER_HOME_DIR:-/home/${USER_NAME}}
 docker build -t "hadoop-build${OS_PLATFORM_SUFFIX}-${USER_ID}" - <<UserSpecificDocker
 FROM hadoop-build
 RUN rm -f /var/log/faillog /var/log/lastlog
+RUN userdel -r \$(getent passwd ${USER_ID} | cut -d: -f1) 2>/dev/null || :
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
 RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME} -d "${DOCKER_HOME_DIR}"
 RUN echo "${USER_NAME} ALL=NOPASSWD: ALL" > "/etc/sudoers.d/hadoop-build-${USER_ID}"


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Ubuntu 24.04 (noble) docker image has a built-in user `ubuntu` (UID 1000)
```
$ docker run --rm -it ubuntu:noble cat /etc/passwd | grep ubuntu
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
```

Dev container failed to bootstrap when the host user happens to have the same UID.
```
$ id
uid=1000(chengpan) gid=1000(chengpan) groups=1000(chengpan),4(adm),27(sudo),108(lpadmin),987(docker)

$ ./start-build-env.sh ubuntu_24

...

 => ERROR [4/5] RUN useradd -g 1000 -u 1000 -k /root -m chengpan -d "/home/chengpan"                                                                                                                             0.2s
------
 > [4/5] RUN useradd -g 1000 -u 1000 -k /root -m chengpan -d "/home/chengpan":
0.187 useradd: UID 1000 is not unique
------

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 6)
Dockerfile:4
--------------------
   2 |     RUN rm -f /var/log/faillog /var/log/lastlog
   3 |     RUN groupadd --non-unique -g 1000 chengpan
   4 | >>> RUN useradd -g 1000 -u 1000 -k /root -m chengpan -d "/home/chengpan"
   5 |     RUN echo "chengpan ALL=NOPASSWD: ALL" > "/etc/sudoers.d/hadoop-build-1000"
   6 |     ENV HOME "/home/chengpan"
--------------------
ERROR: failed to build: failed to solve: process "/bin/bash -o pipefail -c useradd -g 1000 -u 1000 -k /root -m chengpan -d \"/home/chengpan\"" did not complete successfully: exit code: 4
```

### How was this patch tested?

Manual test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

