### PR TITLE
HADOOP-19617. [JDK17] Remove JUnit4 Dependency (YARN) .

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -186,7 +186,7 @@
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
     <!-- Plugin versions and config -->
-    <maven-surefire-plugin.argLine>-Xmx4096m -Xss2m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.argLine>-Xmx4096m -Xss4m -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs}</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -93,11 +88,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Only required to run tests in an IDE that bundles an older version -->

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
@@ -40,12 +40,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
     </dependency>
@@ -180,11 +174,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-unmanaged-am-launcher/pom.xml
@@ -33,11 +33,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-api/pom.xml
@@ -187,11 +187,6 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-services-core</artifactId>
       <type>test-jar</type>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
@@ -245,12 +245,6 @@
     <!-- ======================================================== -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
@@ -287,11 +281,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/pom.xml
@@ -119,11 +119,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -189,11 +184,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestGetGroups.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestGetGroups.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.tools.GetGroupsTestBase;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class TestGetGroups extends GetGroupsTestBase {
   
   private static Configuration conf;
   
-  @BeforeClass
+  @BeforeAll
   public static void setUpResourceManager() throws InterruptedException {
     conf = new YarnConfiguration();
     resourceManager = new ResourceManager() {
@@ -77,19 +77,19 @@ public class TestGetGroups extends GetGroupsTestBase {
     }.start();
 
     boolean rmStarted = rmStartedSignal.await(60000L, TimeUnit.MILLISECONDS);
-    Assert.assertTrue("ResourceManager failed to start up.", rmStarted);
+    Assertions.assertTrue(rmStarted, "ResourceManager failed to start up.");
 
     LOG.info("ResourceManager RMAdmin address: {}.",
         conf.get(YarnConfiguration.RM_ADMIN_ADDRESS));
   }
   
   @SuppressWarnings("static-access")
-  @Before
+  @BeforeEach
   public void setUpConf() {
     super.conf = this.conf;
   }
   
-  @AfterClass
+  @AfterAll
   public static void tearDownResourceManager() throws InterruptedException {
     if (resourceManager != null) {
       LOG.info("Stopping ResourceManager...");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.yarn.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -56,10 +56,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMFatalEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.RMFatalEventType;
 import org.apache.hadoop.yarn.server.webproxy.WebAppProxyServer;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
   private MiniYARNCluster cluster;
   private ApplicationId fakeAppId;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     fakeAppId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
     conf = new YarnConfiguration();
@@ -98,7 +98,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     cluster = new MiniYARNCluster(TestRMFailover.class.getName(), 2, 1, 1, 1);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.stop();
   }
@@ -123,8 +123,8 @@ public class TestRMFailover extends ClientBaseWithFixes {
   }
 
   private void verifyConnections() throws InterruptedException, YarnException {
-    assertTrue("NMs failed to connect to the RM",
-        cluster.waitForNodeManagersToConnect(20000));
+    assertTrue(
+       cluster.waitForNodeManagersToConnect(20000), "NMs failed to connect to the RM");
     verifyClientConnection();
   }
 
@@ -137,15 +137,15 @@ public class TestRMFailover extends ClientBaseWithFixes {
     int newActiveRMIndex = (activeRMIndex + 1) % 2;
     getAdminService(activeRMIndex).transitionToStandby(req);
     getAdminService(newActiveRMIndex).transitionToActive(req);
-    assertEquals("Failover failed", newActiveRMIndex, cluster.getActiveRMIndex());
+    assertEquals(newActiveRMIndex, cluster.getActiveRMIndex(), "Failover failed");
   }
 
   private void failover()
       throws IOException, InterruptedException, YarnException {
     int activeRMIndex = cluster.getActiveRMIndex();
     cluster.stopResourceManager(activeRMIndex);
-    assertEquals("Failover failed",
-        (activeRMIndex + 1) % 2, cluster.getActiveRMIndex());
+    assertEquals(
+       (activeRMIndex + 1) % 2, cluster.getActiveRMIndex(), "Failover failed");
     cluster.restartResourceManager(activeRMIndex);
   }
 
@@ -155,7 +155,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     explicitFailover();
@@ -189,7 +189,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     failover();
@@ -220,14 +220,14 @@ public class TestRMFailover extends ClientBaseWithFixes {
       cluster.init(conf);
       cluster.start();
       getAdminService(0).transitionToActive(req);
-      assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+      assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
       verifyConnections();
       webAppProxyServer.init(conf);
 
       // Start webAppProxyServer
-      Assert.assertEquals(STATE.INITED, webAppProxyServer.getServiceState());
+      Assertions.assertEquals(STATE.INITED, webAppProxyServer.getServiceState());
       webAppProxyServer.start();
-      Assert.assertEquals(STATE.STARTED, webAppProxyServer.getServiceState());
+      Assertions.assertEquals(STATE.STARTED, webAppProxyServer.getServiceState());
 
       // send httpRequest with fakeApplicationId
       // expect to get "Not Found" response and 404 response code
@@ -253,7 +253,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     // send httpRequest with fakeApplicationId
@@ -391,7 +391,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.set(YarnConfiguration.RM_ZK_ADDRESS, hostPort);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
 
     ResourceManager resourceManager = cluster.getResourceManager(
         cluster.getActiveRMIndex());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -124,7 +124,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
   private void verifyConnections() throws InterruptedException, YarnException {
     assertTrue(
-       cluster.waitForNodeManagersToConnect(20000), "NMs failed to connect to the RM");
+        cluster.waitForNodeManagersToConnect(20000), "NMs failed to connect to the RM");
     verifyClientConnection();
   }
 
@@ -145,7 +145,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     int activeRMIndex = cluster.getActiveRMIndex();
     cluster.stopResourceManager(activeRMIndex);
     assertEquals(
-       (activeRMIndex + 1) % 2, cluster.getActiveRMIndex(), "Failover failed");
+        (activeRMIndex + 1) % 2, cluster.getActiveRMIndex(), "Failover failed");
     cluster.restartResourceManager(activeRMIndex);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -96,11 +96,6 @@
       <artifactId>hadoop-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestLRUCache.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestLRUCache.java
@@ -17,8 +17,11 @@
  */
 
 package org.apache.hadoop.yarn.util;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestLRUCache {
   public static final int CACHE_EXPIRE_TIME = 200;
@@ -29,21 +32,21 @@ public class TestLRUCache {
     lruCache.put("2", 1);
     lruCache.put("3", 3);
     lruCache.put("4", 4);
-    Assert.assertEquals(lruCache.size(), 3);
-    Assert.assertNull(lruCache.get("1"));
-    Assert.assertNotNull(lruCache.get("2"));
-    Assert.assertNotNull(lruCache.get("3"));
-    Assert.assertNotNull(lruCache.get("3"));
+    assertEquals(lruCache.size(), 3);
+    assertNull(lruCache.get("1"));
+    assertNotNull(lruCache.get("2"));
+    assertNotNull(lruCache.get("3"));
+    assertNotNull(lruCache.get("3"));
     lruCache.clear();
 
     lruCache.put("1", 1);
     Thread.sleep(201);
-    Assert.assertEquals(lruCache.size(), 1);
+    assertEquals(lruCache.size(), 1);
     lruCache.get("1");
-    Assert.assertEquals(lruCache.size(), 0);
+    assertEquals(lruCache.size(), 0);
     lruCache.put("2", 2);
-    Assert.assertEquals(lruCache.size(), 1);
+    assertEquals(lruCache.size(), 1);
     lruCache.put("3", 3);
-    Assert.assertEquals(lruCache.size(), 2);
+    assertEquals(lruCache.size(), 2);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/webapp/JerseyTestBase.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.yarn.webapp;
 
 import org.glassfish.jersey.jettison.internal.entity.JettisonObjectProvider;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 
 import javax.ws.rs.client.WebTarget;
@@ -35,7 +34,6 @@ public abstract class JerseyTestBase extends JerseyTest {
   }
 
   @BeforeEach
-  @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -75,11 +75,6 @@
       <scope>${transient.protobuf2.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/pom.xml
@@ -92,11 +92,6 @@
       <scope>${transient.protobuf2.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
@@ -193,11 +188,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
@@ -206,7 +206,7 @@ public class TestLocalityMulticastAMRMProxyPolicy
   }
 
   @Test
-  @Timeout(value = 8)
+  @Timeout(value = 16)
   public void testStressPolicy() throws Exception {
 
     // Tests how the headroom info are used to split based on the capacity

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/scheduler/TestOpportunisticContainerContext.java
@@ -21,10 +21,8 @@ import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Spy;
 
 import java.util.HashMap;
@@ -32,6 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 /**
  * Test cases for OpportunisticContainerContext.
@@ -45,9 +47,9 @@ public class TestOpportunisticContainerContext {
   private TreeMap<SchedulerRequestKey,
           Map<Resource, OpportunisticContainerAllocator.EnrichedResourceRequest>> outstandingOpReqs;
 
-  @Before
+  @BeforeEach
   public void setUp() {
-    opportunisticContainerContext = Mockito.spy(new OpportunisticContainerContext());
+    opportunisticContainerContext = spy(new OpportunisticContainerContext());
     outstandingOpReqs = new TreeMap<>();
   }
 
@@ -63,7 +65,7 @@ public class TestOpportunisticContainerContext {
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(request);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
   }
 
   /**
@@ -76,12 +78,12 @@ public class TestOpportunisticContainerContext {
   public void testAddToOutstandingReqsWithZeroContainer() {
     ResourceRequest request = getResourceRequest("resource", 0);
     createOutstandingOpReqs(request, getResource());
-    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+    doReturn(outstandingOpReqs).when(opportunisticContainerContext)
             .getOutstandingOpReqs();
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(request);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
   }
 
   /**
@@ -96,13 +98,13 @@ public class TestOpportunisticContainerContext {
     ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 0);
     createOutstandingOpReqs(req1, getResource());
     createOutstandingOpReqs(req2, getResource());
-    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+    doReturn(outstandingOpReqs).when(opportunisticContainerContext)
             .getOutstandingOpReqs();
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(req1);
     resourceRequestList.add(req2);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
   }
 
   /**
@@ -117,13 +119,13 @@ public class TestOpportunisticContainerContext {
     ResourceRequest req2 = getResourceRequest(ResourceRequest.ANY, 1);
     createOutstandingOpReqs(req1, getResource());
     createOutstandingOpReqs(req2, getResource());
-    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+    doReturn(outstandingOpReqs).when(opportunisticContainerContext)
             .getOutstandingOpReqs();
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(req1);
     resourceRequestList.add(req2);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
   }
 
   /**
@@ -137,12 +139,12 @@ public class TestOpportunisticContainerContext {
   public void testAddToOutstandingReqsWithZeroContainerAndNullCapability() {
     ResourceRequest request = getResourceRequestWithoutCapability();
     createOutstandingOpReqs(request, getResource());
-    Mockito.doReturn(outstandingOpReqs).when(opportunisticContainerContext)
+    doReturn(outstandingOpReqs).when(opportunisticContainerContext)
             .getOutstandingOpReqs();
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(request);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 1);
   }
 
   /**
@@ -155,12 +157,12 @@ public class TestOpportunisticContainerContext {
   @Test
   public void testAddToOutstandingReqsWithEmptyReqMap() {
     ResourceRequest request = getResourceRequest("resource", 0);
-    Mockito.doReturn(new TreeMap<>()).when(opportunisticContainerContext)
+    doReturn(new TreeMap<>()).when(opportunisticContainerContext)
             .getOutstandingOpReqs();
     List<ResourceRequest> resourceRequestList = new ArrayList<>();
     resourceRequestList.add(request);
     opportunisticContainerContext.addToOutstandingReqs(resourceRequestList);
-    Assert.assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 0);
+    assertEquals(opportunisticContainerContext.getOutstandingOpReqs().size(), 0);
   }
 
   private void createOutstandingOpReqs(ResourceRequest req, Resource resource) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-globalpolicygenerator/pom.xml
@@ -73,12 +73,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
@@ -149,12 +143,6 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/pom.xml
@@ -118,11 +118,6 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-       <groupId>org.junit.vintage</groupId>
-       <artifactId>junit-vintage-engine</artifactId>
-       <scope>test</scope>
-    </dependency>
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -143,11 +138,6 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/pom.xml
@@ -53,11 +53,6 @@
       <artifactId>hadoop-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -358,11 +353,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/pom.xml
@@ -95,11 +95,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
@@ -99,7 +99,7 @@ public class TestFederationSubCluster {
       String connectString = curatorTestingServer.getConnectString();
       curatorFramework = CuratorFrameworkFactory.builder()
           .connectString(connectString)
-          .retryPolicy(new RetryNTimes(100, 100))
+          .retryPolicy(new RetryNTimes(200, 200))
           .build();
       curatorFramework.start();
       curatorFramework.getConnectionStateListenable().addListener((client, newState) -> {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/TestFederationSubCluster.java
@@ -202,7 +202,7 @@ public class TestFederationSubCluster {
       } catch (Exception e) {
       }
       return false;
-    }, 5000, 50 * 1000);
+    }, 5000, 100 * 1000);
   }
 
   public static <T> T performGetCalls(final String routerAddress, final String path,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/subcluster/capacity/TestYarnFederationWithCapacityScheduler.java
@@ -121,10 +121,10 @@ public class TestYarnFederationWithCapacityScheduler {
   public static void setUp()
       throws IOException, InterruptedException, YarnException, TimeoutException {
     testFederationSubCluster = new TestFederationSubCluster();
-    testFederationSubCluster.startFederationSubCluster(2181,
-        "18032,18030,18031,18088,18033,SC-1,127.0.0.1:2181,capacity-scheduler",
-        "28032,28030,28031,28088,28033,SC-2,127.0.0.1:2181,capacity-scheduler",
-        "18050,18052,18089,127.0.0.1:2181");
+    testFederationSubCluster.startFederationSubCluster(2183,
+        "18032,18030,18031,18088,18033,SC-1,127.0.0.1:2183,capacity-scheduler",
+        "28032,28030,28031,28088,28033,SC-2,127.0.0.1:2183,capacity-scheduler",
+        "18050,18052,18089,127.0.0.1:2183");
     subClusters = Sets.newHashSet();
     subClusters.add("SC-1");
     subClusters.add("SC-2");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/pom.xml
@@ -51,11 +51,6 @@
       <artifactId>hadoop-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timeline-pluginstorage/pom.xml
@@ -61,11 +61,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <type>test-jar</type>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-documentstore/pom.xml
@@ -58,11 +58,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <version>4.11.0</version>
@@ -181,11 +176,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase-tests/pom.xml
@@ -35,11 +35,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Since hbase 1.0.1 requires an older version of hadoop we enforce an
          older version of hadoop just for the hbase unit tests. We also need to
@@ -124,11 +119,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-client/pom.xml
@@ -109,11 +109,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19617. [JDK17] Remove JUnit4 Dependency(YARN).

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

