### PR TITLE
HADOOP-19607. Remove workaround for protoc on M1 mac and unused property build.platform

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2580,30 +2580,6 @@
 
   <profiles>
     <profile>
-      <id>os.linux</id>
-      <activation>
-        <os>
-          <family>!Mac</family>
-        </os>
-      </activation>
-      <properties>
-        <build.platform>${os.name}-${os.arch}-${sun.arch.data.model}</build.platform>
-      </properties>
-    </profile>
-    <profile>
-      <id>os.mac</id>
-      <activation>
-        <os>
-          <family>Mac</family>
-        </os>
-      </activation>
-      <properties>
-        <build.platform>Mac_OS_X-${sun.arch.data.model}</build.platform>
-        <!-- To make protoc work on Apple Silicon via fallback -->
-        <os.detected.classifier>osx-x86_64</os.detected.classifier>
-      </properties>
-    </profile>
-    <profile>
       <id>native-win</id>
       <activation>
         <os>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR reverts HADOOP-17939 because protoc now has `osx-aarch_64` artifacts available in Maven Central since v3.17.3
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/

I also removed the Maven property `build.platform`, which has been useless for a long time.

### How was this patch tested?
```
$ uname -a                                            
Darwin H27212-MAC-01.local 24.5.0 Darwin Kernel Version 24.5.0: Tue Apr 22 19:54:49 PDT 2025; root:xnu-11417.121.6~2/RELEASE_ARM64_T6000 arm64
$ mvn clean compile -pl :hadoop-common -am -DskipTests
...
[INFO] Reactor Summary for Apache Hadoop Main 3.5.0-SNAPSHOT:
[INFO] 
[INFO] Apache Hadoop Main ................................. SUCCESS [  0.160 s]
[INFO] Apache Hadoop Build Tools .......................... SUCCESS [  1.487 s]
[INFO] Apache Hadoop Project POM .......................... SUCCESS [  0.288 s]
[INFO] Apache Hadoop Annotations .......................... SUCCESS [  0.392 s]
[INFO] Apache Hadoop Project Dist POM ..................... SUCCESS [  0.033 s]
[INFO] Apache Hadoop Maven Plugins ........................ SUCCESS [  1.371 s]
[INFO] Apache Hadoop MiniKDC .............................. SUCCESS [  0.267 s]
[INFO] Apache Hadoop Auth ................................. SUCCESS [  1.187 s]
[INFO] Apache Hadoop Common ............................... SUCCESS [ 13.202 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.209 s
[INFO] Finished at: 2025-07-07T12:50:13+08:00
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

