### PR TITLE
bswap: add RISC-V support.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
@@ -101,6 +101,8 @@ inline uint32_t bswap(uint32_t val) {
   __asm__("rev %w[dst], %w[src]" : [dst]"=r"(val) : [src]"r"(val));
 #elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)
   return  __builtin_bswap32(val);
+#elif #elif defined(__riscv) && __riscv_xlen == 32
+  return  __builtin_bswap32(val);
 #else
   __asm__("bswap %0" : "=r" (val) : "0" (val));
 #endif
@@ -112,6 +114,8 @@ inline uint64_t bswap64(uint64_t val) {
   __asm__("rev %[dst], %[src]" : [dst]"=r"(val) : [src]"r"(val));
 #elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)
   return __builtin_bswap64(val);
+#elif #elif defined(__riscv) && __riscv_xlen == 64
+  return  __builtin_bswap64(val);
 #else
 #ifdef __X64
   __asm__("bswapq %0" : "=r" (val) : "0" (val));


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The intention of this PR is to support bswap native function on riscv . Without this part of the change, compiling the bswap related code on RISCV will result in an error.This part of the change is controlled by the compilation macro and will not affect running on other architecture.

### How was this patch tested?
unit test

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

