### PR TITLE
HADOOP-19627. S3A: testIfMatchOverwriteWithOutdatedEtag() fails when not using SSE-KMS

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestS3APutIfMatchAndIfNoneMatch.java
@@ -469,8 +469,11 @@ public class ITestS3APutIfMatchAndIfNoneMatch extends AbstractS3ATestBase {
             .as("ETag should not be null after file creation")
             .isNotNull();
 
+    String updatedFileContent = "Updated content";
+    byte[] updatedData = updatedFileContent.getBytes(StandardCharsets.UTF_8);
+
     // Overwrite the file. Will update the etag, making the previously fetched etag outdated.
-    createFileWithFlags(fs, path, SMALL_FILE_BYTES, false, null);
+    createFileWithFlags(fs, path, updatedData, false, null);
 
     // overwrite file with outdated etag. Should throw RemoteFileChangedException
     RemoteFileChangedException exception = intercept(RemoteFileChangedException.class,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

We were previously creating second file with the same object content, so the etag will always be the same, leading to test failures, except when testing with an encryption method set, as in that case eTag is no longer the md5. 

### How was this patch tested?

Can't test on trunk as the all tests in this class fail due to the Junit5 migration. Tested on 3.4 with and without SSE-KMS, all good.


