### PR TITLE
YARN-11836. Fixed AM log fetching with YARN CLI

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -48,6 +48,8 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -55,6 +57,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 @Private
 @Evolving
 public class WebAppUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(WebAppUtils.class);
   public static final String WEB_APP_TRUSTSTORE_PASSWORD_KEY =
       "ssl.server.truststore.password";
   public static final String WEB_APP_KEYSTORE_PASSWORD_KEY =
@@ -107,26 +110,27 @@ public class WebAppUtils {
    */
   public static <T, R> R execOnActiveRM(Configuration conf,
       ThrowingBiFunction<String, T, R> func, T arg) throws Exception {
-    int activeRMIndex = 0;
-    int rmCount = 1;
+    if (!HAUtil.isHAEnabled(conf)) {
+      String rmAddress = getRMWebAppURLWithScheme(conf, 0);
+      return func.apply(rmAddress, arg);
+    }
 
-    if (HAUtil.isHAEnabled(conf)) {
-      ArrayList<String> rmIds = (ArrayList<String>) HAUtil.getRMHAIds(conf);
-      rmCount = rmIds.size();
-      String activeRMId = RMHAUtils.findActiveRMHAId(conf);
-      if (activeRMId != null) {
-        activeRMIndex = rmIds.indexOf(activeRMId);
-      }
+    int activeRMIndex = 0;
+    List<String> rmIds = (List<String>) HAUtil.getRMHAIds(conf);
+    String activeRMId = RMHAUtils.findActiveRMHAId(conf);
+    if (activeRMId != null) {
+      activeRMIndex = rmIds.indexOf(activeRMId);
     }
 
     // In HA mode activeRMId can be fetched only if user have permission to check service states.
     // Otherwise, we find the active one by iterating through the RMs
-    for (int i = activeRMIndex; i < rmCount; i++) {
+    for (int i = activeRMIndex; i < rmIds.size(); i++) {
       try {
         String rmAddress = getRMWebAppURLWithScheme(conf, i);
         return func.apply(rmAddress, arg);
       } catch (Exception e) {
-        // Ignore and try next RM if there are any
+        // Log and try next RM if there are any
+        LOG.trace("Exception while connecting to RM", e);
       }
     }
     throw new ConnectException("No active RM available to execute this command");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -123,13 +123,13 @@ public class WebAppUtils {
     }
 
     // In HA mode activeRMId can be fetched only if user have permission to check service states.
-    // Otherwise, we find the active one by iterating through the RMs
+    // Otherwise, we find the active one by iterating through the RMs.
     for (int i = activeRMIndex; i < rmIds.size(); i++) {
       try {
         String rmAddress = getRMWebAppURLWithScheme(conf, i);
         return func.apply(rmAddress, arg);
       } catch (Exception e) {
-        // Log and try next RM if there are any
+        // Log and try next RM if there are any.
         LOG.trace("Exception while connecting to RM", e);
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -107,17 +107,29 @@ public class WebAppUtils {
    */
   public static <T, R> R execOnActiveRM(Configuration conf,
       ThrowingBiFunction<String, T, R> func, T arg) throws Exception {
-    int haIndex = 0;
+    int activeRMIndex = 0;
+    int rmCount = 1;
+
     if (HAUtil.isHAEnabled(conf)) {
+      ArrayList<String> rmIds = (ArrayList<String>) HAUtil.getRMHAIds(conf);
+      rmCount = rmIds.size();
       String activeRMId = RMHAUtils.findActiveRMHAId(conf);
       if (activeRMId != null) {
-        haIndex = new ArrayList<>(HAUtil.getRMHAIds(conf)).indexOf(activeRMId);
-      } else {
-        throw new ConnectException("No Active RM available");
+        activeRMIndex = rmIds.indexOf(activeRMId);
       }
     }
-    String rm1Address = getRMWebAppURLWithScheme(conf, haIndex);
-    return func.apply(rm1Address, arg);
+
+    // In HA mode activeRMId can be fetched only if user have permission to check service states.
+    // Otherwise, we find the active one by iterating through the RMs
+    for (int i = activeRMIndex; i < rmCount; i++) {
+      try {
+        String rmAddress = getRMWebAppURLWithScheme(conf, i);
+        return func.apply(rmAddress, arg);
+      } catch (Exception e) {
+        // Ignore and try next RM if there are any
+      }
+    }
+    throw new ConnectException("No active RM available to execute this command");
   }
 
   /** A BiFunction which throws on Exception. */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java
@@ -110,26 +110,30 @@ public class WebAppUtils {
    */
   public static <T, R> R execOnActiveRM(Configuration conf,
       ThrowingBiFunction<String, T, R> func, T arg) throws Exception {
+    // If HA is not enabled we are running the function on the only RM that is available.
     if (!HAUtil.isHAEnabled(conf)) {
       String rmAddress = getRMWebAppURLWithScheme(conf, 0);
       return func.apply(rmAddress, arg);
     }
 
-    int activeRMIndex = 0;
+    // In HA mode we can find the active RM if user has admin permissions to check service states.
+    // Otherwise, activeRMId will be null.
     List<String> rmIds = (List<String>) HAUtil.getRMHAIds(conf);
     String activeRMId = RMHAUtils.findActiveRMHAId(conf);
     if (activeRMId != null) {
-      activeRMIndex = rmIds.indexOf(activeRMId);
+      int activeRMIndex = rmIds.indexOf(activeRMId);
+      String rmAddress = getRMWebAppURLWithScheme(conf, activeRMIndex);
+      return func.apply(rmAddress, arg);
     }
 
-    // In HA mode activeRMId can be fetched only if user have permission to check service states.
-    // Otherwise, we find the active one by iterating through the RMs.
-    for (int i = activeRMIndex; i < rmIds.size(); i++) {
+    // If user does not have the necessary permissions we have to iterate through the RMs
+    // to find the active one.
+    for (int i = 0; i < rmIds.size(); i++) {
       try {
         String rmAddress = getRMWebAppURLWithScheme(conf, i);
         return func.apply(rmAddress, arg);
       } catch (Exception e) {
-        // Log and try next RM if there are any.
+        // Log exception and try next RM if there are any.
         LOG.trace("Exception while connecting to RM", e);
       }
     }


### PR DESCRIPTION
Change-Id: I04678a04503e01e67f1075f3fc543887cf80ac47

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[YARN-10767](https://issues.apache.org/jira/browse/YARN-10767) introduced a bug, where YARN Logs CLI is unable to fetch the AM logs using "-am" option if the user is not in the Admin ACLs.

This commit changed the logic for requesting the AM logs and it fetches the "id" of the active RM from the HA service, and requesting the logs from there.

**Reproduction:**

The issue can be reproduced by calling "yarn logs -applicationId ‹appId› -am 1" command with a user who has not got admin access.

In the RM logs of the test cluster I can see the following error, which states that the user doesn't have permission to call 'getServiceState':

```
IPC Server handler 0 on default port 8033, call Call#3 Retry#0 org.apache.hadoop.ha.HAServiceProtocol.getServiceStatus
org.apache.hadoop.security.AccessControlException: User systest doesn't have permission to call 'getServiceState'
at org.apache.hadoop.yarn.server.resourcemanager.RMServerUtils.verifyAdminAccess(RMServerUtils.java:433)
at org.apache.hadoop.yarn.server.resourcemanager.RMServerUtils.verifyAdminAccess(RMServerUtils.java:398)
at org.apache.hadoop.yarn.server.resourcemanager.AdminService.checkAccess(AdminService.java:243)
at org.apache.hadoop.yarn.server.resourcemanager.AdminService.getServiceStatus(AdminService.java:396)
at org.apache.hadoop.ha.protocolPB.HAServiceProtocolServerSideTranslatorPB.getServiceStatus(HAServiceProtocolServerSideTranslatorPB.java:148)
at org.apache.hadoop.ha.proto.HAServiceProtocolProtos$HAServiceProtocolService$2.callBlockingMethod(HAServiceProtocolProtos.java:6154)
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:621)
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:589)
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:573)
at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1227)
at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1247)
at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1170)
at java.security.AccessController.doPrivileged(Native Method)
at javax.security.auth.Subject.doAs(Subject.java:422)
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1964)
at org.apache.hadoop.ipc.Server$Handler.run(Server.java:3200)
```

Currently in WebAppUtils's execOnActiveRM method we throw an exception when RMHAUtils.findActiveRMHAId returns null [here](https://github.com/apache/hadoop/blob/trunk/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/util/WebAppUtils.java#L116), stating that "No active RM is available". However that method will return null if the permissions are missing to check the service states. I think at this point we could fall back to the original code here, and try to find the active RM by iterating through them. 

The issue only happens in HA mode, and only if we use "-am" option, without this option the AM logs can be retrieved together with the aggregated logs.

### How was this patch tested?
Tested manually on a cluster by fetching application logs

- with and without "-am" option
- HA and non-HA mode
- with admin/non-admin user

The aggregated logs and AM logs could be fetched in every cases.

When I stopped the first RM, and the user could not check the active one, we found it when the connection timed out after 30 retries. With admin user it could find the active one for the first time

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

