### PR TITLE
YARN-11837. RM UI2 cannot show logs for non-MapReduce jobs with MR ACLs enabled.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
@@ -144,7 +144,7 @@ public class HsWebServices extends WebServices {
       AMWebServices.getJobFromContainerIdString(containerIdStr, ctx);
       return true;
     } catch (NotFoundException e) {
-      LOG.trace("Container " + containerIdStr + " does not belong to a MapReduce job");
+      LOG.trace("Container {} does not belong to a MapReduce job", containerIdStr);
       return false;
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsWebServices.java
@@ -83,11 +83,14 @@ import org.apache.hadoop.yarn.webapp.BadRequestException;
 import org.apache.hadoop.yarn.webapp.NotFoundException;
 import org.apache.hadoop.yarn.webapp.WebApp;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.VisibleForTesting;
 
 @Singleton
 @Path("/ws/v1/history")
 public class HsWebServices extends WebServices {
+  private static final Logger LOG = LoggerFactory.getLogger(HsWebServices.class);
   private final HistoryContext ctx;
   private WebApp webapp;
   private LogServlet logServlet;
@@ -127,8 +130,22 @@ public class HsWebServices extends WebServices {
     }
   }
   private void checkAccess(String containerIdStr, HttpServletRequest hsr) {
-    if (mrAclsEnabled) {
-      checkAccess(AMWebServices.getJobFromContainerIdString(containerIdStr, ctx), hsr);
+    // Apply MR ACLs only if the container belongs to a MapReduce job.
+    // For non-MapReduce jobs, no corresponding Job will be found,
+    // so ACLs are not enforced.
+    if (mrAclsEnabled && isMRJobContainer(containerIdStr)) {
+      Job job = AMWebServices.getJobFromContainerIdString(containerIdStr, ctx);
+      checkAccess(job, hsr);
+    }
+  }
+
+  private boolean isMRJobContainer(String containerIdStr) {
+    try {
+      AMWebServices.getJobFromContainerIdString(containerIdStr, ctx);
+      return true;
+    } catch (NotFoundException e) {
+      LOG.trace("Container " + containerIdStr + " does not belong to a MapReduce job");
+      return false;
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

YARN-11837. RM UI2 cannot show logs for non-MapReduce jobs with MR ACLs enabled.

### How was this patch tested?

Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

