### PR TITLE
HDFS-17806. Increase dfs.checksum.ec.socket-timeout

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/FileChecksumHelper.java
@@ -613,8 +613,9 @@ final class FileChecksumHelper {
 
     @Override
     void checksumBlocks() throws IOException {
-      int tmpTimeout = getClient().getConf().getChecksumEcSocketTimeout() * 1 +
-          getClient().getConf().getSocketTimeout();
+      int tmpTimeout =
+          getClient().getConf().getChecksumEcSocketTimeout() * ecPolicy.getNumDataUnits()
+              + getClient().getConf().getSocketTimeout();
       setTimeout(tmpTimeout);
 
       for (bgIdx = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -136,7 +136,7 @@ public interface HdfsClientConfigKeys {
   String  DFS_CHECKSUM_COMBINE_MODE_KEY = "dfs.checksum.combine.mode";
   String  DFS_CHECKSUM_COMBINE_MODE_DEFAULT = "MD5MD5CRC";
   String  DFS_CHECKSUM_EC_SOCKET_TIMEOUT_KEY = "dfs.checksum.ec.socket-timeout";
-  int     DFS_CHECKSUM_EC_SOCKET_TIMEOUT_DEFAULT = 3000;
+  int     DFS_CHECKSUM_EC_SOCKET_TIMEOUT_DEFAULT = 30000;
   String  DFS_DATANODE_SOCKET_WRITE_TIMEOUT_KEY =
       "dfs.datanode.socket.write.timeout";
   String  DFS_CLIENT_DOMAIN_SOCKET_DATA_TRAFFIC =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -4465,7 +4465,7 @@
 
 <property>
   <name>dfs.checksum.ec.socket-timeout</name>
-  <value>3000</value>
+  <value>30000</value>
   <description>
     Default timeout value in milliseconds for computing the checksum of striped blocks.
     Recommended to set the same value between client and DNs in a cluster because mismatching


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When getFileChecksum with ec file , Datanode will throw SocketTimeoutException when load is high.  
`
java.net.SocketTimeoutException: 3000 millis timeout while waiting for channel to be ready for read. ch : java.nio.channels.SocketChannel[connected local=/****:48666 remote=/****:50010]
at org.apache.hadoop.net.SocketIOWithTimeout.doIO(SocketIOWithTimeout.java:163)
at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:161)
at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:131)
at org.apache.hadoop.net.SocketInputStream.read(SocketInputStream.java:118)
at java.io.FilterInputStream.read(FilterInputStream.java:83)
at java.io.FilterInputStream.read(FilterInputStream.java:83)
at org.apache.hadoop.hdfs.protocolPB.PBHelperClient.vintPrefixed(PBHelperClient.java:520)
at org.apache.hadoop.hdfs.server.datanode.BlockChecksumHelper$BlockGroupNonStripedChecksumComputer.checksumBlock(BlockChecksumHelper.java:632)
at org.apache.hadoop.hdfs.server.datanode.BlockChecksumHelper$BlockGroupNonStripedChecksumComputer.compute(BlockChecksumHelper.java:493)
at org.apache.hadoop.hdfs.server.datanode.DataXceiver.blockGroupChecksum(DataXceiver.java:1107)
at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.opStripedBlockChecksum(Receiver.java:336)
at org.apache.hadoop.hdfs.protocol.datatransfer.Receiver.processOp(Receiver.java:123)
at org.apache.hadoop.hdfs.server.datanode.DataXceiver.run(DataXceiver.java:314)
at java.lang.Thread.run(Thread.java:748)
`



<img width="2758" height="1830" alt="ec checksum timeout" src="https://github.com/user-attachments/assets/056ab0f5-e65c-44de-bbeb-326cc4066950" />


EC file checksum will serial execution to connect datanode with dataunit block for checksum.  And 3000 millis is too short for high load data.  We should increase EC socket timeout.


