### PR TITLE
HDFS-17804. [JDK17] Recover test for hadoop-hdfs-native-client

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/pom.xml
@@ -77,6 +77,31 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
@@ -263,8 +263,8 @@ jthrowable newRuntimeError(JNIEnv *env, const char *fmt, ...)
         // Too bad...
         return getPendingExceptionAndClear(env);
     }
-    exc = constructNewObjectOfClass(env, &out, "RuntimeException",
-        "(java/lang/String;)V", jstr);
+    exc = constructNewObjectOfClass(env, &out, "java/lang/RuntimeException",
+        "(Ljava/lang/String;)V", jstr);
     (*env)->DeleteLocalRef(env, jstr);
     // Again, we'll either get an out of memory exception or the
     // RuntimeException we wanted.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HDFS-17804. [JDK17] Recover test for hadoop-hdfs-native-client.

The following test happens in x86 `./start-build-env.sh` (Ubuntu focal)

Currently, `hadoop-hdfs-native-client` fails to start due to JUnit 5 upgrade.
```
$ mvn -Pnative -pl :hadoop-hdfs-native-client -am clean install -DskipTests
$ mvn -Pnative -pl :hadoop-hdfs-native-client test
...
     [exec] testRecursiveJvmMutex error:
     [exec] ClassNotFoundException: RuntimeExceptionjava.lang.NoClassDefFoundError: RuntimeException
     [exec] Caused by: java.lang.ClassNotFoundException: RuntimeException
     [exec] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
     [exec] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
     [exec] 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
     [exec] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
     [exec] nmdCreate: NativeMiniDfsCluster#Builder#Builder error:
     [exec] ClassNotFoundException: org.junit.jupiter.api.Assertionsjava.lang.NoClassDefFoundError: org/junit/jupiter/api/Assertions
     [exec] 	at org.apache.hadoop.test.GenericTestUtils.assertExists(GenericTestUtils.java:281)
     [exec] 	at org.apache.hadoop.test.GenericTestUtils.getTestDir(GenericTestUtils.java:225)
     [exec] 	at org.apache.hadoop.test.GenericTestUtils.getTestDir(GenericTestUtils.java:234)
     [exec] 	at org.apache.hadoop.hdfs.MiniDFSCluster.getBaseDirectory(MiniDFSCluster.java:3126)
     [exec] 	at org.apache.hadoop.hdfs.MiniDFSCluster$Builder.<init>(MiniDFSCluster.java:239)
     [exec] Caused by: java.lang.ClassNotFoundException: org.junit.jupiter.api.Assertions
     [exec] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
     [exec] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
     [exec] 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
     [exec] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
     [exec] 	... 5 more
...
     [exec] 79% tests passed, 10 tests failed out of 48
     [exec]
     [exec] Total Test time (real) =  28.59 sec
     [exec]
     [exec] The following tests FAILED:
     [exec] 	  1 - test_test_libhdfs_ops_hdfs_static (Failed)
     [exec] 	  2 - test_test_libhdfs_threaded_hdfs_static (Failed)
     [exec] 	  3 - test_test_libhdfs_zerocopy_hdfs_static (Failed)
     [exec] 	  4 - test_test_native_mini_dfs (Failed)
     [exec] 	 37 - test_libhdfs_threaded_hdfspp_test_shim_static (Failed)
     [exec] 	 38 - test_hdfspp_mini_dfs_smoke_hdfspp_test_shim_static (Child aborted)
     [exec] 	 39 - libhdfs_mini_stress_valgrind_hdfspp_test_static (Failed)
     [exec] 	 40 - memcheck_libhdfs_mini_stress_valgrind_hdfspp_test_static (Failed)
     [exec] 	 41 - test_libhdfs_mini_stress_hdfspp_test_shim_static (Failed)
     [exec] 	 42 - test_hdfs_ext_hdfspp_test_shim_static (Child aborted)
```

### How was this patch tested?

UTs of hadoop-hdfs-native-client are correctly run, though UT failures are still there. (should be caused by independent issues)
```
$ mvn -Pnative -pl :hadoop-hdfs-native-client -am clean install -DskipTests
$ mvn -Pnative -pl :hadoop-hdfs-native-client test
...
     [exec] 98% tests passed, 1 tests failed out of 48
     [exec]
     [exec] Total Test time (real) = 161.88 sec
     [exec]
     [exec] The following tests FAILED:
     [exec] 	 37 - test_libhdfs_threaded_hdfspp_test_shim_static (Failed)
     [exec] Errors while running CTest
```

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

