### PR TITLE
YARN-11838: YARN ConcurrentModificationException When Refreshing Node Attributes

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/NodeAttributesManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/nodelabels/NodeAttributesManagerImpl.java
@@ -741,7 +741,14 @@ public class NodeAttributesManagerImpl extends NodeAttributesManager {
     if (host == null || host.attributes == null) {
       return;
     }
-    newNodeToAttributesMap.put(hostName, host.attributes.keySet());
+    // Use read lock and create defensive copy since
+    // other threads might access host.attributes
+    readLock.lock();
+    try {
+      newNodeToAttributesMap.put(hostName, new HashSet<>(host.attributes.keySet()));
+    } finally {
+      readLock.unlock();
+    }
 
     // Notify RM
     if (rmContext != null && rmContext.getDispatcher() != null) {


### PR DESCRIPTION
### Description of PR

Refer YARN-11838 for more details.

The issue is that.

1. The LOG statement which prints newNodeToAttributesMap tries to iterate host.attribute
2. host.attribute gets modified by some other thread - leading to concurrent modification exception.

There are two ways to solve this
1.  To readLock before LOG statement so that host.attribute does not get modified during LOG statement
2.  Create a defensive copy of host.attribute (under read lock because the modification can happen at that time as well).

The rationale behind using option 2 to avoid logging inconsistency- Assume that we readLock before LOG statement. Once the LOG statement is executed, some other thread modifies the host.attribute this will lead to we logging something and processing something else.

Creating a defensive copy make sure that we don't change value. i.e what is LOGed gets processed as well.


### How was this patch tested?

Added unit test

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

