### PR TITLE
HADOOP-19610. S3A: ITests to run under JUnit5

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractMultipartUploaderTest.java
@@ -30,6 +30,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -99,6 +100,7 @@ public abstract class AbstractContractMultipartUploaderTest extends
   }
 
   @Override
+  @AfterEach
   public void teardown() throws Exception {
     MultipartUploader uploader = getUploader(1);
     if (uploader != null) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractRootDirectoryTest.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.hadoop.test.tags.RootFilesystemTest;
 
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
@@ -52,6 +53,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.treeWalk;
  * Only subclass this for tests against transient filesystems where
  * you don't care about the data.
  */
+@RootFilesystemTest
 public abstract class AbstractContractRootDirectoryTest extends AbstractFSContractTestBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(AbstractContractRootDirectoryTest.class);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -33,7 +33,12 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 
 /**
  * Contract tests for {@link org.apache.hadoop.fs.CanUnbuffer#unbuffer}.
+ * Some of these test cases can fail if the FS read() call returns less
+ * than requested, which is a valid (possibly correct) implementation
+ * of {@code InputStream.read(buffer[])} which may return only those bytes
+ * which can be returned without blocking for more data.
  */
+@FlakyTest("buffer underflow")
 public abstract class AbstractContractUnbufferTest extends AbstractFSContractTestBase {
 
   private Path file;
@@ -50,7 +55,6 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
-  @FlakyTest("buffer underflow")
   public void testUnbufferAfterRead() throws IOException {
     describe("unbuffer a file after a single read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -60,7 +64,6 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
-  @FlakyTest("buffer underflow")
   public void testUnbufferBeforeRead() throws IOException {
     describe("unbuffer a file before a read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -80,7 +83,6 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
-  @FlakyTest("buffer underflow")
   public void testUnbufferOnClosedFile() throws IOException {
     describe("unbuffer a file before a read");
     FSDataInputStream stream = null;
@@ -98,7 +100,6 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
-  @FlakyTest("buffer underflow")
   public void testMultipleUnbuffers() throws IOException {
     describe("unbuffer a file multiple times");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -110,7 +111,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
     }
   }
 
-  @FlakyTest("buffer underflow")
+
   @Test
   public void testUnbufferMultipleReads() throws IOException {
     describe("unbuffer a file multiple times");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.tags.FlakyTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
@@ -49,6 +50,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
+  @FlakyTest("buffer underflow")
   public void testUnbufferAfterRead() throws IOException {
     describe("unbuffer a file after a single read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -58,6 +60,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
+  @FlakyTest("buffer underflow")
   public void testUnbufferBeforeRead() throws IOException {
     describe("unbuffer a file before a read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -77,6 +80,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
+  @FlakyTest("buffer underflow")
   public void testUnbufferOnClosedFile() throws IOException {
     describe("unbuffer a file before a read");
     FSDataInputStream stream = null;
@@ -94,6 +98,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
   }
 
   @Test
+  @FlakyTest("buffer underflow")
   public void testMultipleUnbuffers() throws IOException {
     describe("unbuffer a file multiple times");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
@@ -105,6 +110,7 @@ public abstract class AbstractContractUnbufferTest extends AbstractFSContractTes
     }
   }
 
+  @FlakyTest("buffer underflow")
   @Test
   public void testUnbufferMultipleReads() throws IOException {
     describe("unbuffer a file multiple times");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractVectoredRead.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/localfs/TestLocalFSContractVectoredRead.java
@@ -34,15 +34,20 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.validateVectoredReadResult;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
+@ParameterizedClass(name="buffer-{0}")
+@MethodSource("params")
 public class TestLocalFSContractVectoredRead extends AbstractContractVectoredReadTest {
 
-  public TestLocalFSContractVectoredRead() {
+  public TestLocalFSContractVectoredRead(final String bufferType) {
+    super(bufferType);
   }
 
   @Override
@@ -50,11 +55,8 @@ public class TestLocalFSContractVectoredRead extends AbstractContractVectoredRea
     return new LocalFSContract(conf);
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "Buffer type : {0}")
-  public void testChecksumValidationDuringVectoredRead(
-      String pBufferType) throws Exception {
-    initAbstractContractVectoredReadTest(pBufferType);
+  @Test
+  public void testChecksumValidationDuringVectoredRead() throws Exception {
     Path testPath = path("big_range_checksum_file");
     List<FileRange> someRandomRanges = new ArrayList<>();
     someRandomRanges.add(FileRange.createFileRange(10, 1024));
@@ -67,11 +69,8 @@ public class TestLocalFSContractVectoredRead extends AbstractContractVectoredRea
    * Test for file size less than checksum chunk size.
    * {@code ChecksumFileSystem#bytesPerChecksum}.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "Buffer type : {0}")
-  public void testChecksumValidationDuringVectoredReadSmallFile(
-      String pBufferType) throws Exception {
-    initAbstractContractVectoredReadTest(pBufferType);
+  @Test
+  public void testChecksumValidationDuringVectoredReadSmallFile() throws Exception {
     Path testPath = path("big_range_checksum_file");
     final int length = 471;
     List<FileRange> smallFileRanges = new ArrayList<>();
@@ -110,10 +109,9 @@ public class TestLocalFSContractVectoredRead extends AbstractContractVectoredRea
           () -> validateVectoredReadResult(ranges, datasetCorrupted, 0));
     }
   }
-  @MethodSource("params")
-  @ParameterizedTest(name = "Buffer type : {0}")
-  public void tesChecksumVectoredReadBoundaries(String pBufferType) throws Exception {
-    initAbstractContractVectoredReadTest(pBufferType);
+
+  @Test
+  public void tesChecksumVectoredReadBoundaries() throws Exception {
     Path testPath = path("boundary_range_checksum_file");
     final int length = 1071;
     LocalFileSystem localFs = (LocalFileSystem) getFileSystem();

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawLocalContractVectoredRead.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawLocalContractVectoredRead.java
@@ -18,13 +18,19 @@
 
 package org.apache.hadoop.fs.contract.rawlocal;
 
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 
+@ParameterizedClass(name="buffer-{0}")
+@MethodSource("params")
 public class TestRawLocalContractVectoredRead extends AbstractContractVectoredReadTest {
 
-  public TestRawLocalContractVectoredRead() {
+  public TestRawLocalContractVectoredRead(final String bufferType) {
+    super(bufferType);
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/FlakyTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/FlakyTest.java
@@ -16,28 +16,30 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.s3a.auth.delegation;
+package org.apache.hadoop.test.tags;
 
-import org.apache.hadoop.test.tags.LoadTest;
-import org.apache.hadoop.test.tags.ScaleTest;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_ROLE_BINDING;
+import org.junit.jupiter.api.Tag;
 
 /**
- * This looks at the cost of assume role, to see if it is more expensive
- * than creating simple session credentials.
+ * JUnit 5 tag to indicate that a test is flaky, which can be used by test runners
+ * to skip tests which may fail in CI builds.
+ * <p> The test runner tag to filter on is {@code flaky}.
+ *
+ * <p>
+ * Only use this for tests which really are flaky due to some external factor, such as
+ * network status. If a test fails intermittently due to some timing/race condition,
+ * fix that.
  */
-@LoadTest
-@ScaleTest
-public class ILoadTestRoleCredentials extends ILoadTestSessionCredentials {
-
-  @Override
-  protected String getDelegationBinding() {
-    return DELEGATION_TOKEN_ROLE_BINDING;
-  }
-
-  @Override
-  protected String getFilePrefix() {
-    return "role";
-  }
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("flaky")
+@Inherited
+public @interface FlakyTest {
+  String value();
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/IntegrationTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/IntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+/**
+ * JUnit 5 tag to indicate that a test is an integration test which is
+ * to be executed against a running service -a service whose
+ * deployment and operation is not part of the codebase.
+ * <p>
+ * This is primarily for test suites which are targeted at
+ * remote cloud stores.
+ * <p>
+ * Key aspects of these tests are not just that they depend upon
+ * an external service -the test run must be configured such that
+ * it can connect to and authenticate with the service.
+ * <p>
+ * Consult the documentation of the specific module to
+ * determine how to do this.
+ *
+ * <p> The test runner tag to filter on is {@code integration}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag("integration")
+public @interface IntegrationTest {
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/LoadTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/LoadTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+/**
+ * JUnit 5 tag to indicate that a test suite is a load test suite, which is
+ * designed to load/overload the target system.
+ * <p> If this test is directed at cloud infrastructure the load may be significant
+ * enough to trigger throttling, which may be observed not only by other tests, but
+ * by other users/applications using the same account.
+ * <p> The test runner tag to filter on is {@code load}.
+ * <p> Note: this annotation should be accompanied by the {@link ScaleTest}
+ * tag to indicate it is a specific type of scale test.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag("load")
+public @interface LoadTest {
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/RootFilesystemTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/RootFilesystemTest.java
@@ -16,28 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.s3a.auth.delegation;
+package org.apache.hadoop.test.tags;
 
-import org.apache.hadoop.test.tags.LoadTest;
-import org.apache.hadoop.test.tags.ScaleTest;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_ROLE_BINDING;
+import org.junit.jupiter.api.Tag;
 
 /**
- * This looks at the cost of assume role, to see if it is more expensive
- * than creating simple session credentials.
+ * JUnit 5 tag to indicate that a filesystem test works against the root FS.
+ * . which can be used by test runners
+ * to skip slower tests.
+ * <p> The test runner tag to filter on is {@code scale}.
  */
-@LoadTest
-@ScaleTest
-public class ILoadTestRoleCredentials extends ILoadTestSessionCredentials {
-
-  @Override
-  protected String getDelegationBinding() {
-    return DELEGATION_TOKEN_ROLE_BINDING;
-  }
-
-  @Override
-  protected String getFilePrefix() {
-    return "role";
-  }
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag("rootfilesystem")
+public @interface RootFilesystemTest {
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/ScaleTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/ScaleTest.java
@@ -16,28 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.s3a.auth.delegation;
+package org.apache.hadoop.test.tags;
 
-import org.apache.hadoop.test.tags.LoadTest;
-import org.apache.hadoop.test.tags.ScaleTest;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_ROLE_BINDING;
+import org.junit.jupiter.api.Tag;
 
 /**
- * This looks at the cost of assume role, to see if it is more expensive
- * than creating simple session credentials.
+ * JUnit 5 tag to indicate that a test is a scale test. which can be used by test runners
+ * to skip slower tests.
+ * <p> The test runner tag to filter on is {@code scale}.
  */
-@LoadTest
-@ScaleTest
-public class ILoadTestRoleCredentials extends ILoadTestSessionCredentials {
-
-  @Override
-  protected String getDelegationBinding() {
-    return DELEGATION_TOKEN_ROLE_BINDING;
-  }
-
-  @Override
-  protected String getFilePrefix() {
-    return "role";
-  }
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Tag("scale")
+public @interface ScaleTest {
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/tags/package-info.java
@@ -16,28 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.s3a.auth.delegation;
-
-import org.apache.hadoop.test.tags.LoadTest;
-import org.apache.hadoop.test.tags.ScaleTest;
-
-import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_ROLE_BINDING;
-
 /**
- * This looks at the cost of assume role, to see if it is more expensive
- * than creating simple session credentials.
+ * JUnit 5 tags.
+ * <p>
+ * For use in Hadoop's own test suites, and those which extend them, such as FileSystem contract
+ * tests.
  */
-@LoadTest
-@ScaleTest
-public class ILoadTestRoleCredentials extends ILoadTestSessionCredentials {
-
-  @Override
-  protected String getDelegationBinding() {
-    return DELEGATION_TOKEN_ROLE_BINDING;
-  }
-
-  @Override
-  protected String getFilePrefix() {
-    return "role";
-  }
-}
+@org.apache.hadoop.classification.InterfaceStability.Unstable
+@org.apache.hadoop.classification.InterfaceAudience.LimitedPrivate("Derived Test Suites")
+package org.apache.hadoop.test.tags;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/contract/hdfs/TestHDFSContractVectoredRead.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/contract/hdfs/TestHDFSContractVectoredRead.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
@@ -30,10 +32,13 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 /**
  * Contract test for vectored reads through HDFS connector.
  */
+@ParameterizedClass(name="buffer-{0}")
+@MethodSource("params")
 public class TestHDFSContractVectoredRead
     extends AbstractContractVectoredReadTest {
 
-  public TestHDFSContractVectoredRead() {
+  public TestHDFSContractVectoredRead(final String bufferType) {
+    super(bufferType);
   }
 
   @BeforeAll

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -21,7 +21,10 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSSES3;
@@ -34,15 +37,13 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSS
  * implementation of readVectored {@link org.apache.hadoop.fs.PositionedReadable}
  * still works.
  */
+@IntegrationTest
+@ParameterizedClass(name="buffer-{0}")
+@MethodSource("params")
 public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContractVectoredReadTest {
 
-  public ITestS3AContractAnalyticsStreamVectoredRead() {
-  }
-
-  @BeforeEach
-  @Override
-  public void setup() throws Exception {
-    super.setup();
+  public ITestS3AContractAnalyticsStreamVectoredRead(String bufferType) {
+    super(bufferType);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractContentSummary.java
@@ -27,9 +27,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractContentSummaryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.touch;
 
+@IntegrationTest
 public class ITestS3AContractContentSummary extends AbstractContractContentSummaryTest {
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
@@ -21,13 +21,15 @@ package org.apache.hadoop.fs.contract.s3a;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_PERFORMANCE_TESTS_ENABLED;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_EXPECT_CONTINUE;
@@ -41,6 +43,9 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfNotEnabled;
  * Parameterized on the create performance flag as all overwrite
  * tests are required to fail in create performance mode.
  */
+@IntegrationTest
+@ParameterizedClass(name="performance-{0}-continue={1}")
+@MethodSource("params")
 public class ITestS3AContractCreate extends AbstractContractCreateTest {
 
   /**
@@ -58,17 +63,17 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
   /**
    * Is this test run in create performance mode?
    */
-  private boolean createPerformance;
+  private final boolean createPerformance;
 
   /**
    * Expect a 100-continue response?
    */
-  private boolean expectContinue;
+  private final boolean expectContinue;
 
-  public void initITestS3AContractCreate(final boolean pCreatePerformance,
-      final boolean pExpectContinue) {
-    this.createPerformance = pCreatePerformance;
-    this.expectContinue = pExpectContinue;
+  public ITestS3AContractCreate(final boolean createPerformance,
+      final boolean expectContinue) {
+    this.createPerformance = createPerformance;
+    this.expectContinue = expectContinue;
   }
 
   @Override
@@ -92,11 +97,8 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
     return conf;
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testOverwriteNonEmptyDirectory(boolean pCreatePerformance,
-      boolean pExpectContinue) throws Throwable {
-    initITestS3AContractCreate(pCreatePerformance, pExpectContinue);
+  @Test
+  public void testOverwriteNonEmptyDirectory() throws Throwable {
     try {
        // Currently analytics accelerator does not support reading of files that have been overwritten.
        // This is because the analytics accelerator library caches metadata, and when a file is
@@ -112,11 +114,9 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
     }
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testOverwriteEmptyDirectory(boolean pCreatePerformance,
-      boolean pExpectContinue) throws Throwable {
-    initITestS3AContractCreate(pCreatePerformance, pExpectContinue);
+  @Override
+  @Test
+  public void testOverwriteEmptyDirectory() throws Throwable {
     try {
       super.testOverwriteEmptyDirectory();
       failWithCreatePerformance();
@@ -125,11 +125,9 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
     }
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFileOverExistingFileNoOverwrite(boolean pCreatePerformance,
-      boolean pExpectContinue) throws Throwable {
-    initITestS3AContractCreate(pCreatePerformance, pExpectContinue);
+  @Test
+  @Override
+  public void testCreateFileOverExistingFileNoOverwrite() throws Throwable {
     try {
       super.testCreateFileOverExistingFileNoOverwrite();
       failWithCreatePerformance();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDelete.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDelete.java
@@ -21,10 +21,12 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractDeleteTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 /**
  * S3A contract tests covering deletes.
  */
+@IntegrationTest
 public class ITestS3AContractDelete extends AbstractContractDeleteTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDistCp.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDistCp.java
@@ -18,12 +18,15 @@
 
 package org.apache.hadoop.fs.contract.s3a;
 
+import org.junit.jupiter.api.Test;
+
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.SCALE_TEST_TIMEOUT_MILLIS;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.test.tags.IntegrationTest;
 import org.apache.hadoop.tools.contract.AbstractContractDistCpTest;
 
 /**
@@ -31,6 +34,7 @@ import org.apache.hadoop.tools.contract.AbstractContractDistCpTest;
  * Uses the block output stream, buffered to disk. This is the
  * recommended output mechanism for DistCP due to its scalability.
  */
+@IntegrationTest
 public class ITestS3AContractDistCp extends AbstractContractDistCpTest {
 
   private static final long MULTIPART_SETTING = MULTIPART_MIN_SIZE;
@@ -62,6 +66,7 @@ public class ITestS3AContractDistCp extends AbstractContractDistCpTest {
     return new S3AContract(conf);
   }
 
+  @Test
   @Override
   public void testDistCpWithIterator() throws Exception {
     final long renames = getRenameOperationCount();
@@ -70,6 +75,7 @@ public class ITestS3AContractDistCp extends AbstractContractDistCpTest {
         renames, "Expected no renames for a direct write distcp");
   }
 
+  @Test
   @Override
   public void testNonDirectWrite() throws Exception {
     final long renames = getRenameOperationCount();
@@ -78,6 +84,7 @@ public class ITestS3AContractDistCp extends AbstractContractDistCpTest {
         "Expected 2 renames for a non-direct write distcp");
   }
 
+  @Test
   @Override
   public void testDistCpUpdateCheckFileSkip() throws Exception {
     // Currently analytics accelerator does not support reading of files that have been overwritten.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractEtag.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractEtag.java
@@ -21,10 +21,12 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractEtagTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 /**
  * Test S3A etag support.
  */
+@IntegrationTest
 public class ITestS3AContractEtag extends AbstractContractEtagTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractGetFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractGetFileStatus.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.fs.contract.AbstractContractGetFileStatusTest;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.AfterEach;
 
 /**
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
  * Some of the tests can take too long when the fault injection rate is high,
  * so the test timeout is extended.
  */
+@IntegrationTest
 public class ITestS3AContractGetFileStatus
     extends AbstractContractGetFileStatusTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdir.java
@@ -21,12 +21,14 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
 
 /**
  * Test dir operations on S3A.
  */
+@IntegrationTest
 public class ITestS3AContractMkdir extends AbstractContractMkdirTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdirWithCreatePerf.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMkdirWithCreatePerf.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
@@ -36,6 +37,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfNotEnabled;
 /**
  * Test mkdir operations on S3A with create performance mode.
  */
+@IntegrationTest
 public class ITestS3AContractMkdirWithCreatePerf extends AbstractContractMkdirTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMultipartUploader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMultipartUploader.java
@@ -22,7 +22,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractMultipartUploaderTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.IntegrationTest;
+import org.apache.hadoop.test.tags.ScaleTest;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.DEFAULT_SCALE_TESTS_ENABLED;
@@ -43,6 +47,8 @@ import static org.apache.hadoop.fs.s3a.scale.AbstractSTestS3AHugeFiles.DEFAULT_H
  * to enable it, and partition size option to control the size of
  * parts uploaded.
  */
+@IntegrationTest
+@ScaleTest
 public class ITestS3AContractMultipartUploader extends
     AbstractContractMultipartUploaderTest {
 
@@ -112,21 +118,26 @@ public class ITestS3AContractMultipartUploader extends
   /**
    * S3 has no concept of directories, so this test does not apply.
    */
+  @Test
+  @Override
   public void testDirectoryInTheWay() throws Exception {
     skip("Unsupported");
   }
 
+  @Test
   @Override
   public void testMultipartUploadReverseOrder() throws Exception {
     skip("skipped for speed");
   }
 
+  @Test
   @Override
   public void testMultipartUploadReverseOrderNonContiguousPartNumbers() throws Exception {
     assumeNotS3ExpressFileSystem(getFileSystem());
     super.testMultipartUploadReverseOrderNonContiguousPartNumbers();
   }
 
+  @Test
   @Override
   public void testConcurrentUploads() throws Throwable {
     assumeNotS3ExpressFileSystem(getFileSystem());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractOpen.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
@@ -37,6 +38,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * S3A contract tests opening files.
  */
+@IntegrationTest
 public class ITestS3AContractOpen extends AbstractContractOpenTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRename.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRename.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
@@ -40,6 +41,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestConstants.S3A_TEST_TIMEOUT;
 /**
  * S3A contract tests covering rename.
  */
+@IntegrationTest
 public class ITestS3AContractRename extends AbstractContractRenameTest {
 
   public static final Logger LOG = LoggerFactory.getLogger(
@@ -55,6 +57,7 @@ public class ITestS3AContractRename extends AbstractContractRenameTest {
     return new S3AContract(conf);
   }
 
+  @Test
   @Override
   public void testRenameDirIntoExistingDir() throws Throwable {
     describe("S3A rename into an existing directory returns false");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractRootDir.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.contract.s3a;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,12 +28,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeSkipRootTests;
 
 /**
  * root dir operations against an S3 bucket.
  */
+@IntegrationTest
 public class ITestS3AContractRootDir extends
     AbstractContractRootDirectoryTest {
 
@@ -57,6 +60,7 @@ public class ITestS3AContractRootDir extends
   }
 
   @Override
+  @Test
   @Disabled("S3 always return false when non-recursively remove root dir")
   public void testRmNonEmptyRootDirNonRecursive() throws Throwable {
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractUnbuffer.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractUnbuffer.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractUnbufferTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
+@IntegrationTest
 public class ITestS3AContractUnbuffer extends AbstractContractUnbufferTest {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AWrappedIO.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AWrappedIO.java
@@ -21,10 +21,12 @@ package org.apache.hadoop.fs.contract.s3a;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.io.wrappedio.impl.TestWrappedIO;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 /**
  * Test S3A access through the wrapped operations class.
  */
+@IntegrationTest
 public class ITestS3AWrappedIO extends TestWrappedIO {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/AbstractS3ATestBase.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.statistics.IOStatisticsContext;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +50,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 /**
  * An extension of the contract test base set up for S3A tests.
  */
+@IntegrationTest
 public abstract class AbstractS3ATestBase extends AbstractFSContractTestBase
     implements S3ATestConstants {
   protected static final Logger LOG =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestBlockingThreadPoolExecutorService.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestBlockingThreadPoolExecutorService.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import org.apache.hadoop.test.AbstractHadoopTestBase;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.hadoop.util.SemaphoredDelegatingExecutor;
 import org.apache.hadoop.util.StopWatch;
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Basic test for S3A's blocking executor service.
  */
 @Timeout(60)
-public class ITestBlockingThreadPoolExecutorService {
+public class ITestBlockingThreadPoolExecutorService extends AbstractHadoopTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestBlockingThreadPoolExecutorService.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClientSideEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AClientSideEncryption.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.fs.s3a.impl.RequestFactoryImpl;
 import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
@@ -160,6 +161,7 @@ public abstract class ITestS3AClientSideEncryption extends AbstractS3ATestBase {
    * verifying the contents of the uploaded file.
    */
   @Test
+  @ScaleTest
   public void testBigFilePutAndGet() throws IOException {
     maybeSkipTest();
     assume("Scale test disabled: to enable set property " +

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.http.HttpStatus;
 
@@ -83,6 +84,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * S3A tests for configuration, especially credentials.
  */
 @Timeout(value = S3A_TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
+@IntegrationTest
 public class ITestS3AConfiguration extends AbstractHadoopTestBase {
   private static final String EXAMPLE_ID = "AKASOMEACCESSKEY";
   private static final String EXAMPLE_KEY =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContractGetFileStatusV1List.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AContractGetFileStatusV1List.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractGetFileStatusTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.AfterEach;
 
 import static org.apache.hadoop.fs.s3a.Constants.LIST_VERSION;
@@ -33,6 +35,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfS3ExpressBucket;
 /**
  * S3A contract tests for getFileStatus, using the v1 List Objects API.
  */
+@IntegrationTest
 public class ITestS3AContractGetFileStatusV1List
     extends AbstractContractGetFileStatusTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACopyFromLocalFile.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ACopyFromLocalFile.java
@@ -29,9 +29,11 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.fs.s3a.Constants.OPTIMIZED_COPY_FROM_LOCAL;
@@ -45,6 +47,9 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * Parameterized on whether or not the optimized
  * copyFromLocalFile is enabled.
  */
+@IntegrationTest
+@ParameterizedClass(name="optimized-{0}")
+@MethodSource("params")
 public class ITestS3ACopyFromLocalFile extends
         AbstractContractCopyFromLocalTest {
   /**
@@ -56,10 +61,10 @@ public class ITestS3ACopyFromLocalFile extends
         {false},
     });
   }
-  private boolean enabled;
+  private final boolean enabled;
 
-  public void initITestS3ACopyFromLocalFile(final boolean pEnabled) {
-    this.enabled = pEnabled;
+  public ITestS3ACopyFromLocalFile(final boolean enabled) {
+    this.enabled = enabled;
   }
 
   @Override
@@ -78,10 +83,8 @@ public class ITestS3ACopyFromLocalFile extends
     return new S3AContract(conf);
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testOptionPropagation(boolean pEnabled) throws Throwable {
-    initITestS3ACopyFromLocalFile(pEnabled);
+  @Test
+  public void testOptionPropagation() throws Throwable {
     Assertions.assertThat(getFileSystem().hasPathCapability(new Path("/"),
         OPTIMIZED_COPY_FROM_LOCAL))
         .describedAs("path capability of %s", OPTIMIZED_COPY_FROM_LOCAL)
@@ -89,10 +92,8 @@ public class ITestS3ACopyFromLocalFile extends
 
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testLocalFilesOnly(boolean pEnabled) throws Throwable {
-    initITestS3ACopyFromLocalFile(pEnabled);
+  @Test
+  public void testLocalFilesOnly() throws Throwable {
     describe("Copying into other file systems must fail");
     Path dest = fileToPath(createTempDirectory("someDir"));
 
@@ -100,10 +101,8 @@ public class ITestS3ACopyFromLocalFile extends
         () -> getFileSystem().copyFromLocalFile(false, true, dest, dest));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testOnlyFromLocal(boolean pEnabled) throws Throwable {
-    initITestS3ACopyFromLocalFile(pEnabled);
+  @Test
+  public void testOnlyFromLocal() throws Throwable {
     describe("Copying must be from a local file system");
     File source = createTempFile("someFile");
     Path dest = copyFromLocal(source, true);
@@ -112,10 +111,8 @@ public class ITestS3ACopyFromLocalFile extends
         () -> getFileSystem().copyFromLocalFile(true, true, dest, dest));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCopyFromLocalWithNoFileScheme(boolean pEnabled) throws IOException {
-    initITestS3ACopyFromLocalFile(pEnabled);
+  @Test
+  public void testCopyFromLocalWithNoFileScheme() throws IOException {
     describe("Copying from local file with no file scheme to remote s3 destination");
     File source = createTempFile("tempData");
     Path dest = path(getMethodName());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFSMainOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFSMainOperations.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.fs.FSMainOperationsBaseTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.Disabled;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.createTestPath;
@@ -36,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * S3A Test suite for the FSMainOperationsBaseTest tests.
  */
+@IntegrationTest
 public class ITestS3AFSMainOperations extends FSMainOperationsBaseTest {
 
   private S3AContract contract;
@@ -53,13 +56,6 @@ public class ITestS3AFSMainOperations extends FSMainOperationsBaseTest {
     contract = new S3AContract(conf);
     contract.init();
     return contract.getTestFileSystem();
-  }
-
-  @Override
-  public void tearDown() throws Exception {
-    if (contract.getTestFileSystem() != null) {
-      super.tearDown();
-    }
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemContract.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemContract.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *  Tests a live S3 system. If your keys and bucket aren't specified, all tests
  *  are marked as passed.
  */
+@IntegrationTest
 public class ITestS3AFileSystemContract extends FileSystemContractBaseTest {
 
   protected static final Logger LOG =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingLruEviction.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3APrefetchingLruEviction.java
@@ -28,7 +28,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.junit.jupiter.params.ParameterizedTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,9 +56,11 @@ import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_B
 /**
  * Test the prefetching input stream with LRU cache eviction on S3ACachingInputStream.
  */
+@ParameterizedClass(name="max-blocks-{0}")
+@MethodSource("params")
 public class ITestS3APrefetchingLruEviction extends AbstractS3ACostTest {
 
-  private String maxBlocks;
+  private final String maxBlocks;
 
   public static Collection<Object[]> params() {
     return Arrays.asList(new Object[][]{
@@ -65,8 +69,8 @@ public class ITestS3APrefetchingLruEviction extends AbstractS3ACostTest {
     });
   }
 
-  public void initITestS3APrefetchingLruEviction(final String pMaxBlocks) {
-    this.maxBlocks = pMaxBlocks;
+  public ITestS3APrefetchingLruEviction(final String maxBlocks) {
+    this.maxBlocks = maxBlocks;
   }
 
   private static final Logger LOG =
@@ -91,10 +95,8 @@ public class ITestS3APrefetchingLruEviction extends AbstractS3ACostTest {
     return conf;
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "max-blocks-{0}")
-  public void testSeeksWithLruEviction(String pMaxBlocks) throws Throwable {
-    initITestS3APrefetchingLruEviction(pMaxBlocks);
+  @Test
+  public void testSeeksWithLruEviction() throws Throwable {
     IOStatistics ioStats;
     byte[] data = ContractTestUtils.dataset(SMALL_FILE_SIZE, 'x', 26);
     // Path for file which should have length > block size so S3ACachingInputStream is used

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AStorageClass.java
@@ -24,7 +24,8 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +50,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * Tests of storage class.
  */
+@ParameterizedClass(name="-{0}")
+@MethodSource("params")
 public class ITestS3AStorageClass extends AbstractS3ATestBase {
 
   /**
@@ -62,10 +65,10 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
     });
   }
 
-  private String fastUploadBufferType;
+  private final String fastUploadBufferType;
 
-  public void initITestS3AStorageClass(String pFastUploadBufferType) {
-    this.fastUploadBufferType = pFastUploadBufferType;
+  public ITestS3AStorageClass(String fastUploadBufferType) {
+    this.fastUploadBufferType = fastUploadBufferType;
   }
 
   @Override
@@ -83,11 +86,8 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * This test ensures the default storage class configuration (no config or null)
    * works well with create and copy operations
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "fast-upload-buffer-{0}")
-  public void testCreateAndCopyObjectWithStorageClassDefault(
-      String pFastUploadBufferType) throws Throwable {
-    initITestS3AStorageClass(pFastUploadBufferType);
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassDefault() throws Throwable {
     Configuration conf = this.createConfiguration();
     S3AContract contract = (S3AContract) createContract(conf);
     contract.init();
@@ -108,11 +108,8 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * Verify object can be created and copied correctly
    * with specified storage class
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "fast-upload-buffer-{0}")
-  public void testCreateAndCopyObjectWithStorageClassReducedRedundancy(
-      String pFastUploadBufferType) throws Throwable {
-    initITestS3AStorageClass(pFastUploadBufferType);
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassReducedRedundancy() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, STORAGE_CLASS_REDUCED_REDUNDANCY);
     S3AContract contract = (S3AContract) createContract(conf);
@@ -136,11 +133,8 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * Archive storage classes have different behavior
    * from general storage classes
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "fast-upload-buffer-{0}")
-  public void testCreateAndCopyObjectWithStorageClassGlacier(
-      String pFastUploadBufferType) throws Throwable {
-    initITestS3AStorageClass(pFastUploadBufferType);
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassGlacier() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, STORAGE_CLASS_GLACIER);
     S3AContract contract = (S3AContract) createContract(conf);
@@ -168,11 +162,8 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * Verify object can be created and copied correctly
    * with completely invalid storage class
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "fast-upload-buffer-{0}")
-  public void testCreateAndCopyObjectWithStorageClassInvalid(
-      String pFastUploadBufferType) throws Throwable {
-    initITestS3AStorageClass(pFastUploadBufferType);
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassInvalid() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, "testing");
     S3AContract contract = (S3AContract) createContract(conf);
@@ -196,11 +187,8 @@ public class ITestS3AStorageClass extends AbstractS3ATestBase {
    * Verify object can be created and copied correctly
    * with empty string configuration
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "fast-upload-buffer-{0}")
-  public void testCreateAndCopyObjectWithStorageClassEmpty(
-      String pFastUploadBufferType) throws Throwable {
-    initITestS3AStorageClass(pFastUploadBufferType);
+  @Test
+  public void testCreateAndCopyObjectWithStorageClassEmpty() throws Throwable {
     Configuration conf = this.createConfiguration();
     conf.set(STORAGE_CLASS, "");
     S3AContract contract = (S3AContract) createContract(conf);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATestUtils.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.fs.s3a;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.*;
  * Test the test utils. Why an integration test? it's needed to
  * verify property pushdown.
  */
+@IntegrationTest
 public class ITestS3ATestUtils extends Assertions {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3ATestUtils.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -1195,6 +1196,17 @@ public final class S3ATestUtils {
       conf.set(FS_S3A_PERFORMANCE_FLAGS, flagStr);
     }
     return conf;
+  }
+
+  /**
+   * CLose the filesystem if it not in the cache.
+   * @param fs filesystem to check. May be null
+   */
+  public static void maybeCloseFilesystem(final S3AFileSystem fs) {
+    if (fs != null && fs.getConf().getBoolean(FS_S3A_IMPL_DISABLE_CACHE,
+        false)) {
+      IOUtils.closeQuietly(fs);
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditSpanLifecycle.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditSpanLifecycle.java
@@ -39,6 +39,7 @@ public class TestAuditSpanLifecycle extends AbstractAuditingTest {
   private AuditSpan resetSpan;
 
   @BeforeEach
+  @Override
   public void setup() throws Exception {
     super.setup();
     resetSpan = getManager().getActiveAuditSpan();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestHttpReferrerAuditHeader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestHttpReferrerAuditHeader.java
@@ -71,6 +71,7 @@ public class TestHttpReferrerAuditHeader extends AbstractAuditingTest {
   private LoggingAuditor auditor;
 
   @BeforeEach
+  @Override
   public void setup() throws Exception {
     super.setup();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestLoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestLoggingAuditor.java
@@ -61,6 +61,7 @@ public class TestLoggingAuditor extends AbstractAuditingTest {
   private LoggingAuditor auditor;
 
   @BeforeEach
+  @Override
   public void setup() throws Exception {
     super.setup();
     auditor = (LoggingAuditor) getManager().getAuditor();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ILoadTestSessionCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ILoadTestSessionCredentials.java
@@ -28,6 +28,8 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 
+import org.apache.hadoop.test.tags.LoadTest;
+import org.apache.hadoop.test.tags.ScaleTest;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +80,8 @@ import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEG
  * @see <a href="https://github.com/steveloughran/datasets/releases/tag/tag_2018-09-17-aws">
  *   AWS STS login throttling statistics</a>
  */
+@LoadTest
+@ScaleTest
 public class ILoadTestSessionCredentials extends S3AScaleTestBase {
 
   private static final Logger LOG =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/AbstractYarnClusterITest.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,6 +227,7 @@ public abstract class AbstractYarnClusterITest extends AbstractCommitITest {
    * the user's home directory, as that is often rejected by CI test
    * runners.
    */
+  @TempDir
   public File stagingFilesDir;
 
   /**
@@ -259,7 +261,6 @@ public abstract class AbstractYarnClusterITest extends AbstractCommitITest {
     assertNotNull(
        getClusterBinding(), "cluster is not bound");
     String methodName = getMethodName();
-    stagingFilesDir = File.createTempFile(methodName, "");
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestS3ACommitterFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestS3ACommitterFactory.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +55,13 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * Tests for the committer factory creation/override process.
  */
+@ParameterizedClass(name="committer={3}")
+@MethodSource("params")
 public final class ITestS3ACommitterFactory extends AbstractCommitITest {
+
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3ACommitterFactory.class);
+
   /**
    * Name for invalid committer: {@value}.
    */
@@ -114,18 +120,18 @@ public final class ITestS3ACommitterFactory extends AbstractCommitITest {
   /**
    * Name of committer to set in filesystem config. If "" do not set one.
    */
-  private String fsCommitterName;
+  private final String fsCommitterName;
 
   /**
    * Name of committer to set in job config.
    */
-  private String jobCommitterName;
+  private final String jobCommitterName;
 
   /**
    * Expected committer class.
    * If null: an exception is expected
    */
-  private Class<? extends AbstractS3ACommitter> committerClass;
+  private final Class<? extends AbstractS3ACommitter> committerClass;
 
   /**
    * Description from parameters, simply for thread names to be more informative.
@@ -134,21 +140,20 @@ public final class ITestS3ACommitterFactory extends AbstractCommitITest {
 
   /**
    * Create a parameterized instance.
-   * @param pFsCommitterName committer to set in filesystem config
-   * @param pJobCommitterName committer to set in job config
-   * @param pCommitterClass expected committer class
-   * @param pDescription debug text for thread names.
+   * @param fsCommitterName committer to set in filesystem config
+   * @param jobCommitterName committer to set in job config
+   * @param committerClass expected committer class
+   * @param description debug text for thread names.
    */
-  public void initITestS3ACommitterFactory(
-      final String pFsCommitterName,
-      final String pJobCommitterName,
-      final Class<? extends AbstractS3ACommitter> pCommitterClass,
-      final String pDescription) throws Exception {
-    this.fsCommitterName = pFsCommitterName;
-    this.jobCommitterName = pJobCommitterName;
-    this.committerClass = pCommitterClass;
-    this.description = pDescription;
-    setup();
+  public ITestS3ACommitterFactory(
+      final String fsCommitterName,
+      final String jobCommitterName,
+      final Class<? extends AbstractS3ACommitter> committerClass,
+      final String description) {
+    this.fsCommitterName = fsCommitterName;
+    this.jobCommitterName = jobCommitterName;
+    this.committerClass = committerClass;
+    this.description = description;
   }
 
   @Override
@@ -176,6 +181,7 @@ public final class ITestS3ACommitterFactory extends AbstractCommitITest {
   }
 
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     // destroy all filesystems from previous runs.
     FileSystem.closeAllForUGI(UserGroupInformation.getCurrentUser());
@@ -210,14 +216,8 @@ public final class ITestS3ACommitterFactory extends AbstractCommitITest {
    * Verify that if all config options are unset, the FileOutputCommitter
    * is returned.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{3}-fs=[{0}]-task=[{1}]-[{2}]")
-  public void testBinding(String pFsCommitterName,
-      String pJobCommitterName,
-      Class<? extends AbstractS3ACommitter> pCommitterClass,
-      String pDescription) throws Throwable {
-    initITestS3ACommitterFactory(pFsCommitterName, pJobCommitterName, pCommitterClass,
-        pDescription);
+  @Test
+  public void testBinding() throws Throwable {
     assertFactoryCreatesExpectedCommitter(committerClass);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/integration/ITestS3ACommitterMRJob.java
@@ -37,10 +37,12 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,7 +128,7 @@ import static org.apache.hadoop.mapred.JobConf.MAPRED_TASK_ENV;
  *     outcome.
  *   </li>
  *   <li>
- *     {@link #test_500(CommitterTestBinding)} test is relayed to
+ *     {@link #test_500()} test is relayed to
  *     {@link CommitterTestBinding#test_500()}, for any post-MR-job tests.
  * </ol>
  *
@@ -138,6 +140,8 @@ import static org.apache.hadoop.mapred.JobConf.MAPRED_TASK_ENV;
  * instance.
  */
 @TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@ParameterizedClass(name="binding={0}")
+@MethodSource("params")
 public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
 
   private static final Logger LOG =
@@ -159,19 +163,19 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
   /**
    * The committer binding for this instance.
    */
-  private CommitterTestBinding committerTestBinding;
+  private final CommitterTestBinding committerTestBinding;
 
   /**
    * Parameterized constructor.
-   * @param pCommitterTestBinding binding for the test.
+   * @param committerTestBinding binding for the test.
    */
-  public void initITestS3ACommitterMRJob(
-      final CommitterTestBinding pCommitterTestBinding) throws Exception {
-    this.committerTestBinding = pCommitterTestBinding;
-    setup();
+  public ITestS3ACommitterMRJob(
+      final CommitterTestBinding committerTestBinding) {
+    this.committerTestBinding = committerTestBinding;
   }
 
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     // configure the test binding for this specific test case.
@@ -193,25 +197,19 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
   /**
    * Verify that the committer binding is happy.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void test_000(CommitterTestBinding pCommitterTestBinding) throws Throwable {
-    initITestS3ACommitterMRJob(pCommitterTestBinding);
+  @Test
+  public void test_000() throws Throwable {
     committerTestBinding.validate();
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void test_100(CommitterTestBinding pCommitterTestBinding) throws Throwable {
-    initITestS3ACommitterMRJob(pCommitterTestBinding);
+  @Test
+  public void test_100() throws Throwable {
     committerTestBinding.test_100();
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void test_200_execute(CommitterTestBinding pCommitterTestBinding,
+  @Test
+  public void test_200_execute(
       @TempDir java.nio.file.Path localFilesDir) throws Exception {
-    initITestS3ACommitterMRJob(pCommitterTestBinding);
     describe("Run an MR with committer %s", committerName());
 
     S3AFileSystem fs = getFileSystem();
@@ -359,10 +357,8 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
   /**
    * This is the extra test which committer test bindings can add.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void test_500(CommitterTestBinding pCommitterTestBinding) throws Throwable {
-    initITestS3ACommitterMRJob(pCommitterTestBinding);
+  @Test
+  public void test_500() throws Throwable {
     committerTestBinding.test_500();
   }
 
@@ -499,8 +495,7 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
     }
 
     /**
-     * A test to run before the main
-     * {@link #test_200_execute(CommitterTestBinding, java.nio.file.Path)} test is
+     * A test to run before the main {@link #test_200_execute()} test is
      * invoked.
      * @throws Throwable failure.
      */
@@ -509,8 +504,7 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
     }
 
     /**
-     * A test to run after the main
-     * {@link #test_200_execute(CommitterTestBinding, java.nio.file.Path)} test is
+     * A test to run after the main {@link #test_200_execute()} test is
      * invoked.
      * @throws Throwable failure.
      */
@@ -520,7 +514,7 @@ public class ITestS3ACommitterMRJob extends AbstractYarnClusterITest {
 
     /**
      * Validate the state of the binding.
-     * This is called in {@link #test_000(CommitterTestBinding)} so will
+     * This is called in {@link #test_000()} so will
      * fail independently of the other tests.
      * @throws Throwable failure.
      */

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/magic/ITestS3AHugeMagicCommits.java
@@ -24,7 +24,9 @@ import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +44,7 @@ import org.apache.hadoop.fs.s3a.commit.impl.CommitContext;
 import org.apache.hadoop.fs.s3a.commit.impl.CommitOperations;
 import org.apache.hadoop.fs.s3a.scale.AbstractSTestS3AHugeFiles;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.s3a.MultipartTestUtils.listMultipartUploads;
 import static org.apache.hadoop.fs.s3a.Statistic.MULTIPART_UPLOAD_ABORT_UNDER_PATH_INVOKED;
@@ -57,6 +60,8 @@ import static org.apache.hadoop.fs.s3a.impl.HeaderProcessing.extractXAttrLongVal
  *
  * This is a scale test.
  */
+@ScaleTest
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 public class ITestS3AHugeMagicCommits extends AbstractSTestS3AHugeFiles {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3AHugeMagicCommits.class);
@@ -136,6 +141,7 @@ public class ITestS3AHugeMagicCommits extends AbstractSTestS3AHugeFiles {
     LOG.info("Aborted {} uploads under {}", count, key);
   }
 
+  @Test
   @Override
   public void test_030_postCreationAssertions() throws Throwable {
     describe("Committing file");
@@ -191,21 +197,25 @@ public class ITestS3AHugeMagicCommits extends AbstractSTestS3AHugeFiles {
     describe("Skipping: %s", text);
   }
 
+  @Test
   @Override
   public void test_040_PositionedReadHugeFile() {
     skipQuietly("test_040_PositionedReadHugeFile");
   }
 
+  @Test
   @Override
   public void test_050_readHugeFile() {
     skipQuietly("readHugeFile");
   }
 
+  @Test
   @Override
   public void test_100_renameHugeFile() {
     skipQuietly("renameHugeFile");
   }
 
+  @Test
   @Override
   public void test_800_DeleteHugeFiles() throws IOException {
     if (getFileSystem() != null) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContext.java
@@ -23,12 +23,14 @@ import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TestFileContext;
 import org.apache.hadoop.fs.UnsupportedFileSystemException;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Implementation of TestFileContext for S3a.
  */
+@IntegrationTest
 public class ITestS3AFileContext extends TestFileContext {
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextCreateMkdir.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextCreateMkdir.java
@@ -16,6 +16,8 @@ package org.apache.hadoop.fs.s3a.fileContext;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContextCreateMkdirBaseTest;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
@@ -23,6 +25,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
 /**
  * Extends FileContextCreateMkdirBaseTest for a S3a FileContext.
  */
+@IntegrationTest
 public class ITestS3AFileContextCreateMkdir
         extends FileContextCreateMkdirBaseTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextCreateMkdirCreatePerf.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextCreateMkdirCreatePerf.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContextCreateMkdirBaseTest;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -27,6 +28,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * Extends FileContextCreateMkdirBaseTest for a S3a FileContext with
  * create performance mode.
  */
+@IntegrationTest
 public class ITestS3AFileContextCreateMkdirCreatePerf
         extends FileContextCreateMkdirBaseTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextMainOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextMainOperations.java
@@ -26,12 +26,14 @@ import org.apache.hadoop.fs.FileContextMainOperationsBaseTest;
 import org.apache.hadoop.fs.FileContextTestHelper;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
 
 /**
  * S3A implementation of FileContextMainOperationsBaseTest.
  */
+@IntegrationTest
 public class ITestS3AFileContextMainOperations
     extends FileContextMainOperationsBaseTest {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.auth.STSClientFactory;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * S3a implementation of FCStatisticsBaseTest.
  */
+@IntegrationTest
 public class ITestS3AFileContextStatistics extends FCStatisticsBaseTest {
 
   private static final Logger LOG =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextURI.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextURI.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContextURIBase;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
 /**
  * S3a implementation of FileContextURIBase.
  */
+@IntegrationTest
 public class ITestS3AFileContextURI extends FileContextURIBase {
 
   private Configuration conf;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextUtil.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextUtil.java
@@ -17,11 +17,14 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContextUtilBase;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.IntegrationTest;
+
 import org.junit.jupiter.api.BeforeEach;
 
 /**
  * S3A implementation of FileContextUtilBase.
  */
+@IntegrationTest
 public class ITestS3AFileContextUtil extends FileContextUtilBase {
 
   @BeforeEach

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3AConditionalCreateBehavior.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3AConditionalCreateBehavior.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -51,7 +51,8 @@ import static org.apache.hadoop.fs.s3a.impl.InternalConstants.UPLOAD_PART_COUNT_
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name="conditionalCreateEnabled-{0}")
+@MethodSource("data")
 public class ITestS3AConditionalCreateBehavior extends AbstractS3ATestBase {
 
   private static final byte[] SMALL_FILE_BYTES = dataset(TEST_FILE_LEN, 0, 255);
@@ -62,7 +63,6 @@ public class ITestS3AConditionalCreateBehavior extends AbstractS3ATestBase {
     this.conditionalCreateEnabled = conditionalCreateEnabled;
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
             {true},

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -97,6 +98,7 @@ public class ITestS3APutIfMatchAndIfNoneMatch extends AbstractS3ATestBase {
   }
 
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     Configuration conf = getConfiguration();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestCreateFileCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestCreateFileCost.java
@@ -24,6 +24,9 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -34,8 +37,6 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.RemoteFileChangedException;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 
 import static java.util.Objects.requireNonNull;
@@ -62,6 +63,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * with the FS_S3A_CREATE_PERFORMANCE option.
  */
 @SuppressWarnings("resource")
+@ParameterizedClass(name="performance-{0}")
+@MethodSource("params")
 public class ITestCreateFileCost extends AbstractS3ACostTest {
 
   /**
@@ -79,14 +82,14 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
   /**
    * Flag for performance creation; all cost asserts need changing.
    */
-  private boolean createPerformance;
+  private final boolean createPerformance;
 
   /**
    * Create.
-   * @param pCreatePerformance use the performance flag
+   * @param createPerformance use the performance flag
    */
-  public void initITestCreateFileCost(final boolean pCreatePerformance) {
-    this.createPerformance = pCreatePerformance;
+  public ITestCreateFileCost(final boolean createPerformance) {
+    this.createPerformance = createPerformance;
   }
 
   /**
@@ -108,10 +111,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
     return conf;
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateNoOverwrite(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateNoOverwrite() throws Throwable {
     describe("Test file creation without overwrite");
     Path testFile = methodPath();
     // when overwrite is false, the path is checked for existence.
@@ -119,20 +120,16 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
         expected(CREATE_FILE_NO_OVERWRITE));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateOverwrite(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateOverwrite() throws Throwable {
     describe("Test file creation with overwrite");
     Path testFile = methodPath();
     // when overwrite is true: only the directory checks take place.
     create(testFile, true, expected(CREATE_FILE_OVERWRITE));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateNoOverwriteFileExists(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateNoOverwriteFileExists() throws Throwable {
     describe("Test cost of create file failing with existing file");
     Path testFile = file(methodPath());
 
@@ -147,10 +144,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
     }
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFileOverDirNoOverwrite(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateFileOverDirNoOverwrite() throws Throwable {
     describe("Test cost of create file overwrite=false failing with existing dir");
     Path testFile = dir(methodPath());
 
@@ -165,10 +160,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
     }
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFileOverDirWithOverwrite(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateFileOverDirWithOverwrite() throws Throwable {
     describe("Test cost of create file overwrite=false failing with existing dir");
     Path testFile = dir(methodPath());
 
@@ -187,10 +180,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
    * Use the builder API.
    * on s3a this skips parent checks, always.
    */
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateBuilderSequence(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateBuilderSequence() throws Throwable {
     describe("Test builder file creation cost");
     Path testFile = methodPath();
     dir(testFile.getParent());
@@ -216,10 +207,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
     }
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFilePerformanceFlag(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateFilePerformanceFlag() throws Throwable {
     describe("createFile with performance flag skips safety checks");
     S3AFileSystem fs = getFileSystem();
 
@@ -245,10 +234,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
         .isGreaterThanOrEqualTo(1);
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFileRecursive(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateFileRecursive() throws Throwable {
     describe("createFile without performance flag performs overwrite safety checks");
     S3AFileSystem fs = getFileSystem();
 
@@ -274,10 +261,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
         .isEqualTo(custom);
   }
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateFileNonRecursive(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateFileNonRecursive() throws Throwable {
     describe("nonrecursive createFile does not check parents");
     S3AFileSystem fs = getFileSystem();
 
@@ -287,10 +272,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
   }
 
 
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testCreateNonRecursive(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testCreateNonRecursive() throws Throwable {
     describe("nonrecursive createFile does not check parents");
     S3AFileSystem fs = getFileSystem();
 
@@ -313,10 +296,8 @@ public class ITestCreateFileCost extends AbstractS3ACostTest {
   /**
    * Shows how the performance option allows the FS to become ill-formed.
    */
-  @MethodSource("params")
-  @ParameterizedTest
-  public void testPerformanceFlagPermitsInvalidStores(boolean pCreatePerformance) throws Throwable {
-    initITestCreateFileCost(pCreatePerformance);
+  @Test
+  public void testPerformanceFlagPermitsInvalidStores() throws Throwable {
     describe("createFile with performance flag over a directory");
     S3AFileSystem fs = getFileSystem();
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AMiscOperationCost.java
@@ -20,12 +20,9 @@ package org.apache.hadoop.fs.s3a.performance;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,55 +51,30 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(ITestS3AMiscOperationCost.class);
 
-  /**
-   * Parameter: should auditing be enabled?
-   */
-  private boolean auditing;
-
-  /**
-   * Parameterization.
-   */
-  public static Collection<Object[]> params() {
-    return Arrays.asList(new Object[][]{
-        {"auditing", true},
-        {"unaudited", false}
-    });
-  }
-
-  public void initITestS3AMiscOperationCost(final String pName,
-      final boolean pAuditing) throws Exception {
-    this.auditing = pAuditing;
-  }
-
   @Override
   public Configuration createConfiguration() {
     final Configuration conf = super.createConfiguration();
     removeBaseAndBucketOverrides(conf, AUDIT_ENABLED);
-    conf.setBoolean(AUDIT_ENABLED, auditing);
+    conf.setBoolean(AUDIT_ENABLED, true);
     return conf;
   }
 
   /**
-   * Expected audit count when auditing is enabled; expect 0
-   * when disabled.
+   * Expected audit count.
    * @param expected expected value.
    * @return the probe.
    */
   protected OperationCostValidator.ExpectedProbe withAuditCount(
       final int expected) {
-    return probe(AUDIT_SPAN_CREATION,
-        auditing ? expected : 0);
+    return probe(AUDIT_SPAN_CREATION, expected);
 
   }
 
   /**
    * Common operation which should be low cost as possible.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void testMkdirOverDir(String pName,
-      boolean pAuditing) throws Throwable {
-    initITestS3AMiscOperationCost(pName, pAuditing);
+  @Test
+  public void testMkdirOverDir() throws Throwable {
     describe("create a dir over a dir");
     S3AFileSystem fs = getFileSystem();
     // create base dir with marker
@@ -116,11 +88,8 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
         with(OBJECT_LIST_REQUEST, FILESTATUS_DIR_PROBE_L));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void testGetContentSummaryRoot(String pName,
-      boolean pAuditing) throws Throwable {
-    initITestS3AMiscOperationCost(pName, pAuditing);
+  @Test
+  public void testGetContentSummaryRoot() throws Throwable {
     describe("getContentSummary on Root");
     S3AFileSystem fs = getFileSystem();
 
@@ -129,11 +98,8 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
         with(INVOCATION_GET_CONTENT_SUMMARY, 1));
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void testGetContentSummaryDir(String pName,
-      boolean pAuditing) throws Throwable {
-    initITestS3AMiscOperationCost(pName, pAuditing);
+  @Test
+  public void testGetContentSummaryDir() throws Throwable {
     describe("getContentSummary on test dir with children");
     S3AFileSystem fs = getFileSystem();
     Path baseDir = methodPath();
@@ -157,11 +123,8 @@ public class ITestS3AMiscOperationCost extends AbstractS3ACostTest {
         .isEqualTo(1);
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}")
-  public void testGetContentMissingPath(String pName,
-      boolean pAuditing) throws Throwable {
-    initITestS3AMiscOperationCost(pName, pAuditing);
+  @Test
+  public void testGetContentMissingPath() throws Throwable {
     describe("getContentSummary on a missing path");
     Path baseDir = methodPath();
     verifyMetricsIntercepting(FileNotFoundException.class,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ABlockOutputStreamInterruption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ABlockOutputStreamInterruption.java
@@ -28,7 +28,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
@@ -83,6 +85,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * Marked as a scale test even though it tries to aggressively abort streams being written
  * and should, if working, complete fast.
  */
+@ParameterizedClass(name = "{0}-{1}")
+@MethodSource("params")
 public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
 
   public static final int MAX_RETRIES_IN_SDK = 2;
@@ -104,23 +108,22 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
   /**
    * Buffer type.
    */
-  private String bufferType;
+  private final String bufferType;
 
   /**
    * How many blocks can a stream have uploading?
    */
-  private int activeBlocks;
+  private final int activeBlocks;
 
   /**
    * Constructor.
-   * @param pBufferType buffer type
-   * @param pActiveBlocks number of active blocks which can be uploaded
+   * @param bufferType buffer type
+   * @param activeBlocks number of active blocks which can be uploaded
    */
-  public void initITestS3ABlockOutputStreamInterruption(final String pBufferType,
-      int pActiveBlocks) throws Exception {
-    this.bufferType = requireNonNull(pBufferType);
-    this.activeBlocks = pActiveBlocks;
-    setup();
+  public ITestS3ABlockOutputStreamInterruption(final String bufferType,
+      int activeBlocks) {
+    this.bufferType = requireNonNull(bufferType);
+    this.activeBlocks = activeBlocks;
   }
 
   /**
@@ -164,6 +167,7 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
    * Setup MUST set up the evaluator before the FS is created.
    */
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     SdkFaultInjector.resetFaultInjector();
     super.setup();
@@ -179,11 +183,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
     super.teardown();
   }
 
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testInterruptMultipart(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testInterruptMultipart() throws Throwable {
     describe("Interrupt a thread performing close() on a multipart upload");
 
     interruptMultipartUpload(methodPath(), 6 * _1MB);
@@ -228,11 +229,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
    * then go on to simulate an NPE in the part upload and verify
    * that this does not get escalated.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testAbortDuringUpload(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testAbortDuringUpload() throws Throwable {
     describe("Abort during multipart upload");
     int len = 6 * _1MB;
     final byte[] dataset = dataset(len, 'a', 'z' - 'a');
@@ -286,11 +284,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
    * Test that a part upload failure is propagated to
    * the close() call.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testPartUploadFailure(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testPartUploadFailure() throws Throwable {
     describe("Trigger a failure during a multipart upload");
     int len = 6 * _1MB;
     final byte[] dataset = dataset(len, 'a', 'z' - 'a');
@@ -339,11 +334,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
   /**
    * Write a small dataset and interrupt the close() operation.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testInterruptMagicWrite(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testInterruptMagicWrite() throws Throwable {
     describe("Interrupt a thread performing close() on a magic upload");
 
     // write a smaller file to a magic path and assert multipart outcome
@@ -354,11 +346,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
   /**
    * Write a small dataset and interrupt the close() operation.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testInterruptWhenAbortingAnUpload(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testInterruptWhenAbortingAnUpload() throws Throwable {
     describe("Interrupt a thread performing close() on a magic upload");
 
     // fail more than the SDK will retry
@@ -384,11 +373,8 @@ public class ITestS3ABlockOutputStreamInterruption extends S3AScaleTestBase {
    * a {@code InterruptedIOException} and the count of interrupted events
    * to increase.
    */
-  @MethodSource("params")
-  @ParameterizedTest(name = "{0}-{1}")
-  public void testInterruptSimplePut(String pBufferType,
-      int pActiveBlocks) throws Throwable {
-    initITestS3ABlockOutputStreamInterruption(pBufferType, pActiveBlocks);
+  @Test
+  public void testInterruptSimplePut() throws Throwable {
     describe("Interrupt simple object PUT");
 
     // dataset is less than one block

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AConcurrentOps.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AConcurrentOps.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.contract.ContractTestUtils.NanoTimer;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +52,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides
 /**
  * Tests concurrent operations on a single S3AFileSystem instance.
  */
+@ScaleTest
 public class ITestS3AConcurrentOps extends S3AScaleTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3AConcurrentOps.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ACreatePerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ACreatePerformance.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.fs.s3a.scale;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.ScaleTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.*;
 /**
  * Tests for create(): performance and/or load testing.
  */
+@ScaleTest
 public class ITestS3ACreatePerformance extends S3AScaleTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3ADirectoryPerformance.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADeleteFilesOneByOne.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADeleteFilesOneByOne.java
@@ -20,10 +20,12 @@ package org.apache.hadoop.fs.s3a.scale;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 /**
  * Tests file deletion with multi-delete disabled.
  */
+@ScaleTest
 public class ITestS3ADeleteFilesOneByOne extends ITestS3ADeleteManyFiles {
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADeleteManyFiles.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADeleteManyFiles.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.test.tags.ScaleTest;
 import org.apache.hadoop.util.DurationInfo;
 
 import org.assertj.core.api.Assertions;
@@ -47,6 +48,7 @@ import static org.apache.hadoop.test.GenericTestUtils.filenameOfIndex;
  * issue multiple delete requests during a delete sequence -so test that
  * operation more efficiently.
  */
+@ScaleTest
 public class ITestS3ADeleteManyFiles extends S3AScaleTestBase {
 
   private static final Logger LOG =

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3ADirectoryPerformance.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.s3a.WriteOperationHelper;
 import org.apache.hadoop.fs.s3a.api.RequestFactory;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.test.tags.ScaleTest;
 import org.apache.hadoop.util.functional.RemoteIterators;
 
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ import static org.apache.hadoop.fs.statistics.StoreStatisticNames.OBJECT_LIST_RE
 /**
  * Test the performance of listing files/directories.
  */
+@ScaleTest
 public class ITestS3ADirectoryPerformance extends S3AScaleTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3ADirectoryPerformance.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesArrayBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesArrayBlocks.java
@@ -19,10 +19,12 @@
 package org.apache.hadoop.fs.s3a.scale;
 
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 /**
  * Use {@link Constants#FAST_UPLOAD_BUFFER_ARRAY} for buffering.
  */
+@ScaleTest
 public class ITestS3AHugeFilesArrayBlocks extends AbstractSTestS3AHugeFiles {
 
   protected String getBlockOutputBufferName() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesByteBufferBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesByteBufferBlocks.java
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BYTEBUFFER;
 
@@ -33,6 +34,7 @@ import static org.apache.hadoop.fs.s3a.Constants.FAST_UPLOAD_BYTEBUFFER;
  * This also renames by parent directory, so validates parent
  * dir renaming of huge files.
  */
+@ScaleTest
 public class ITestS3AHugeFilesByteBufferBlocks
     extends AbstractSTestS3AHugeFiles {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesDiskBlocks.java
@@ -19,11 +19,13 @@
 package org.apache.hadoop.fs.s3a.scale;
 
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 /**
  * Use {@link Constants#FAST_UPLOAD_BUFFER_DISK} for buffering.
  * Also uses direct buffers for the vector IO.
  */
+@ScaleTest
 public class ITestS3AHugeFilesDiskBlocks extends AbstractSTestS3AHugeFiles {
 
   protected String getBlockOutputBufferName() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesEncryption.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.EncryptionTestUtils;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.ScaleTest;
+
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_ALGORITHM;
@@ -43,6 +45,7 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.getS3EncryptionKey;
  * is set in the configuration. The testing bucket must be configured with this
  * same key else test might fail.
  */
+@ScaleTest
 public class ITestS3AHugeFilesEncryption extends AbstractSTestS3AHugeFiles {
 
   @BeforeEach

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesNoMultipart.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesNoMultipart.java
@@ -19,9 +19,11 @@
 package org.apache.hadoop.fs.s3a.scale;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.IO_CHUNK_BUFFER_SIZE;
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_EXPECT_CONTINUE;
@@ -37,6 +39,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides
  * Use a single PUT for the whole upload/rename/delete workflow; include verification
  * that the transfer manager will fail fast unless the multipart threshold is huge.
  */
+@ScaleTest
 public class ITestS3AHugeFilesNoMultipart extends AbstractSTestS3AHugeFiles {
 
   public static final String SINGLE_PUT_REQUEST_TIMEOUT = "1h";
@@ -98,6 +101,7 @@ public class ITestS3AHugeFilesNoMultipart extends AbstractSTestS3AHugeFiles {
   /**
    * Verify multipart copy is disabled.
    */
+  @Test
   @Override
   public void test_030_postCreationAssertions() throws Throwable {
     super.test_030_postCreationAssertions();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSUnsupportedFeatureException;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
+import org.apache.hadoop.test.tags.ScaleTest;
+
 import org.junit.jupiter.api.BeforeEach;
 
 import java.nio.file.AccessDeniedException;
@@ -40,6 +42,7 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionTestsDisable
  * and tests huge files operations with SSE-C encryption enabled.
  * Skipped if the SSE tests are disabled.
  */
+@ScaleTest
 public class ITestS3AHugeFilesSSECDiskBlocks
     extends ITestS3AHugeFilesDiskBlocks {
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesStorageClass.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.fs.s3a.scale;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +32,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.bandwidth;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.toHuman;
@@ -42,6 +46,8 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfStorageClassTestsDisab
  * Class to verify that {@link Constants#STORAGE_CLASS} is set correctly
  * for creating and renaming huge files with multipart upload requests.
  */
+@ScaleTest
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
 public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
 
   private static final Logger LOG = LoggerFactory.getLogger(ITestS3AHugeFilesStorageClass.class);
@@ -62,12 +68,14 @@ public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
     return Constants.FAST_UPLOAD_BUFFER_ARRAY;
   }
 
+  @Test
   @Override
   public void test_010_CreateHugeFile() throws IOException {
     super.test_010_CreateHugeFile();
     assertStorageClass(getPathOfFileToCreate());
   }
 
+  @Test
   @Override
   public void test_030_postCreationAssertions() throws Throwable {
     super.test_030_postCreationAssertions();
@@ -75,20 +83,24 @@ public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
   }
 
   @Override
+  @Test
   public void test_040_PositionedReadHugeFile() throws Throwable {
     skipQuietly("PositionedReadHugeFile");
   }
 
+  @Test
   @Override
   public void test_050_readHugeFile() throws Throwable {
     skipQuietly("readHugeFile");
   }
 
+  @Test
   @Override
   public void test_090_verifyRenameSourceEncryption() throws IOException {
     skipQuietly("verifyRenameSourceEncryption");
   }
 
+  @Test
   @Override
   public void test_100_renameHugeFile() throws Throwable {
     Path hugefile = getHugefile();
@@ -110,6 +122,7 @@ public class ITestS3AHugeFilesStorageClass extends AbstractSTestS3AHugeFiles {
     assertStorageClass(hugefileRenamed);
   }
 
+  @Test
   @Override
   public void test_110_verifyRenameDestEncryption() throws IOException {
     skipQuietly("verifyRenameDestEncryption");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AInputStreamPerformance.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.test.tags.ScaleTest;
 import org.apache.hadoop.util.LineReader;
 
 import org.assertj.core.api.Assertions;
@@ -79,6 +80,7 @@ import static org.apache.hadoop.util.functional.FutureIO.awaitFuture;
 /**
  * Look at the performance of S3a Input Stream Reads.
  */
+@ScaleTest
 public class ITestS3AInputStreamPerformance extends S3AScaleTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(
       ITestS3AInputStreamPerformance.class);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AMultipartUploadSizeLimits.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AMultipartUploadSizeLimits.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.auth.ProgressCounter;
 import org.apache.hadoop.fs.s3a.commit.impl.CommitOperations;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import static org.apache.hadoop.fs.StreamCapabilities.ABORTABLE_STREAM;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.createFile;
@@ -57,6 +58,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 /**
  * Testing S3 multipart upload for s3.
  */
+@ScaleTest
 public class ITestS3AMultipartUploadSizeLimits extends S3AScaleTestBase {
 
   public static final int MPU_SIZE = 5 * _1MB;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/S3AScaleTestBase.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.AbstractS3ATestBase;
 import org.apache.hadoop.fs.s3a.S3ATestConstants;
 import org.apache.hadoop.fs.s3a.Statistic;
+import org.apache.hadoop.test.tags.ScaleTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.lookupGaugeS
  * <i>very bad form</i> in Java code (indeed, in C++ it is actually permitted;
  * the base class implementations get invoked instead).
  */
+@ScaleTest
 public class S3AScaleTestBase extends AbstractS3ATestBase {
 
   public static final int _1KB = 1024;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
@@ -21,11 +21,14 @@ package org.apache.hadoop.fs.s3a.statistics;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractStreamIOStatisticsTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.s3a.S3AContract;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
+import org.apache.hadoop.test.tags.IntegrationTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
@@ -33,6 +36,7 @@ import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 /**
  * Test the S3A Streams IOStatistics support.
  */
+@IntegrationTest
 public class ITestS3AContractStreamIOStatistics extends
     AbstractContractStreamIOStatisticsTest {
 
@@ -79,6 +83,7 @@ public class ITestS3AContractStreamIOStatistics extends
         STREAM_WRITE_EXCEPTIONS);
   }
 
+  @Test
   @Override
   public void testInputStreamStatisticRead() throws Throwable {
     // Analytics accelerator currently does not support IOStatistics, this will be added as

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/TestErrorCodeMapping.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/TestErrorCodeMapping.java
@@ -23,7 +23,9 @@ import java.util.Collection;
 
 import org.apache.hadoop.fs.s3a.statistics.impl.StatisticsFromAwsSdkImpl;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
-import org.junit.jupiter.params.ParameterizedTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.fs.s3a.impl.InternalConstants.SC_400_BAD_REQUEST;
@@ -42,6 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test mapping logic of {@link StatisticsFromAwsSdkImpl}.
  */
+@ParameterizedClass(name = "http {0} to {1}")
+@MethodSource("params")
 public class TestErrorCodeMapping extends AbstractHadoopTestBase {
 
   /**
@@ -61,19 +65,17 @@ public class TestErrorCodeMapping extends AbstractHadoopTestBase {
     });
   }
 
-  private int code;
+  private final int code;
 
-  private String name;
+  private final String name;
 
-  public void initTestErrorCodeMapping(final int pCode, final String pName) {
-    this.code = pCode;
-    this.name = pName;
+  public TestErrorCodeMapping(final int code, final String name) {
+    this.code = code;
+    this.name = name;
   }
 
-  @ParameterizedTest(name = "http {0} to {1}")
-  @MethodSource("params")
-  public void testMapping(int pCode, String pName) throws Throwable {
-    initTestErrorCodeMapping(pCode, pName);
+  @Test
+  public void testMapping() {
     assertThat(mapErrorStatusCodeToStatisticName(code))
         .describedAs("Mapping of status code %d", code)
         .isEqualTo(name);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/AbstractMarkerToolTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/AbstractMarkerToolTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +72,7 @@ public class AbstractMarkerToolTest extends AbstractS3ATestBase {
   }
 
   @Override
+  @AfterEach
   public void teardown() throws Exception {
     // do this ourselves to avoid audits teardown failing
     // when surplus markers are found

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestMarkerToolRootOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/tools/ITestMarkerToolRootOperations.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.test.tags.RootFilesystemTest;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeSkipRootTests;
 import static org.apache.hadoop.fs.s3a.tools.MarkerTool.AUDIT;
@@ -36,7 +37,9 @@ import static org.apache.hadoop.fs.s3a.tools.MarkerTool.OPT_OUT;
 /**
  * Marker tool tests against the root FS; run in the sequential phase.
  */
+@RootFilesystemTest
 @TestMethodOrder(MethodOrderer.Alphanumeric.class)
+
 public class ITestMarkerToolRootOperations extends AbstractMarkerToolTest {
 
   private Path rootPath;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractVectoredRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractVectoredRead.java
@@ -21,17 +21,22 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Contract test for vectored reads through ABFS connector.
  */
+@ParameterizedClass(name="buffer-{0}")
+@MethodSource("params")
 public class ITestAbfsFileSystemContractVectoredRead
     extends AbstractContractVectoredReadTest {
 
   private final boolean isSecure;
   private final ABFSContractTestBinding binding;
 
-  public ITestAbfsFileSystemContractVectoredRead() throws Exception {
+  public ITestAbfsFileSystemContractVectoredRead(final String bufferType) throws Exception {
+    super(bufferType);
     this.binding = new ABFSContractTestBinding();
     this.isSecure = binding.isSecureMode();
   }


### PR DESCRIPTION
Fixing parameterized ITests in hadoop-aws to work under Junit 5.

This is on top of PR #7785


### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

