### PR TITLE
HDFS-17813. NameCache promote wrong name to cache map

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameCache.java
@@ -108,7 +108,7 @@ class NameCache<K> {
       if (useCount != null) {
         useCount.increment();
         if (useCount.get() >= useThreshold) {
-          promote(name);
+          promote(useCount.value);
         }
         return useCount.value;
       }


### PR DESCRIPTION
### Description of PR
Refer to [HDFS-17813](https://issues.apache.org/jira/browse/HDFS-17813).

The NameCache class is used to cache frequently used names in namenode, it promotes a name used more than useThreshold to the cache, the promote logic:

```
K put(final K name) {
  K internal = cache.get(name);
  if (internal != null) {
    lookups++;
    return internal;
  }

  // Track the usage count only during initialization
  if (!initialized) {
    UseCount useCount = transientMap.get(name);
    if (useCount != null) {
      useCount.increment();
      if (useCount.get() >= useThreshold) {
        promote(name); // name got promoted
      }
      return useCount.value;
    }
    useCount = new UseCount(name);
    transientMap.put(name, useCount);
  }
  return null;
} 

```
When promoting, the cache stores the `name` parameter from put() instead of the existing useCount.value. This causes the returned value to change after a name is promoted, resulting in memory duplication.

