### PR TITLE
HADOOP-19575. ABFS: [Backport to 3.4][FNSOverBlob] Add Distinct String In User Agent to Get Telemetry for FNS-Blob

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -127,6 +127,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.PLUS_ENC
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SEMICOLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SINGLE_WHITE_SPACE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.UTF_8;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsServiceType.BLOB;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_IDENTITY_TRANSFORM_CLASS;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DEFAULT_DELETE_CONSIDERED_IDEMPOTENT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
@@ -152,6 +153,7 @@ public abstract class AbfsClient implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   public static final String HUNDRED_CONTINUE_USER_AGENT = SINGLE_WHITE_SPACE + HUNDRED_CONTINUE + SEMICOLON;
   public static final String ABFS_CLIENT_TIMER_THREAD_NAME = "abfs-timer-client";
+  public static final String FNS_BLOB_USER_AGENT_IDENTIFIER = "FNS";
 
   private final URL baseUrl;
   private final SharedKeyCredentials sharedKeyCredentials;
@@ -1322,6 +1324,14 @@ public abstract class AbfsClient implements Closeable {
     sb.append(abfsConfiguration.getClusterName());
     sb.append(FORWARD_SLASH);
     sb.append(abfsConfiguration.getClusterType());
+
+    // Add a unique identifier in FNS-Blob user agent string
+    if (!getIsNamespaceEnabled()
+        && abfsConfiguration.getFsConfiguredServiceType() == BLOB) {
+      sb.append(SEMICOLON)
+          .append(SINGLE_WHITE_SPACE)
+          .append(FNS_BLOB_USER_AGENT_IDENTIFIER);
+    }
 
     sb.append(")");
 


### PR DESCRIPTION
### Description of PR
Commit on trunk: ff6600cf1c4d2ce80b12ccfc750d8e5cf4f4c71f
Target JIRA: https://issues.apache.org/jira/browse/HADOOP-19575
Adding a unique identifier in the user agent for FNS-Blob case for telemetry purposes.

### How was this patch tested?
Test suite was run, results for which is added in the comments below

