### PR TITLE
HDFS-17807. Support balanced read distribution ordering in getBlockLocations()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1122,6 +1122,9 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int     DFS_BLOCK_INVALIDATE_LIMIT_DEFAULT = 1000;
   public static final String  DFS_DEFAULT_MAX_CORRUPT_FILES_RETURNED_KEY = "dfs.corruptfilesreturned.max";
   public static final int     DFS_DEFAULT_MAX_CORRUPT_FILES_RETURNED = 500;
+  /* Flag to uniformly distribute read across replica based on read rate */
+  public static final String  DFS_READ_REPLICA_UNIFORM_DISTRIBUTION_ENABLED_KEY = "dfs.read.replica.uniform.distribution.enabled";
+  public static final boolean DFS_READ_REPLICA_UNIFORM_DISTRIBUTION_ENABLED_DEFAULT = false;
   /* Maximum number of blocks to process for initializing replication queues */
   public static final String  DFS_BLOCK_MISREPLICATION_PROCESSING_LIMIT = "dfs.block.misreplication.processing.limit";
   public static final int     DFS_BLOCK_MISREPLICATION_PROCESSING_LIMIT_DEFAULT = 10000;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -178,6 +179,8 @@ public class DFSUtil {
     private final long staleInterval;
     private final boolean avoidSlowDataNodesForRead;
     private final Set<String> slowNodesUuidSet;
+    private final boolean enableUniformReadDistribution;
+    private Map<String, AtomicInteger> nodeReplicaSelectionCountUuidMap;
 
     /**
      * Constructor of ServiceAndStaleComparator
@@ -190,14 +193,22 @@ public class DFSUtil {
      *          Whether or not to avoid using slow DataNodes for reading.
      * @param slowNodesUuidSet
      *          Slow DataNodes UUID set.
+     * @param enableUniformReadDistribution
+     *          Flag to sort based on read-rate distribution of the replica datanodes.
+     * @param nodeReplicaSelectionCountUuidMap
+     *          Map to store read-rate distribution of the replica datanodes.
      */
     public StaleAndSlowComparator(
         boolean avoidStaleDataNodesForRead, long interval,
-        boolean avoidSlowDataNodesForRead, Set<String> slowNodesUuidSet) {
+        boolean avoidSlowDataNodesForRead, Set<String> slowNodesUuidSet,
+        boolean enableUniformReadDistribution,
+        Map<String, AtomicInteger> nodeReplicaSelectionCountUuidMap) {
       this.avoidStaleDataNodesForRead = avoidStaleDataNodesForRead;
       this.staleInterval = interval;
       this.avoidSlowDataNodesForRead = avoidSlowDataNodesForRead;
       this.slowNodesUuidSet = slowNodesUuidSet;
+      this.enableUniformReadDistribution = enableUniformReadDistribution;
+      this.nodeReplicaSelectionCountUuidMap = nodeReplicaSelectionCountUuidMap;
     }
 
     @Override
@@ -222,6 +233,19 @@ public class DFSUtil {
         boolean aSlow = slowNodesUuidSet.contains(a.getDatanodeUuid());
         boolean bSlow = slowNodesUuidSet.contains(b.getDatanodeUuid());
         ret = aSlow == bSlow ? 0 : (aSlow ? 1 : -1);
+        if (ret != 0) {
+          return ret;
+        }
+      }
+
+      // higher read served nodes will be moved behind based on read-distribution rate
+      if (enableUniformReadDistribution) {
+        AtomicInteger aCount = nodeReplicaSelectionCountUuidMap.get(a.getDatanodeUuid());
+        AtomicInteger bCount = nodeReplicaSelectionCountUuidMap.get(b.getDatanodeUuid());
+        ret = (aCount != null && bCount != null) ? (aCount.get() - bCount.get()) : 0;
+        if (ret != 0) {
+          return ret;
+        }
       }
       return ret;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeAdminManager.java
@@ -81,12 +81,14 @@ public class DatanodeAdminManager {
   private final Namesystem namesystem;
   private final BlockManager blockManager;
   private final HeartbeatManager hbManager;
+  private final DatanodeManager dataManager;
   private final ScheduledExecutorService executor;
 
   private DatanodeAdminMonitorInterface monitor = null;
 
-  DatanodeAdminManager(final Namesystem namesystem,
+  DatanodeAdminManager(final DatanodeManager dm, final Namesystem namesystem,
       final BlockManager blockManager, final HeartbeatManager hbManager) {
+    this.dataManager = dm;
     this.namesystem = namesystem;
     this.blockManager = blockManager;
     this.hbManager = hbManager;
@@ -125,8 +127,16 @@ public class DatanodeAdminManager {
     }
     executor.scheduleWithFixedDelay(monitor, intervalSecs, intervalSecs,
         TimeUnit.SECONDS);
+    if (dataManager.isReplicaUniformReadDistribution()) {
+      executor.scheduleAtFixedRate(() -> resetDataNodeReadRate(), 60, 60,
+          TimeUnit.SECONDS);
+    }
 
     LOG.debug("Activating DatanodeAdminManager with interval {} seconds.", intervalSecs);
+  }
+
+  public void resetDataNodeReadRate() {
+    dataManager.resetNodeSelectionCount();
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.server.protocol.DatanodeProtocol.DNA_ERASURE_CODING_RECONSTRUCTION;
 import static org.apache.hadoop.util.Time.monotonicNow;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
@@ -70,9 +69,12 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Manage datanodes, include decommission and other activities.
@@ -211,6 +213,7 @@ public class DatanodeManager {
   @Nullable
   private SlowPeerTracker slowPeerTracker;
   private static Set<String> slowNodesUuidSet = Sets.newConcurrentHashSet();
+  public static Map<String, AtomicInteger> nodeReplicaSelectionCountUuidMap = new ConcurrentHashMap<>();
   private Daemon slowPeerCollectorDaemon;
   private volatile long slowPeerCollectionInterval;
   private volatile int maxSlowPeerReportNodes;
@@ -229,6 +232,7 @@ public class DatanodeManager {
   private final long timeBetweenResendingCachingDirectivesMs;
 
   private final boolean randomNodeOrderEnabled;
+  private final boolean replicaUniformReadDistribution;
 
   DatanodeManager(final BlockManager blockManager, final Namesystem namesystem,
       final Configuration conf) throws IOException {
@@ -245,7 +249,7 @@ public class DatanodeManager {
     }
     this.heartbeatManager = new HeartbeatManager(namesystem,
         blockManager, conf);
-    this.datanodeAdminManager = new DatanodeAdminManager(namesystem,
+    this.datanodeAdminManager = new DatanodeAdminManager(this, namesystem,
         blockManager, heartbeatManager);
     this.fsClusterStats = newFSClusterStats();
     this.dataNodeDiskStatsEnabled = Util.isDiskStatsEnabled(conf.getInt(
@@ -364,6 +368,24 @@ public class DatanodeManager {
     this.randomNodeOrderEnabled = conf.getBoolean(
         DFSConfigKeys.DFS_NAMENODE_RANDOM_NODE_ORDER_ENABLED,
         DFSConfigKeys.DFS_NAMENODE_RANDOM_NODE_ORDER_ENABLED_DEFAULT);
+    this.replicaUniformReadDistribution = conf.getBoolean(
+        DFSConfigKeys.DFS_READ_REPLICA_UNIFORM_DISTRIBUTION_ENABLED_KEY,
+        DFSConfigKeys
+            .DFS_READ_REPLICA_UNIFORM_DISTRIBUTION_ENABLED_DEFAULT);
+  }
+
+  public void incrementNodeSelectionCount(String uuid) {
+    nodeReplicaSelectionCountUuidMap
+        .computeIfAbsent(uuid, (id) -> new AtomicInteger()).incrementAndGet();
+  }
+
+  public void resetNodeSelectionCount() {
+    nodeReplicaSelectionCountUuidMap.forEach((id, count) -> count.set(0));
+  }
+
+  @VisibleForTesting
+  public AtomicInteger getNodeSelectionCount(String nodeUuid) {
+    return nodeReplicaSelectionCountUuidMap.get(nodeUuid);
   }
 
   /**
@@ -574,10 +596,13 @@ public class DatanodeManager {
   public void sortLocatedBlocks(final String targetHost,
       final List<LocatedBlock> locatedBlocks) {
     Comparator<DatanodeInfo> comparator =
-        avoidStaleDataNodesForRead || avoidSlowDataNodesForRead ?
+        avoidStaleDataNodesForRead || avoidSlowDataNodesForRead
+            || replicaUniformReadDistribution
+                ?
         new DFSUtil.StaleAndSlowComparator(
             avoidStaleDataNodesForRead, staleInterval,
-            avoidSlowDataNodesForRead, slowNodesUuidSet) :
+            avoidSlowDataNodesForRead, slowNodesUuidSet,
+            replicaUniformReadDistribution, nodeReplicaSelectionCountUuidMap) :
         new DFSUtil.ServiceComparator();
     // sort located block
     for (LocatedBlock lb : locatedBlocks) {
@@ -667,7 +692,14 @@ public class DatanodeManager {
       --lastActiveIndex;
     }
     int activeLen = lastActiveIndex + 1;
-    if (!randomNodeOrderEnabled) {
+    if (replicaUniformReadDistribution) {
+      if (LOG.isDebugEnabled()) {
+        String dnCountLogStr = Arrays.stream(di)
+            .map(dn -> "uuid:" + dn.getDatanodeUuid() + " count:" + nodeReplicaSelectionCountUuidMap.get(dn.getDatanodeUuid()))
+            .collect(Collectors.joining(", "));
+        LOG.debug("Uniform read replica distribution count {}.", dnCountLogStr);
+      }
+    } else if (!randomNodeOrderEnabled) {
       if(nonDatanodeReader) {
         networktopology.sortByDistanceUsingNetworkLocation(client,
             lb.getLocations(), activeLen, createSecondaryNodeSorter());
@@ -682,6 +714,23 @@ public class DatanodeManager {
     lb.moveProvidedToEnd(activeLen);
     // must update cache since we modified locations array
     lb.updateCachedStorageInfo();
+  }
+
+  public void incrementDataNodeBlockGetCount(
+      final List<LocatedBlock> locatedblocks) {
+    if (!replicaUniformReadDistribution || locatedblocks == null) {
+      return;
+    }
+    for (LocatedBlock b : locatedblocks) {
+      DatanodeInfo[] locations = b.getLocations();
+      DatanodeInfo dn = locations[0];
+      incrementNodeSelectionCount(dn.getDatanodeUuid());
+    }
+
+  }
+
+  public boolean isReplicaUniformReadDistribution() {
+    return replicaUniformReadDistribution;
   }
 
   private Consumer<List<DatanodeInfoWithStorage>> createSecondaryNodeSorter() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -2284,6 +2284,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
 
     LocatedBlocks blocks = res.blocks;
     sortLocatedBlocks(clientMachine, blocks);
+    blockManager.getDatanodeManager()
+        .incrementDataNodeBlockGetCount(blocks.getLocatedBlocks());
     return blocks;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6455,6 +6455,15 @@
   </property>
 
   <property>
+    <name>dfs.read.replica.uniform.distribution.enabled</name>
+    <value>false</value>
+    <description>
+      Sort DataNodes by their current read rate before returning them to clients,
+      enabling more balanced and uniform read distribution across DataNodes at all times.
+    </description>
+  </property>
+
+  <property>
     <name>dfs.journalnode.edits.dir.perm</name>
     <value>700</value>
     <description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReplacement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReplacement.java
@@ -27,7 +27,10 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 
@@ -53,6 +56,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocol.proto.DataTransferProtos.Status;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
+import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.io.IOUtils;
@@ -480,6 +484,72 @@ public class TestBlockReplacement {
           locatedBlocks1.get(0).getLocations().length);
     } finally {
       IOUtils.cleanupWithLogger(null, client);
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * This test validates that uniform read replica distribution should select
+   * node read preference equally to all the replica nodes.
+   * @throws Exception
+   */
+  @Test
+  public void testUniformReadReplicaDistribution() throws Exception {
+    final Configuration CONF = new HdfsConfiguration();
+    final short REPLICATION_FACTOR = (short) 3;
+    final int DEFAULT_BLOCK_SIZE = 1024;
+    final Random r = new Random();
+
+    CONF.setBoolean(
+        DFSConfigKeys.DFS_READ_REPLICA_UNIFORM_DISTRIBUTION_ENABLED_KEY, true);
+    CONF.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY,
+        DEFAULT_BLOCK_SIZE / 10);
+    CONF.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
+    CONF.setInt(HdfsClientConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY,
+        DEFAULT_BLOCK_SIZE / 2);
+    CONF.setLong(DFSConfigKeys.DFS_BLOCKREPORT_INTERVAL_MSEC_KEY, 500);
+    cluster = new MiniDFSCluster.Builder(CONF).numDataNodes(REPLICATION_FACTOR)
+        .build();
+    try {
+      cluster.waitActive();
+      FileSystem fs = cluster.getFileSystem();
+      Path file;
+      // Create a file and read the file to check first prefered datanode for
+      // the read.
+      // Uniform read throughput distribution should select each datanode for
+      // the first node preference in the result-set.
+      InetSocketAddress addr =
+          new InetSocketAddress("localhost", cluster.getNameNodePort());
+      DFSClient client = new DFSClient(addr, CONF);
+      DatanodeManager datamanager = cluster.getNamesystem().getBlockManager().getDatanodeManager();
+      Map<String, Integer> dataNodeCount = new HashMap<>();
+      for (int i = 0; i < 300; i++) {
+        String fileName = "/tmp" + i + ".txt";
+        file = new Path(fileName);
+        DFSTestUtil.createFile(fs, file, false, 1024, DEFAULT_BLOCK_SIZE,
+            fs.getDefaultBlockSize(file), REPLICATION_FACTOR, r.nextLong(),
+            true);
+        List<LocatedBlock> locatedBlocks = client.getNamenode()
+            .getBlockLocations(fileName, 0, DEFAULT_BLOCK_SIZE)
+            .getLocatedBlocks();
+        assertEquals(1, locatedBlocks.size());
+        LocatedBlock block = locatedBlocks.get(0);
+        DatanodeInfo[] nodes = block.getLocations();
+        assertEquals(nodes.length, 3);
+        int count = dataNodeCount.getOrDefault(nodes[0].getDatanodeUuid(), 0);
+        dataNodeCount.put(nodes[0].getDatanodeUuid(), count + 1);
+      }
+      Iterator<Integer> ite = dataNodeCount.values().iterator();
+      int node1SelectionCount = ite.next();
+      int node2SelectionCount = ite.next();
+      int node3SelectionCount = ite.next();
+      assertEquals(node1SelectionCount, node2SelectionCount);
+      assertEquals(node2SelectionCount, node3SelectionCount);
+      // reset the count
+      datamanager.resetNodeSelectionCount();
+      assertEquals(datamanager.getNodeSelectionCount(dataNodeCount.keySet().iterator().next()).get(), 0);
+      client.close();
+    } finally {
       cluster.shutdown();
     }
   }


### PR DESCRIPTION

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The current getBlockLocations method returns replica locations without considering the real-time load on individual DataNodes. This can lead to clients repeatedly selecting the same DataNode, particularly when network distance or rack locality remains unchanged. Since data locality isn’t always reliable due to various operational factors, the existing network topology–based ordering has not fully optimized performance and may inadvertently create load hotspots. so, replica ordering based on dynamic weight metric and specifically current read rate or read load will create more balanced read across the dataodes in a cluster.

Adding `dfs.read.replica.uniform.distribution.enabled` to enable this feature. The policy is disabled by default and can be enabled to replace the current ordering mechanism, offering a more adaptive and performance-aware read path strategy.

### How was this patch tested?

Unit test & mvn clean install

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

