### PR TITLE
HADOOP-19616. Add bswap support for RISC-V

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/lib/primitives.h
@@ -99,7 +99,7 @@ inline void simple_memcpy(void * dest, const void * src, size_t len) {
 inline uint32_t bswap(uint32_t val) {
 #ifdef __aarch64__
   __asm__("rev %w[dst], %w[src]" : [dst]"=r"(val) : [src]"r"(val));
-#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)
+#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)||(__riscv)
   return  __builtin_bswap32(val);
 #else
   __asm__("bswap %0" : "=r" (val) : "0" (val));
@@ -110,7 +110,7 @@ inline uint32_t bswap(uint32_t val) {
 inline uint64_t bswap64(uint64_t val) {
 #ifdef __aarch64__
   __asm__("rev %[dst], %[src]" : [dst]"=r"(val) : [src]"r"(val));
-#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)
+#elif defined(__ppc64__)||(__PPC64__)||(__powerpc64__)||(__loongarch64)||(__riscv)
   return __builtin_bswap64(val);
 #else
 #ifdef __X64


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

While building Hadoop native code on the riscv64 architecture, the build fails due to missing support for bswap operations. The standard implementation relies on compiler intrinsics or platform-specific assembly which are not defined for RISC-V targets.

This results in compilation errors such as:
```
Error: unrecognized opcode `bswap a4'
Error: unrecognized opcode `bswap a3'
```
Add bswap support for RISC-V can solve the problem.

### How was this patch tested?

mvn package -Pdist,native -DskipTests -Dtar

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

