### PR TITLE
HADOOP-19615. Upgrade os-maven-plugin to 1.7.1 to support riscv64

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -154,7 +154,7 @@
 
     <protobuf-compile.version>3.5.1</protobuf-compile.version>
     <grpc.version>1.10.0</grpc.version>
-    <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
When building Hadoop on the  riscv64 architecture, the current version of os-maven-plugin (1.7.0) fails with the following error:

> os.detected.arch: unknown
> org.apache.maven.MavenExecutionException: unknown os.arch: riscv64

This indicates that version 1.7.0 does not recognize or support the riscv64 target, causing native or plugin-based build failures.

Upgrading os-maven-plugin to version 1.7.1 resolves the issue. The newer version includes updated architecture detection logic and supports riscv64 without error.

### How was this patch tested?
mvn package -Pdist,native -DskipTests -Dtar
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

