### PR TITLE
HADOOP-19621: hadoop-client-api exclude webapps/static front-end resources

### DIFF
--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -120,6 +120,7 @@
                         <exclude>org/apache/hadoop/yarn/factory/providers/package-info.class</exclude>
                         <exclude>org/apache/hadoop/yarn/client/api/impl/package-info.class</exclude>
                         <exclude>org/apache/hadoop/yarn/client/api/package-info.class</exclude>
+                        <exclude>webapps/static/**/*</exclude>
                       </excludes>
                     </filter>
                   </filters>

--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -120,7 +120,7 @@
                         <exclude>org/apache/hadoop/yarn/factory/providers/package-info.class</exclude>
                         <exclude>org/apache/hadoop/yarn/client/api/impl/package-info.class</exclude>
                         <exclude>org/apache/hadoop/yarn/client/api/package-info.class</exclude>
-                        <exclude>webapps/static/**/*</exclude>
+                        <exclude>webapps/**/*</exclude>
                       </excludes>
                     </filter>
                   </filters>


### PR DESCRIPTION
### Description of PR

`hadoop-client-api` contains some front-end resources in the webapps/static path.

<img width="403" height="605" alt="image" src="https://github.com/user-attachments/assets/0799bed6-196e-46ea-811d-ff16e0aacab2" />



### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

