### PR TITLE
YARN-11835 DockerContainerDeletionTask did not clear tasks in leveldb

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/deletion/task/DockerContainerDeletionTask.java
@@ -56,6 +56,7 @@ public class DockerContainerDeletionTask extends DeletionTask
     LinuxContainerExecutor exec = ((LinuxContainerExecutor)
         getDeletionService().getContainerExecutor());
     exec.removeDockerContainer(containerId);
+    deletionTaskFinished();
   }
 
   /**


### PR DESCRIPTION
YARN-11835 DockerContainerDeletionTask did not clear tasks in leveldb


### Description of PR
DockerContainerDeletionTask did not clear tasks in leveldb, which can result in tasks that were expected to be cleared remaining in leveldb. Each time the nodemanager is restarted, the corresponding deletion task is triggered

### How was this patch tested?
Tested in our own production environment and passed


