### PR TITLE
HDFS-17808. EC: End block group in advance to prevent write failure for long-time running OutputStream

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -74,6 +74,8 @@ public class DFSClientFaultInjector {
   public void failCreateBlockReader() throws InvalidBlockTokenException {}
 
   public void failWhenReadWithStrategy(boolean isRetryRead) throws IOException {}
-  
-  public boolean mockEndBlockGroupInAdvance() {return false;}
+
+  public boolean mockEndBlockGroupInAdvance() {
+    return false;
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClientFaultInjector.java
@@ -73,5 +73,7 @@ public class DFSClientFaultInjector {
 
   public void failCreateBlockReader() throws InvalidBlockTokenException {}
 
-  public void failWhenReadWithStrategy(boolean isRetryRead) throws IOException {};
+  public void failWhenReadWithStrategy(boolean isRetryRead) throws IOException {}
+  
+  public boolean mockEndBlockGroupInAdvance() {return false;}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -580,6 +580,12 @@ public class DFSStripedOutputStream extends DFSOutputStream
     if (!allowEndBlockGroupInAdvance) {
       return false;
     }
+    if (DFSClientFaultInjector.get().mockEndBlockGroupInAdvance()) {
+      LOG.info("Block group {} ends in advance.", currentBlockGroup);
+      this.endBlockGroupInAdvance = true;
+      return true;
+    }
+
     Set<StripedDataStreamer> newFailed = checkStreamersWithoutThrowException();
     boolean overFailedStreamer =
         failedStreamers.size() + newFailed.size() >= failedBlocksTolerated;
@@ -632,6 +638,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
     // 1. Forward the current index pointer
     // 2. Generate parity packets if a full stripe of data cells are present
     if (cellFull) {
+      LOG.info("BZL#Test. cellFull cellFull cellFull");
       int next = index + 1;
       //When all data cells in a stripe are ready, we need to encode
       //them and generate some parity cells. These cells will be
@@ -643,6 +650,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
 
         // if this is the end of the block group, end each internal block
         if (shouldEndBlockGroup() || shouldEndBlockGroupInAdvance()) {
+          LOG.info("BZL#Test. here here here");
           flushAllInternals();
           checkStreamerFailures(false);
           for (int i = 0; i < numAllBlocks; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -638,7 +638,6 @@ public class DFSStripedOutputStream extends DFSOutputStream
     // 1. Forward the current index pointer
     // 2. Generate parity packets if a full stripe of data cells are present
     if (cellFull) {
-      LOG.info("BZL#Test. cellFull cellFull cellFull");
       int next = index + 1;
       //When all data cells in a stripe are ready, we need to encode
       //them and generate some parity cells. These cells will be
@@ -650,7 +649,6 @@ public class DFSStripedOutputStream extends DFSOutputStream
 
         // if this is the end of the block group, end each internal block
         if (shouldEndBlockGroup() || shouldEndBlockGroupInAdvance()) {
-          LOG.info("BZL#Test. here here here");
           flushAllInternals();
           checkStreamerFailures(false);
           for (int i = 0; i < numAllBlocks; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -73,6 +73,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT;
 
@@ -287,6 +289,8 @@ public class DFSStripedOutputStream extends DFSOutputStream
   private int blockGroupIndex;
   private long datanodeRestartTimeout;
   private final int failedBlocksTolerated;
+  private final boolean allowEndBlockGroupInAdvance;
+  private boolean endBlockGroupInAdvance;
 
   /** Construct a new output stream for creating a file. */
   DFSStripedOutputStream(DFSClient dfsClient, String src, HdfsFileStatus stat,
@@ -335,6 +339,9 @@ public class DFSStripedOutputStream extends DFSOutputStream
     }
     failedBlocksTolerated = Math.min(failedBlocksToleratedTmp,
         ecPolicy.getNumParityUnits());
+    allowEndBlockGroupInAdvance = dfsClient.getConfiguration().getBoolean(
+        DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE,
+        DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT);
   }
 
   /** Construct a new output stream for appending to a file. */
@@ -420,6 +427,16 @@ public class DFSStripedOutputStream extends DFSOutputStream
       throw new IOException("Failed: the number of failed blocks = "
           + failCount + " > the number of failed blocks tolerated = "
           + failedBlocksTolerated);
+    }
+    return newFailed;
+  }
+
+  private Set<StripedDataStreamer> checkStreamersWithoutThrowException() {
+    Set<StripedDataStreamer> newFailed = new HashSet<>();
+    for(StripedDataStreamer s : streamers) {
+      if (!s.isHealthy() && !failedStreamers.contains(s)) {
+        newFailed.add(s);
+      }
     }
     return newFailed;
   }
@@ -559,6 +576,34 @@ public class DFSStripedOutputStream extends DFSOutputStream
         currentBlockGroup.getNumBytes() == blockSize * numDataBlocks;
   }
 
+  private boolean shouldEndBlockGroupInAdvance() {
+    if (!allowEndBlockGroupInAdvance) {
+      return false;
+    }
+    Set<StripedDataStreamer> newFailed = checkStreamersWithoutThrowException();
+    boolean overFailedStreamer =
+        failedStreamers.size() + newFailed.size() >= failedBlocksTolerated;
+    boolean stripeFull = currentBlockGroup.getNumBytes() > 0 &&
+        currentBlockGroup.getNumBytes() % ((long) numDataBlocks * cellSize) == 0;
+    if (overFailedStreamer && stripeFull) {
+      LOG.info("Block group {} ends in advance.", currentBlockGroup);
+      this.endBlockGroupInAdvance = true;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  void endBlock() throws IOException {
+    if (getStreamer().getBytesCurBlock() == blockSize || getStreamer().isEndBlockFlag()) {
+      setCurrentPacketToEmpty();
+      enqueueCurrentPacket();
+      getStreamer().setBytesCurBlock(0);
+      getStreamer().setEndBlockFlag(false);
+      lastFlushOffset = 0;
+    }
+  }
+
   @Override
   protected synchronized void writeChunk(byte[] bytes, int offset, int len,
       byte[] checksum, int ckoff, int cklen) throws IOException {
@@ -566,8 +611,9 @@ public class DFSStripedOutputStream extends DFSOutputStream
     final int pos = cellBuffers.addTo(index, bytes, offset, len);
     final boolean cellFull = pos == cellSize;
 
-    if (currentBlockGroup == null || shouldEndBlockGroup()) {
-      // the incoming data should belong to a new block. Allocate a new block.
+    if (currentBlockGroup == null || shouldEndBlockGroup() || endBlockGroupInAdvance) {
+      this.endBlockGroupInAdvance = false;
+      // The incoming data should belong to a new block. Allocate a new block.
       allocateNewBlock();
     }
 
@@ -596,13 +642,14 @@ public class DFSStripedOutputStream extends DFSOutputStream
         next = 0;
 
         // if this is the end of the block group, end each internal block
-        if (shouldEndBlockGroup()) {
+        if (shouldEndBlockGroup() || shouldEndBlockGroupInAdvance()) {
           flushAllInternals();
           checkStreamerFailures(false);
           for (int i = 0; i < numAllBlocks; i++) {
             final StripedDataStreamer s = setCurrentStreamer(i);
             if (s.isHealthy()) {
               try {
+                getStreamer().setEndBlockFlag(true);
                 endBlock();
               } catch (IOException ignored) {}
             }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java
@@ -75,6 +75,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED_DEFAILT;
 
@@ -289,6 +291,8 @@ public class DFSStripedOutputStream extends DFSOutputStream
   private int blockGroupIndex;
   private long datanodeRestartTimeout;
   private final int failedBlocksTolerated;
+  private final int maxEndBlockGroupInAdvanceCount;
+  private int curEndBlockGroupInAdvanceCount;
   private final boolean allowEndBlockGroupInAdvance;
   private boolean endBlockGroupInAdvance;
 
@@ -342,6 +346,9 @@ public class DFSStripedOutputStream extends DFSOutputStream
     allowEndBlockGroupInAdvance = dfsClient.getConfiguration().getBoolean(
         DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE,
         DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT);
+    maxEndBlockGroupInAdvanceCount = dfsClient.getConfiguration().getInt(
+        DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT,
+        DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT_DEFAULT);
   }
 
   /** Construct a new output stream for appending to a file. */
@@ -577,12 +584,14 @@ public class DFSStripedOutputStream extends DFSOutputStream
   }
 
   private boolean shouldEndBlockGroupInAdvance() {
-    if (!allowEndBlockGroupInAdvance) {
+    if (!allowEndBlockGroupInAdvance ||
+        curEndBlockGroupInAdvanceCount > maxEndBlockGroupInAdvanceCount) {
       return false;
     }
     if (DFSClientFaultInjector.get().mockEndBlockGroupInAdvance()) {
       LOG.info("Block group {} ends in advance.", currentBlockGroup);
       this.endBlockGroupInAdvance = true;
+      curEndBlockGroupInAdvanceCount++;
       return true;
     }
 
@@ -594,6 +603,7 @@ public class DFSStripedOutputStream extends DFSOutputStream
     if (overFailedStreamer && stripeFull) {
       LOG.info("Block group {} ends in advance.", currentBlockGroup);
       this.endBlockGroupInAdvance = true;
+      curEndBlockGroupInAdvanceCount++;
       return true;
     }
     return false;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DataStreamer.java
@@ -539,6 +539,7 @@ class DataStreamer extends Daemon {
   protected final LoadingCache<DatanodeInfo, DatanodeInfo> excludedNodes;
   private final String[] favoredNodes;
   private final EnumSet<AddBlockFlag> addBlockFlags;
+  private volatile boolean endBlockFlag = false;
 
   private DataStreamer(HdfsFileStatus stat, ExtendedBlock block,
                        DFSClient dfsClient, String src,
@@ -2284,5 +2285,13 @@ class DataStreamer extends Daemon {
     final ExtendedBlock extendedBlock = block.getCurrentBlock();
     return extendedBlock == null ?
         "block==null" : "" + extendedBlock.getLocalBlock();
+  }
+
+  public boolean isEndBlockFlag() {
+    return endBlockFlag;
+  }
+
+  public void setEndBlockFlag(boolean endBlockFlag) {
+    this.endBlockFlag = endBlockFlag;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -300,6 +300,10 @@ public interface HdfsClientConfigKeys {
       "dfs.client.ec.write.allow.end.blockgroup.inadvance";
   boolean DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT = false;
 
+  String DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT =
+      "dfs.client.ec.write.max.end.blockgroup.inadvance.count";
+  int DFS_CLIENT_EC_WRITE_MAX_END_BLOCKGROUP_INADVANCE_COUNT_DEFAULT = 10;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -296,6 +296,10 @@ public interface HdfsClientConfigKeys {
   int DFS_CLIENT_CONGESTION_BACKOFF_MAX_TIME_DEFAULT =
       DFS_CLIENT_CONGESTION_BACKOFF_MEAN_TIME_DEFAULT * 10;
 
+  String DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE =
+      "dfs.client.ec.write.allow.end.blockgroup.inadvance";
+  boolean DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE_DEFAULT = false;
+
   /**
    * These are deprecated config keys to client code.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6701,4 +6701,11 @@
       Enables observer reads for clients. This should only be enabled when clients are using routers.
     </description>
   </property>
+  <property>
+    <name>dfs.client.ec.write.allow.end.blockgroup.inadvance</name>
+    <value>false</value>
+    <description>
+      Whether allow client ends non-full block group in advance or not.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -6708,4 +6708,12 @@
       Whether allow client ends non-full block group in advance or not.
     </description>
   </property>
+  <property>
+    <name>dfs.client.ec.write.max.end.blockgroup.inadvance.count</name>
+    <value>10</value>
+    <description>
+      Max count of ending block group in advance allowed.
+      This prevents the creation of large amounts of metadata in NameNode.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs;
 
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -189,6 +190,16 @@ public class TestDFSStripedOutputStream {
         blockSize * dataBlocks * 3 + cellSize * dataBlocks
         + cellSize + 123);
   }
+
+  @Test
+  public void testEndBlockGroupInadvance() throws Exception {
+    Configuration config = new Configuration();
+    config.setBoolean(DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE, true);
+    DFSClient client =
+        new DFSClient(cluster.getNameNode(0).getNameNodeAddress(), config);
+    DFSClient spyClient = Mockito.spy(client);
+  }
+
 
   /**
    * {@link DFSStripedOutputStream} doesn't support hflush() or hsync() yet.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdfs;
 
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE;
-import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.mockito.Mockito;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedOutputStream.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.hdfs;
 
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.ECRedundancy.DFS_CLIENT_EC_WRITE_FAILED_BLOCKS_TOLERATED;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.Write.RECOVER_LEASE_ON_CLOSE_EXCEPTION_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -29,10 +31,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +103,7 @@ public class TestDFSStripedOutputStream {
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_CONSIDERLOAD_KEY,
         false);
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, 0);
+    conf.setBoolean(DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE, true);
     if (ErasureCodeNative.isNativeCodeLoaded()) {
       conf.set(
           CodecUtil.IO_ERASURECODE_CODEC_RS_RAWCODERS_KEY,
@@ -193,11 +200,27 @@ public class TestDFSStripedOutputStream {
 
   @Test
   public void testEndBlockGroupInadvance() throws Exception {
-    Configuration config = new Configuration();
-    config.setBoolean(DFS_CLIENT_EC_WRITE_ALLOW_END_BLOCKGROUP_INADVANCE, true);
-    DFSClient client =
-        new DFSClient(cluster.getNameNode(0).getNameNodeAddress(), config);
-    DFSClient spyClient = Mockito.spy(client);
+    DFSClientFaultInjector old = DFSClientFaultInjector.get();
+    String src = "/testEndBlockGroupInadvance";
+    Path testPath = new Path(src);
+    try {
+      DFSClientFaultInjector.set(new DFSClientFaultInjector() {
+        @Override
+        public boolean mockEndBlockGroupInAdvance() {
+          return true;
+        }
+      });
+      byte[] bytes = StripedFileTestUtil.generateBytes(2 * cellSize * dataBlocks + 123);
+      DFSTestUtil.writeFile(fs, testPath, new String(bytes));
+      StripedFileTestUtil.waitBlockGroupsReported(fs, src);
+      StripedFileTestUtil.verifyLength(fs, testPath, bytes.length);
+      List<List<LocatedBlock>> blockGroupList = new ArrayList<>();
+      LocatedBlocks lbs = fs.getClient().getLocatedBlocks(testPath.toString(), 0L,
+          Long.MAX_VALUE);
+      assertEquals(3, lbs.getLocatedBlocks().size());
+    } finally {
+      DFSClientFaultInjector.set(old);
+    }
   }
 
 


### PR DESCRIPTION
### Description of PR
Refer to HDFS-17808.

Recently, we met an EC problem in our production.

User creates an output stream to write ec files.  That output stream writes some bytes and will be idle for a long time until data is ready.  If we restart our cluster's datanodes to version up,  those applications will  finally fail due to not have enough healthy streamers.

This PR try to solve above problem by end block group in advance when we already have failed streamers but less than parity number.
