### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part9.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBatchIbr.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBatchIbr.java
@@ -45,8 +45,8 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test verifies that incremental block reports are sent in batch mode
@@ -161,7 +161,7 @@ public class TestBatchIbr {
         });
       }
       for(int i = 0; i < NUM_FILES; i++) {
-        Assert.assertTrue(verifyService.take().get());
+        Assertions.assertTrue(verifyService.take().get());
       }
       final long testEndTime = Time.monotonicNow();
 
@@ -247,7 +247,7 @@ public class TestBatchIbr {
       for(int i = 0; i < numBlocks; i++) {
         in.read(computed);
         nextBytes(i, seed, expected);
-        Assert.assertArrayEquals(expected, computed);
+        Assertions.assertArrayEquals(expected, computed);
       }
       return true;
     } catch(Exception e) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockCountersInPendingIBR.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockCountersInPendingIBR.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStatus;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.MetricsAsserts;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockHasMultipleReplicasOnSameDN.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockHasMultipleReplicasOnSameDN.java
@@ -40,13 +40,11 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This test verifies NameNode behavior when it gets unexpected block reports
@@ -68,7 +66,7 @@ public class TestBlockHasMultipleReplicasOnSameDN {
   private DFSClient client;
   private String bpid;
 
-  @Before
+  @BeforeEach
   public void startUpCluster() throws IOException {
     conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -79,7 +77,7 @@ public class TestBlockHasMultipleReplicasOnSameDN {
     bpid = cluster.getNamesystem().getBlockPoolId();
   }
 
-  @After
+  @AfterEach
   public void shutDownCluster() throws IOException {
     if (cluster != null) {
       fs.close();
@@ -142,8 +140,8 @@ public class TestBlockHasMultipleReplicasOnSameDN {
     // Make sure that each block has two replicas, one on each DataNode.
     for (LocatedBlock locatedBlock : locatedBlocks.getLocatedBlocks()) {
       DatanodeInfo[] locations = locatedBlock.getLocations();
-      assertThat(locations.length, is((int) NUM_DATANODES));
-      assertThat(locations[0].getDatanodeUuid(), not(locations[1].getDatanodeUuid()));
+      assertThat(locations.length).isEqualTo((int) NUM_DATANODES);
+      assertThat(locations[0].getDatanodeUuid()).isNotEqualTo(locations[1].getDatanodeUuid());
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolManager.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -47,7 +47,7 @@ public class TestBlockPoolManager {
   private final StringBuilder log = new StringBuilder();
   private int mockIdx = 1;
   
-  @Before
+  @BeforeEach
   public void setupBPM() {
     bpm = new BlockPoolManager(mockDN){
 
@@ -159,9 +159,9 @@ public class TestBlockPoolManager {
     bpm.refreshNamenodes(conf);
     assertEquals("create #1\n", log.toString());
     Map<String, BPOfferService> map = bpm.getBpByNameserviceId();
-    Assert.assertFalse(map.containsKey("ns2"));
-    Assert.assertFalse(map.containsKey("ns3"));
-    Assert.assertTrue(map.containsKey("ns1"));
+    Assertions.assertFalse(map.containsKey("ns2"));
+    Assertions.assertFalse(map.containsKey("ns3"));
+    Assertions.assertTrue(map.containsKey("ns1"));
     log.setLength(0);
   }
 
@@ -179,18 +179,18 @@ public class TestBlockPoolManager {
             "create #2\n" +
             "create #3\n", log.toString());
     Map<String, BPOfferService> map = bpm.getBpByNameserviceId();
-    Assert.assertTrue(map.containsKey("ns1"));
-    Assert.assertTrue(map.containsKey("ns2"));
-    Assert.assertTrue(map.containsKey("ns3"));
-    Assert.assertEquals(2, map.get("ns3").getBPServiceActors().size());
-    Assert.assertEquals("ns3-" +  MockDomainNameResolver.FQDN_1 + "-8020",
+    Assertions.assertTrue(map.containsKey("ns1"));
+    Assertions.assertTrue(map.containsKey("ns2"));
+    Assertions.assertTrue(map.containsKey("ns3"));
+    Assertions.assertEquals(2, map.get("ns3").getBPServiceActors().size());
+    Assertions.assertEquals("ns3-" + MockDomainNameResolver.FQDN_1 + "-8020",
         map.get("ns3").getBPServiceActors().get(0).getNnId());
-    Assert.assertEquals("ns3-" +  MockDomainNameResolver.FQDN_2 + "-8020",
+    Assertions.assertEquals("ns3-" + MockDomainNameResolver.FQDN_2 + "-8020",
         map.get("ns3").getBPServiceActors().get(1).getNnId());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new InetSocketAddress(MockDomainNameResolver.FQDN_1, 8020),
         map.get("ns3").getBPServiceActors().get(0).getNNSocketAddress());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new InetSocketAddress(MockDomainNameResolver.FQDN_2, 8020),
         map.get("ns3").getBPServiceActors().get(1).getNNSocketAddress());
     log.setLength(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolSliceStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolSliceStorage.java
@@ -18,7 +18,8 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.hdfs.server.common.Storage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -27,8 +28,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test that BlockPoolSliceStorage can correctly generate trash and
@@ -52,7 +52,7 @@ public class TestBlockPoolSliceStorage {
                               String clusterId) {
       super(namespaceID, bpID, cTime, clusterId);
       addStorageDir(new StorageDirectory(new File("/tmp/dontcare/" + bpID)));
-      assertThat(getStorageDirs().size(), is(1));
+      assertThat(getStorageDirs().size()).isEqualTo(1);
     }
   }
 
@@ -111,7 +111,7 @@ public class TestBlockPoolSliceStorage {
 
     ReplicaInfo info = Mockito.mock(ReplicaInfo.class);
     Mockito.when(info.getBlockURI()).thenReturn(new File(testFilePath).toURI());
-    assertThat(storage.getTrashDirectory(info), is(expectedTrashPath));
+    assertThat(storage.getTrashDirectory(info)).isEqualTo(expectedTrashPath);
   }
 
   /*
@@ -134,12 +134,13 @@ public class TestBlockPoolSliceStorage {
             blockFileSubdir.substring(0, blockFileSubdir.length() - 1);
 
     LOG.info("Generated deleted file path {}", deletedFilePath);
-    assertThat(storage.getRestoreDirectory(new File(deletedFilePath)),
-               is(expectedRestorePath));
+    assertThat(storage.getRestoreDirectory(new File(deletedFilePath)))
+        .isEqualTo(expectedRestorePath);
 
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testGetTrashAndRestoreDirectories() {
     storage = makeBlockPoolStorage();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReplacement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReplacement.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -57,7 +57,8 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests if block replacement request to data nodes work correctly.
@@ -208,7 +209,8 @@ public class TestBlockReplacement {
    * datanode will throw IOException with error code Status.ERROR_BLOCK_PINNED.
    *
    */
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testBlockReplacementWithPinnedBlocks() throws Exception {
     final Configuration conf = new HdfsConfiguration();
 
@@ -229,7 +231,7 @@ public class TestBlockReplacement {
 
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(fileName, 0).get(0);
       DatanodeInfo[] oldNodes = lb.getLocations();
-      assertEquals("Wrong block locations", oldNodes.length, 1);
+      assertEquals(oldNodes.length, 1, "Wrong block locations");
       DatanodeInfo source = oldNodes[0];
       ExtendedBlock b = lb.getBlock();
 
@@ -243,10 +245,10 @@ public class TestBlockReplacement {
         }
       }
 
-      assertNotNull("Failed to choose destination datanode!", destin);
+      assertNotNull(destin, "Failed to choose destination datanode!");
 
-      assertFalse("Source and destin datanode should be different",
-          source.equals(destin));
+      assertFalse(source.equals(destin),
+          "Source and destin datanode should be different");
 
       // Mock FsDatasetSpi#getPinning to show that the block is pinned.
       for (int i = 0; i < cluster.getDataNodes().size(); i++) {
@@ -257,8 +259,8 @@ public class TestBlockReplacement {
 
       // Block movement to a different datanode should fail as the block is
       // pinned.
-      assertTrue("Status code mismatches!", replaceBlock(b, source, source,
-          destin, StorageType.ARCHIVE, Status.ERROR_BLOCK_PINNED));
+      assertTrue(replaceBlock(b, source, source, destin,
+          StorageType.ARCHIVE, Status.ERROR_BLOCK_PINNED), "Status code mismatches!");
     } finally {
       cluster.shutdown();
     }
@@ -299,10 +301,10 @@ public class TestBlockReplacement {
       locatedBlocks = dfs.getClient().getLocatedBlocks(file.toString(), 0);
       // get the current 
       locatedBlock = locatedBlocks.get(0);
-      assertEquals("Storage should be only one", 1,
-          locatedBlock.getLocations().length);
-      assertTrue("Block should be moved to ARCHIVE", locatedBlock
-          .getStorageTypes()[0] == StorageType.ARCHIVE);
+      assertEquals(1, locatedBlock.getLocations().length,
+          "Storage should be only one");
+      assertTrue(locatedBlock.getStorageTypes()[0] == StorageType.ARCHIVE,
+          "Block should be moved to ARCHIVE");
     } finally {
       cluster.shutdown();
     }
@@ -398,14 +400,14 @@ public class TestBlockReplacement {
     DFSClient client = null;
     try {
       cluster.waitActive();
-      assertEquals("Number of namenodes is not 2", 2,
-          cluster.getNumNameNodes());
+      assertEquals(2, cluster.getNumNameNodes(),
+          "Number of namenodes is not 2");
       // Transitioning the namenode 0 to active.
       cluster.transitionToActive(0);
-      assertTrue("Namenode 0 should be in active state",
-          cluster.getNameNode(0).isActiveState());
-      assertTrue("Namenode 1 should be in standby state",
-          cluster.getNameNode(1).isStandbyState());
+      assertTrue(cluster.getNameNode(0).isActiveState(),
+          "Namenode 0 should be in active state");
+      assertTrue(cluster.getNameNode(1).isStandbyState(),
+          "Namenode 1 should be in standby state");
 
       // Trigger heartbeat to mark DatanodeStorageInfo#heartbeatedSinceFailover
       // to true.
@@ -430,8 +432,7 @@ public class TestBlockReplacement {
 
       // add a second datanode to the cluster
       cluster.startDataNodes(conf, 1, true, null, null, null, null);
-      assertEquals("Number of datanodes should be 2", 2,
-          cluster.getDataNodes().size());
+      assertEquals(2, cluster.getDataNodes().size(), "Number of datanodes should be 2");
 
       DataNode dn0 = cluster.getDataNodes().get(0);
       DataNode dn1 = cluster.getDataNodes().get(1);
@@ -464,10 +465,10 @@ public class TestBlockReplacement {
       cluster.transitionToStandby(0);
       cluster.transitionToActive(1);
 
-      assertTrue("Namenode 1 should be in active state",
-         cluster.getNameNode(1).isActiveState());
-      assertTrue("Namenode 0 should be in standby state",
-         cluster.getNameNode(0).isStandbyState());
+      assertTrue(cluster.getNameNode(1).isActiveState(),
+          "Namenode 1 should be in active state");
+      assertTrue(cluster.getNameNode(0).isStandbyState(),
+          "Namenode 0 should be in standby state");
       client.close();
 
       // Opening a new client for new active  namenode
@@ -476,8 +477,8 @@ public class TestBlockReplacement {
           .getBlockLocations("/tmp.txt", 0, 10L).getLocatedBlocks();
 
       assertEquals(1, locatedBlocks1.size());
-      assertEquals("The block should be only on 1 datanode ", 1,
-          locatedBlocks1.get(0).getLocations().length);
+      assertEquals(1, locatedBlocks1.get(0).getLocations().length,
+          "The block should be only on 1 datanode ");
     } finally {
       IOUtils.cleanupWithLogger(null, client);
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
@@ -24,10 +24,10 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_SCANNER_VOLUME_BYTE
 import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_DFS_DATANODE_SCAN_PERIOD_MS;
 import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_VOLUME_SCANNER_SCAN_RESULT_HANDLER;
 import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_DFS_BLOCK_SCANNER_CURSOR_SAVE_INTERVAL_MS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Closeable;
 import java.io.File;
@@ -62,9 +62,10 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.hdfs.server.datanode.VolumeScanner.Statistics;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -73,7 +74,7 @@ public class TestBlockScanner {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestBlockScanner.class);
 
-  @Before
+  @BeforeEach
   public void before() {
     BlockScanner.Conf.allowUnitTestSettings = true;
     GenericTestUtils.setLogLevel(BlockScanner.LOG, Level.TRACE);
@@ -220,7 +221,7 @@ public class TestBlockScanner {
             assertEquals(savedBlock, loadedBlock);
           }
           boolean blockRemoved = blocks.remove(block);
-          assertTrue("Found unknown block " + block, blockRemoved);
+          assertTrue(blockRemoved, "Found unknown block " + block);
           if (blocksProcessed > (numFiles / 3)) {
             if (!testedSave) {
               LOG.info("Processed {} blocks out of {}.  Saving iterator.",
@@ -268,17 +269,20 @@ public class TestBlockScanner {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testVolumeIteratorWithoutCaching() throws Exception {
     testVolumeIteratorImpl(5, 0);
   }
 
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testVolumeIteratorWithCaching() throws Exception {
     testVolumeIteratorImpl(600, 100);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDisableVolumeScanner() throws Exception {
     Configuration conf = new Configuration();
     disableBlockScanner(conf);
@@ -287,7 +291,8 @@ public class TestBlockScanner {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDisableVolumeScanner2() throws Exception {
     Configuration conf = new Configuration();
     conf.setLong(DFS_BLOCK_SCANNER_VOLUME_BYTES_PER_SECOND, -1L);
@@ -444,7 +449,8 @@ public class TestBlockScanner {
    * Test scanning all blocks.  Set the scan period high enough that
    * we shouldn't rescan any block during this test.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testScanAllBlocksNoRescan() throws Exception {
     testScanAllBlocksImpl(false);
   }
@@ -453,7 +459,8 @@ public class TestBlockScanner {
    * Test scanning all blocks.  Set the scan period high enough that
    * we should rescan all blocks at least twice during this test.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testScanAllBlocksWithRescan() throws Exception {
     testScanAllBlocksImpl(true);
   }
@@ -461,7 +468,8 @@ public class TestBlockScanner {
   /**
    * Test that we don't scan too many blocks per second.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testScanRateLimit() throws Exception {
     Configuration conf = new Configuration();
     // Limit scan bytes per second dramatically
@@ -494,15 +502,16 @@ public class TestBlockScanner {
       // Should scan no more than one block a second.
       long seconds = ((endMs + 999 - startMs) / 1000);
       long maxBlocksScanned = seconds * 1;
-      assertTrue("The number of blocks scanned is too large.  Scanned " +
-          info.blocksScanned + " blocks; only expected to scan at most " +
-          maxBlocksScanned + " in " + seconds + " seconds.",
-          info.blocksScanned <= maxBlocksScanned);
+      assertTrue(info.blocksScanned <= maxBlocksScanned,
+          "The number of blocks scanned is too large.  Scanned " +
+              info.blocksScanned + " blocks; only expected to scan at most " +
+              maxBlocksScanned + " in " + seconds + " seconds.");
     }
     ctx.close();
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testCorruptBlockHandling() throws Exception {
     Configuration conf = new Configuration();
     conf.setLong(DFS_DATANODE_SCAN_PERIOD_HOURS_KEY, 100L);
@@ -544,7 +553,8 @@ public class TestBlockScanner {
    * Test that we save the scan cursor when shutting down the datanode, and
    * restart scanning from there when the datanode is restarted.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testDatanodeCursor() throws Exception {
     Configuration conf = new Configuration();
     conf.setLong(DFS_DATANODE_SCAN_PERIOD_HOURS_KEY, 100L);
@@ -579,8 +589,8 @@ public class TestBlockScanner {
     URI vURI = ctx.volumes.get(0).getStorageLocation().getUri();
     File cursorPath = new File(new File(new File(new File(vURI), "current"),
           ctx.bpids[0]), "scanner.cursor");
-    assertTrue("Failed to find cursor save file in " +
-        cursorPath.getAbsolutePath(), cursorPath.exists());
+    assertTrue(cursorPath.exists(),
+        "Failed to find cursor save file in " + cursorPath.getAbsolutePath());
     Set<ExtendedBlock> prevGoodBlocks = new HashSet<ExtendedBlock>();
     synchronized (info) {
       info.sem = new Semaphore(4);
@@ -636,7 +646,8 @@ public class TestBlockScanner {
     ctx.close();
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testMultipleBlockPoolScanning() throws Exception {
     Configuration conf = new Configuration();
     conf.setLong(DFS_DATANODE_SCAN_PERIOD_HOURS_KEY, 100L);
@@ -681,47 +692,48 @@ public class TestBlockScanner {
     Statistics stats = ctx.blockScanner.getVolumeStats(
         ctx.volumes.get(0).getStorageID());
     assertEquals(TOTAL_FILES, stats.blocksScannedSinceRestart);
-    assertEquals(BYTES_SCANNED_PER_FILE * TOTAL_FILES,
-        stats.bytesScannedInPastHour);
+    assertEquals(BYTES_SCANNED_PER_FILE * TOTAL_FILES, stats.bytesScannedInPastHour);
     ctx.close();
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testNextSorted() throws Exception {
     List<String> arr = new LinkedList<String>();
     arr.add("1");
     arr.add("3");
     arr.add("5");
     arr.add("7");
-    Assert.assertEquals("3", FsVolumeImpl.nextSorted(arr, "2"));
-    Assert.assertEquals("3", FsVolumeImpl.nextSorted(arr, "1"));
-    Assert.assertEquals("1", FsVolumeImpl.nextSorted(arr, ""));
-    Assert.assertEquals("1", FsVolumeImpl.nextSorted(arr, null));
-    Assert.assertEquals(null, FsVolumeImpl.nextSorted(arr, "9"));
+    Assertions.assertEquals("3", FsVolumeImpl.nextSorted(arr, "2"));
+    Assertions.assertEquals("3", FsVolumeImpl.nextSorted(arr, "1"));
+    Assertions.assertEquals("1", FsVolumeImpl.nextSorted(arr, ""));
+    Assertions.assertEquals("1", FsVolumeImpl.nextSorted(arr, null));
+    Assertions.assertEquals(null, FsVolumeImpl.nextSorted(arr, "9"));
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testCalculateNeededBytesPerSec() throws Exception {
     // If we didn't check anything the last hour, we should scan now.
-    Assert.assertTrue(
+    Assertions.assertTrue(
         VolumeScanner.calculateShouldScan("test", 100, 0, 0, 60));
 
     // If, on average, we checked 101 bytes/s checked during the last hour,
     // stop checking now.
-    Assert.assertFalse(VolumeScanner.
+    Assertions.assertFalse(VolumeScanner.
         calculateShouldScan("test", 100, 101 * 3600, 1000, 5000));
 
     // Target is 1 byte / s, but we didn't scan anything in the last minute.
     // Should scan now.
-    Assert.assertTrue(VolumeScanner.
+    Assertions.assertTrue(VolumeScanner.
         calculateShouldScan("test", 1, 3540, 0, 60));
 
     // Target is 1000000 byte / s, but we didn't scan anything in the last
     // minute.  Should scan now.
-    Assert.assertTrue(VolumeScanner.
+    Assertions.assertTrue(VolumeScanner.
         calculateShouldScan("test", 100000L, 354000000L, 0, 60));
 
-    Assert.assertFalse(VolumeScanner.
+    Assertions.assertFalse(VolumeScanner.
         calculateShouldScan("test", 100000L, 365000000L, 0, 60));
   }
 
@@ -729,7 +741,8 @@ public class TestBlockScanner {
    * Test that we can mark certain blocks as suspect, and get them quickly
    * rescanned that way.  See HDFS-7686 and HDFS-7548.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testMarkSuspectBlock() throws Exception {
     Configuration conf = new Configuration();
     // Set a really long scan period.
@@ -766,10 +779,10 @@ public class TestBlockScanner {
     }, 50, 30000);
     // We should have scanned 4 blocks
     synchronized (info) {
-      assertEquals("Expected 4 good blocks.", 4, info.goodBlocks.size());
+      assertEquals(4, info.goodBlocks.size(), "Expected 4 good blocks.");
       info.goodBlocks.clear();
-      assertEquals("Expected 4 blocksScanned", 4, info.blocksScanned);
-      assertEquals("Did not expect bad blocks.", 0, info.badBlocks.size());
+      assertEquals(4, info.blocksScanned, "Expected 4 blocksScanned");
+      assertEquals(0, info.badBlocks.size(), "Did not expect bad blocks.");
       info.blocksScanned = 0;
     }
     ExtendedBlock first = ctx.getFileBlock(0, 0);
@@ -799,11 +812,11 @@ public class TestBlockScanner {
     }, 50, 30000);
 
     synchronized (info) {
-      assertTrue("Expected block " + first + " to have been scanned.",
-          info.goodBlocks.contains(first));
+      assertTrue(info.goodBlocks.contains(first),
+          "Expected block " + first + " to have been scanned.");
       assertEquals(2, info.goodBlocks.size());
       info.goodBlocks.clear();
-      assertEquals("Did not expect bad blocks.", 0, info.badBlocks.size());
+      assertEquals(0, info.badBlocks.size(), "Did not expect bad blocks.");
       assertEquals(2, info.blocksScanned);
       info.blocksScanned = 0;
     }
@@ -834,9 +847,9 @@ public class TestBlockScanner {
       // We should not have rescanned the "suspect block",
       // because it was recently rescanned by the suspect block system.
       // This is a test of the "suspect block" rate limiting.
-      Assert.assertFalse("We should not " +
+      Assertions.assertFalse(info.goodBlocks.contains(first), "We should not " +
           "have rescanned block " + first + ", because it should have been " +
-          "in recentSuspectBlocks.", info.goodBlocks.contains(first));
+          "in recentSuspectBlocks.");
       info.blocksScanned = 0;
     }
     ctx.close();
@@ -845,7 +858,8 @@ public class TestBlockScanner {
   /**
    * Test that blocks which are in the wrong location are ignored.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testIgnoreMisplacedBlock() throws Exception {
     Configuration conf = new Configuration();
     // Set a really long scan period.
@@ -889,10 +903,10 @@ public class TestBlockScanner {
     synchronized (info) {
       assertFalse(info.goodBlocks.contains(unreachableBlock));
       assertFalse(info.badBlocks.contains(unreachableBlock));
-      assertEquals("Expected 3 good blocks.", 3, info.goodBlocks.size());
+      assertEquals(3, info.goodBlocks.size(), "Expected 3 good blocks.");
       info.goodBlocks.clear();
-      assertEquals("Expected 3 blocksScanned", 3, info.blocksScanned);
-      assertEquals("Did not expect bad blocks.", 0, info.badBlocks.size());
+      assertEquals(3, info.blocksScanned, "Expected 3 blocksScanned");
+      assertEquals(0, info.badBlocks.size(), "Did not expect bad blocks.");
       info.blocksScanned = 0;
     }
     info.sem.release(1);
@@ -903,7 +917,8 @@ public class TestBlockScanner {
    * Test concurrent append and scan.
    * @throws Exception
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testAppendWhileScanning() throws Exception {
     GenericTestUtils.setLogLevel(DataNode.LOG, Level.TRACE);
     Configuration conf = new Configuration();
@@ -985,12 +1000,12 @@ public class TestBlockScanner {
     }, 1000, 30000);
 
     synchronized (info) {
-      assertEquals("Expected 1 good block.",
-          numExpectedBlocks, info.goodBlocks.size());
+      assertEquals(numExpectedBlocks, info.goodBlocks.size(),
+          "Expected 1 good block.");
       info.goodBlocks.clear();
-      assertEquals("Expected 1 blocksScanned",
-          numExpectedBlocks, info.blocksScanned);
-      assertEquals("Did not expect bad blocks.", 0, info.badBlocks.size());
+      assertEquals(numExpectedBlocks, info.blocksScanned, "Expected 1 blocksScanned");
+      assertEquals(0, info.badBlocks.size(),
+          "Did not expect bad blocks.");
       info.blocksScanned = 0;
     }
   }
@@ -1029,8 +1044,8 @@ public class TestBlockScanner {
       info.shouldRun = false;
       info.notify();
     }
-    assertEquals("Should not scan block accessed in last period",
-        0, info.blocksScanned);
+    assertEquals(0, info.blocksScanned,
+        "Should not scan block accessed in last period");
     ctx.close();
   }
 
@@ -1040,7 +1055,8 @@ public class TestBlockScanner {
    *
    * @throws Exception
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testFastDatanodeShutdown() throws Exception {
     // set the joinTimeOut to a value smaller than the completion time of the
     // VolumeScanner.
@@ -1052,7 +1068,8 @@ public class TestBlockScanner {
    *
    * @throws Exception
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testSlowDatanodeShutdown() throws Exception {
     // Set the joinTimeOut to a value larger than the completion time of the
     // volume scanner
@@ -1101,18 +1118,19 @@ public class TestBlockScanner {
       long totalTimeShutdown = endShutdownTime - startShutdownTime;
 
       if (isFastShutdown) {
-        assertTrue("total shutdown time of DN must be smaller than "
-                + "VolumeScanner Response time: " + totalTimeShutdown,
-            totalTimeShutdown < delayMS
-                && totalTimeShutdown >= joinTimeOutMS);
+        assertTrue(totalTimeShutdown < delayMS
+                && totalTimeShutdown >= joinTimeOutMS,
+            "total shutdown time of DN must be smaller than "
+                + "VolumeScanner Response time: " + totalTimeShutdown
+        );
         // wait for scanners to terminate before we move to the next test.
         injectDelay.waitForScanners();
         return;
       }
-      assertTrue("total shutdown time of DN must be larger than " +
-              "VolumeScanner Response time: " + totalTimeShutdown,
-          totalTimeShutdown >= delayMS
-              && totalTimeShutdown < joinTimeOutMS);
+      assertTrue(totalTimeShutdown >= delayMS
+              && totalTimeShutdown < joinTimeOutMS,
+          "total shutdown time of DN must be larger than " +
+              "VolumeScanner Response time: " + totalTimeShutdown);
     } finally {
       // restore the VolumeScanner callback injector.
       VolumeScannerCBInjector.set(prevVolumeScannerCBInject);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBpServiceActorScheduler.java
@@ -19,37 +19,32 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdfs.server.datanode.BPServiceActor.Scheduler;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
 import static java.lang.Math.abs;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verify the block report and heartbeat scheduling logic of BPServiceActor
  * using a few different values .
  */
+@Timeout(300)
 public class TestBpServiceActorScheduler {
   protected static final Logger LOG =
       LoggerFactory.getLogger(TestBpServiceActorScheduler.class);
-
-  @Rule
-  public Timeout timeout = new Timeout(300000);
 
   private static final long HEARTBEAT_INTERVAL_MS = 5000;      // 5 seconds
   private static final long LIFELINE_INTERVAL_MS = 3 * HEARTBEAT_INTERVAL_MS;
@@ -72,7 +67,7 @@ public class TestBpServiceActorScheduler {
       Scheduler scheduler = makeMockScheduler(now);
       scheduler.scheduleBlockReport(0, true);
       assertTrue(scheduler.resetBlockReportTime);
-      assertThat(scheduler.getNextBlockReportTime(), is(now));
+      assertThat(scheduler.getNextBlockReportTime()).isEqualTo(now);
     }
   }
 
@@ -113,8 +108,7 @@ public class TestBpServiceActorScheduler {
       Scheduler scheduler = makeMockScheduler(now);
       scheduler.resetBlockReportTime = false;
       scheduler.scheduleNextBlockReport();
-      assertThat(scheduler.getNextBlockReportTime(),
-          is(now + BLOCK_REPORT_INTERVAL_MS));
+      assertThat(scheduler.getNextBlockReportTime()).isEqualTo(now + BLOCK_REPORT_INTERVAL_MS);
     }
   }
 
@@ -137,8 +131,8 @@ public class TestBpServiceActorScheduler {
       scheduler.scheduleNextBlockReport();
       assertTrue((scheduler.getNextBlockReportTime() - now)
           < BLOCK_REPORT_INTERVAL_MS);
-      assertEquals(0, ((scheduler.getNextBlockReportTime() - origBlockReportTime)
-          % BLOCK_REPORT_INTERVAL_MS));
+      assertEquals(0,
+          ((scheduler.getNextBlockReportTime() - origBlockReportTime) % BLOCK_REPORT_INTERVAL_MS));
     }
   }
 
@@ -198,10 +192,10 @@ public class TestBpServiceActorScheduler {
       Scheduler scheduler = makeMockScheduler(now);
       scheduler.scheduleNextLifeline(now);
       assertFalse(scheduler.isLifelineDue(now));
-      assertThat(scheduler.getLifelineWaitTime(), is(LIFELINE_INTERVAL_MS));
+      assertThat(scheduler.getLifelineWaitTime()).isEqualTo(LIFELINE_INTERVAL_MS);
       scheduler.scheduleNextLifeline(now - LIFELINE_INTERVAL_MS);
       assertTrue(scheduler.isLifelineDue(now));
-      assertThat(scheduler.getLifelineWaitTime(), is(0L));
+      assertThat(scheduler.getLifelineWaitTime()).isEqualTo(0L);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCachingStrategy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCachingStrategy.java
@@ -43,9 +43,10 @@ import org.apache.hadoop.io.nativeio.NativeIOException;
 
 import static org.apache.hadoop.io.nativeio.NativeIO.POSIX.POSIX_FADV_DONTNEED;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCachingStrategy {
   private static final Logger LOG =
@@ -56,7 +57,7 @@ public class TestCachingStrategy {
   private final static TestRecordingCacheTracker tracker =
       new TestRecordingCacheTracker();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTest() {
     EditLogFileOutputStream.setShouldSkipFsyncForTesting(true);
 
@@ -211,7 +212,8 @@ public class TestCachingStrategy {
     throw new RuntimeException("unreachable");
   }
  
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testFadviseAfterWriteThenRead() throws Exception {
     // start a cluster
     LOG.info("testFadviseAfterWriteThenRead");
@@ -239,7 +241,7 @@ public class TestCachingStrategy {
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, true);
       // verify that we dropped everything from the cache.
-      Assert.assertNotNull(stats);
+      Assertions.assertNotNull(stats);
       stats.assertDroppedInRange(0, TEST_PATH_LEN - WRITE_PACKET_SIZE);
     } finally {
       if (cluster != null) {
@@ -252,7 +254,8 @@ public class TestCachingStrategy {
    * Test the scenario where the DataNode defaults to not dropping the cache,
    * but our client defaults are set.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testClientDefaults() throws Exception {
     // start a cluster
     LOG.info("testClientDefaults");
@@ -284,7 +287,7 @@ public class TestCachingStrategy {
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, null);
       // verify that we dropped everything from the cache.
-      Assert.assertNotNull(stats);
+      Assertions.assertNotNull(stats);
       stats.assertDroppedInRange(0, TEST_PATH_LEN - WRITE_PACKET_SIZE);
     } finally {
       if (cluster != null) {
@@ -293,7 +296,8 @@ public class TestCachingStrategy {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testFadviseSkippedForSmallReads() throws Exception {
     // start a cluster
     LOG.info("testFadviseSkippedForSmallReads");
@@ -339,7 +343,8 @@ public class TestCachingStrategy {
     }
   }
   
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testNoFadviseAfterWriteThenRead() throws Exception {
     // start a cluster
     LOG.info("testNoFadviseAfterWriteThenRead");
@@ -361,7 +366,7 @@ public class TestCachingStrategy {
           TEST_PATH, 0, Long.MAX_VALUE).get(0).getBlock();
       String fadvisedFileName = cluster.getBlockFile(0, block).getName();
       Stats stats = tracker.getStats(fadvisedFileName);
-      Assert.assertNull(stats);
+      Assertions.assertNull(stats);
       
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, false);
@@ -372,7 +377,8 @@ public class TestCachingStrategy {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testSeekAfterSetDropBehind() throws Exception {
     // start a cluster
     LOG.info("testSeekAfterSetDropBehind");
@@ -388,7 +394,7 @@ public class TestCachingStrategy {
       createHdfsFile(fs, new Path(TEST_PATH), TEST_PATH_LEN, false);
       // verify that we can seek after setDropBehind
       try (FSDataInputStream fis = fs.open(new Path(TEST_PATH))) {
-        Assert.assertTrue(fis.read() != -1); // create BlockReader
+        Assertions.assertTrue(fis.read() != -1); // create BlockReader
         fis.setDropBehind(false); // clear BlockReader
         fis.seek(2); // seek
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCorruptMetadataFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCorruptMetadataFile.java
@@ -28,14 +28,15 @@ import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.RandomAccessFile;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests to ensure that a block is not read successfully from a datanode
@@ -47,7 +48,7 @@ public class TestCorruptMetadataFile {
   private MiniDFSCluster.Builder clusterBuilder;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     // Reduce block acquire retries as we only have 1 DN and it allows the
@@ -57,7 +58,7 @@ public class TestCorruptMetadataFile {
     clusterBuilder = new MiniDFSCluster.Builder(conf).numDataNodes(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -65,7 +66,8 @@ public class TestCorruptMetadataFile {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReadBlockFailsWhenMetaIsCorrupt() throws Exception {
     cluster = clusterBuilder.build();
     cluster.waitActive();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataDirs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataDirs.java
@@ -28,15 +28,17 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.util.Shell;
 import org.opentest4j.TestAbortedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDataDirs {
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testDataDirParsing() throws Throwable {
     Configuration conf = new Configuration();
     List<StorageLocation> locations;
@@ -56,28 +58,28 @@ public class TestDataDirs {
             "[ram_disk]/dir4,[disk]/dir5, [disk] /dir6, [disk] , [nvdimm]/dir7";
     conf.set(DFS_DATANODE_DATA_DIR_KEY, locations1);
     locations = DataNode.getStorageLocations(conf);
-    assertThat(locations.size(), is(9));
-    assertThat(locations.get(0).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(0).getUri(), is(dir0.toURI()));
-    assertThat(locations.get(1).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(1).getUri(), is(dir1.toURI()));
-    assertThat(locations.get(2).getStorageType(), is(StorageType.SSD));
-    assertThat(locations.get(2).getUri(), is(dir2.toURI()));
-    assertThat(locations.get(3).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(3).getUri(), is(dir3.toURI()));
-    assertThat(locations.get(4).getStorageType(), is(StorageType.RAM_DISK));
-    assertThat(locations.get(4).getUri(), is(dir4.toURI()));
-    assertThat(locations.get(5).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(5).getUri(), is(dir5.toURI()));
-    assertThat(locations.get(6).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(6).getUri(), is(dir6.toURI()));
+    assertThat(locations.size()).isEqualTo(9);
+    assertThat(locations.get(0).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(0).getUri()).isEqualTo(dir0.toURI());
+    assertThat(locations.get(1).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(1).getUri()).isEqualTo(dir1.toURI());
+    assertThat(locations.get(2).getStorageType()).isEqualTo(StorageType.SSD);
+    assertThat(locations.get(2).getUri()).isEqualTo(dir2.toURI());
+    assertThat(locations.get(3).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(3).getUri()).isEqualTo(dir3.toURI());
+    assertThat(locations.get(4).getStorageType()).isEqualTo(StorageType.RAM_DISK);
+    assertThat(locations.get(4).getUri()).isEqualTo(dir4.toURI());
+    assertThat(locations.get(5).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(5).getUri()).isEqualTo(dir5.toURI());
+    assertThat(locations.get(6).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(6).getUri()).isEqualTo(dir6.toURI());
 
     // not asserting the 8th URI since it is incomplete and it in the
     // test set to make sure that we don't fail if we get URIs like that.
-    assertThat(locations.get(7).getStorageType(), is(StorageType.DISK));
+    assertThat(locations.get(7).getStorageType()).isEqualTo(StorageType.DISK);
 
-    assertThat(locations.get(8).getStorageType(), is(StorageType.NVDIMM));
-    assertThat(locations.get(8).getUri(), is(dir7.toURI()));
+    assertThat(locations.get(8).getStorageType()).isEqualTo(StorageType.NVDIMM);
+    assertThat(locations.get(8).getUri()).isEqualTo(dir7.toURI());
 
     // Verify that an unrecognized storage type result in an exception.
     String locations2 = "[BadMediaType]/dir0,[ssd]/dir1,[disk]/dir2";
@@ -94,11 +96,11 @@ public class TestDataDirs {
     String locations3 = "/dir0,/dir1";
     conf.set(DFS_DATANODE_DATA_DIR_KEY, locations3);
     locations = DataNode.getStorageLocations(conf);
-    assertThat(locations.size(), is(2));
-    assertThat(locations.get(0).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(0).getUri(), is(dir0.toURI()));
-    assertThat(locations.get(1).getStorageType(), is(StorageType.DISK));
-    assertThat(locations.get(1).getUri(), is(dir1.toURI()));
+    assertThat(locations.size()).isEqualTo(2);
+    assertThat(locations.get(0).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(0).getUri()).isEqualTo(dir0.toURI());
+    assertThat(locations.get(1).getStorageType()).isEqualTo(StorageType.DISK);
+    assertThat(locations.get(1).getUri()).isEqualTo(dir1.toURI());
   }
 
   @Test
@@ -136,10 +138,8 @@ public class TestDataDirs {
     // Good case
     String config = "[0.9 ]/disk /2, [0.1]/disk2/1";
     Map<URI, Double> map = StorageLocation.parseCapacityRatio(config);
-    assertEquals(0.9,
-        map.get(new Path("/disk/2").toUri()), 0);
-    assertEquals(0.1,
-        map.get(new Path("/disk2/1").toUri()), 0);
+    assertEquals(0.9, map.get(new Path("/disk/2").toUri()), 0);
+    assertEquals(0.1, map.get(new Path("/disk2/1").toUri()), 0);
 
     // config without capacity ratio
     config = "[0.9 ]/disk /2, /disk2/1";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeECN.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeECN.java
@@ -21,17 +21,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.datatransfer.PipelineAck;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
+@Timeout(300)
 public class TestDataNodeECN {
-
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
 
   @Test
   public void testECNFlag() throws IOException {
@@ -41,7 +38,7 @@ public class TestDataNodeECN {
     try {
       cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
       PipelineAck.ECN ecn = cluster.getDataNodes().get(0).getECN();
-      Assert.assertNotEquals(PipelineAck.ECN.DISABLED, ecn);
+      Assertions.assertNotEquals(PipelineAck.ECN.DISABLED, ecn);
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
@@ -38,13 +38,14 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounterWithoutCheck;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 
 /**
@@ -67,7 +68,7 @@ public class TestDataNodeErasureCodingMetrics {
   private Configuration conf;
   private DistributedFileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
@@ -81,80 +82,84 @@ public class TestDataNodeErasureCodingMetrics {
         StripedFileTestUtil.getDefaultECPolicy().getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testFullBlock() throws Exception {
-    Assert.assertEquals(0, getLongMetric("EcReconstructionReadTimeMillis"));
-    Assert.assertEquals(0, getLongMetric("EcReconstructionDecodingTimeMillis"));
-    Assert.assertEquals(0, getLongMetric("EcReconstructionWriteTimeMillis"));
+    Assertions.assertEquals(0, getLongMetric("EcReconstructionReadTimeMillis"));
+    Assertions.assertEquals(0, getLongMetric("EcReconstructionDecodingTimeMillis"));
+    Assertions.assertEquals(0, getLongMetric("EcReconstructionWriteTimeMillis"));
 
     doTest("/testEcMetrics", blockGroupSize, 0);
 
-    Assert.assertEquals("EcReconstructionTasks should be ",
-        1, getLongMetric("EcReconstructionTasks"));
-    Assert.assertEquals("EcFailedReconstructionTasks should be ",
-        0, getLongMetric("EcFailedReconstructionTasks"));
-    Assert.assertTrue(getLongMetric("EcDecodingTimeNanos") > 0);
-    Assert.assertEquals("EcReconstructionBytesRead should be ",
-        blockGroupSize, getLongMetric("EcReconstructionBytesRead"));
-    Assert.assertEquals("EcReconstructionBytesWritten should be ",
-        blockSize, getLongMetric("EcReconstructionBytesWritten"));
-    Assert.assertEquals("EcReconstructionRemoteBytesRead should be ",
-        0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"));
-    Assert.assertTrue(getLongMetric("EcReconstructionReadTimeMillis") > 0);
-    Assert.assertTrue(getLongMetric("EcReconstructionDecodingTimeMillis") > 0);
-    Assert.assertTrue(getLongMetric("EcReconstructionWriteTimeMillis") > 0);
+    Assertions.assertEquals(1, getLongMetric("EcReconstructionTasks"),
+        "EcReconstructionTasks should be ");
+    Assertions.assertEquals(0, getLongMetric("EcFailedReconstructionTasks"),
+        "EcFailedReconstructionTasks should be ");
+    Assertions.assertTrue(getLongMetric("EcDecodingTimeNanos") > 0);
+    Assertions.assertEquals(blockGroupSize, getLongMetric("EcReconstructionBytesRead"),
+        "EcReconstructionBytesRead should be ");
+    Assertions.assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
+        "EcReconstructionBytesWritten should be ");
+    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+        "EcReconstructionRemoteBytesRead should be ");
+    Assertions.assertTrue(getLongMetric("EcReconstructionReadTimeMillis") > 0);
+    Assertions.assertTrue(getLongMetric("EcReconstructionDecodingTimeMillis") > 0);
+    Assertions.assertTrue(getLongMetric("EcReconstructionWriteTimeMillis") > 0);
   }
 
   // A partial block, reconstruct the partial block
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testReconstructionBytesPartialGroup1() throws Exception {
     final int fileLen = blockSize / 10;
     doTest("/testEcBytes", fileLen, 0);
 
-    Assert.assertEquals("EcReconstructionBytesRead should be ",
-        fileLen,  getLongMetric("EcReconstructionBytesRead"));
-    Assert.assertEquals("EcReconstructionBytesWritten should be ",
-        fileLen, getLongMetric("EcReconstructionBytesWritten"));
-    Assert.assertEquals("EcReconstructionRemoteBytesRead should be ",
-        0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"));
+    Assertions.assertEquals(fileLen, getLongMetric("EcReconstructionBytesRead"),
+        "EcReconstructionBytesRead should be ");
+    Assertions.assertEquals(fileLen, getLongMetric("EcReconstructionBytesWritten"),
+        "EcReconstructionBytesWritten should be ");
+    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+        "EcReconstructionRemoteBytesRead should be ");
   }
 
   // 1 full block + 5 partial block, reconstruct the full block
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testReconstructionBytesPartialGroup2() throws Exception {
     final int fileLen = cellSize * dataBlocks + cellSize + cellSize / 10;
     doTest("/testEcBytes", fileLen, 0);
 
-    Assert.assertEquals("ecReconstructionBytesRead should be ",
-        cellSize * dataBlocks + cellSize + cellSize / 10,
-        getLongMetric("EcReconstructionBytesRead"));
-    Assert.assertEquals("EcReconstructionBytesWritten should be ",
-        blockSize, getLongMetric("EcReconstructionBytesWritten"));
-    Assert.assertEquals("EcReconstructionRemoteBytesRead should be ",
-        0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"));
+    Assertions.assertEquals(cellSize * dataBlocks
+            + cellSize + cellSize / 10,
+        getLongMetric("EcReconstructionBytesRead"), "ecReconstructionBytesRead should be ");
+    Assertions.assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
+        "EcReconstructionBytesWritten should be ");
+    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+        "EcReconstructionRemoteBytesRead should be ");
   }
 
   // 1 full block + 5 partial block, reconstruct the partial block
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testReconstructionBytesPartialGroup3() throws Exception {
     final int fileLen = cellSize * dataBlocks + cellSize + cellSize / 10;
     doTest("/testEcBytes", fileLen, 1);
 
-    Assert.assertEquals("ecReconstructionBytesRead should be ",
-        cellSize * dataBlocks + (cellSize / 10) * 2 ,
-        getLongMetric("EcReconstructionBytesRead"));
-    Assert.assertEquals("ecReconstructionBytesWritten should be ",
-        cellSize + cellSize / 10,
-        getLongMetric("EcReconstructionBytesWritten"));
-    Assert.assertEquals("EcReconstructionRemoteBytesRead should be ",
-        0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"));
+    Assertions.assertEquals(cellSize * dataBlocks + (cellSize / 10) * 2,
+        getLongMetric("EcReconstructionBytesRead"),
+        "ecReconstructionBytesRead should be ");
+    Assertions.assertEquals(cellSize + cellSize / 10,
+        getLongMetric("EcReconstructionBytesWritten"),
+        "ecReconstructionBytesWritten should be ");
+    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+        "EcReconstructionRemoteBytesRead should be ");
   }
 
   private long getLongMetric(String metricName) {
@@ -195,14 +200,14 @@ public class TestDataNodeErasureCodingMetrics {
     final DataNode toCorruptDn = cluster.getDataNode(
         lastBlock.getLocations()[deadNodeIndex].getIpcPort());
     LOG.info("Datanode to be corrupted: " + toCorruptDn);
-    assertNotNull("Failed to find a datanode to be corrupted", toCorruptDn);
+    assertNotNull(toCorruptDn, "Failed to find a datanode to be corrupted");
     toCorruptDn.shutdown();
     setDataNodeDead(toCorruptDn.getDatanodeId());
     DFSTestUtil.waitForDatanodeState(cluster, toCorruptDn.getDatanodeUuid(),
         false, 10000);
 
     final int workCount = getComputedDatanodeWork();
-    assertTrue("Wrongly computed block reconstruction work", workCount > 0);
+    assertTrue(workCount > 0, "Wrongly computed block reconstruction work");
     cluster.triggerHeartbeats();
     int totalBlocks =  (fileLen / blockGroupSize) * groupSize;
     final int remainder = fileLen % blockGroupSize;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeExit.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeExit.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,9 +31,9 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /** 
@@ -44,7 +44,7 @@ public class TestDataNodeExit {
   Configuration conf;
   MiniDFSCluster cluster = null;
   
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 100);
@@ -57,7 +57,7 @@ public class TestDataNodeExit {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -78,8 +78,7 @@ public class TestDataNodeExit {
       Thread.sleep(WAIT_TIME_IN_MILLIS);
       iterations--;
     }
-    assertEquals("Mismatch in number of BPServices running", expected,
-        dn.getBpOsCount());
+    assertEquals(expected, dn.getBpOsCount(), "Mismatch in number of BPServices running");
   }
 
   @Test
@@ -100,9 +99,9 @@ public class TestDataNodeExit {
   public void testBPServiceExit() throws Exception {
     DataNode dn = cluster.getDataNodes().get(0);
     stopBPServiceThreads(1, dn);
-    assertTrue("DataNode should not exit", dn.isDatanodeUp());
+    assertTrue(dn.isDatanodeUp(), "DataNode should not exit");
     stopBPServiceThreads(2, dn);
-    assertFalse("DataNode should exit", dn.isDatanodeUp());
+    assertFalse(dn.isDatanodeUp(), "DataNode should exit");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeFSDataSetSink.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeFSDataSetSink.java
@@ -25,12 +25,12 @@ import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsSink;
 import org.apache.hadoop.metrics2.MetricsTag;
 import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDataNodeFSDataSetSink {
   private static final MetricsSystemImpl ms = new

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeFaultInjector.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -33,7 +33,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests various cases where faults are injected to DataNode.
@@ -76,7 +77,8 @@ public class TestDataNodeFaultInjector {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDelaySendingAckToUpstream() throws Exception {
     final MetricsDataNodeFaultInjector mdnFaultInjector =
         new MetricsDataNodeFaultInjector() {
@@ -95,7 +97,8 @@ public class TestDataNodeFaultInjector {
     verifyFaultInjectionDelayPipeline(mdnFaultInjector);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDelaySendingPacketDownstream() throws Exception {
     final MetricsDataNodeFaultInjector mdnFaultInjector =
         new MetricsDataNodeFaultInjector() {
@@ -161,8 +164,8 @@ public class TestDataNodeFaultInjector {
       }
       LOG.info("delay info: " + mdnFaultInjector.getDelayMs() + ":"
           + datanodeSlowLogThresholdMs);
-      assertTrue("Injected delay should be longer than the configured one",
-          mdnFaultInjector.getDelayMs() > datanodeSlowLogThresholdMs);
+      assertTrue(mdnFaultInjector.getDelayMs() > datanodeSlowLogThresholdMs,
+          "Injected delay should be longer than the configured one");
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeInitStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeInitStorage.java
@@ -27,7 +27,8 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test to verify that the DataNode Uuid is correctly initialized before
@@ -68,7 +69,8 @@ public class TestDataNodeInitStorage {
   }
 
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDataNodeInitStorage() throws Throwable {
     // Create configuration to use SimulatedFsDatasetVerifier#Factory.
     Configuration conf = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeLifeline.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeLifeline.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStatistics;
 import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -60,12 +60,11 @@ import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -78,6 +77,7 @@ import java.util.function.Supplier;
 /**
  * Test suite covering lifeline protocol handling in the DataNode.
  */
+@Timeout(60)
 public class TestDataNodeLifeline {
 
   private static final Logger LOG = LoggerFactory.getLogger(
@@ -86,9 +86,6 @@ public class TestDataNodeLifeline {
   static {
     GenericTestUtils.setLogLevel(DataNode.LOG, Level.TRACE);
   }
-
-  @Rule
-  public Timeout timeout = new Timeout(60000);
 
   private MiniDFSCluster cluster;
   private HdfsConfiguration conf;
@@ -105,7 +102,7 @@ public class TestDataNodeLifeline {
     }
   };
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // Configure cluster with lifeline RPC server enabled, and down-tune
     // heartbeat timings to try to force quick dead/stale DataNodes.
@@ -152,7 +149,7 @@ public class TestDataNodeLifeline {
     bpsa.setNameNode(namenode);
   }
 
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -198,12 +195,12 @@ public class TestDataNodeLifeline {
     // poll DataNode tracking information.  Thanks to the lifeline, we expect
     // that the DataNode always stays alive, and never goes stale or dead.
     while (!lifelinesSent.await(1, SECONDS)) {
-      assertEquals("Expect DataNode to be kept alive by lifeline.", 1,
-          namesystem.getNumLiveDataNodes());
-      assertEquals("Expect DataNode not marked dead due to lifeline.", 0,
-          namesystem.getNumDeadDataNodes());
-      assertEquals("Expect DataNode not marked stale due to lifeline.", 0,
-          namesystem.getNumStaleDataNodes());
+      assertEquals(1, namesystem.getNumLiveDataNodes(),
+          "Expect DataNode to be kept alive by lifeline.");
+      assertEquals(0, namesystem.getNumDeadDataNodes(),
+          "Expect DataNode not marked dead due to lifeline.");
+      assertEquals(0, namesystem.getNumStaleDataNodes(),
+          "Expect DataNode not marked stale due to lifeline.");
       // add a new volume on the next heartbeat
       cluster.getDataNodes().get(0).reconfigurePropertyImpl(
           DFS_DATANODE_DATA_DIR_KEY,
@@ -225,9 +222,9 @@ public class TestDataNodeLifeline {
     // numLifelines, guaranteed by waiting on the latch.  There is a small
     // possibility of extra lifeline calls depending on timing, so we allow
     // slack in the assertion.
-    assertTrue("Expect metrics to count at least " + numLifelines + " calls.",
-        getLongCounter("LifelinesNumOps", getMetrics(metrics.name())) >=
-            numLifelines);
+    assertTrue(getLongCounter("LifelinesNumOps",
+            getMetrics(metrics.name())) >= numLifelines,
+        "Expect metrics to count at least " + numLifelines + " calls.");
   }
 
   @Test
@@ -255,12 +252,12 @@ public class TestDataNodeLifeline {
     // poll DataNode tracking information.  We expect that the DataNode always
     // stays alive, and never goes stale or dead.
     while (!heartbeatsSent.await(1, SECONDS)) {
-      assertEquals("Expect DataNode to be kept alive by lifeline.", 1,
-          namesystem.getNumLiveDataNodes());
-      assertEquals("Expect DataNode not marked dead due to lifeline.", 0,
-          namesystem.getNumDeadDataNodes());
-      assertEquals("Expect DataNode not marked stale due to lifeline.", 0,
-          namesystem.getNumStaleDataNodes());
+      assertEquals(1, namesystem.getNumLiveDataNodes(),
+          "Expect DataNode to be kept alive by lifeline.");
+      assertEquals(0, namesystem.getNumDeadDataNodes(),
+          "Expect DataNode not marked dead due to lifeline.");
+      assertEquals(0, namesystem.getNumStaleDataNodes(),
+          "Expect DataNode not marked stale due to lifeline.");
     }
 
     // Verify that we did not call the lifeline RPC.
@@ -275,8 +272,8 @@ public class TestDataNodeLifeline {
         any());
 
     // Also verify no lifeline calls through metrics.
-    assertEquals("Expect metrics to count no lifeline calls.", 0,
-        getLongCounter("LifelinesNumOps", getMetrics(metrics.name())));
+    assertEquals(0, getLongCounter("LifelinesNumOps", getMetrics(metrics.name())),
+        "Expect metrics to count no lifeline calls.");
   }
 
   @Test
@@ -285,11 +282,11 @@ public class TestDataNodeLifeline {
     assertTrue(initialCapacity > 0);
     dn.setHeartbeatsDisabledForTests(true);
     cluster.setDataNodesDead();
-    assertEquals("Capacity should be 0 after all DNs dead", 0, cluster
-        .getNamesystem(0).getCapacityTotal());
+    assertEquals(0, cluster.getNamesystem(0).getCapacityTotal(),
+        "Capacity should be 0 after all DNs dead");
     bpsa.sendLifelineForTests();
-    assertEquals("Lifeline should be ignored for dead node", 0, cluster
-        .getNamesystem(0).getCapacityTotal());
+    assertEquals(0, cluster.getNamesystem(0).getCapacityTotal(),
+        "Lifeline should be ignored for dead node");
     // Wait for re-registration and heartbeat
     dn.setHeartbeatsDisabledForTests(false);
     final DatanodeDescriptor dnDesc = cluster.getNamesystem(0).getBlockManager()
@@ -301,8 +298,8 @@ public class TestDataNodeLifeline {
         return dnDesc.isAlive() && dnDesc.isHeartbeatedSinceRegistration();
       }
     }, 100, 5000);
-    assertEquals("Capacity should include only live capacity", initialCapacity,
-        cluster.getNamesystem(0).getCapacityTotal());
+    assertEquals(initialCapacity, cluster.getNamesystem(0).getCapacityTotal(),
+        "Capacity should include only live capacity");
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMultipleRegistrations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMultipleRegistrations.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -44,16 +44,17 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDataNodeMultipleRegistrations {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDataNodeMultipleRegistrations.class);
   Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
   }
@@ -73,8 +74,8 @@ public class TestDataNodeMultipleRegistrations {
       cluster.waitActive();
       NameNode nn1 = cluster.getNameNode(0);
       NameNode nn2 = cluster.getNameNode(1);
-      assertNotNull("cannot create nn1", nn1);
-      assertNotNull("cannot create nn2", nn2);
+      assertNotNull(nn1, "cannot create nn1");
+      assertNotNull(nn2, "cannot create nn2");
 
       String bpid1 = FSImageTestUtil.getFSImage(nn1).getBlockPoolID();
       String bpid2 = FSImageTestUtil.getFSImage(nn2).getBlockPoolID();
@@ -84,7 +85,7 @@ public class TestDataNodeMultipleRegistrations {
       int lv2 = FSImageTestUtil.getFSImage(nn2).getLayoutVersion();
       int ns1 = FSImageTestUtil.getFSImage(nn1).getNamespaceID();
       int ns2 = FSImageTestUtil.getFSImage(nn2).getNamespaceID();
-      assertNotSame("namespace ids should be different", ns1, ns2);
+      assertNotSame(ns1, ns2, "namespace ids should be different");
       LOG.info("nn1: lv=" + lv1 + ";cid=" + cid1 + ";bpid=" + bpid1 + ";uri="
           + nn1.getNameNodeAddress());
       LOG.info("nn2: lv=" + lv2 + ";cid=" + cid2 + ";bpid=" + bpid2 + ";uri="
@@ -93,15 +94,14 @@ public class TestDataNodeMultipleRegistrations {
       // check number of volumes in fsdataset
       DataNode dn = cluster.getDataNodes().get(0);
       final Map<String, Object> volInfos = dn.data.getVolumeInfoMap();
-      Assert.assertTrue("No volumes in the fsdataset", volInfos.size() > 0);
+      Assertions.assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
       int i = 0;
       for (Map.Entry<String, Object> e : volInfos.entrySet()) {
         LOG.info("vol " + i++ + ") " + e.getKey() + ": " + e.getValue());
       }
       // number of volumes should be 2 - [data1, data2]
-      assertEquals("number of volumes is wrong",
-          cluster.getFsDatasetTestUtils(0).getDefaultNumOfDataDirs(),
-          volInfos.size());
+      assertEquals(cluster.getFsDatasetTestUtils(0).getDefaultNumOfDataDirs(), volInfos.size(),
+          "number of volumes is wrong");
 
       for (BPOfferService bpos : dn.getAllBpOs()) {
         LOG.info("BP: " + bpos);
@@ -117,18 +117,14 @@ public class TestDataNodeMultipleRegistrations {
         bpos2 = tmp;
       }
 
-      assertEquals("wrong nn address", getNNSocketAddress(bpos1),
-          nn1.getNameNodeAddress());
-      assertEquals("wrong nn address", getNNSocketAddress(bpos2),
-          nn2.getNameNodeAddress());
-      assertEquals("wrong bpid", bpos1.getBlockPoolId(), bpid1);
-      assertEquals("wrong bpid", bpos2.getBlockPoolId(), bpid2);
-      assertEquals("wrong cid", dn.getClusterId(), cid1);
-      assertEquals("cid should be same", cid2, cid1);
-      assertEquals("namespace should be same",
-          bpos1.bpNSInfo.namespaceID, ns1);
-      assertEquals("namespace should be same",
-          bpos2.bpNSInfo.namespaceID, ns2);
+      assertEquals(getNNSocketAddress(bpos1), nn1.getNameNodeAddress(), "wrong nn address");
+      assertEquals(getNNSocketAddress(bpos2), nn2.getNameNodeAddress(), "wrong nn address");
+      assertEquals(bpos1.getBlockPoolId(), bpid1, "wrong bpid");
+      assertEquals(bpos2.getBlockPoolId(), bpid2, "wrong bpid");
+      assertEquals(dn.getClusterId(), cid1, "wrong cid");
+      assertEquals(cid2, cid1, "cid should be same");
+      assertEquals(bpos1.bpNSInfo.namespaceID, ns1, "namespace should be same");
+      assertEquals(bpos2.bpNSInfo.namespaceID, ns2, "namespace should be same");
     } finally {
       cluster.shutdown();
     }
@@ -151,7 +147,7 @@ public class TestDataNodeMultipleRegistrations {
         .nameNodePort(9927).build();
     try {
       NameNode nn1 = cluster.getNameNode();
-      assertNotNull("cannot create nn1", nn1);
+      assertNotNull(nn1, "cannot create nn1");
 
       String bpid1 = FSImageTestUtil.getFSImage(nn1).getBlockPoolID();
       String cid1 = FSImageTestUtil.getFSImage(nn1).getClusterID();
@@ -162,15 +158,14 @@ public class TestDataNodeMultipleRegistrations {
       // check number of vlumes in fsdataset
       DataNode dn = cluster.getDataNodes().get(0);
       final Map<String, Object> volInfos = dn.data.getVolumeInfoMap();
-      Assert.assertTrue("No volumes in the fsdataset", volInfos.size() > 0);
+      Assertions.assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
       int i = 0;
       for (Map.Entry<String, Object> e : volInfos.entrySet()) {
         LOG.info("vol " + i++ + ") " + e.getKey() + ": " + e.getValue());
       }
       // number of volumes should be 2 - [data1, data2]
-      assertEquals("number of volumes is wrong",
-          cluster.getFsDatasetTestUtils(0).getDefaultNumOfDataDirs(),
-          volInfos.size());
+      assertEquals(cluster.getFsDatasetTestUtils(0).getDefaultNumOfDataDirs(), volInfos.size(),
+          "number of volumes is wrong");
 
       for (BPOfferService bpos : dn.getAllBpOs()) {
         LOG.info("reg: bpid=" + "; name=" + bpos.bpRegistration + "; sid="
@@ -182,11 +177,11 @@ public class TestDataNodeMultipleRegistrations {
       BPOfferService bpos1 = dn.getAllBpOs().get(0);
       bpos1.triggerBlockReportForTests();
 
-      assertEquals("wrong nn address",
-          getNNSocketAddress(bpos1),
-          nn1.getNameNodeAddress());
-      assertEquals("wrong bpid", bpos1.getBlockPoolId(), bpid1);
-      assertEquals("wrong cid", dn.getClusterId(), cid1);
+      assertEquals(getNNSocketAddress(bpos1),
+          nn1.getNameNodeAddress(),
+          "wrong nn address");
+      assertEquals(bpos1.getBlockPoolId(), bpid1, "wrong bpid");
+      assertEquals(dn.getClusterId(), cid1, "wrong cid");
       cluster.shutdown();
       
       // Ensure all the BPOfferService threads are shutdown
@@ -210,31 +205,32 @@ public class TestDataNodeMultipleRegistrations {
       DataNode dn = cluster.getDataNodes().get(0);
       List<BPOfferService> bposs = dn.getAllBpOs();
       LOG.info("dn bpos len (should be 2):" + bposs.size());
-      Assert.assertEquals("should've registered with two namenodes", bposs.size(),2);
+      Assertions.assertEquals(bposs.size(), 2, "should've registered with two namenodes");
       
       // add another namenode
       cluster.addNameNode(conf, 9938);
       Thread.sleep(500);// lets wait for the registration to happen
       bposs = dn.getAllBpOs(); 
       LOG.info("dn bpos len (should be 3):" + bposs.size());
-      Assert.assertEquals("should've registered with three namenodes", bposs.size(),3);
+      Assertions.assertEquals(bposs.size(), 3, "should've registered with three namenodes");
       
       // change cluster id and another Namenode
       StartupOption.FORMAT.setClusterId("DifferentCID");
       cluster.addNameNode(conf, 9948);
       NameNode nn4 = cluster.getNameNode(3);
-      assertNotNull("cannot create nn4", nn4);
+      assertNotNull(nn4, "cannot create nn4");
 
       Thread.sleep(500);// lets wait for the registration to happen
       bposs = dn.getAllBpOs(); 
       LOG.info("dn bpos len (still should be 3):" + bposs.size());
-      Assert.assertEquals("should've registered with three namenodes", 3, bposs.size());
+      Assertions.assertEquals(3, bposs.size(), "should've registered with three namenodes");
     } finally {
         cluster.shutdown();
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testClusterIdMismatchAtStartupWithHA() throws Exception {
     MiniDFSNNTopology top = new MiniDFSNNTopology()
       .addNameservice(new MiniDFSNNTopology.NSConf("ns1")
@@ -254,9 +250,8 @@ public class TestDataNodeMultipleRegistrations {
       // let the initialization be complete
       cluster.waitActive();
       DataNode dn = cluster.getDataNodes().get(0);
-      assertTrue("Datanode should be running", dn.isDatanodeUp());
-      assertEquals("Only one BPOfferService should be running", 1,
-          dn.getAllBpOs().size());
+      assertTrue(dn.isDatanodeUp(), "Datanode should be running");
+      assertEquals(1, dn.getAllBpOs().size(), "Only one BPOfferService should be running");
     } finally {
       cluster.shutdown();
     }
@@ -278,9 +273,8 @@ public class TestDataNodeMultipleRegistrations {
       // let the initialization be complete
       cluster.waitActive();
       DataNode dn = cluster.getDataNodes().get(0);
-      assertTrue("Datanode should be running", dn.isDatanodeUp());
-      assertEquals("BPOfferService should be running", 1,
-          dn.getAllBpOs().size());
+      assertTrue(dn.isDatanodeUp(), "Datanode should be running");
+      assertEquals(1, dn.getAllBpOs().size(), "BPOfferService should be running");
       DataNodeProperties dnProp = cluster.stopDataNode(0);
 
       cluster.getNameNode(0).stop();
@@ -328,12 +322,12 @@ public class TestDataNodeMultipleRegistrations {
     // add a node
     try {
       cluster.waitActive();
-      Assert.assertEquals("(1)Should be 2 namenodes", 2, cluster.getNumNameNodes());
+      Assertions.assertEquals(2, cluster.getNumNameNodes(), "(1)Should be 2 namenodes");
 
       cluster.addNameNode(conf, 0);
-      Assert.assertEquals("(1)Should be 3 namenodes", 3, cluster.getNumNameNodes());
+      Assertions.assertEquals(3, cluster.getNumNameNodes(), "(1)Should be 3 namenodes");
     } catch (IOException ioe) {
-      Assert.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
+      Assertions.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
     } finally {
       cluster.shutdown();
     }
@@ -345,15 +339,15 @@ public class TestDataNodeMultipleRegistrations {
       .build();
     
     try {
-      Assert.assertNotNull(cluster);
+      Assertions.assertNotNull(cluster);
       cluster.waitActive();
-      Assert.assertEquals("(2)Should be 1 namenodes", 1, cluster.getNumNameNodes());
+      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
     
       // add a node
       cluster.addNameNode(conf, 0);
-      Assert.assertEquals("(2)Should be 2 namenodes", 2, cluster.getNumNameNodes());
+      Assertions.assertEquals(2, cluster.getNumNameNodes(), "(2)Should be 2 namenodes");
     } catch (IOException ioe) {
-      Assert.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
+      Assertions.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
     } finally {
       cluster.shutdown();
     }
@@ -365,15 +359,15 @@ public class TestDataNodeMultipleRegistrations {
     // add a node
     try {
       cluster.waitActive();
-      Assert.assertNotNull(cluster);
-      Assert.assertEquals("(2)Should be 1 namenodes", 1, cluster.getNumNameNodes());
+      Assertions.assertNotNull(cluster);
+      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
 
       cluster.addNameNode(conf, 9929);
-      Assert.fail("shouldn't be able to add another NN to non federated cluster");
+      Assertions.fail("shouldn't be able to add another NN to non federated cluster");
     } catch (IOException e) {
       // correct 
-      Assert.assertTrue(e.getMessage().startsWith("cannot add namenode"));
-      Assert.assertEquals("(3)Should be 1 namenodes", 1, cluster.getNumNameNodes());
+      Assertions.assertTrue(e.getMessage().startsWith("cannot add namenode"));
+      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(3)Should be 1 namenodes");
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodePeerMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodePeerMetrics.java
@@ -29,20 +29,21 @@ import org.apache.hadoop.metrics2.lib.MutableRollingAverages;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PEER_METRICS_MIN_OUTLIER_DETECTION_SAMPLES_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PEER_STATS_ENABLED_KEY;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class tests various cases of DataNode peer metrics.
  */
 public class TestDataNodePeerMetrics {
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testGetSendPacketDownstreamAvgInfo() throws Exception {
     final int windowSize = 5; // 5s roll over interval
     final int numWindows = 2; // 2 rolling windows
@@ -83,11 +84,12 @@ public class TestDataNodePeerMetrics {
        *  "[49.236.149.246:9801]RollingAvgTime":504.463,
        *  "[84.125.113.65:9801]RollingAvgTime":497.954}
        */
-      assertThat(json, containsString(peerAddr));
+      assertThat(json).contains(peerAddr);
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testRemoveStaleRecord() throws Exception {
     final int numWindows = 5;
     final long scheduleInterval = 1000;
@@ -124,7 +126,7 @@ public class TestDataNodePeerMetrics {
     assertEquals(3, rollingAverages.getStats(numSamples).size());
     String json = peerMetrics.dumpSendPacketDownstreamAvgInfoAsJson();
     for (String peerAddr : peerAddrList) {
-      assertThat(json, containsString(peerAddr));
+      assertThat(json).contains(peerAddr);
     }
     /* wait for stale report to be removed */
     GenericTestUtils.waitFor(
@@ -146,7 +148,7 @@ public class TestDataNodePeerMetrics {
     assertEquals(3, rollingAverages.getStats(numSamples).size());
     json = peerMetrics.dumpSendPacketDownstreamAvgInfoAsJson();
     for (String peerAddr : peerAddrList) {
-      assertThat(json, containsString(peerAddr));
+      assertThat(json).contains(peerAddr);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
@@ -55,11 +55,11 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,10 +81,10 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.BlockPoolSlice;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test to reconfigure some parameters for DataNode without restart
@@ -100,12 +100,12 @@ public class TestDataNodeReconfiguration {
   private MiniDFSCluster cluster;
   private static long counter = 0;
 
-  @Before
+  @BeforeEach
   public void Setup() throws IOException {
     startDFSCluster(NUM_NAME_NODE, NUM_DATA_NODE);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -114,8 +114,8 @@ public class TestDataNodeReconfiguration {
 
     File dir = new File(DATA_DIR);
     if (dir.exists())
-      Assert.assertTrue("Cannot delete data-node dirs",
-          FileUtil.fullyDelete(dir));
+      Assertions.assertTrue(FileUtil.fullyDelete(dir),
+          "Cannot delete data-node dirs");
   }
 
   private void startDFSCluster(int numNameNodes, int numDataNodes)
@@ -164,8 +164,8 @@ public class TestDataNodeReconfiguration {
             DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
       try {
         dn.reconfigureProperty(
@@ -173,8 +173,8 @@ public class TestDataNodeReconfiguration {
             String.valueOf(-1));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
       try {
         dn.reconfigureProperty(
@@ -182,8 +182,8 @@ public class TestDataNodeReconfiguration {
             String.valueOf(0));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
 
       // change properties
@@ -191,28 +191,25 @@ public class TestDataNodeReconfiguration {
           String.valueOf(maxConcurrentMovers));
 
       // verify change
-      assertEquals(String.format("%s has wrong value",
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY),
-          maxConcurrentMovers, dn.xserver.balanceThrottler.getMaxConcurrentMovers());
+      assertEquals(maxConcurrentMovers, dn.xserver.balanceThrottler.getMaxConcurrentMovers(),
+          String.format("%s has wrong value", DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY));
 
-      assertEquals(String.format("%s has wrong value",
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY),
-          maxConcurrentMovers, Integer.parseInt(dn.getConf().get(
-              DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY)));
+      assertEquals(maxConcurrentMovers,
+          Integer.parseInt(dn.getConf().get(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY)),
+          String.format("%s has wrong value", DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY));
 
       // revert to default
       dn.reconfigureProperty(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
           null);
 
       // verify default
-      assertEquals(String.format("%s has wrong value",
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY),
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_DEFAULT,
-          dn.xserver.balanceThrottler.getMaxConcurrentMovers());
+      assertEquals(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_DEFAULT,
+          dn.xserver.balanceThrottler.getMaxConcurrentMovers(),
+          String.format("%s has wrong value", DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY));
 
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY), null, dn
-          .getConf().get(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY),
+          String.format("expect %s is not configured",
+              DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY));
     }
   }
 
@@ -263,7 +260,7 @@ public class TestDataNodeReconfiguration {
       // Attempt to set new maximum to 1
       final boolean success =
           dataNode.xserver.updateBalancerMaxConcurrentMovers(1);
-      Assert.assertFalse(success);
+      Assertions.assertFalse(success);
     } finally {
       dataNode.shutdown();
     }
@@ -272,32 +269,34 @@ public class TestDataNodeReconfiguration {
   /**
    * Test with invalid configuration.
    */
-  @Test(expected = ReconfigurationException.class)
+  @Test
   public void testFailedDecreaseConcurrentMoversReconfiguration()
       throws IOException, ReconfigurationException {
-    final DataNode[] dns = createDNsForTest(1);
-    final DataNode dataNode = dns[0];
-    try {
-      // Set the current max to 2
-      dataNode.xserver.updateBalancerMaxConcurrentMovers(2);
+    Assertions.assertThrows(ReconfigurationException.class, () -> {
+      final DataNode[] dns = createDNsForTest(1);
+      final DataNode dataNode = dns[0];
+      try {
+        // Set the current max to 2
+        dataNode.xserver.updateBalancerMaxConcurrentMovers(2);
 
-      // Simulate grabbing 2 threads
-      dataNode.xserver.balanceThrottler.acquire();
-      dataNode.xserver.balanceThrottler.acquire();
+        // Simulate grabbing 2 threads
+        dataNode.xserver.balanceThrottler.acquire();
+        dataNode.xserver.balanceThrottler.acquire();
 
-      dataNode.xserver.setMaxReconfigureWaitTime(1);
+        dataNode.xserver.setMaxReconfigureWaitTime(1);
 
-      // Now try reconfigure maximum downwards with threads released
-      dataNode.reconfigurePropertyImpl(
-          DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, "1");
-    } catch (ReconfigurationException e) {
-      Assert.assertEquals(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
-          e.getProperty());
-      Assert.assertEquals("1", e.getNewValue());
-      throw e;
-    } finally {
-      dataNode.shutdown();
-    }
+        // Now try reconfigure maximum downwards with threads released
+        dataNode.reconfigurePropertyImpl(
+            DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, "1");
+      } catch (ReconfigurationException e) {
+        Assertions.assertEquals(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
+            e.getProperty());
+        Assertions.assertEquals("1", e.getNewValue());
+        throw e;
+      } finally {
+        dataNode.shutdown();
+      }
+    });
   }
 
   private void testAcquireOnMaxConcurrentMoversReconfiguration(
@@ -310,12 +309,12 @@ public class TestDataNodeReconfiguration {
     /** Test that the default setup is working */
 
     for (int i = 0; i < defaultMaxThreads; i++) {
-      assertEquals("should be able to get thread quota", true,
-          dataNode.xserver.balanceThrottler.acquire());
+      assertEquals(true, dataNode.xserver.balanceThrottler.acquire(),
+          "should be able to get thread quota");
     }
 
-    assertEquals("should not be able to get thread quota", false,
-        dataNode.xserver.balanceThrottler.acquire());
+    assertEquals(false, dataNode.xserver.balanceThrottler.acquire(),
+        "should not be able to get thread quota");
 
     // Give back the threads
     for (int i = 0; i < defaultMaxThreads; i++) {
@@ -329,16 +328,16 @@ public class TestDataNodeReconfiguration {
         DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
         String.valueOf(maxConcurrentMovers));
 
-    assertEquals("thread quota is wrong", maxConcurrentMovers,
-        dataNode.xserver.balanceThrottler.getMaxConcurrentMovers());
+    assertEquals(maxConcurrentMovers, dataNode.xserver.balanceThrottler.getMaxConcurrentMovers(),
+        "thread quota is wrong");
 
     for (int i = 0; i < maxConcurrentMovers; i++) {
-      assertEquals("should be able to get thread quota", true,
-          dataNode.xserver.balanceThrottler.acquire());
+      assertEquals(true, dataNode.xserver.balanceThrottler.acquire(),
+          "should be able to get thread quota");
     }
 
-    assertEquals("should not be able to get thread quota", false,
-        dataNode.xserver.balanceThrottler.acquire());
+    assertEquals(false, dataNode.xserver.balanceThrottler.acquire(),
+        "should not be able to get thread quota");
   }
 
   @Test
@@ -360,8 +359,8 @@ public class TestDataNodeReconfiguration {
           dn.reconfigureProperty(blockReportParameter, "text");
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting NumberFormatException",
-              expected.getCause() instanceof NumberFormatException);
+          assertTrue(expected.getCause() instanceof NumberFormatException,
+              "expecting NumberFormatException");
         }
       }
 
@@ -369,15 +368,15 @@ public class TestDataNodeReconfiguration {
         dn.reconfigureProperty(DFS_BLOCKREPORT_INTERVAL_MSEC_KEY, String.valueOf(-1));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
       try {
         dn.reconfigureProperty(DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY, String.valueOf(-1));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
       dn.reconfigureProperty(DFS_BLOCKREPORT_INITIAL_DELAY_KEY, String.valueOf(-1));
       assertEquals(0, dn.getDnConf().initialBlockReportDelayMs);
@@ -388,10 +387,8 @@ public class TestDataNodeReconfiguration {
       for (BPOfferService bpos : blockPoolManager.getAllNamenodeThreads()) {
         if (bpos != null) {
           for (BPServiceActor actor : bpos.getBPServiceActors()) {
-            assertEquals(String.format("%s has wrong value",
-                DFS_BLOCKREPORT_INTERVAL_MSEC_KEY),
-                blockReportInterval,
-                actor.getScheduler().getBlockReportIntervalMs());
+            assertEquals(blockReportInterval, actor.getScheduler().getBlockReportIntervalMs(),
+                String.format("%s has wrong value", DFS_BLOCKREPORT_INTERVAL_MSEC_KEY));
           }
         }
       }
@@ -407,23 +404,22 @@ public class TestDataNodeReconfiguration {
       for (BPOfferService bpos : blockPoolManager.getAllNamenodeThreads()) {
         if (bpos != null) {
           for (BPServiceActor actor : bpos.getBPServiceActors()) {
-            assertEquals(String.format("%s has wrong value",
-                DFS_BLOCKREPORT_INTERVAL_MSEC_KEY),
-                DFS_BLOCKREPORT_INTERVAL_MSEC_DEFAULT,
-                actor.getScheduler().getBlockReportIntervalMs());
+            assertEquals(DFS_BLOCKREPORT_INTERVAL_MSEC_DEFAULT,
+                actor.getScheduler().getBlockReportIntervalMs(),
+                String.format("%s has wrong value", DFS_BLOCKREPORT_INTERVAL_MSEC_KEY));
           }
         }
       }
-      assertNull(String.format("expect %s is not configured", DFS_BLOCKREPORT_INTERVAL_MSEC_KEY),
-          dn.getConf().get(DFS_BLOCKREPORT_INTERVAL_MSEC_KEY));
+      assertNull(dn.getConf().get(DFS_BLOCKREPORT_INTERVAL_MSEC_KEY),
+          String.format("expect %s is not configured", DFS_BLOCKREPORT_INTERVAL_MSEC_KEY));
 
       dn.reconfigureProperty(DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY, null);
-      assertNull(String.format("expect %s is not configured", DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY),
-          dn.getConf().get(DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY));
+      assertNull(dn.getConf().get(DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY),
+          String.format("expect %s is not configured", DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY));
 
       dn.reconfigureProperty(DFS_BLOCKREPORT_INITIAL_DELAY_KEY, null);
-      assertNull(String.format("expect %s is not configured", DFS_BLOCKREPORT_INITIAL_DELAY_KEY),
-          dn.getConf().get(DFS_BLOCKREPORT_INITIAL_DELAY_KEY));
+      assertNull(dn.getConf().get(DFS_BLOCKREPORT_INITIAL_DELAY_KEY),
+          String.format("expect %s is not configured", DFS_BLOCKREPORT_INITIAL_DELAY_KEY));
     }
   }
 
@@ -438,92 +434,83 @@ public class TestDataNodeReconfiguration {
         dn.reconfigureProperty(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
       try {
         dn.reconfigureProperty(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY, String.valueOf(-1));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
       try {
         dn.reconfigureProperty(DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
       try {
         dn.reconfigureProperty(DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
       try {
         dn.reconfigureProperty(DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
 
       // Change properties and verify change.
       dn.reconfigureProperty(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY, String.valueOf(123));
-      assertEquals(String.format("%s has wrong value", DFS_DATANODE_MAX_RECEIVER_THREADS_KEY),
-          123, dn.getXferServer().getMaxXceiverCount());
+      assertEquals(123, dn.getXferServer().getMaxXceiverCount(),
+          String.format("%s has wrong value", DFS_DATANODE_MAX_RECEIVER_THREADS_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY,
           String.valueOf(1000));
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY),
-          1000, dn.getXferServer().getTransferThrottler().getBandwidth());
+      assertEquals(1000, dn.getXferServer().getTransferThrottler().getBandwidth(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY,
           String.valueOf(1000));
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY),
-          1000, dn.getXferServer().getWriteThrottler().getBandwidth());
+      assertEquals(1000, dn.getXferServer().getWriteThrottler().getBandwidth(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY,
           String.valueOf(1000));
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY),
-          1000, dn.getXferServer().getReadThrottler().getBandwidth());
+      assertEquals(1000, dn.getXferServer().getReadThrottler().getBandwidth(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY));
 
       // Revert to default.
       dn.reconfigureProperty(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY, null);
-      assertEquals(String.format("%s has wrong value", DFS_DATANODE_MAX_RECEIVER_THREADS_KEY),
-          DFS_DATANODE_MAX_RECEIVER_THREADS_DEFAULT, dn.getXferServer().getMaxXceiverCount());
-      assertNull(String.format("expect %s is not configured",
-          DFS_DATANODE_MAX_RECEIVER_THREADS_KEY),
-          dn.getConf().get(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY));
+      assertEquals(DFS_DATANODE_MAX_RECEIVER_THREADS_DEFAULT,
+          dn.getXferServer().getMaxXceiverCount(),
+          String.format("%s has wrong value", DFS_DATANODE_MAX_RECEIVER_THREADS_KEY));
+      assertNull(dn.getConf().get(DFS_DATANODE_MAX_RECEIVER_THREADS_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_MAX_RECEIVER_THREADS_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY, null);
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY),
-          null, dn.getXferServer().getTransferThrottler());
-      assertNull(String.format("expect %s is not configured",
-              DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY),
-          dn.getConf().get(DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY));
+      assertEquals(null, dn.getXferServer().getTransferThrottler(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY));
+      assertNull(dn.getConf().get(DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY), String
+          .format("expect %s is not configured", DFS_DATANODE_DATA_TRANSFER_BANDWIDTHPERSEC_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY, null);
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY),
-          null, dn.getXferServer().getWriteThrottler());
-      assertNull(String.format("expect %s is not configured",
-              DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY),
-          dn.getConf().get(DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY));
+      assertEquals(null, dn.getXferServer().getWriteThrottler(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY));
+      assertNull(dn.getConf().get(DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY), String
+          .format("expect %s is not configured", DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY, null);
-      assertEquals(String.format("%s has wrong value",
-              DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY),
-          null, dn.getXferServer().getReadThrottler());
-      assertNull(String.format("expect %s is not configured",
-              DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY),
-          dn.getConf().get(DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY));
+      assertEquals(null, dn.getXferServer().getReadThrottler(),
+          String.format("%s has wrong value", DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY));
+      assertNull(dn.getConf().get(DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY));
     }
   }
 
@@ -539,15 +526,15 @@ public class TestDataNodeReconfiguration {
         dn.reconfigureProperty(DFS_CACHEREPORT_INTERVAL_MSEC_KEY, "text");
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
       try {
         dn.reconfigureProperty(DFS_CACHEREPORT_INTERVAL_MSEC_KEY, String.valueOf(-1));
         fail("ReconfigurationException expected");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting IllegalArgumentException",
-            expected.getCause() instanceof IllegalArgumentException);
+        assertTrue(expected.getCause() instanceof IllegalArgumentException,
+            "expecting IllegalArgumentException");
       }
 
       // Change properties.
@@ -555,16 +542,16 @@ public class TestDataNodeReconfiguration {
           String.valueOf(cacheReportInterval));
 
       // Verify change.
-      assertEquals(String.format("%s has wrong value", DFS_CACHEREPORT_INTERVAL_MSEC_KEY),
-          cacheReportInterval, dn.getDnConf().getCacheReportInterval());
+      assertEquals(cacheReportInterval, dn.getDnConf().getCacheReportInterval(),
+          String.format("%s has wrong value", DFS_CACHEREPORT_INTERVAL_MSEC_KEY));
 
       // Revert to default.
       dn.reconfigureProperty(DFS_CACHEREPORT_INTERVAL_MSEC_KEY, null);
-      assertEquals(String.format("%s has wrong value", DFS_CACHEREPORT_INTERVAL_MSEC_KEY),
-          DFS_CACHEREPORT_INTERVAL_MSEC_DEFAULT, dn.getDnConf().getCacheReportInterval());
+      assertEquals(DFS_CACHEREPORT_INTERVAL_MSEC_DEFAULT, dn.getDnConf().getCacheReportInterval(),
+          String.format("%s has wrong value", DFS_CACHEREPORT_INTERVAL_MSEC_KEY));
 
-      assertNull(String.format("expect %s is not configured", DFS_CACHEREPORT_INTERVAL_MSEC_KEY),
-          dn.getConf().get(DFS_CACHEREPORT_INTERVAL_MSEC_KEY));
+      assertNull(dn.getConf().get(DFS_CACHEREPORT_INTERVAL_MSEC_KEY),
+          String.format("expect %s is not configured", DFS_CACHEREPORT_INTERVAL_MSEC_KEY));
     }
   }
 
@@ -588,16 +575,16 @@ public class TestDataNodeReconfiguration {
           dn.reconfigureProperty(parameter, "text");
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting NumberFormatException",
-              expected.getCause() instanceof NumberFormatException);
+          assertTrue(expected.getCause() instanceof NumberFormatException,
+              "expecting NumberFormatException");
         }
 
         try {
           dn.reconfigureProperty(parameter, String.valueOf(-1));
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting IllegalArgumentException",
-              expected.getCause() instanceof IllegalArgumentException);
+          assertTrue(expected.getCause() instanceof IllegalArgumentException,
+              "expecting IllegalArgumentException");
         }
       }
 
@@ -613,16 +600,13 @@ public class TestDataNodeReconfiguration {
       assertEquals(123, dn.getPeerMetrics().getMinOutlierDetectionNodes());
       assertEquals(123, dn.getPeerMetrics().getLowThresholdMs());
       assertEquals(123, dn.getPeerMetrics().getMinOutlierDetectionSamples());
-      assertEquals(123,
-          dn.getPeerMetrics().getSlowNodeDetector().getMinOutlierDetectionNodes());
-      assertEquals(123,
-          dn.getPeerMetrics().getSlowNodeDetector().getLowThresholdMs());
+      assertEquals(123, dn.getPeerMetrics().getSlowNodeDetector().getMinOutlierDetectionNodes());
+      assertEquals(123, dn.getPeerMetrics().getSlowNodeDetector().getLowThresholdMs());
 
       // Revert to default and verify.
       dn.reconfigureProperty(DFS_DATANODE_PEER_STATS_ENABLED_KEY, null);
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_PEER_STATS_ENABLED_KEY), null,
-          dn.getConf().get(DFS_DATANODE_PEER_STATS_ENABLED_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_PEER_STATS_ENABLED_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_PEER_STATS_ENABLED_KEY));
 
       // Reset DFS_DATANODE_PEER_STATS_ENABLED_KEY to true.
       dn.reconfigureProperty(DFS_DATANODE_PEER_STATS_ENABLED_KEY, "true");
@@ -630,15 +614,14 @@ public class TestDataNodeReconfiguration {
       for (String parameter : slowPeersParameters) {
         dn.reconfigureProperty(parameter, null);
       }
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY), null,
-          dn.getConf().get(DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY));
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_SLOWPEER_LOW_THRESHOLD_MS_KEY), null,
-          dn.getConf().get(DFS_DATANODE_SLOWPEER_LOW_THRESHOLD_MS_KEY));
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_PEER_METRICS_MIN_OUTLIER_DETECTION_SAMPLES_KEY), null,
-          dn.getConf().get(DFS_DATANODE_PEER_METRICS_MIN_OUTLIER_DETECTION_SAMPLES_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY), String
+          .format("expect %s is not configured", DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_SLOWPEER_LOW_THRESHOLD_MS_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_SLOWPEER_LOW_THRESHOLD_MS_KEY));
+      assertEquals(null,
+          dn.getConf().get(DFS_DATANODE_PEER_METRICS_MIN_OUTLIER_DETECTION_SAMPLES_KEY),
+          String.format("expect %s is not configured",
+              DFS_DATANODE_PEER_METRICS_MIN_OUTLIER_DETECTION_SAMPLES_KEY));
       assertEquals(dn.getPeerMetrics().getSlowNodeDetector().getMinOutlierDetectionNodes(),
           DFS_DATANODE_MIN_OUTLIER_DETECTION_NODES_DEFAULT);
       assertEquals(dn.getPeerMetrics().getSlowNodeDetector().getLowThresholdMs(),
@@ -659,15 +642,15 @@ public class TestDataNodeReconfiguration {
       try {
         dn.reconfigureProperty(DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY, "text");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
 
       try {
         dn.reconfigureProperty(DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY, "text");
       } catch (ReconfigurationException expected) {
-        assertTrue("expecting NumberFormatException",
-            expected.getCause() instanceof NumberFormatException);
+        assertTrue(expected.getCause() instanceof NumberFormatException,
+            "expecting NumberFormatException");
       }
 
       // Enable disk stats, make DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY > 0.
@@ -677,16 +660,16 @@ public class TestDataNodeReconfiguration {
           dn.reconfigureProperty(parameter, "text");
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting NumberFormatException",
-              expected.getCause() instanceof NumberFormatException);
+          assertTrue(expected.getCause() instanceof NumberFormatException,
+              "expecting NumberFormatException");
         }
 
         try {
           dn.reconfigureProperty(parameter, String.valueOf(-1));
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting IllegalArgumentException",
-              expected.getCause() instanceof IllegalArgumentException);
+          assertTrue(expected.getCause() instanceof IllegalArgumentException,
+              "expecting IllegalArgumentException");
         }
       }
 
@@ -699,9 +682,8 @@ public class TestDataNodeReconfiguration {
       for (BPOfferService bpos : blockPoolManager.getAllNamenodeThreads()) {
         if (bpos != null) {
           for (BPServiceActor actor : bpos.getBPServiceActors()) {
-            assertEquals(String.format("%s has wrong value",
-                DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY),
-                1, actor.getScheduler().getOutliersReportIntervalMs());
+            assertEquals(1, actor.getScheduler().getOutliersReportIntervalMs(),
+                String.format("%s has wrong value", DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY));
           }
         }
       }
@@ -725,39 +707,32 @@ public class TestDataNodeReconfiguration {
       assertEquals((int) ((double) 99 / 100 * Integer.MAX_VALUE),
           dn.getFileIoProvider().getProfilingEventHook().getSampleRangeMax());
       // Assert slowDiskDetector.
-      assertEquals(99,
-          dn.getDiskMetrics().getSlowDiskDetector().getMinOutlierDetectionNodes());
-      assertEquals(99,
-          dn.getDiskMetrics().getSlowDiskDetector().getLowThresholdMs());
+      assertEquals(99, dn.getDiskMetrics().getSlowDiskDetector().getMinOutlierDetectionNodes());
+      assertEquals(99, dn.getDiskMetrics().getSlowDiskDetector().getLowThresholdMs());
 
       // Revert to default and verify.
       dn.reconfigureProperty(DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY, null);
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY), null,
-          dn.getConf().get(DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY));
 
       dn.reconfigureProperty(DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY, null);
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY), null,
-          dn.getConf().get(DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY),
+          String.format("expect %s is not configured",
+              DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY));
       assertFalse(dn.getFileIoProvider().getProfilingEventHook().getDiskStatsEnabled());
-      assertEquals(0,
-          dn.getFileIoProvider().getProfilingEventHook().getSampleRangeMax());
+      assertEquals(0, dn.getFileIoProvider().getProfilingEventHook().getSampleRangeMax());
 
       // Enable disk stats, make DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY > 0.
       dn.reconfigureProperty(DFS_DATANODE_FILEIO_PROFILING_SAMPLING_PERCENTAGE_KEY, "1");
       dn.reconfigureProperty(DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY, null);
       dn.reconfigureProperty(DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY, null);
       dn.reconfigureProperty(DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY, null);
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY), null,
-          dn.getConf().get(DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY));
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY), null,
-          dn.getConf().get(DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY));
-      assertEquals(String.format("expect %s is not configured",
-          DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY), null,
-          dn.getConf().get(DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY), String
+          .format("expect %s is not configured", DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_KEY));
+      assertEquals(null, dn.getConf().get(DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY),
+          String.format("expect %s is not configured", DFS_DATANODE_MAX_SLOWDISKS_TO_EXCLUDE_KEY));
       assertEquals(DFS_DATANODE_MIN_OUTLIER_DETECTION_DISKS_DEFAULT,
           dn.getDiskMetrics().getSlowDiskDetector().getMinOutlierDetectionNodes());
       assertEquals(DFS_DATANODE_SLOWDISK_LOW_THRESHOLD_MS_DEFAULT,
@@ -780,16 +755,16 @@ public class TestDataNodeReconfiguration {
           dn.reconfigureProperty(parameter, "text");
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting NumberFormatException",
-              expected.getCause() instanceof NumberFormatException);
+          assertTrue(expected.getCause() instanceof NumberFormatException,
+              "expecting NumberFormatException");
         }
 
         try {
           dn.reconfigureProperty(parameter, String.valueOf(-1));
           fail("ReconfigurationException expected");
         } catch (ReconfigurationException expected) {
-          assertTrue("expecting IllegalArgumentException",
-              expected.getCause() instanceof IllegalArgumentException);
+          assertTrue(expected.getCause() instanceof IllegalArgumentException,
+              "expecting IllegalArgumentException");
         }
       }
 
@@ -805,8 +780,7 @@ public class TestDataNodeReconfiguration {
           if (dfsUsage instanceof CachingGetSpaceUsed) {
             assertEquals(99,
                 ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getRefreshInterval());
-            assertEquals(99,
-                ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getJitter());
+            assertEquals(99, ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getJitter());
           }
         }
       }
@@ -820,19 +794,17 @@ public class TestDataNodeReconfiguration {
         for (Map.Entry<String, BlockPoolSlice> entry : blockPoolSlices.entrySet()) {
           GetSpaceUsed dfsUsage = entry.getValue().getDfsUsage();
           if (dfsUsage instanceof CachingGetSpaceUsed) {
-            assertEquals(String.format("expect %s is not configured",
-                FS_DU_INTERVAL_KEY), FS_DU_INTERVAL_DEFAULT,
-                ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getRefreshInterval());
-            assertEquals(String.format("expect %s is not configured",
-                FS_GETSPACEUSED_JITTER_KEY), FS_GETSPACEUSED_JITTER_DEFAULT,
-                ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getJitter());
+            assertEquals(FS_DU_INTERVAL_DEFAULT,
+                ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getRefreshInterval(),
+                String.format("expect %s is not configured", FS_DU_INTERVAL_KEY));
+            assertEquals(FS_GETSPACEUSED_JITTER_DEFAULT,
+                ((CachingGetSpaceUsed) entry.getValue().getDfsUsage()).getJitter(),
+                String.format("expect %s is not configured", FS_GETSPACEUSED_JITTER_KEY));
           }
-          assertEquals(String.format("expect %s is not configured",
-              FS_DU_INTERVAL_KEY), null,
-              dn.getConf().get(FS_DU_INTERVAL_KEY));
-          assertEquals(String.format("expect %s is not configured",
-              FS_GETSPACEUSED_JITTER_KEY), null,
-              dn.getConf().get(FS_GETSPACEUSED_JITTER_KEY));
+          assertEquals(null, dn.getConf().get(FS_DU_INTERVAL_KEY),
+              String.format("expect %s is not configured", FS_DU_INTERVAL_KEY));
+          assertEquals(null, dn.getConf().get(FS_GETSPACEUSED_JITTER_KEY),
+              String.format("expect %s is not configured", FS_GETSPACEUSED_JITTER_KEY));
         }
       }
     }
@@ -880,8 +852,9 @@ public class TestDataNodeReconfiguration {
 
       // Set default value.
       dn.reconfigureProperty(DFS_DISK_BALANCER_ENABLED, null);
-      assertEquals(dn.getConf().getBoolean(DFS_DISK_BALANCER_ENABLED,
-              DFS_DISK_BALANCER_ENABLED_DEFAULT), dn.getDiskBalancer().isDiskBalancerEnabled());
+      assertEquals(
+          dn.getConf().getBoolean(DFS_DISK_BALANCER_ENABLED, DFS_DISK_BALANCER_ENABLED_DEFAULT),
+          dn.getDiskBalancer().isDiskBalancerEnabled());
 
       // Set DFS_DISK_BALANCER_ENABLED to false.
       dn.reconfigureProperty(DFS_DISK_BALANCER_ENABLED, "false");
@@ -900,10 +873,12 @@ public class TestDataNodeReconfiguration {
 
       // Set default value.
       dn.reconfigureProperty(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL, null);
-      assertEquals(dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
-          DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS),
+      assertEquals(
+          dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
+              DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS),
           dn.getDiskBalancer().getPlanValidityInterval());
-      assertEquals(dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
+      assertEquals(
+          dn.getConf().getTimeDuration(DFS_DISK_BALANCER_PLAN_VALID_INTERVAL,
               DFS_DISK_BALANCER_PLAN_VALID_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS),
           dn.getDiskBalancer().getPlanValidityIntervalInConfig());
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeTcpNoDelay.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeTcpNoDelay.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_SOCKET_FACTORY_CLASS_DEFAULT_KEY;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +34,9 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.StandardSocketFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.net.SocketFactory;
 import java.io.IOException;
@@ -59,12 +59,12 @@ public class TestDataNodeTcpNoDelay {
       LoggerFactory.getLogger(TestDataNodeTcpNoDelay.class);
   private static Configuration baseConf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     baseConf = new HdfsConfiguration();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
 
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeTransferSocketSize.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeTransferSocketSize.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -26,7 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDataNodeTransferSocketSize {
 
@@ -40,8 +40,8 @@ public class TestDataNodeTransferSocketSize {
     try {
       List<DataNode> datanodes = cluster.getDataNodes();
       DataNode datanode = datanodes.get(0);
-      assertEquals("Receive buffer size should be 4K",
-        4 * 1024, datanode.getXferServer().getPeerServer().getReceiveBufferSize());
+      assertEquals(4 * 1024, datanode.getXferServer().getPeerServer().getReceiveBufferSize(),
+          "Receive buffer size should be 4K");
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -60,8 +60,8 @@ public class TestDataNodeTransferSocketSize {
       List<DataNode> datanodes = cluster.getDataNodes();
       DataNode datanode = datanodes.get(0);
       assertTrue(
-        "Receive buffer size should be a default value (determined by kernel)",
-        datanode.getXferServer().getPeerServer().getReceiveBufferSize() > 0);
+          datanode.getXferServer().getPeerServer().getReceiveBufferSize() > 0,
+          "Receive buffer size should be a default value (determined by kernel)");
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.hdfs.server.datanode;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -56,16 +57,15 @@ import org.apache.hadoop.hdfs.server.protocol.VolumeFailureSummary;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test reporting of DN volume failure counts and metrics.
  */
+@Timeout(120)
 public class TestDataNodeVolumeFailureReporting {
 
   private static final Logger LOG =
@@ -88,11 +88,7 @@ public class TestDataNodeVolumeFailureReporting {
   // a datanode to be considered dead by the namenode.  
   final int WAIT_FOR_DEATH = 15000;
 
-  // specific the timeout for entire test class
-  @Rule
-  public Timeout timeout = new Timeout(120 * 1000);
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // These tests use DataNodeTestUtils#injectDataDirFailure() to simulate
     // volume failures which is currently not supported on Windows.
@@ -101,7 +97,7 @@ public class TestDataNodeVolumeFailureReporting {
     initCluster(1, 2, 1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     IOUtils.cleanupWithLogger(LOG, fs);
     if (cluster != null) {
@@ -156,9 +152,9 @@ public class TestDataNodeVolumeFailureReporting {
     DFSTestUtil.createFile(fs, file1, 1024, (short)3, 1L);
     DFSTestUtil.waitReplication(fs, file1, (short)3);
     ArrayList<DataNode> dns = cluster.getDataNodes();
-    assertTrue("DN1 should be up", dns.get(0).isDatanodeUp());
-    assertTrue("DN2 should be up", dns.get(1).isDatanodeUp());
-    assertTrue("DN3 should be up", dns.get(2).isDatanodeUp());
+    assertTrue(dns.get(0).isDatanodeUp(), "DN1 should be up");
+    assertTrue(dns.get(1).isDatanodeUp(), "DN2 should be up");
+    assertTrue(dns.get(2).isDatanodeUp(), "DN3 should be up");
 
     /*
      * The metrics should confirm the volume failures.
@@ -186,7 +182,7 @@ public class TestDataNodeVolumeFailureReporting {
     Path file2 = new Path("/test2");
     DFSTestUtil.createFile(fs, file2, 1024, (short)3, 1L);
     DFSTestUtil.waitReplication(fs, file2, (short)3);
-    assertTrue("DN3 should still be up", dns.get(2).isDatanodeUp());
+    assertTrue(dns.get(2).isDatanodeUp(), "DN3 should still be up");
     checkFailuresAtDataNode(dns.get(2), 1, true, dn3Vol1.getAbsolutePath());
 
     DataNodeTestUtils.triggerHeartbeat(dns.get(2));
@@ -338,9 +334,9 @@ public class TestDataNodeVolumeFailureReporting {
     DFSTestUtil.waitReplication(fs, file2, (short)3);
 
     ArrayList<DataNode> dns = cluster.getDataNodes();
-    assertTrue("DN1 should be up", dns.get(0).isDatanodeUp());
-    assertTrue("DN2 should be up", dns.get(1).isDatanodeUp());
-    assertTrue("DN3 should be up", dns.get(2).isDatanodeUp());
+    assertTrue(dns.get(0).isDatanodeUp(), "DN1 should be up");
+    assertTrue(dns.get(1).isDatanodeUp(), "DN2 should be up");
+    assertTrue(dns.get(2).isDatanodeUp(), "DN3 should be up");
 
     checkFailuresAtDataNode(dns.get(0), 1, true, dn1Vol1.getAbsolutePath(),
         dn1Vol2.getAbsolutePath());
@@ -387,9 +383,9 @@ public class TestDataNodeVolumeFailureReporting {
     DFSTestUtil.waitReplication(fs, file1, (short)2);
 
     ArrayList<DataNode> dns = cluster.getDataNodes();
-    assertTrue("DN1 should be up", dns.get(0).isDatanodeUp());
-    assertTrue("DN2 should be up", dns.get(1).isDatanodeUp());
-    assertTrue("DN3 should be up", dns.get(2).isDatanodeUp());
+    assertTrue(dns.get(0).isDatanodeUp(), "DN1 should be up");
+    assertTrue(dns.get(1).isDatanodeUp(), "DN2 should be up");
+    assertTrue(dns.get(2).isDatanodeUp(), "DN3 should be up");
 
     checkFailuresAtDataNode(dns.get(0), 1, true, dn1Vol1.getAbsolutePath());
     checkFailuresAtDataNode(dns.get(1), 1, true, dn2Vol1.getAbsolutePath());
@@ -478,8 +474,7 @@ public class TestDataNodeVolumeFailureReporting {
     cluster.waitActive();
     ArrayList<DataNode> dns = cluster.getDataNodes();
     DataNode dn = dns.get(0);
-    assertFalse("DataNode should not reformat if VERSION is missing",
-        currentVersion.exists());
+    assertFalse(currentVersion.exists(), "DataNode should not reformat if VERSION is missing");
 
     // Make sure DN's JMX sees the failed volume
     final String[] expectedFailedVolumes = {dn1Vol1.getAbsolutePath()};
@@ -516,8 +511,7 @@ public class TestDataNodeVolumeFailureReporting {
     assertTrue(cluster.restartDataNodes(true));
     // the DN should tolerate one volume failure.
     cluster.waitActive();
-    assertFalse("DataNode should not reformat if VERSION is missing",
-        currentVersion.exists());
+    assertFalse(currentVersion.exists(), "DataNode should not reformat if VERSION is missing");
   }
 
   /**
@@ -538,8 +532,7 @@ public class TestDataNodeVolumeFailureReporting {
         "Hadoop:service=DataNode,name=FSDatasetState-" + dn0.getDatanodeUuid());
     int numFailedVolumes = (int) mbs.getAttribute(mxbeanName,
         "NumFailedVolumes");
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
-        numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, false, new String[] {});
 
     // Fail dn0Vol1 first.
@@ -548,9 +541,8 @@ public class TestDataNodeVolumeFailureReporting {
     DataNodeTestUtils.waitForDiskError(dn0,
         DataNodeTestUtils.getVolume(dn0, dn0Vol1));
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assert.assertEquals(1, numFailedVolumes);
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
-            numFailedVolumes);
+    Assertions.assertEquals(1, numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol1.getAbsolutePath()});
 
@@ -561,13 +553,12 @@ public class TestDataNodeVolumeFailureReporting {
           oldDataDirs);
       fail("Reconfigure with failed disk should throw exception.");
     } catch (ReconfigurationException e) {
-      Assert.assertTrue("Reconfigure exception doesn't have expected path!",
-          e.getCause().getMessage().contains(dn0Vol1.getAbsolutePath()));
+      Assertions.assertTrue(e.getCause().getMessage().contains(dn0Vol1.getAbsolutePath()),
+          "Reconfigure exception doesn't have expected path!");
     }
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assert.assertEquals(1, numFailedVolumes);
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
-        numFailedVolumes);
+    Assertions.assertEquals(1, numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol1.getAbsolutePath()});
 
@@ -577,9 +568,9 @@ public class TestDataNodeVolumeFailureReporting {
     dn0.reconfigurePropertyImpl(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
             dataDirs);
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assert.assertEquals(0, numFailedVolumes);
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
-            numFailedVolumes);
+    Assertions.assertEquals(0, numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+        numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, true, new String[] {});
 
     // Fix failure volume dn0Vol1 and remount it back.
@@ -588,8 +579,8 @@ public class TestDataNodeVolumeFailureReporting {
     dn0.reconfigurePropertyImpl(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
             oldDataDirs);
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assert.assertEquals(0, numFailedVolumes);
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+    Assertions.assertEquals(0, numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
         numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, true, new String[] {});
 
@@ -599,8 +590,8 @@ public class TestDataNodeVolumeFailureReporting {
     DataNodeTestUtils.waitForDiskError(dn0,
         DataNodeTestUtils.getVolume(dn0, dn0Vol2));
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assert.assertEquals(1, numFailedVolumes);
-    Assert.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+    Assertions.assertEquals(1, numFailedVolumes);
+    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
         numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol2.getAbsolutePath()});
@@ -658,9 +649,9 @@ public class TestDataNodeVolumeFailureReporting {
     LOG.info(strBuilder.toString());
     final long actualVolumeFailures =
         getLongCounter("VolumeFailures", getMetrics(dn.getMetrics().name()));
-    assertTrue("Actual async detected volume failures should be greater or " +
-        "equal than " + expectedFailedVolumes,
-        actualVolumeFailures >= expectedVolumeFailuresCounter);
+    assertTrue(actualVolumeFailures >= expectedVolumeFailuresCounter,
+        "Actual async detected volume failures should be greater or " + "equal than "
+            + expectedFailedVolumes);
     assertEquals(expectedFailedVolumes.length, fsd.getNumFailedVolumes());
     assertArrayEquals(expectedFailedVolumes,
         convertToAbsolutePaths(fsd.getFailedStorageLocations()));
@@ -696,13 +687,11 @@ public class TestDataNodeVolumeFailureReporting {
     VolumeFailureSummary volumeFailureSummary = dd.getVolumeFailureSummary();
     if (expectedFailedVolumes.length > 0) {
       assertArrayEquals(expectedFailedVolumes,
-          convertToAbsolutePaths(volumeFailureSummary
-              .getFailedStorageLocations()));
+          convertToAbsolutePaths(volumeFailureSummary.getFailedStorageLocations()));
       assertTrue(volumeFailureSummary.getLastVolumeFailureDate() > 0);
       long expectedCapacityLost = getExpectedCapacityLost(expectCapacityKnown,
           expectedFailedVolumes.length);
-      assertEquals(expectedCapacityLost,
-          volumeFailureSummary.getEstimatedCapacityLostTotal());
+      assertEquals(expectedCapacityLost, volumeFailureSummary.getEstimatedCapacityLostTotal());
     } else {
       assertNull(volumeFailureSummary);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataSetLockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataSetLockManager.java
@@ -19,21 +19,23 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import org.apache.hadoop.hdfs.server.common.AutoCloseDataSetLock;
 import org.apache.hadoop.hdfs.server.common.DataNodeLockManager.LockLevel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestDataSetLockManager {
   private DataSetLockManager manager;
 
-  @Before
+  @BeforeEach
   public void init() {
     manager = new DataSetLockManager();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testBaseFunc() {
     manager.addLock(LockLevel.BLOCK_POOl, "BPtest");
     manager.addLock(LockLevel.VOLUME, "BPtest", "Volumetest");
@@ -80,7 +82,8 @@ public class TestDataSetLockManager {
     assertEquals(lastException.getMessage(), "lock Leak");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testAcquireWriteLockError() throws InterruptedException {
     Thread t = new Thread(() -> {
       manager.readLock(LockLevel.BLOCK_POOl, "test");
@@ -93,7 +96,8 @@ public class TestDataSetLockManager {
     assertEquals(lastException.getMessage(), "lock Leak");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testLockLeakCheck() {
     manager.writeLock(LockLevel.BLOCK_POOl, "test");
     manager.lockLeakCheck();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataStorage.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.hdfs.server.common.Storage;
 import org.apache.hadoop.hdfs.server.common.Storage.StorageDirectory;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -37,9 +37,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestDataStorage {
   private final static String DEFAULT_BPID = "bp-0";
@@ -55,18 +55,18 @@ public class TestDataStorage {
   private NamespaceInfo nsInfo;
   private DataStorage storage;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     Configuration conf = new HdfsConfiguration();
     storage = new DataStorage();
     nsInfo = new NamespaceInfo(0, CLUSTER_ID, DEFAULT_BPID, CTIME,
         BUILD_VERSION, SOFTWARE_VERSION);
     FileUtil.fullyDelete(TEST_DIR);
-    assertTrue("Failed to make test dir.", TEST_DIR.mkdirs());
+    assertTrue(TEST_DIR.mkdirs(), "Failed to make test dir.");
     Mockito.when(mockDN.getConf()).thenReturn(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     storage.unlockAll();
     FileUtil.fullyDelete(TEST_DIR);
@@ -206,7 +206,7 @@ public class TestDataStorage {
     // create a fake directory under current/
     File currentDir = new File(sd.getCurrentDir(),
         "BP-787466439-172.26.24.43-1462305406642");
-    assertTrue("unable to mkdir " + currentDir.getName(), currentDir.mkdirs());
+    assertTrue(currentDir.mkdirs(), "unable to mkdir " + currentDir.getName());
 
     // Add volumes for multiple namespaces.
     List<NamespaceInfo> namespaceInfos = createNamespaceInfos(numNamespace);
@@ -215,7 +215,7 @@ public class TestDataStorage {
     }
 
     // It should not format the directory because VERSION is missing.
-    assertTrue("Storage directory was formatted", currentDir.exists());
+    assertTrue(currentDir.exists(), "Storage directory was formatted");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataTransferThrottler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataTransferThrottler.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.util.Time.monotonicNow;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests throttle the data transfers related functions.
@@ -54,10 +54,10 @@ public class TestDataTransferThrottler {
       DataNode dataNode = cluster.getDataNodes().get(0);
       // DataXceiverServer#readThrottler is null if
       // dfs.datanode.data.read.bandwidthPerSec default value is 0.
-      Assert.assertNull(dataNode.xserver.getReadThrottler());
+      Assertions.assertNull(dataNode.xserver.getReadThrottler());
 
       // Read file.
-      Assert.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
+      Assertions.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
 
       // Set dfs.datanode.data.read.bandwidthPerSec.
       long bandwidthPerSec = 1024 * 1024 * 8;
@@ -67,11 +67,11 @@ public class TestDataTransferThrottler {
       cluster.stopDataNode(0);
       cluster.startDataNodes(conf, 1, true, null, null);
       dataNode = cluster.getDataNodes().get(0);
-      Assert.assertEquals(bandwidthPerSec, dataNode.xserver.getReadThrottler().getBandwidth());
+      Assertions.assertEquals(bandwidthPerSec, dataNode.xserver.getReadThrottler().getBandwidth());
 
       // Read file with throttler.
       long start = monotonicNow();
-      Assert.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
+      Assertions.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
       long elapsedTime = monotonicNow() - start;
       // Ensure throttler is effective, read 1024 * 1024 * 10 * 8 bytes,
       // should take approximately 10 seconds (1024 * 1024 * 8 bytes per second).

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverBackwardsCompat.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverBackwardsCompat.java
@@ -35,9 +35,8 @@ import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.DataChecksum;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
@@ -49,7 +48,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.UUID;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -62,9 +61,8 @@ import static org.mockito.Mockito.spy;
  * Mock-based unit test to verify that DataXceiver does not fail when no
  * storageId or targetStorageTypes are passed - as is the case in Hadoop 2.x.
  */
+@Timeout(60)
 public class TestDataXceiverBackwardsCompat {
-  @Rule
-  public Timeout timeout = new Timeout(60000);
 
   private void failWithException(String message, Exception exception) {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
@@ -50,10 +50,11 @@ import org.apache.hadoop.hdfs.server.protocol.NNHAStatusHeartbeat;
 import org.apache.hadoop.hdfs.server.protocol.RegisterCommand;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -85,7 +86,7 @@ public class TestDatanodeProtocolRetryPolicy {
    * Starts an instance of DataNode
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void startUp() throws IOException, URISyntaxException {
     tearDownDone = false;
     conf = new HdfsConfiguration();
@@ -107,7 +108,7 @@ public class TestDatanodeProtocolRetryPolicy {
    * Cleans the resources and closes the instance of datanode
    * @throws IOException if an error occurred
    */
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (!tearDownDone && dn != null) {
       try {
@@ -117,8 +118,8 @@ public class TestDatanodeProtocolRetryPolicy {
       } finally {
         File dir = new File(DATA_DIR);
         if (dir.exists())
-          Assert.assertTrue(
-              "Cannot delete data-node dirs", FileUtil.fullyDelete(dir));
+          Assertions.assertTrue(FileUtil.fullyDelete(dir),
+              "Cannot delete data-node dirs");
       }
       tearDownDone = true;
     }
@@ -154,7 +155,8 @@ public class TestDatanodeProtocolRetryPolicy {
    * 6. DN retries.
    * 7. DatanodeProtocol.registerDatanode succeeds.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDatanodeRegistrationRetry() throws Exception {
     final DatanodeProtocolClientSideTranslatorPB namenode =
         mock(DatanodeProtocolClientSideTranslatorPB.class);
@@ -222,7 +224,7 @@ public class TestDatanodeProtocolRetryPolicy {
       @Override
       DatanodeProtocolClientSideTranslatorPB connectToNN(
           InetSocketAddress nnAddr) throws IOException {
-        Assert.assertEquals(NN_ADDR, nnAddr);
+        Assertions.assertEquals(NN_ADDR, nnAddr);
         return namenode;
       }
     };

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeRegister.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeRegister.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,9 +43,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.VersionInfo;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public class TestDatanodeRegister {
   NamespaceInfo fakeNsInfo;
   DNConf mockDnConf;
   
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     mockDnConf = mock(DNConf.class);
     doReturn(VersionInfo.getVersion()).when(mockDnConf).getMinimumNameNodeVersion();
@@ -91,8 +91,7 @@ public class TestDatanodeRegister {
   @Test
   public void testSoftwareVersionDifferences() throws Exception {
     // We expect no exception to be thrown when the software versions match.
-    assertEquals(VersionInfo.getVersion(),
-        actor.retrieveNamespaceInfo().getSoftwareVersion());
+    assertEquals(VersionInfo.getVersion(), actor.retrieveNamespaceInfo().getSoftwareVersion());
     
     // We expect no exception to be thrown when the min NN version is below the
     // reported NN version.
@@ -158,8 +157,7 @@ public class TestDatanodeRegister {
       localActor.stop();
       localActor.register(nsInfo);
     } catch (IOException e) {
-      Assert.assertEquals("DN shut down before block pool registered",
-          e.getMessage());
+      Assertions.assertEquals("DN shut down before block pool registered", e.getMessage());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeStartupOptions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeStartupOptions.java
@@ -21,11 +21,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.StartupOption;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This test verifies DataNode command line processing.
@@ -58,10 +58,10 @@ public class TestDatanodeStartupOptions {
 
     boolean returnValue = DataNode.parseArguments(args, conf);
     StartupOption option = DataNode.getStartupOption(conf);
-    assertThat(returnValue, is(expectSuccess));
+    assertThat(returnValue).isEqualTo(expectSuccess);
 
     if (expectSuccess) {
-      assertThat(option, is(expectedOption));
+      assertThat(option).isEqualTo(expectedOption);
     }
   }
 
@@ -69,7 +69,7 @@ public class TestDatanodeStartupOptions {
    * Reinitialize configuration before every test since DN stores the
    * parsed StartupOption in the configuration.
    */
-  @Before
+  @BeforeEach
   public void initConfiguration() {
     conf = new HdfsConfiguration();
   }
@@ -77,7 +77,8 @@ public class TestDatanodeStartupOptions {
   /**
    * A few options that should all parse successfully.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testStartupSuccess() {
     checkExpected(true, StartupOption.REGULAR, conf);
     checkExpected(true, StartupOption.REGULAR, conf, "-regular");
@@ -88,7 +89,8 @@ public class TestDatanodeStartupOptions {
   /**
    * A few options that should all fail to parse.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testStartupFailure() {
     checkExpected(false, StartupOption.REGULAR, conf, "unknownoption");
     checkExpected(false, StartupOption.REGULAR, conf, "-regular -rollback");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDeleteBlockPool.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDeleteBlockPool.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests deleteBlockPool functionality.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -19,14 +19,13 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.protocol.Block.BLOCK_FILE_PREFIX;
 import static org.apache.hadoop.util.Shell.getMemlockLimit;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -88,8 +87,9 @@ import org.apache.hadoop.util.AutoCloseableLock;
 import org.apache.hadoop.util.Time;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,7 +123,7 @@ public class TestDirectoryScanner {
     return configuration;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     LazyPersistTestCase.initCacheManipulator();
   }
@@ -375,7 +375,8 @@ public class TestDirectoryScanner {
     assertEquals(duplicateBlocks, stats.duplicateBlocks);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testRetainBlockOnPersistentStorage() throws Exception {
     Configuration conf = getConfiguration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -418,7 +419,8 @@ public class TestDirectoryScanner {
   /**
    * test scan only meta file NOT generate wrong folder structure warn log.
    */
-  @Test(timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testScanDirectoryStructureWarn() throws Exception {
 
     //add a logger stream to check what has printed to log
@@ -464,10 +466,9 @@ public class TestDirectoryScanner {
           " for the deleted block";
       String dirStructureWarnLog = " found in invalid directory." +
           "  Expected directory: ";
-      assertFalse("directory check print meaningless warning message",
-          logContent.contains(dirStructureWarnLog));
-      assertTrue("missing block warn log not appear",
-          logContent.contains(missingBlockWarn));
+      assertFalse(logContent.contains(dirStructureWarnLog),
+          "directory check print meaningless warning message");
+      assertTrue(logContent.contains(missingBlockWarn), "missing block warn log not appear");
       LOG.info("check pass");
 
     } finally {
@@ -480,7 +481,8 @@ public class TestDirectoryScanner {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteBlockOnTransientStorage() throws Exception {
     Configuration conf = getConfiguration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -522,7 +524,8 @@ public class TestDirectoryScanner {
     }
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testRegularBlock() throws Exception {
     Configuration conf = getConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).build();
@@ -569,7 +572,8 @@ public class TestDirectoryScanner {
     }
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDirectoryScannerDuringUpdateBlockMeta() throws Exception {
     Configuration conf = getConfiguration();
     DataNodeFaultInjector oldDnInjector = DataNodeFaultInjector.get();
@@ -651,7 +655,8 @@ public class TestDirectoryScanner {
     }
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDirectoryScanner() throws Exception {
     // Run the test with and without parallel scanning
     for (int parallelism = 1; parallelism < 3; parallelism++) {
@@ -792,10 +797,9 @@ public class TestDirectoryScanner {
       scan(totalBlocks + 1, 0, 0, 0, 0, 0);
 
       // Test14: make sure no throttling is happening
-      assertTrue("Throttle appears to be engaged",
-          scanner.timeWaitingMs.get() < 10L);
-      assertTrue("Report complier threads logged no execution time",
-          scanner.timeRunningMs.get() > 0L);
+      assertTrue(scanner.timeWaitingMs.get() < 10L, "Throttle appears to be engaged");
+      assertTrue(scanner.timeRunningMs.get() > 0L,
+          "Report complier threads logged no execution time");
 
       scanner.shutdown();
       assertFalse(scanner.getRunStatus());
@@ -862,8 +866,8 @@ public class TestDirectoryScanner {
 
       // Waiting should be about 9x running.
       LOG.info("RATIO: " + ratio);
-      assertTrue("Throttle is too restrictive", ratio <= 10f);
-      assertTrue("Throttle is too permissive" + ratio, ratio >= 7f);
+      assertTrue(ratio <= 10f, "Throttle is too restrictive");
+      assertTrue(ratio >= 7f, "Throttle is too permissive" + ratio);
 
       // Test with a different limit
       conf.setInt(
@@ -880,8 +884,8 @@ public class TestDirectoryScanner {
 
       // Waiting should be about 4x running.
       LOG.info("RATIO: " + ratio);
-      assertTrue("Throttle is too restrictive", ratio <= 4.5f);
-      assertTrue("Throttle is too permissive", ratio >= 2.75f);
+      assertTrue(ratio <= 4.5f, "Throttle is too restrictive");
+      assertTrue(ratio >= 2.75f, "Throttle is too permissive");
 
       // Test with more than 1 thread
       conf.setInt(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY, 3);
@@ -899,8 +903,8 @@ public class TestDirectoryScanner {
 
       // Waiting should be about 9x running.
       LOG.info("RATIO: " + ratio);
-      assertTrue("Throttle is too restrictive", ratio <= 10f);
-      assertTrue("Throttle is too permissive", ratio >= 7f);
+      assertTrue(ratio <= 10f, "Throttle is too restrictive");
+      assertTrue(ratio >= 7f, "Throttle is too permissive");
 
       // Test with no limit
       scanner = new DirectoryScanner(fds, getConfiguration());
@@ -909,10 +913,9 @@ public class TestDirectoryScanner {
       scanner.shutdown();
       assertFalse(scanner.getRunStatus());
 
-      assertTrue("Throttle appears to be engaged",
-          scanner.timeWaitingMs.get() < 10L);
-      assertTrue("Report complier threads logged no execution time",
-          scanner.timeRunningMs.get() > 0L);
+      assertTrue(scanner.timeWaitingMs.get() < 10L, "Throttle appears to be engaged");
+      assertTrue(scanner.timeRunningMs.get() > 0L,
+          "Report complier threads logged no execution time");
 
       // Test with a 1ms limit. This also tests whether the scanner can be
       // shutdown cleanly in mid stride.
@@ -951,8 +954,8 @@ public class TestDirectoryScanner {
           if (finalMs > 0) {
             LOG.info("Scanner took " + (Time.monotonicNow() - finalMs)
                 + "ms to shutdown");
-            assertTrue("Scanner took too long to shutdown",
-                Time.monotonicNow() - finalMs < 1000L);
+            assertTrue(Time.monotonicNow() - finalMs < 1000L,
+                "Scanner took too long to shutdown");
           }
 
           ratio =
@@ -965,9 +968,9 @@ public class TestDirectoryScanner {
 
       // We just want to test that it waits a lot, but it also runs some
       LOG.info("RATIO: " + ratio);
-      assertTrue("Throttle is too permissive", ratio > 8);
-      assertTrue("Report complier threads logged no execution time",
-          scanner.timeRunningMs.get() > 0L);
+      assertTrue(ratio > 8, "Throttle is too permissive");
+      assertTrue(scanner.timeRunningMs.get() > 0L,
+          "Report complier threads logged no execution time");
 
       // Test with a 0 limit, i.e. disabled
       conf.setInt(
@@ -979,10 +982,9 @@ public class TestDirectoryScanner {
       scanner.shutdown();
       assertFalse(scanner.getRunStatus());
 
-      assertTrue("Throttle appears to be engaged",
-          scanner.timeWaitingMs.get() < 10L);
-      assertTrue("Report complier threads logged no execution time",
-          scanner.timeRunningMs.get() > 0L);
+      assertTrue(scanner.timeWaitingMs.get() < 10L, "Throttle appears to be engaged");
+      assertTrue(scanner.timeRunningMs.get() > 0L,
+          "Report complier threads logged no execution time");
 
       // Test with a 1000 limit, i.e. disabled
       conf.setInt(
@@ -994,10 +996,9 @@ public class TestDirectoryScanner {
       scanner.shutdown();
       assertFalse(scanner.getRunStatus());
 
-      assertTrue("Throttle appears to be engaged",
-          scanner.timeWaitingMs.get() < 10L);
-      assertTrue("Report complier threads logged no execution time",
-          scanner.timeRunningMs.get() > 0L);
+      assertTrue(scanner.timeWaitingMs.get() < 10L, "Throttle appears to be engaged");
+      assertTrue(scanner.timeRunningMs.get() > 0L,
+          "Report complier threads logged no execution time");
 
       // Test that throttle works from regular start
       conf.setInt(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_THREADS_KEY, 1);
@@ -1018,7 +1019,7 @@ public class TestDirectoryScanner {
 
       scanner.shutdown();
       assertFalse(scanner.getRunStatus());
-      assertTrue("Throttle does not appear to be engaged", count > 0);
+      assertTrue(count > 0, "Throttle does not appear to be engaged");
     } finally {
       cluster.shutdown();
     }
@@ -1041,8 +1042,7 @@ public class TestDirectoryScanner {
 
     // Added block has the same file as the one created by the test
     File file = new File(getBlockFile(blockId));
-    assertEquals(file.getName(),
-        FsDatasetTestUtil.getFile(fds, bpid, blockId).getName());
+    assertEquals(file.getName(), FsDatasetTestUtil.getFile(fds, bpid, blockId).getName());
 
     // Generation stamp is same as that of created file
     assertEquals(genStamp, replicainfo.getGenerationStamp());
@@ -1067,7 +1067,7 @@ public class TestDirectoryScanner {
     final ReplicaInfo memBlock;
     memBlock = FsDatasetTestUtil.fetchReplicaInfo(fds, bpid, blockId);
     assertNotNull(memBlock);
-    assertThat(memBlock.getVolume().isTransientStorage(), is(expectTransient));
+    assertThat(memBlock.getVolume().isTransientStorage()).isEqualTo(expectTransient);
   }
 
   private static class TestFsVolumeSpi implements FsVolumeSpi {
@@ -1219,7 +1219,8 @@ public class TestDirectoryScanner {
     assertNull(scanInfo.getMetaFile());
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void TestScanInfo() throws Exception {
     testScanInfoObject(123,
         new File(TEST_VOLUME.getFinalizedDir(BPID_1).getAbsolutePath()),
@@ -1242,7 +1243,8 @@ public class TestDirectoryScanner {
    * Directory scanner shouldn't abort the scan on every directory just because
    * one had an error.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testExceptionHandlingWhileDirectoryScan() throws Exception {
     Configuration conf = getConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).build();
@@ -1334,7 +1336,8 @@ public class TestDirectoryScanner {
    * Test parsing LocalReplica. We should be able to find the replica's path
    * even if the replica's dir doesn't match the idToBlockDir.
    */
-  @Test(timeout = 3000)
+  @Test
+  @Timeout(value = 3)
   public void testLocalReplicaParsing() {
     String baseDir = GenericTestUtils.getRandomizedTempPath();
     long blkId = getRandomBlockId();
@@ -1369,7 +1372,8 @@ public class TestDirectoryScanner {
    * Test whether can LocalReplica.updateWithReplica() correct the wrongly
    * recorded replica location.
    */
-  @Test(timeout = 3000)
+  @Test
+  @Timeout(value = 3)
   public void testLocalReplicaUpdateWithReplica() throws Exception {
     String baseDir = GenericTestUtils.getRandomizedTempPath();
     long blkId = getRandomBlockId();
@@ -1393,7 +1397,8 @@ public class TestDirectoryScanner {
     assertEquals(realBlkFile, localReplica.getBlockFile());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testLastDirScannerFinishTimeIsUpdated() throws Exception {
     Configuration conf = getConfiguration();
     conf.setLong(DFSConfigKeys.DFS_DATANODE_DIRECTORYSCAN_INTERVAL_KEY, 3L);
@@ -1423,7 +1428,8 @@ public class TestDirectoryScanner {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNullStorage() throws Exception {
     DataNodeFaultInjector oldInjector = DataNodeFaultInjector.get();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDiskError.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -53,9 +53,10 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DataChecksum;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 /**
@@ -67,7 +68,7 @@ public class TestDiskError {
   private MiniDFSCluster cluster;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 512L);
@@ -79,7 +80,7 @@ public class TestDiskError {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -112,8 +113,8 @@ public class TestDiskError {
     File dir2 = MiniDFSCluster.getRbwDir(storageDir, bpid);
     try {
       // make the data directory of the first datanode to be readonly
-      assertTrue("Couldn't chmod local vol", dir1.setReadOnly());
-      assertTrue("Couldn't chmod local vol", dir2.setReadOnly());
+      assertTrue(dir1.setReadOnly(), "Couldn't chmod local vol");
+      assertTrue(dir2.setReadOnly(), "Couldn't chmod local vol");
 
       // create files and make sure that first datanode will be down
       DataNode dn = cluster.getDataNodes().get(dnIndex);
@@ -145,7 +146,7 @@ public class TestDiskError {
     // get the block belonged to the created file
     LocatedBlocks blocks = NameNodeAdapter.getBlockLocations(
         cluster.getNameNode(), fileName.toString(), 0, (long)fileLen);
-    assertEquals("Should only find 1 block", blocks.locatedBlockCount(), 1);
+    assertEquals(blocks.locatedBlockCount(), 1, "Should only find 1 block");
     LocatedBlock block = blocks.get(0);
 
     // bring up a second datanode
@@ -207,8 +208,8 @@ public class TestDiskError {
         for (FsVolumeSpi vol : volumes) {
           Path dataDir = new Path(vol.getStorageLocation().getNormalizedUri());
           FsPermission actual = localFS.getFileStatus(dataDir).getPermission();
-          assertEquals("Permission for dir: " + dataDir + ", is " + actual +
-              ", while expected is " + expected, expected, actual);
+          assertEquals(expected, actual, "Permission for dir: " + dataDir + ", is " + actual
+              + ", while expected is " + expected);
         }
       }
     }
@@ -219,7 +220,8 @@ public class TestDiskError {
    * Before refactoring the code the above function was not getting called 
    * @throws IOException, InterruptedException
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testcheckDiskError() throws Exception {
     if(cluster.getDataNodes().size() <= 0) {
       cluster.startDataNodes(conf, 1, true, null, null);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDnRespectsBlockReportSplitThreshold.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDnRespectsBlockReportSplitThreshold.java
@@ -34,16 +34,16 @@ import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCKREPORT_SPLIT_THRESHOLD_KEY;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests that the DataNode respects
@@ -73,7 +73,7 @@ public class TestDnRespectsBlockReportSplitThreshold {
     bpid = cluster.getNamesystem().getBlockPoolId();
   }
 
-  @After
+  @AfterEach
   public void shutDownCluster() throws IOException {
     if (cluster != null) {
       fs.close();
@@ -97,7 +97,7 @@ public class TestDnRespectsBlockReportSplitThreshold {
     List<StorageBlockReport[]> listOfReports = captor.getAllValues();
     int numBlocksReported = 0;
     for (StorageBlockReport[] reports : listOfReports) {
-      assertThat(reports.length, is(expectedReportsPerCall));
+      assertThat(reports.length).isEqualTo(expectedReportsPerCall);
 
       for (StorageBlockReport report : reports) {
         BlockListAsLongs blockList = report.getBlocks();
@@ -112,7 +112,8 @@ public class TestDnRespectsBlockReportSplitThreshold {
    * Test that if splitThreshold is zero, then we always get a separate
    * call per storage.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testAlwaysSplit() throws IOException, InterruptedException {
     startUpCluster(0);
     NameNode nn = cluster.getNameNode();
@@ -144,7 +145,8 @@ public class TestDnRespectsBlockReportSplitThreshold {
    * Tests the behavior when the count of blocks is exactly one less than
    * the threshold.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCornerCaseUnderThreshold() throws IOException, InterruptedException {
     startUpCluster(BLOCKS_IN_FILE + 1);
     NameNode nn = cluster.getNameNode();
@@ -176,7 +178,8 @@ public class TestDnRespectsBlockReportSplitThreshold {
    * Tests the behavior when the count of blocks is exactly equal to the
    * threshold.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCornerCaseAtThreshold() throws IOException, InterruptedException {
     startUpCluster(BLOCKS_IN_FILE);
     NameNode nn = cluster.getNameNode();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestHSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestHSync.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
 import org.apache.hadoop.io.SequenceFile.Writer;
 import org.apache.hadoop.io.compress.DefaultCodec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHSync {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestHdfsServerConstants.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestHdfsServerConstants.java
@@ -17,13 +17,12 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.RollingUpgradeStartupOption;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.StartupOption;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 /**
  * Test enumerations in TestHdfsServerConstants.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBrVariations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBrVariations.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdfs.server.datanode;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -46,9 +46,10 @@ import org.apache.hadoop.hdfs.server.protocol.*;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStatus;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This test verifies that incremental block reports from a single DataNode are
@@ -89,7 +90,7 @@ public class TestIncrementalBrVariations {
     GenericTestUtils.setLogLevel(TestIncrementalBrVariations.LOG, Level.TRACE);
   }
 
-  @Before
+  @BeforeEach
   public void startUpCluster() throws IOException {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(NUM_DATANODES).build();
@@ -101,7 +102,7 @@ public class TestIncrementalBrVariations {
     dn0Reg = dn0.getDNRegistrationForBP(poolId);
   }
 
-  @After
+  @AfterEach
   public void shutDownCluster() throws IOException {
     if (cluster != null) {
       client.close();
@@ -138,7 +139,7 @@ public class TestIncrementalBrVariations {
     // Get the block list for the file with the block locations.
     LocatedBlocks blocks = client.getLocatedBlocks(
         filePath.toString(), 0, BLOCK_SIZE * NUM_BLOCKS);
-    assertThat(cluster.getNamesystem().getUnderReplicatedBlocks(), is(0L));
+    assertThat(cluster.getNamesystem().getUnderReplicatedBlocks()).isEqualTo(0L);
     return blocks;
   }
 
@@ -195,8 +196,7 @@ public class TestIncrementalBrVariations {
       // by the NameNode.  IBRs are async, make sure the NN processes
       // all of them.
       cluster.getNamesystem().getBlockManager().flushBlockOps();
-      assertThat(cluster.getNamesystem().getMissingBlocksCount(),
-          is((long) reports.length));
+      assertThat(cluster.getNamesystem().getMissingBlocksCount()).isEqualTo((long) reports.length);
     }
   }
 
@@ -206,11 +206,12 @@ public class TestIncrementalBrVariations {
    * @throws IOException
    * @throws InterruptedException
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDataNodeDoesNotSplitReports()
       throws IOException, InterruptedException {
     LocatedBlocks blocks = createFileGetBlocks(GenericTestUtils.getMethodName());
-    assertThat(cluster.getDataNodes().size(), is(1));
+    assertThat(cluster.getDataNodes().size()).isEqualTo(1);
 
     // Remove all blocks from the DataNode.
     for (LocatedBlock block : blocks.getLocatedBlocks()) {
@@ -242,7 +243,8 @@ public class TestIncrementalBrVariations {
    * @throws IOException
    * @throws InterruptedException
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testNnLearnsNewStorages()
       throws IOException, InterruptedException {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestLargeBlockReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestLargeBlockReport.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH;
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH_DEFAULT;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +37,9 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**
@@ -59,13 +59,13 @@ public class TestLargeBlockReport {
   private final long reportId = 1;
   private final long fullBrLeaseId = 0;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     DFSTestUtil.setNameNodeLogLevel(Level.WARN);
     FsDatasetImplTestUtils.setFsDatasetImplLogLevel(Level.WARN);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestRefreshNamenodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestRefreshNamenodes.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,7 +34,8 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology.NNConf;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology.NSConf;
 import org.apache.hadoop.util.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
@@ -97,7 +98,8 @@ public class TestRefreshNamenodes {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testRefreshNameNodeDeadLock() throws Exception {
     Configuration conf = new HdfsConfiguration();
     MiniDFSCluster cluster = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestSimulatedFSDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestSimulatedFSDataset.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -39,8 +39,8 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.ReplicaOutputStreams;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetFactory;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.util.DataChecksum;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * this class tests the methods of the  SimulatedFSDataset.
@@ -52,17 +52,13 @@ public class TestSimulatedFSDataset {
   static final int BLOCK_LENGTH_MULTIPLIER = 79;
   static final long FIRST_BLK_ID = 1;
 
-  private final int storageCount;
+  private int storageCount = 1;
 
-  public TestSimulatedFSDataset() {
-    this(1);
+  protected void pTestSimulatedFSDataset(int pStorageCount) {
+    this.storageCount = pStorageCount;
   }
 
-  protected TestSimulatedFSDataset(int storageCount) {
-    this.storageCount = storageCount;
-  }
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     SimulatedFSDataset.setFactory(conf);
@@ -141,7 +137,7 @@ public class TestSimulatedFSDataset {
     ExtendedBlock b = new ExtendedBlock(bpid, FIRST_BLK_ID, 5, 0);
     try {
       assertTrue(fsdataset.getMetaDataInputStream(b) == null);
-      assertTrue("Expected an IO exception", false);
+      assertTrue(false, "Expected an IO exception");
     } catch (IOException e) {
       // ok - as expected
     }
@@ -250,7 +246,7 @@ public class TestSimulatedFSDataset {
       sfsdataset = getSimulatedFSDataset();
       sfsdataset.addBlockPool(bpid, conf);
       injectBlocksFromBlockReport(fsdataset, sfsdataset);
-      assertTrue("Expected an IO exception", false);
+      assertTrue(false, "Expected an IO exception");
     } catch (IOException e) {
       // ok - as expected
     }
@@ -261,21 +257,21 @@ public class TestSimulatedFSDataset {
     assertFalse(fsdataset.isValidBlock(b));
     try {
       fsdataset.getLength(b);
-      assertTrue("Expected an IO exception", false);
+      assertTrue(false, "Expected an IO exception");
     } catch (IOException e) {
       // ok - as expected
     }
     
     try {
       fsdataset.getBlockInputStream(b);
-      assertTrue("Expected an IO exception", false);
+      assertTrue(false, "Expected an IO exception");
     } catch (IOException e) {
       // ok - as expected
     }
     
     try {
       fsdataset.finalizeBlock(b, false);
-      assertTrue("Expected an IO exception", false);
+      assertTrue(false, "Expected an IO exception");
     } catch (IOException e) {
       // ok - as expected
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestSimulatedFSDatasetWithMultipleStorages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestSimulatedFSDatasetWithMultipleStorages.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY;
-import static org.junit.Assert.assertEquals;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test that the {@link SimulatedFSDataset} works correctly when configured
@@ -32,10 +31,10 @@ public class TestSimulatedFSDatasetWithMultipleStorages
     extends TestSimulatedFSDataset {
 
   public TestSimulatedFSDatasetWithMultipleStorages() {
-    super(2);
+    pTestSimulatedFSDataset(2);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     conf.set(DFS_DATANODE_DATA_DIR_KEY, "data1,data2");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestStorageReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestStorageReport.java
@@ -34,18 +34,17 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
 import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStorageReport {
   public static final Logger LOG =
@@ -59,7 +58,7 @@ public class TestStorageReport {
   private DistributedFileSystem fs;
   static String bpid;
 
-  @Before
+  @BeforeEach
   public void startUpCluster() throws IOException {
     conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -70,7 +69,7 @@ public class TestStorageReport {
     bpid = cluster.getNamesystem().getBlockPoolId();
   }
 
-  @After
+  @AfterEach
   public void shutDownCluster() throws IOException {
     if (cluster != null) {
       fs.close();
@@ -115,8 +114,8 @@ public class TestStorageReport {
     StorageReport[] reports = captor.getValue();
 
     for (StorageReport report: reports) {
-      assertThat(report.getStorage().getStorageType(), is(storageType));
-      assertThat(report.getStorage().getState(), is(DatanodeStorage.State.NORMAL));
+      assertThat(report.getStorage().getStorageType()).isEqualTo(storageType);
+      assertThat(report.getStorage().getState()).isEqualTo(DatanodeStorage.State.NORMAL);
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTriggerBlockReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTriggerBlockReport.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStatus;
 import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part9.

### How was this patch tested?
Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

