### PR TITLE
HADOOP-19645. [ABFS][ReadAheadV2] Improve Metrics for Read Calls to identify type of read done.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -958,6 +958,10 @@ public class AbfsConfiguration{
     return this.footerReadBufferSize;
   }
 
+  /**
+   * Returns whether the buffered pread is disabled.
+   * @return true if buffered pread is disabled, false otherwise.
+   */
   public boolean isBufferedPReadDisabled() {
     return this.isBufferedPReadDisabled;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -139,6 +139,11 @@ public class AbfsConfiguration{
   private int footerReadBufferSize;
 
   @BooleanConfigurationValidatorAnnotation(
+      ConfigurationKey = FS_AZURE_BUFFERED_PREAD_DISABLE,
+      DefaultValue = DEFAULT_BUFFERED_PREAD_DISABLE)
+  private boolean isBufferedPReadDisabled;
+
+  @BooleanConfigurationValidatorAnnotation(
       ConfigurationKey = FS_AZURE_ACCOUNT_IS_EXPECT_HEADER_ENABLED,
       DefaultValue = DEFAULT_FS_AZURE_ACCOUNT_IS_EXPECT_HEADER_ENABLED)
   private boolean isExpectHeaderEnabled;
@@ -951,6 +956,10 @@ public class AbfsConfiguration{
 
   public int getFooterReadBufferSize() {
     return this.footerReadBufferSize;
+  }
+
+  public boolean isBufferedPReadDisabled() {
+    return this.isBufferedPReadDisabled;
   }
 
   public int getReadBufferSize() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -945,8 +945,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   private AbfsInputStreamContext populateAbfsInputStreamContext(
       Optional<Configuration> options, ContextEncryptionAdapter contextEncryptionAdapter) {
     boolean bufferedPreadDisabled = options
-        .map(c -> c.getBoolean(FS_AZURE_BUFFERED_PREAD_DISABLE, false))
-        .orElse(false);
+        .map(c -> c.getBoolean(FS_AZURE_BUFFERED_PREAD_DISABLE,
+            getAbfsConfiguration().isBufferedPReadDisabled()))
+        .orElse(getAbfsConfiguration().isBufferedPReadDisabled());
     int footerReadBufferSize = options.map(c -> c.getInt(
         AZURE_FOOTER_READ_BUFFER_SIZE, getAbfsConfiguration().getFooterReadBufferSize()))
         .orElse(getAbfsConfiguration().getFooterReadBufferSize());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -203,6 +203,27 @@ public final class AbfsHttpConstants {
     }
   }
 
+  public enum TracingHeaderVersion {
+
+    V0(""),
+    V1("v1");
+
+    private final String tracingHeaderVersion;
+
+    TracingHeaderVersion(String tracingHeaderVersion) {
+      this.tracingHeaderVersion = tracingHeaderVersion;
+    }
+
+    @Override
+    public String toString() {
+      return tracingHeaderVersion;
+    }
+
+    public static TracingHeaderVersion getCurrentVersion() {
+      return V1;
+    }
+  }
+
   /**
    * List of Constants Used by Blob Endpoint Rest APIs.
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -175,6 +175,8 @@ public final class AbfsHttpConstants {
   public static final char CHAR_STAR = '*';
   public static final char CHAR_PLUS = '+';
 
+  public static final int SPLIT_NO_LIMIT = -1;
+
   /**
    * Specifies the version of the REST protocol used for processing the request.
    * Versions should be added in enum list in ascending chronological order.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -128,7 +128,6 @@ public final class AbfsHttpConstants {
   public static final String STAR = "*";
   public static final String COMMA = ",";
   public static final String COLON = ":";
-  public static final String HYPHEN = "-";
   public static final String EQUAL = "=";
   public static final String QUESTION_MARK = "?";
   public static final String AND_MARK = "&";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -128,6 +128,7 @@ public final class AbfsHttpConstants {
   public static final String STAR = "*";
   public static final String COMMA = ",";
   public static final String COLON = ":";
+  public static final String HYPHEN = "-";
   public static final String EQUAL = "=";
   public static final String QUESTION_MARK = "?";
   public static final String AND_MARK = "&";
@@ -200,27 +201,6 @@ public final class AbfsHttpConstants {
 
     public static ApiVersion getCurrentVersion() {
       return NOV_04_2024;
-    }
-  }
-
-  public enum TracingHeaderVersion {
-
-    V0(""),
-    V1("v1");
-
-    private final String tracingHeaderVersion;
-
-    TracingHeaderVersion(String tracingHeaderVersion) {
-      this.tracingHeaderVersion = tracingHeaderVersion;
-    }
-
-    @Override
-    public String toString() {
-      return tracingHeaderVersion;
-    }
-
-    public static TracingHeaderVersion getCurrentVersion() {
-      return V1;
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -75,6 +75,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_READ_SMALL_FILES_COMPLETELY = false;
   public static final boolean DEFAULT_OPTIMIZE_FOOTER_READ = true;
   public static final int DEFAULT_FOOTER_READ_BUFFER_SIZE = 512 * ONE_KB;
+  public static final boolean DEFAULT_BUFFERED_PREAD_DISABLE = false;
   public static final boolean DEFAULT_ALWAYS_READ_BUFFER_SIZE = false;
   public static final int DEFAULT_READ_AHEAD_BLOCK_SIZE = 4 * ONE_MB;
   public static final int DEFAULT_READ_AHEAD_RANGE = 64 * ONE_KB; // 64 KB

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
@@ -16,22 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.fs.azurebfs.utils;
+package org.apache.hadoop.fs.azurebfs.constants;
 
-import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
-import org.apache.hadoop.fs.azurebfs.constants.ReadType;
+public enum ReadType {
+  DIRECT_READ("DR"),
+  NORMAL_READ("NR"),
+  PREFETCH_READ("PR"),
+  MISSEDCACHE_READ("MR"),
+  FOOTER_READ("FR"),
+  SMALLFILE_READ("SR"),
+  UNKNOWN_READ("UR");
 
-/**
- * Interface for testing identifiers tracked via TracingContext
- * Implemented in TracingHeaderValidator
- */
+  private final String readType;
 
-public interface Listener {
-  void callTracingHeaderValidator(String header, TracingHeaderFormat format);
-  void updatePrimaryRequestID(String primaryRequestID);
-  Listener getClone();
-  void setOperation(FSOperationType operation);
-  void updateIngressHandler(String ingressHandler);
-  void updatePosition(String position);
-  void updateReadType(ReadType readType);
+  ReadType(String readType) {
+    this.readType = readType;
+  }
+
+  @Override
+  public String toString() {
+    return readType;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
@@ -59,6 +59,11 @@ public enum ReadType {
     this.readType = readType;
   }
 
+  /**
+   * Get the read type as a string.
+   *
+   * @return the read type string
+   */
   @Override
   public String toString() {
     return readType;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ReadType.java
@@ -18,13 +18,39 @@
 
 package org.apache.hadoop.fs.azurebfs.constants;
 
+/**
+ * Enumeration for different types of read operations triggered by AbfsInputStream.
+ */
 public enum ReadType {
+  /**
+   * Synchronous read from the storage service. No optimization is being applied.
+   */
   DIRECT_READ("DR"),
+  /**
+   * Synchronous read from the storage service where optimization were considered but found disabled.
+   */
   NORMAL_READ("NR"),
+  /**
+   * Asynchronous read from the storage service for filling up cache.
+   */
   PREFETCH_READ("PR"),
+  /**
+   * Synchronous read from the storage service when nothing was found in cache.
+   */
   MISSEDCACHE_READ("MR"),
+  /**
+   * Synchronous read from the storage service for reading the footer of a file.
+   * Only triggered when footer read optimization kicks in.
+   */
   FOOTER_READ("FR"),
+  /**
+   * Synchronous read from the storage service for reading a small file fully.
+   * Only triggered when small file read optimization kicks in.
+   */
   SMALLFILE_READ("SR"),
+  /**
+   * None of the above read types were applicable.
+   */
   UNKNOWN_READ("UR");
 
   private final String readType;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.impl.BackReference;
 import org.apache.hadoop.util.Preconditions;
 
@@ -165,6 +166,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     this.tracingContext = new TracingContext(tracingContext);
     this.tracingContext.setOperation(FSOperationType.READ);
     this.tracingContext.setStreamID(inputStreamId);
+    this.tracingContext.setReadType(ReadType.UNKNOWN_READ);
     this.context = abfsInputStreamContext;
     readAheadBlockSize = abfsInputStreamContext.getReadAheadBlockSize();
     if (abfsReadFooterMetrics != null) {
@@ -227,7 +229,9 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     if (streamStatistics != null) {
       streamStatistics.readOperationStarted();
     }
-    int bytesRead = readRemote(position, buffer, offset, length, tracingContext);
+    TracingContext tc = new TracingContext(tracingContext);
+    tc.setReadType(ReadType.DIRECT_READ);
+    int bytesRead = readRemote(position, buffer, offset, length, tc);
     if (statistics != null) {
       statistics.incrementBytesRead(bytesRead);
     }
@@ -345,6 +349,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
         buffer = new byte[bufferSize];
       }
 
+      tracingContext.setReadType(ReadType.NORMAL_READ);
       if (alwaysReadBufferSize) {
         bytesRead = readInternal(fCursor, buffer, 0, bufferSize, false);
       } else {
@@ -385,6 +390,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     // data need to be copied to user buffer from index bCursor, bCursor has
     // to be the current fCusor
     bCursor = (int) fCursor;
+    tracingContext.setReadType(ReadType.SMALLFILE_READ);
     return optimisedRead(b, off, len, 0, contentLength);
   }
 
@@ -405,6 +411,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     bCursor = (int) (fCursor - lastBlockStart);
     // 0 if contentlength is < buffersize
     long actualLenToRead = min(footerReadSize, contentLength);
+    tracingContext.setReadType(ReadType.FOOTER_READ);
     return optimisedRead(b, off, len, lastBlockStart, actualLenToRead);
   }
 
@@ -428,6 +435,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       }
     } catch (IOException e) {
       LOG.debug("Optimized read failed. Defaulting to readOneBlock {}", e);
+      tracingContext.setReadType(ReadType.NORMAL_READ);
       restorePointerState();
       return readOneBlock(b, off, len);
     } finally {
@@ -442,6 +450,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     //  bCursor that means the user requested data has not been read.
     if (fCursor < contentLength && bCursor > limit) {
       restorePointerState();
+      tracingContext.setReadType(ReadType.NORMAL_READ);
       return readOneBlock(b, off, len);
     }
     return copyToUserBuffer(b, off, len);
@@ -520,6 +529,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       LOG.debug("read ahead enabled issuing readheads num = {}", numReadAheads);
       TracingContext readAheadTracingContext = new TracingContext(tracingContext);
       readAheadTracingContext.setPrimaryRequestID();
+      readAheadTracingContext.setReadType(ReadType.PREFETCH_READ);
       while (numReadAheads > 0 && nextOffset < contentLength) {
         LOG.debug("issuing read ahead requestedOffset = {} requested size {}",
             nextOffset, nextSize);
@@ -544,7 +554,9 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       }
 
       // got nothing from read-ahead, do our own read now
-      receivedBytes = readRemote(position, b, offset, length, new TracingContext(tracingContext));
+      TracingContext tc = new TracingContext(tracingContext);
+      tc.setReadType(ReadType.MISSEDCACHE_READ);
+      receivedBytes = readRemote(position, b, offset, length, tc);
       return receivedBytes;
     } else {
       LOG.debug("read ahead disabled, reading remote");
@@ -578,6 +590,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
         streamStatistics.remoteReadOperation();
       }
       LOG.trace("Trigger client.read for path={} position={} offset={} length={}", path, position, offset, length);
+      tracingContext.setPosition(String.valueOf(position));
       op = client.read(path, position, b, offset, length,
           tolerateOobAppends ? "*" : eTag, cachedSasToken.get(),
           contextEncryptionAdapter, tracingContext);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -436,7 +436,6 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
       }
     } catch (IOException e) {
       LOG.debug("Optimized read failed. Defaulting to readOneBlock {}", e);
-      tracingContext.setReadType(ReadType.NORMAL_READ);
       restorePointerState();
       return readOneBlock(b, off, len);
     } finally {
@@ -451,7 +450,6 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     //  bCursor that means the user requested data has not been read.
     if (fCursor < contentLength && bCursor > limit) {
       restorePointerState();
-      tracingContext.setReadType(ReadType.NORMAL_READ);
       return readOneBlock(b, off, len);
     }
     return copyToUserBuffer(b, off, len);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -349,6 +349,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
         buffer = new byte[bufferSize];
       }
 
+      // Reset Read Type back to normal and set again based on code flow.
       tracingContext.setReadType(ReadType.NORMAL_READ);
       if (alwaysReadBufferSize) {
         bytesRead = readInternal(fCursor, buffer, 0, bufferSize, false);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobDeleteHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobDeleteHandler.java
@@ -126,7 +126,7 @@ public class BlobDeleteHandler extends ListActionTaker {
        */
       deleted = recursive ? safeDelete(path) : deleteInternal(path);
     } finally {
-      tracingContext.setOperatedBlobCount(null);
+      tracingContext.setOperatedBlobCount(0);
     }
     if (deleteCount.get() == 0) {
       /*

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobRenameHandler.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/BlobRenameHandler.java
@@ -204,7 +204,7 @@ public class BlobRenameHandler extends ListActionTaker {
       }
       throw e;
     } finally {
-      tracingContext.setOperatedBlobCount(null);
+      tracingContext.setOperatedBlobCount(0);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.hadoop.fs.PathIOException;
-import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
-import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 class ReadBufferWorker implements Runnable {
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ReadBufferWorker.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 class ReadBufferWorker implements Runnable {
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -30,7 +30,9 @@ import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HYPHEN;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
 /**
@@ -80,8 +82,7 @@ public class TracingContext {
    * this field shall not be set.
    */
   private String primaryRequestIdForRetry;
-
-  private Integer operatedBlobCount = null;
+  private Integer operatedBlobCount = 1; // Only relevant for rename-delete over blob endpoint where it will be explicitly set.
 
   private static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   public static final int MAX_CLIENT_CORRELATION_ID_LENGTH = 72;
@@ -189,7 +190,7 @@ public class TracingContext {
    * X_MS_CLIENT_REQUEST_ID header of the http operation
    * Following are the components in order of concatenation:
    * <ul>
-   *   <li>version - not present for versions less than < 1</li>
+   *   <li>version - not present for versions less than v1</li>
    *   <li>clientCorrelationId</li>
    *   <li>clientRequestId</li>
    *   <li>fileSystemId</li>
@@ -214,35 +215,32 @@ public class TracingContext {
     clientRequestId = UUID.randomUUID().toString();
     switch (format) {
     case ALL_ID_FORMAT:
-      header =
-          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
-          clientCorrelationID + ":" +
-          clientRequestId + ":" +
-          fileSystemID + ":" +
-          getPrimaryRequestIdForHeader(retryCount > 0) + ":" +
-          streamID + ":" +
-          opType + ":" +
-          getRetryHeader(previousFailure, retryPolicyAbbreviation) + ":" +
-          ingressHandler + ":" +
-          position + ":" +
-          operatedBlobCount + ":" +
-          httpOperation.getTracingContextSuffix() + ":" +
-          getOperationSpecificHeader(opType);
+      header = TracingHeaderVersion.V1.getVersion() + COLON
+          + clientCorrelationID + COLON
+          + clientRequestId + COLON
+          + fileSystemID + COLON
+          + getPrimaryRequestIdForHeader(retryCount > 0) + COLON
+          + streamID + COLON
+          + opType + COLON
+          + getRetryHeader(previousFailure, retryPolicyAbbreviation) + COLON
+          + ingressHandler + COLON
+          + position + COLON
+          + operatedBlobCount + COLON
+          + httpOperation.getTracingContextSuffix() + COLON
+          + getOperationSpecificHeader(opType);
 
-      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
+      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
       break;
     case TWO_ID_FORMAT:
-      header =
-          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
-          clientCorrelationID + ":" + clientRequestId;
-      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
+      header = TracingHeaderVersion.V1.getVersion() + COLON
+          + clientCorrelationID + COLON + clientRequestId;
+      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
       break;
     default:
       //case SINGLE_ID_FORMAT
-      header =
-          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
-          clientRequestId;
-      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
+      header = TracingHeaderVersion.V1.getVersion() + COLON
+          + clientRequestId;
+      metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
     }
     if (listener != null) { //for testing
       listener.callTracingHeaderValidator(header, format);
@@ -258,7 +256,7 @@ public class TracingContext {
     * of the x-ms-client-request-id header in case of retry of the same API-request.
     */
     if (primaryRequestId.isEmpty() && previousFailure == null) {
-      String[] clientRequestIdParts = clientRequestId.split("-");
+      String[] clientRequestIdParts = clientRequestId.split(HYPHEN);
       primaryRequestIdForRetry = clientRequestIdParts[
           clientRequestIdParts.length - 1];
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -67,7 +67,7 @@ public class TracingContext {
   //final concatenated ID list set into x-ms-client-request-id header
   private String header = EMPTY_STRING;
   private String ingressHandler = EMPTY_STRING;
-  private String position = EMPTY_STRING;
+  private String position = String.valueOf(0); // position of read/write in remote file
   private String metricResults = EMPTY_STRING;
   private String metricHeader = EMPTY_STRING;
   private ReadType readType = ReadType.UNKNOWN_READ;
@@ -80,7 +80,7 @@ public class TracingContext {
    * will not change this field. In case {@link  #primaryRequestId} is non-null,
    * this field shall not be set.
    */
-  private String primaryRequestIdForRetry;
+  private String primaryRequestIdForRetry = EMPTY_STRING;
   private Integer operatedBlobCount = 1; // Only relevant for rename-delete over blob endpoint where it will be explicitly set.
 
   private static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
@@ -200,8 +200,8 @@ public class TracingContext {
    *   <li>ingressHandler</li>
    *   <li>position of read/write in the remote file</li>
    *   <li>operatedBlobCount - number of blobs operated on by this request</li>
-   *   <li>httpOperationHeader - suffix for network library used</li>
    *   <li>operationSpecificHeader - different operation types can publish info relevant to that operation</li>
+   *   <li>httpOperationHeader - suffix for network library used</li>
    * </ul>
    * @param httpOperation AbfsHttpOperation instance to set header into
    *                      connection
@@ -275,6 +275,15 @@ public class TracingContext {
     return primaryRequestIdForRetry;
   }
 
+  /**
+   * Get the retry header string in format retryCount_failureReason_retryPolicyAbbreviation
+   * retryCount is always there and 0 for first request.
+   * failureReason is null for first request
+   * retryPolicyAbbreviation is only present when request fails with ConnectionTimeout
+   * @param previousFailure Previous failure reason, null if not a retried request
+   * @param retryPolicyAbbreviation Abbreviation of retry policy used to get retry interval
+   * @return String representing the retry header
+   */
   private String getRetryHeader(final String previousFailure, String retryPolicyAbbreviation) {
     String retryHeader = String.format("%d", retryCount);
     if (previousFailure == null) {
@@ -286,6 +295,11 @@ public class TracingContext {
     return String.format("%s_%s", retryHeader, previousFailure);
   }
 
+  /**
+   * Get the operation specific header for the current operation type.
+   * @param opType The operation type for which the header is needed
+   * @return String representing the operation specific header
+   */
   private String getOperationSpecificHeader(FSOperationType opType) {
     // Similar header can be added for other operations in the future.
     switch (opType) {
@@ -296,6 +310,10 @@ public class TracingContext {
     }
   }
 
+  /**
+   * Get the operation specific header for read operations.
+   * @return String representing the read specific header
+   */
   private String getReadSpecificHeader() {
     // More information on read can be added to this header in the future.
     // As underscore separated values.
@@ -361,14 +379,14 @@ public class TracingContext {
     }
   }
 
+  /**
+   * Sets the read type for the current operation.
+   * @param readType the read type to set, must not be null.
+   */
   public void setReadType(ReadType readType) {
     this.readType = readType;
     if (listener != null) {
       listener.updateReadType(readType);
     }
-  }
-
-  public ReadType getReadType() {
-    return readType;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -67,7 +67,7 @@ public class TracingContext {
   //final concatenated ID list set into x-ms-client-request-id header
   private String header = EMPTY_STRING;
   private String ingressHandler = EMPTY_STRING;
-  private String position = String.valueOf(0); // position of read/write in remote file
+  private String position = EMPTY_STRING; // position of read/write in remote file
   private String metricResults = EMPTY_STRING;
   private String metricHeader = EMPTY_STRING;
   private ReadType readType = ReadType.UNKNOWN_READ;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -23,16 +23,15 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CHAR_HYPHEN;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HYPHEN;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;
 
 /**
@@ -256,7 +255,7 @@ public class TracingContext {
     * of the x-ms-client-request-id header in case of retry of the same API-request.
     */
     if (primaryRequestId.isEmpty() && previousFailure == null) {
-      String[] clientRequestIdParts = clientRequestId.split(HYPHEN);
+      String[] clientRequestIdParts = clientRequestId.split(String.valueOf(CHAR_HYPHEN));
       primaryRequestIdForRetry = clientRequestIdParts[
           clientRequestIdParts.length - 1];
     }
@@ -302,13 +301,13 @@ public class TracingContext {
     // Similar header can be added for other operations in the future.
     switch (opType) {
       case READ:
-        return readSpecificHeader();
+        return getReadSpecificHeader();
       default:
         return EMPTY_STRING; // no operation specific header
     }
   }
 
-  private String readSpecificHeader() {
+  private String getReadSpecificHeader() {
     // More information on read can be added to this header in the future.
     // As underscore separated values.
     String readHeader = String.format("%s", readType.toString());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -23,8 +23,10 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
+import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 
@@ -67,6 +69,7 @@ public class TracingContext {
   private String position = EMPTY_STRING;
   private String metricResults = EMPTY_STRING;
   private String metricHeader = EMPTY_STRING;
+  private ReadType readType;
 
   /**
    * If {@link #primaryRequestId} is null, this field shall be set equal
@@ -142,6 +145,7 @@ public class TracingContext {
       this.listener = originalTracingContext.listener.getClone();
     }
     this.metricResults = originalTracingContext.metricResults;
+    this.readType = originalTracingContext.readType;
   }
   public static String validateClientCorrelationID(String clientCorrelationID) {
     if ((clientCorrelationID.length() > MAX_CLIENT_CORRELATION_ID_LENGTH)
@@ -181,8 +185,24 @@ public class TracingContext {
   }
 
   /**
-   * Concatenate all identifiers separated by (:) into a string and set into
+   * Concatenate all components separated by (:) into a string and set into
    * X_MS_CLIENT_REQUEST_ID header of the http operation
+   * Following are the components in order of concatenation:
+   * <ul>
+   *   <li>version - not present for versions less than < 1</li>
+   *   <li>clientCorrelationId</li>
+   *   <li>clientRequestId</li>
+   *   <li>fileSystemId</li>
+   *   <li>primaryRequestId</li>
+   *   <li>streamId</li>
+   *   <li>opType</li>
+   *   <li>retryHeader - this contains retryCount, failureReason and retryPolicy underscore separated</li>
+   *   <li>ingressHandler</li>
+   *   <li>position of read/write in the remote file</li>
+   *   <li>operatedBlobCount - number of blobs operated on by this request</li>
+   *   <li>httpOperationHeader - suffix for network library used</li>
+   *   <li>operationSpecificHeader - different operation types can publish info relevant to that operation</li>
+   * </ul>
    * @param httpOperation AbfsHttpOperation instance to set header into
    *                      connection
    * @param previousFailure Failure seen before this API trigger on same operation
@@ -193,22 +213,22 @@ public class TracingContext {
   public void constructHeader(AbfsHttpOperation httpOperation, String previousFailure, String retryPolicyAbbreviation) {
     clientRequestId = UUID.randomUUID().toString();
     switch (format) {
-    case ALL_ID_FORMAT: // Optional IDs (e.g. streamId) may be empty
+    case ALL_ID_FORMAT:
       header =
-          clientCorrelationID + ":" + clientRequestId + ":" + fileSystemID + ":"
-              + getPrimaryRequestIdForHeader(retryCount > 0) + ":" + streamID
-              + ":" + opType + ":" + retryCount;
-      header = addFailureReasons(header, previousFailure, retryPolicyAbbreviation);
-      if (!(ingressHandler.equals(EMPTY_STRING))) {
-        header += ":" + ingressHandler;
-      }
-      if (!(position.equals(EMPTY_STRING))) {
-        header += ":" + position;
-      }
-      if (operatedBlobCount != null) {
-        header += (":" + operatedBlobCount);
-      }
-      header += (":" + httpOperation.getTracingContextSuffix());
+          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
+          clientCorrelationID + ":" +
+          clientRequestId + ":" +
+          fileSystemID + ":" +
+          getPrimaryRequestIdForHeader(retryCount > 0) + ":" +
+          streamID + ":" +
+          opType + ":" +
+          getRetryHeader(previousFailure, retryPolicyAbbreviation) + ":" +
+          ingressHandler + ":" +
+          position + ":" +
+          operatedBlobCount + ":" +
+          httpOperation.getTracingContextSuffix() + ":" +
+          getOperationSpecificHeader(opType);
+
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
       break;
     case TWO_ID_FORMAT:
@@ -263,6 +283,34 @@ public class TracingContext {
       return String.format("%s_%s_%s", header, previousFailure, retryPolicyAbbreviation);
     }
     return String.format("%s_%s", header, previousFailure);
+  }
+
+  private String getRetryHeader(final String previousFailure, String retryPolicyAbbreviation) {
+    String retryHeader = String.format("%d", retryCount);
+    if (previousFailure == null) {
+      return retryHeader;
+    }
+    if (CONNECTION_TIMEOUT_ABBREVIATION.equals(previousFailure) && retryPolicyAbbreviation != null) {
+      return String.format("%s_%s_%s", retryHeader, previousFailure, retryPolicyAbbreviation);
+    }
+    return String.format("%s_%s", retryHeader, previousFailure);
+  }
+
+  private String getOperationSpecificHeader(FSOperationType opType) {
+    // Similar header can be added for other operations in the future.
+    switch (opType) {
+      case READ:
+        return readSpecificHeader();
+      default:
+        return EMPTY_STRING; // no operation specific header
+    }
+  }
+
+  private String readSpecificHeader() {
+    // More information on read can be added to this header in the future.
+    // As underscore separated values.
+    String readHeader = String.format("%d", readType.toString());
+    return readHeader;
   }
 
   public void setOperatedBlobCount(Integer count) {
@@ -321,5 +369,16 @@ public class TracingContext {
     if (listener != null) {
       listener.updatePosition(position);
     }
+  }
+
+  public void setReadType(ReadType readType) {
+    this.readType = readType;
+    if (listener != null) {
+      listener.updateReadType(readType);
+    }
+  }
+
+  public ReadType getReadType() {
+    return readType;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -214,7 +214,7 @@ public class TracingContext {
     clientRequestId = UUID.randomUUID().toString();
     switch (format) {
     case ALL_ID_FORMAT:
-      header = TracingHeaderVersion.V1.getVersion() + COLON
+      header = TracingHeaderVersion.getCurrentVersion() + COLON
           + clientCorrelationID + COLON
           + clientRequestId + COLON
           + fileSystemID + COLON
@@ -225,19 +225,19 @@ public class TracingContext {
           + ingressHandler + COLON
           + position + COLON
           + operatedBlobCount + COLON
-          + httpOperation.getTracingContextSuffix() + COLON
-          + getOperationSpecificHeader(opType);
+          + getOperationSpecificHeader(opType) + COLON
+          + httpOperation.getTracingContextSuffix();
 
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
       break;
     case TWO_ID_FORMAT:
-      header = TracingHeaderVersion.V1.getVersion() + COLON
+      header = TracingHeaderVersion.getCurrentVersion() + COLON
           + clientCorrelationID + COLON + clientRequestId;
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
       break;
     default:
       //case SINGLE_ID_FORMAT
-      header = TracingHeaderVersion.V1.getVersion() + COLON
+      header = TracingHeaderVersion.getCurrentVersion() + COLON
           + clientRequestId;
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : EMPTY_STRING;
     }
@@ -273,17 +273,6 @@ public class TracingContext {
       return primaryRequestId;
     }
     return primaryRequestIdForRetry;
-  }
-
-  private String addFailureReasons(final String header,
-      final String previousFailure, String retryPolicyAbbreviation) {
-    if (previousFailure == null) {
-      return header;
-    }
-    if (CONNECTION_TIMEOUT_ABBREVIATION.equals(previousFailure) && retryPolicyAbbreviation != null) {
-      return String.format("%s_%s_%s", header, previousFailure, retryPolicyAbbreviation);
-    }
-    return String.format("%s_%s", header, previousFailure);
   }
 
   private String getRetryHeader(final String previousFailure, String retryPolicyAbbreviation) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -69,7 +69,7 @@ public class TracingContext {
   private String position = EMPTY_STRING;
   private String metricResults = EMPTY_STRING;
   private String metricHeader = EMPTY_STRING;
-  private ReadType readType;
+  private ReadType readType = ReadType.UNKNOWN_READ;
 
   /**
    * If {@link #primaryRequestId} is null, this field shall be set equal
@@ -232,12 +232,16 @@ public class TracingContext {
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
       break;
     case TWO_ID_FORMAT:
-      header = clientCorrelationID + ":" + clientRequestId;
+      header =
+          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
+          clientCorrelationID + ":" + clientRequestId;
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
       break;
     default:
       //case SINGLE_ID_FORMAT
-      header = clientRequestId;
+      header =
+          AbfsHttpConstants.TracingHeaderVersion.V1 + ":" +
+          clientRequestId;
       metricHeader += !(metricResults.trim().isEmpty()) ? metricResults  : "";
     }
     if (listener != null) { //for testing
@@ -309,7 +313,7 @@ public class TracingContext {
   private String readSpecificHeader() {
     // More information on read can be added to this header in the future.
     // As underscore separated values.
-    String readHeader = String.format("%d", readType.toString());
+    String readHeader = String.format("%s", readType.toString());
     return readHeader;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -81,7 +81,7 @@ public class TracingContext {
    * this field shall not be set.
    */
   private String primaryRequestIdForRetry = EMPTY_STRING;
-  private Integer operatedBlobCount = 1; // Only relevant for rename-delete over blob endpoint where it will be explicitly set.
+  private Integer operatedBlobCount = 0; // Only relevant for rename-delete over blob endpoint where it will be explicitly set.
 
   private static final Logger LOG = LoggerFactory.getLogger(AbfsClient.class);
   public static final int MAX_CLIENT_CORRELATION_ID_LENGTH = 72;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -34,6 +34,9 @@ public enum TracingHeaderVersion {
   /**
    * Version 1 of the tracing header, which includes a version prefix and has 13 permanent fields.
    * This version is used for the current tracing header schema.
+   * Schema: version:clientCorrelationId:clientRequestId:fileSystemId
+   *         :primaryRequestId:streamId:opType:retryHeader:ingressHandler
+   *         :position:operatedBlobCount:operationSpecificHeader:httpOperationHeader
    */
   V1("v1", 13);
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.utils;
 
 public enum TracingHeaderVersion {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -1,0 +1,32 @@
+package org.apache.hadoop.fs.azurebfs.utils;
+
+public enum TracingHeaderVersion {
+
+  V0("", 8),
+  V1("v1", 13);
+
+  private final String version;
+  private final int fieldCount;
+
+  TracingHeaderVersion(String version, int fieldCount) {
+    this.version = version;
+    this.fieldCount = fieldCount;
+  }
+
+  @Override
+  public String toString() {
+    return version;
+  }
+
+  public static TracingHeaderVersion getCurrentVersion() {
+    return V1;
+  }
+
+  public int getFieldCount() {
+    return V1.fieldCount;
+  }
+
+  public String getVersion() {
+    return V1.version;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderVersion.java
@@ -18,33 +18,52 @@
 
 package org.apache.hadoop.fs.azurebfs.utils;
 
+/**
+ * Enum representing the version of the tracing header used in Azure Blob File System (ABFS).
+ * It defines two versions: V0 and V1, with their respective field counts.
+ * Any changes to the tracing header should introduce a new version so that every
+ * version has a fixed predefined schema of fields.
+ */
 public enum TracingHeaderVersion {
 
+  /**
+   * Version 0 of the tracing header, which has no version prefix and contains 8 permanent and a few optional fields.
+   * This is the initial version of the tracing header.
+   */
   V0("", 8),
+  /**
+   * Version 1 of the tracing header, which includes a version prefix and has 13 permanent fields.
+   * This version is used for the current tracing header schema.
+   */
   V1("v1", 13);
 
-  private final String version;
+  private final String versionString;
   private final int fieldCount;
 
-  TracingHeaderVersion(String version, int fieldCount) {
-    this.version = version;
+  TracingHeaderVersion(String versionString, int fieldCount) {
+    this.versionString = versionString;
     this.fieldCount = fieldCount;
   }
 
   @Override
   public String toString() {
-    return version;
+    return versionString;
   }
 
+  /**
+   * Returns the latest version of the tracing header. Any changes done to the
+   * schema of tracing context header should be accompanied by a version bump.
+   * @return the latest version of the tracing header.
+   */
   public static TracingHeaderVersion getCurrentVersion() {
     return V1;
   }
 
   public int getFieldCount() {
-    return V1.fieldCount;
+    return fieldCount;
   }
 
-  public String getVersion() {
-    return V1.version;
+  public String getVersionString() {
+    return versionString;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -705,6 +706,12 @@ public abstract class AbstractAbfsIntegrationTest extends
     Assertions.assertThat(path.toString())
         .describedAs("Path does not contain expected DNS")
         .contains(expectedDns);
+  }
+
+  protected byte[] getRandomBytesArray(int length) {
+    final byte[] b = new byte[length];
+    new Random().nextBytes(b);
+    return b;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -227,7 +227,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
     Mockito.doNothing().when(abfsHttpOperation).setRequestProperty(Mockito.anyString(), Mockito.anyString());
     tracingContext.constructHeader(abfsHttpOperation, null, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     String header = tracingContext.getHeader();
-    String clientRequestIdUsed = header.split(":")[1];
+    String clientRequestIdUsed = header.split(":", -1)[2];
     String[] clientRequestIdUsedParts = clientRequestIdUsed.split("-");
     String assertionPrimaryId = clientRequestIdUsedParts[clientRequestIdUsedParts.length - 1];
 
@@ -239,7 +239,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
 
     tracingContext.constructHeader(abfsHttpOperation, READ_TIMEOUT_ABBREVIATION, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     header = tracingContext.getHeader();
-    String primaryRequestId = header.split(":")[3];
+    String primaryRequestId = header.split(":", -1)[4];
 
     Assertions.assertThat(primaryRequestId)
         .describedAs("PrimaryRequestId in a retried request's "
@@ -326,8 +326,8 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
   }
 
   private void checkHeaderForRetryPolicyAbbreviation(String header, String expectedFailureReason, String expectedRetryPolicyAbbreviation) {
-    String[] headerContents = header.split(":");
-    String previousReqContext = headerContents[6];
+    String[] headerContents = header.split(":", -1);
+    String previousReqContext = headerContents[7];
 
     if (expectedFailureReason != null) {
       Assertions.assertThat(previousReqContext.split("_")[1]).describedAs(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -48,7 +48,10 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Preconditions;
 import org.opentest4j.TestAbortedException;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CHAR_HYPHEN;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_CLIENT_CORRELATIONID;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_BUFFER_SIZE;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpOperationType.APACHE_HTTP_CLIENT;
@@ -227,8 +230,8 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
     Mockito.doNothing().when(abfsHttpOperation).setRequestProperty(Mockito.anyString(), Mockito.anyString());
     tracingContext.constructHeader(abfsHttpOperation, null, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     String header = tracingContext.getHeader();
-    String clientRequestIdUsed = header.split(":", -1)[2];
-    String[] clientRequestIdUsedParts = clientRequestIdUsed.split("-");
+    String clientRequestIdUsed = header.split(COLON, SPLIT_NO_LIMIT)[2];
+    String[] clientRequestIdUsedParts = clientRequestIdUsed.split(String.valueOf(CHAR_HYPHEN));
     String assertionPrimaryId = clientRequestIdUsedParts[clientRequestIdUsedParts.length - 1];
 
     tracingContext.setRetryCount(1);
@@ -239,7 +242,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
 
     tracingContext.constructHeader(abfsHttpOperation, READ_TIMEOUT_ABBREVIATION, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     header = tracingContext.getHeader();
-    String primaryRequestId = header.split(":", -1)[4];
+    String primaryRequestId = header.split(COLON, SPLIT_NO_LIMIT)[4];
 
     Assertions.assertThat(primaryRequestId)
         .describedAs("PrimaryRequestId in a retried request's "
@@ -326,7 +329,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
   }
 
   private void checkHeaderForRetryPolicyAbbreviation(String header, String expectedFailureReason, String expectedRetryPolicyAbbreviation) {
-    String[] headerContents = header.split(":", -1);
+    String[] headerContents = header.split(":", SPLIT_NO_LIMIT);
     String previousReqContext = headerContents[7];
 
     if (expectedFailureReason != null) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -267,7 +267,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
     Mockito.doNothing().when(abfsHttpOperation).setRequestProperty(Mockito.anyString(), Mockito.anyString());
     tracingContext.constructHeader(abfsHttpOperation, null, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     String header = tracingContext.getHeader();
-    String assertionPrimaryId = header.split(":")[3];
+    String assertionPrimaryId = header.split(COLON)[3];
 
     tracingContext.setRetryCount(1);
     tracingContext.setListener(new TracingHeaderValidator(
@@ -277,7 +277,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
 
     tracingContext.constructHeader(abfsHttpOperation, READ_TIMEOUT_ABBREVIATION, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
     header = tracingContext.getHeader();
-    String primaryRequestId = header.split(":")[3];
+    String primaryRequestId = header.split(COLON)[3];
 
     Assertions.assertThat(primaryRequestId)
         .describedAs("PrimaryRequestId in a retried request's tracingContext "
@@ -329,7 +329,7 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
   }
 
   private void checkHeaderForRetryPolicyAbbreviation(String header, String expectedFailureReason, String expectedRetryPolicyAbbreviation) {
-    String[] headerContents = header.split(":", SPLIT_NO_LIMIT);
+    String[] headerContents = header.split(COLON, SPLIT_NO_LIMIT);
     String previousReqContext = headerContents[7];
 
     if (expectedFailureReason != null) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.regex.Pattern;
 
 import org.assertj.core.api.Assertions;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -604,17 +604,6 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     return client.getTokenProvider();
   }
 
-  /**
-   * Test helper method to get random bytes array.
-   * @param length The length of byte buffer.
-   * @return byte buffer.
-   */
-  private byte[] getRandomBytesArray(int length) {
-    final byte[] b = new byte[length];
-    new Random().nextBytes(b);
-    return b;
-  }
-
   @Override
   public AzureBlobFileSystem getFileSystem(final Configuration configuration)
       throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -140,17 +140,6 @@ public class ITestAbfsRestOperation extends AbstractAbfsIntegrationTest {
     super();
   }
 
-  /**
-   * Test helper method to get random bytes array.
-   * @param length The length of byte buffer
-   * @return byte buffer
-   */
-  private byte[] getRandomBytesArray(int length) {
-    final byte[] b = new byte[length];
-    new Random().nextBytes(b);
-    return b;
-  }
-
   @Override
   public AzureBlobFileSystem getFileSystem(final Configuration configuration)
       throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -24,7 +24,6 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -26,10 +26,12 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AbfsCountersImpl;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +44,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore;
+import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
+import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TimeoutException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
 import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
@@ -49,6 +53,13 @@ import org.apache.hadoop.fs.azurebfs.utils.TestCachedSASToken;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.impl.OpenFileParameters;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.FOOTER_READ;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.MISSEDCACHE_READ;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.NORMAL_READ;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.PREFETCH_READ;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.SMALLFILE_READ;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -780,6 +791,131 @@ public class TestAbfsInputStream extends
         .isEqualTo(2);
     in.close();
   }
+
+  @Test
+  public void testReadTypeInTracingContextHeader() throws Exception {
+    AzureBlobFileSystem spiedFs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore spiedStore = Mockito.spy(spiedFs.getAbfsStore());
+    AbfsConfiguration spiedConfig = Mockito.spy(spiedStore.getAbfsConfiguration());
+    AbfsClient spiedClient = Mockito.spy(spiedStore.getClient());
+    Mockito.doReturn(ONE_MB).when(spiedConfig).getReadBufferSize();
+    Mockito.doReturn(ONE_MB).when(spiedConfig).getReadAheadBlockSize();
+    Mockito.doReturn(spiedClient).when(spiedStore).getClient();
+    Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
+    Mockito.doReturn(spiedConfig).when(spiedStore).getAbfsConfiguration();
+    int numOfReadCalls = 0;
+    int fileSize = 0;
+
+    /*
+     * Test to verify Normal Read Type.
+     * Disabling read ahead ensures that read type is normal read.
+     */
+    fileSize = 3 * ONE_MB; // To make sure multiple blocks are read.
+    numOfReadCalls += 3; // 3 blocks of 1MB each.
+    doReturn(false).when(spiedConfig).isReadAheadV2Enabled();
+    doReturn(false).when(spiedConfig).isReadAheadEnabled();
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, NORMAL_READ, numOfReadCalls);
+
+    /*
+     * Test to verify Missed Cache Read Type.
+     * Setting read ahead depth to 0 ensure that nothing can be got from prefetch.
+     * In such a case Input Stream will do a sequential read with missed cache read type.
+     */
+    fileSize = ONE_MB; // To make sure only one block is read.
+    numOfReadCalls += 1; // 1 block of 1MB.
+    Mockito.doReturn(0).when(spiedConfig).getReadAheadQueueDepth();
+    doReturn(true).when(spiedConfig).isReadAheadEnabled();
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, MISSEDCACHE_READ, numOfReadCalls);
+
+    /*
+     * Test to verify Prefetch Read Type.
+     * Setting read ahead depth to 2 with prefetch enabled ensures that prefetch is done.
+     * First read here might be Normal or Missed Cache but the rest 2 should be Prefetched Read.
+     */
+    fileSize = 3 * ONE_MB; // To make sure multiple blocks are read.
+    numOfReadCalls += 3;
+    doReturn(true).when(spiedConfig).isReadAheadEnabled();
+    Mockito.doReturn(3).when(spiedConfig).getReadAheadQueueDepth();
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, PREFETCH_READ, numOfReadCalls);
+
+    /*
+     * Test to verify Footer Read Type.
+     * Having file size less than footer read size and disabling small file opt
+     */
+    fileSize = 8 * ONE_KB;
+    numOfReadCalls += 1; // Full file will be read along with footer.
+    doReturn(false).when(spiedConfig).readSmallFilesCompletely();
+    doReturn(true).when(spiedConfig).optimizeFooterRead();
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, FOOTER_READ, numOfReadCalls);
+
+    /*
+     * Test to verify Small File Read Type.
+     * Having file size less than footer read size and disabling small file opt
+     */
+    fileSize = 8 * ONE_KB;
+    numOfReadCalls += 1; // Full file will be read along with footer.
+    doReturn(true).when(spiedConfig).readSmallFilesCompletely();
+    doReturn(false).when(spiedConfig).optimizeFooterRead();
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, SMALLFILE_READ, numOfReadCalls);
+  }
+
+  private void testReadTypeInTracingContextHeaderInternal(AzureBlobFileSystem fs, int fileSize, ReadType readType, int numOfReadCalls) throws Exception {
+    Path testPath = new Path("testFile");
+    byte[] fileContent = getRandomBytesArray(fileSize);
+    try (FSDataOutputStream oStream = fs.create(testPath)) {
+      oStream.write(fileContent);
+      oStream.flush();
+    }
+    try (FSDataInputStream iStream = fs.open(testPath)) {
+      int bytesRead = iStream.read(new byte[fileSize], 0,
+          fileSize);
+      Assertions.assertThat(fileSize)
+          .describedAs("Read size should match file size")
+          .isEqualTo(bytesRead);
+    }
+
+    ArgumentCaptor<String> captor1 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> captor2 = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<byte[]> captor3 = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> captor4 = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> captor5 = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<String> captor6 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> captor7 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<ContextEncryptionAdapter> captor8 = ArgumentCaptor.forClass(ContextEncryptionAdapter.class);
+    ArgumentCaptor<TracingContext> captor9 = ArgumentCaptor.forClass(TracingContext.class);
+
+    verify(fs.getAbfsStore().getClient(), times(numOfReadCalls)).read(
+        captor1.capture(), captor2.capture(), captor3.capture(),
+        captor4.capture(), captor5.capture(), captor6.capture(),
+        captor7.capture(), captor8.capture(), captor9.capture());
+    TracingContext tracingContext = captor9.getAllValues().get(numOfReadCalls - 1);
+    verifyHeaderForReadTypeInTracingContextHeader(tracingContext, readType);
+  }
+
+  private void verifyHeaderForReadTypeInTracingContextHeader(TracingContext tracingContext, ReadType readType) {
+    AbfsHttpOperation mockOp = Mockito.mock(AbfsHttpOperation.class);
+    doReturn(EMPTY_STRING).when(mockOp).getTracingContextSuffix();
+    tracingContext.constructHeader(mockOp, null, null);
+    String[] idList = tracingContext.getHeader().split(COLON, -1);
+    Assertions.assertThat(idList).describedAs("Client Request Id should have all fields").hasSize(13);
+    Assertions.assertThat(idList[6]).describedAs("Operation Type Shoudl Be Read")
+        .isEqualTo(FSOperationType.READ.toString());
+    Assertions.assertThat(idList[12]).describedAs("Read type in tracing context header should match")
+        .isEqualTo(readType.toString());
+  }
+
+//  private testReadTypeInTracingContextHeaderInternal(ReadType readType) throws Exception {
+//    switch (readType) {
+//      case DIRECT_READ:
+//        return AbfsRestOperationType.Read;
+//      case NORMAL_READ:
+//        return AbfsRestOperationType.ReadAhead;
+//      case PREFETCH_READ:
+//        return AbfsRestOperationType.ReadRemote;
+//      default:
+//        throw new IllegalArgumentException("Unknown read type: " + readType);
+//    }
+//  }
 
 
   private void testReadAheads(AbfsInputStream inputStream,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -936,7 +936,7 @@ public class TestAbfsInputStream extends
     if (readType == PREFETCH_READ) {
       /*
        * For Prefetch Enabled, first read can be Normal or Missed Cache Read.
-       * Sow e will assert only for last 2 calls which should be Prefetched Read.
+       * So we will assert only for last 2 calls which should be Prefetched Read.
        * Since calls are asynchronous, we can not guarantee the order of calls.
        * Therefore, we cannot assert on exact position here.
        */

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
@@ -57,6 +58,7 @@ import org.apache.hadoop.fs.impl.OpenFileParameters;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
+import static org.apache.hadoop.fs.azurebfs.constants.ReadType.DIRECT_READ;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.FOOTER_READ;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.MISSEDCACHE_READ;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.NORMAL_READ;
@@ -805,7 +807,7 @@ public class TestAbfsInputStream extends
     Mockito.doReturn(spiedClient).when(spiedStore).getClient();
     Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
     Mockito.doReturn(spiedConfig).when(spiedStore).getAbfsConfiguration();
-    int numOfReadCalls = 0;
+    int totalReadCalls = 0;
     int fileSize = 0;
 
     /*
@@ -813,10 +815,10 @@ public class TestAbfsInputStream extends
      * Disabling read ahead ensures that read type is normal read.
      */
     fileSize = 3 * ONE_MB; // To make sure multiple blocks are read.
-    numOfReadCalls += 3; // 3 blocks of 1MB each.
+    totalReadCalls += 3; // 3 blocks of 1MB each.
     doReturn(false).when(spiedConfig).isReadAheadV2Enabled();
     doReturn(false).when(spiedConfig).isReadAheadEnabled();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, NORMAL_READ, numOfReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, NORMAL_READ, 3, totalReadCalls);
 
     /*
      * Test to verify Missed Cache Read Type.
@@ -824,10 +826,10 @@ public class TestAbfsInputStream extends
      * In such a case Input Stream will do a sequential read with missed cache read type.
      */
     fileSize = ONE_MB; // To make sure only one block is read.
-    numOfReadCalls += 1; // 1 block of 1MB.
+    totalReadCalls += 1; // 1 block of 1MB.
     Mockito.doReturn(0).when(spiedConfig).getReadAheadQueueDepth();
     doReturn(true).when(spiedConfig).isReadAheadEnabled();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, MISSEDCACHE_READ, numOfReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, MISSEDCACHE_READ, 1, totalReadCalls);
 
     /*
      * Test to verify Prefetch Read Type.
@@ -835,39 +837,69 @@ public class TestAbfsInputStream extends
      * First read here might be Normal or Missed Cache but the rest 2 should be Prefetched Read.
      */
     fileSize = 3 * ONE_MB; // To make sure multiple blocks are read.
-    numOfReadCalls += 3;
+    totalReadCalls += 3;
     doReturn(true).when(spiedConfig).isReadAheadEnabled();
     Mockito.doReturn(3).when(spiedConfig).getReadAheadQueueDepth();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, PREFETCH_READ, numOfReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, PREFETCH_READ, 3, totalReadCalls);
 
     /*
      * Test to verify Footer Read Type.
      * Having file size less than footer read size and disabling small file opt
      */
     fileSize = 8 * ONE_KB;
-    numOfReadCalls += 1; // Full file will be read along with footer.
+    totalReadCalls += 1; // Full file will be read along with footer.
     doReturn(false).when(spiedConfig).readSmallFilesCompletely();
     doReturn(true).when(spiedConfig).optimizeFooterRead();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, FOOTER_READ, numOfReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, FOOTER_READ, 1, totalReadCalls);
 
     /*
      * Test to verify Small File Read Type.
      * Having file size less than footer read size and disabling small file opt
      */
     fileSize = 8 * ONE_KB;
-    numOfReadCalls += 1; // Full file will be read along with footer.
+    totalReadCalls += 1; // Full file will be read along with footer.
     doReturn(true).when(spiedConfig).readSmallFilesCompletely();
     doReturn(false).when(spiedConfig).optimizeFooterRead();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, SMALLFILE_READ, numOfReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, SMALLFILE_READ, 1, totalReadCalls);
+
+    /*
+     * Test to verify Direct Read Type.
+     * Separate AbfsInputStream method needs to be called.
+     */
+    fileSize = ONE_MB;
+    totalReadCalls += 1;
+    doReturn(false).when(spiedConfig).readSmallFilesCompletely();
+    doReturn(true).when(spiedConfig).isBufferedPReadDisabled();
+    Path testPath = createTestFile(spiedFs, fileSize);
+    try (FSDataInputStream iStream = spiedFs.open(testPath)) {
+      AbfsInputStream stream = (AbfsInputStream) iStream.getWrappedStream();
+      int bytesRead = stream.read(0, new byte[fileSize], 0,
+          fileSize);
+      Assertions.assertThat(fileSize)
+          .describedAs("Read size should match file size")
+          .isEqualTo(bytesRead);
+    }
+    assertReadTypeInClientRequestId(spiedFs, 1, totalReadCalls, DIRECT_READ);
   }
 
-  private void testReadTypeInTracingContextHeaderInternal(AzureBlobFileSystem fs, int fileSize, ReadType readType, int numOfReadCalls) throws Exception {
+  private void testReadTypeInTracingContextHeaderInternal(AzureBlobFileSystem fs,
+      int fileSize, ReadType readType, int numOfReadCalls, int totalReadCalls) throws Exception {
+    Path testPath = createTestFile(fs, fileSize);
+    readFile(fs, testPath, fileSize);
+    assertReadTypeInClientRequestId(fs, numOfReadCalls, totalReadCalls, readType);
+  }
+
+  private Path createTestFile(AzureBlobFileSystem fs, int fileSize) throws Exception {
     Path testPath = new Path("testFile");
     byte[] fileContent = getRandomBytesArray(fileSize);
     try (FSDataOutputStream oStream = fs.create(testPath)) {
       oStream.write(fileContent);
       oStream.flush();
     }
+    return testPath;
+  }
+
+  private void readFile(AzureBlobFileSystem fs, Path testPath, int fileSize) throws Exception {
     try (FSDataInputStream iStream = fs.open(testPath)) {
       int bytesRead = iStream.read(new byte[fileSize], 0,
           fileSize);
@@ -875,7 +907,10 @@ public class TestAbfsInputStream extends
           .describedAs("Read size should match file size")
           .isEqualTo(bytesRead);
     }
+  }
 
+  private void assertReadTypeInClientRequestId(AzureBlobFileSystem fs, int numOfReadCalls,
+      int totalReadCalls, ReadType readType) throws Exception {
     ArgumentCaptor<String> captor1 = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> captor2 = ArgumentCaptor.forClass(Long.class);
     ArgumentCaptor<byte[]> captor3 = ArgumentCaptor.forClass(byte[].class);
@@ -886,12 +921,22 @@ public class TestAbfsInputStream extends
     ArgumentCaptor<ContextEncryptionAdapter> captor8 = ArgumentCaptor.forClass(ContextEncryptionAdapter.class);
     ArgumentCaptor<TracingContext> captor9 = ArgumentCaptor.forClass(TracingContext.class);
 
-    verify(fs.getAbfsStore().getClient(), times(numOfReadCalls)).read(
+    verify(fs.getAbfsStore().getClient(), times(totalReadCalls)).read(
         captor1.capture(), captor2.capture(), captor3.capture(),
         captor4.capture(), captor5.capture(), captor6.capture(),
         captor7.capture(), captor8.capture(), captor9.capture());
-    TracingContext tracingContext = captor9.getAllValues().get(numOfReadCalls - 1);
-    verifyHeaderForReadTypeInTracingContextHeader(tracingContext, readType);
+    List<TracingContext> tracingContextList = captor9.getAllValues();
+    if (readType == PREFETCH_READ) {
+      // For Prefetch Enabled, first read can be Normal or Missed Cache Read.
+      // We will assert only for last 2 calls.
+      for (int i = tracingContextList.size() - (numOfReadCalls - 1); i < tracingContextList.size(); i++) {
+        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType);
+      }
+    } else {
+      for (int i = tracingContextList.size() - numOfReadCalls; i < tracingContextList.size(); i++) {
+        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType);
+      }
+    }
   }
 
   private void verifyHeaderForReadTypeInTracingContextHeader(TracingContext tracingContext, ReadType readType) {
@@ -906,19 +951,6 @@ public class TestAbfsInputStream extends
     Assertions.assertThat(tracingContext.getHeader()).describedAs("Read type in tracing context header should match")
         .contains(readType.toString());
   }
-
-//  private testReadTypeInTracingContextHeaderInternal(ReadType readType) throws Exception {
-//    switch (readType) {
-//      case DIRECT_READ:
-//        return AbfsRestOperationType.Read;
-//      case NORMAL_READ:
-//        return AbfsRestOperationType.ReadAhead;
-//      case PREFETCH_READ:
-//        return AbfsRestOperationType.ReadRemote;
-//      default:
-//        throw new IllegalArgumentException("Unknown read type: " + readType);
-//    }
-//  }
 
 
   private void testReadAheads(AbfsInputStream inputStream,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -51,10 +51,12 @@ import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
 import org.apache.hadoop.fs.azurebfs.security.ContextEncryptionAdapter;
 import org.apache.hadoop.fs.azurebfs.utils.TestCachedSASToken;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.apache.hadoop.fs.azurebfs.utils.TracingHeaderVersion;
 import org.apache.hadoop.fs.impl.OpenFileParameters;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COLON;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.FOOTER_READ;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.MISSEDCACHE_READ;
 import static org.apache.hadoop.fs.azurebfs.constants.ReadType.NORMAL_READ;
@@ -896,12 +898,13 @@ public class TestAbfsInputStream extends
     AbfsHttpOperation mockOp = Mockito.mock(AbfsHttpOperation.class);
     doReturn(EMPTY_STRING).when(mockOp).getTracingContextSuffix();
     tracingContext.constructHeader(mockOp, null, null);
-    String[] idList = tracingContext.getHeader().split(COLON, -1);
-    Assertions.assertThat(idList).describedAs("Client Request Id should have all fields").hasSize(13);
-    Assertions.assertThat(idList[6]).describedAs("Operation Type Shoudl Be Read")
-        .isEqualTo(FSOperationType.READ.toString());
-    Assertions.assertThat(idList[12]).describedAs("Read type in tracing context header should match")
-        .isEqualTo(readType.toString());
+    String[] idList = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT);
+    Assertions.assertThat(idList).describedAs("Client Request Id should have all fields").hasSize(
+        TracingHeaderVersion.getCurrentVersion().getFieldCount());
+    Assertions.assertThat(tracingContext.getHeader()).describedAs("Operation Type Should Be Read")
+        .contains(FSOperationType.READ.toString());
+    Assertions.assertThat(tracingContext.getHeader()).describedAs("Read type in tracing context header should match")
+        .contains(readType.toString());
   }
 
 //  private testReadTypeInTracingContextHeaderInternal(ReadType readType) throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -100,6 +100,9 @@ public class TestAbfsInputStream extends
   private static final int INCREASED_READ_BUFFER_AGE_THRESHOLD =
       REDUCED_READ_BUFFER_AGE_THRESHOLD * 10; // 30 sec
   private static final int ALWAYS_READ_BUFFER_SIZE_TEST_FILE_SIZE = 16 * ONE_MB;
+  private static final int POSITION_INDEX = 9;
+  private static final int OPERATION_INDEX = 6;
+  private static final int READTYPE_INDEX = 11;
 
   @Override
   public void teardown() throws Exception {
@@ -929,27 +932,36 @@ public class TestAbfsInputStream extends
     if (readType == PREFETCH_READ) {
       // For Prefetch Enabled, first read can be Normal or Missed Cache Read.
       // We will assert only for last 2 calls.
+      // Since calls are asynchronous, we can not guarantee the order of calls.
+      // Therefore we cannot assert on position here.
       for (int i = tracingContextList.size() - (numOfReadCalls - 1); i < tracingContextList.size(); i++) {
-        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType);
+        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType, -1);
       }
     } else {
+      int expectedReadPos = 0;
       for (int i = tracingContextList.size() - numOfReadCalls; i < tracingContextList.size(); i++) {
-        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType);
+        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType, expectedReadPos);
+        expectedReadPos += ONE_MB;
       }
     }
   }
 
-  private void verifyHeaderForReadTypeInTracingContextHeader(TracingContext tracingContext, ReadType readType) {
+  private void verifyHeaderForReadTypeInTracingContextHeader(TracingContext tracingContext, ReadType readType, int expectedReadPos) {
     AbfsHttpOperation mockOp = Mockito.mock(AbfsHttpOperation.class);
     doReturn(EMPTY_STRING).when(mockOp).getTracingContextSuffix();
     tracingContext.constructHeader(mockOp, null, null);
     String[] idList = tracingContext.getHeader().split(COLON, SPLIT_NO_LIMIT);
     Assertions.assertThat(idList).describedAs("Client Request Id should have all fields").hasSize(
         TracingHeaderVersion.getCurrentVersion().getFieldCount());
-    Assertions.assertThat(tracingContext.getHeader()).describedAs("Operation Type Should Be Read")
-        .contains(FSOperationType.READ.toString());
-    Assertions.assertThat(tracingContext.getHeader()).describedAs("Read type in tracing context header should match")
-        .contains(readType.toString());
+    if (expectedReadPos > 0) {
+      Assertions.assertThat(idList[POSITION_INDEX])
+          .describedAs("Read Position should match")
+          .isEqualTo(Integer.toString(expectedReadPos));
+    }
+    Assertions.assertThat(idList[OPERATION_INDEX]).describedAs("Operation Type Should Be Read")
+        .isEqualTo(FSOperationType.READ.toString());
+    Assertions.assertThat(idList[READTYPE_INDEX]).describedAs("Read type in tracing context header should match")
+        .isEqualTo(readType.toString());
   }
 
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -799,6 +799,11 @@ public class TestAbfsInputStream extends
     in.close();
   }
 
+  /**
+   * Test to verify that the read type and position are correctly set in the
+   * client request id header for various type of read operations performed.
+   * @throws Exception if any error occurs during the test
+   */
   @Test
   public void testReadTypeInTracingContextHeader() throws Exception {
     AzureBlobFileSystem spiedFs = Mockito.spy(getFileSystem());
@@ -811,7 +816,7 @@ public class TestAbfsInputStream extends
     Mockito.doReturn(spiedStore).when(spiedFs).getAbfsStore();
     Mockito.doReturn(spiedConfig).when(spiedStore).getAbfsConfiguration();
     int totalReadCalls = 0;
-    int fileSize = 0;
+    int fileSize;
 
     /*
      * Test to verify Normal Read Type.
@@ -828,11 +833,11 @@ public class TestAbfsInputStream extends
      * Setting read ahead depth to 0 ensure that nothing can be got from prefetch.
      * In such a case Input Stream will do a sequential read with missed cache read type.
      */
-    fileSize = ONE_MB; // To make sure only one block is read.
-    totalReadCalls += 1; // 1 block of 1MB.
+    fileSize = 3 * ONE_MB; // To make sure multiple blocks are read with MR
+    totalReadCalls += 3; // 3 block of 1MB.
     Mockito.doReturn(0).when(spiedConfig).getReadAheadQueueDepth();
     doReturn(true).when(spiedConfig).isReadAheadEnabled();
-    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, MISSEDCACHE_READ, 1, totalReadCalls);
+    testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, MISSEDCACHE_READ, 3, totalReadCalls);
 
     /*
      * Test to verify Prefetch Read Type.
@@ -857,16 +862,15 @@ public class TestAbfsInputStream extends
 
     /*
      * Test to verify Small File Read Type.
-     * Having file size less than footer read size and disabling small file opt
+     * Having file size less than block size and disabling footer read opt
      */
-    fileSize = 8 * ONE_KB;
     totalReadCalls += 1; // Full file will be read along with footer.
     doReturn(true).when(spiedConfig).readSmallFilesCompletely();
     doReturn(false).when(spiedConfig).optimizeFooterRead();
     testReadTypeInTracingContextHeaderInternal(spiedFs, fileSize, SMALLFILE_READ, 1, totalReadCalls);
 
     /*
-     * Test to verify Direct Read Type.
+     * Test to verify Direct Read Type and a read from random position.
      * Separate AbfsInputStream method needs to be called.
      */
     fileSize = ONE_MB;
@@ -876,9 +880,9 @@ public class TestAbfsInputStream extends
     Path testPath = createTestFile(spiedFs, fileSize);
     try (FSDataInputStream iStream = spiedFs.open(testPath)) {
       AbfsInputStream stream = (AbfsInputStream) iStream.getWrappedStream();
-      int bytesRead = stream.read(0, new byte[fileSize], 0,
+      int bytesRead = stream.read(ONE_MB/3, new byte[fileSize], 0,
           fileSize);
-      Assertions.assertThat(fileSize)
+      Assertions.assertThat(fileSize - ONE_MB/3)
           .describedAs("Read size should match file size")
           .isEqualTo(bytesRead);
     }
@@ -930,12 +934,20 @@ public class TestAbfsInputStream extends
         captor7.capture(), captor8.capture(), captor9.capture());
     List<TracingContext> tracingContextList = captor9.getAllValues();
     if (readType == PREFETCH_READ) {
-      // For Prefetch Enabled, first read can be Normal or Missed Cache Read.
-      // We will assert only for last 2 calls.
-      // Since calls are asynchronous, we can not guarantee the order of calls.
-      // Therefore we cannot assert on position here.
+      /*
+       * For Prefetch Enabled, first read can be Normal or Missed Cache Read.
+       * Sow e will assert only for last 2 calls which should be Prefetched Read.
+       * Since calls are asynchronous, we can not guarantee the order of calls.
+       * Therefore, we cannot assert on exact position here.
+       */
       for (int i = tracingContextList.size() - (numOfReadCalls - 1); i < tracingContextList.size(); i++) {
         verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType, -1);
+      }
+    } else if (readType == DIRECT_READ) {
+      int expectedReadPos = ONE_MB/3;
+      for (int i = tracingContextList.size() - numOfReadCalls; i < tracingContextList.size(); i++) {
+        verifyHeaderForReadTypeInTracingContextHeader(tracingContextList.get(i), readType, expectedReadPos);
+        expectedReadPos += ONE_MB;
       }
     } else {
       int expectedReadPos = 0;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
@@ -61,15 +61,15 @@ public class TestApacheHttpClientFallback extends AbstractAbfsTestWithTimeout {
           answer.callRealMethod();
           AbfsHttpOperation op = answer.getArgument(0);
           if (op instanceof AbfsAHCHttpOperation) {
-            Assertions.assertThat(tc.getHeader()).endsWith(APACHE_IMPL);
+            Assertions.assertThat(tc.getHeader()).contains(APACHE_IMPL);
             apacheCallsRegister[0]++;
           }
           if (op instanceof AbfsJdkHttpOperation) {
             jdkCallsRegister[0]++;
             if (AbfsApacheHttpClient.usable()) {
-              Assertions.assertThat(tc.getHeader()).endsWith(JDK_IMPL);
+              Assertions.assertThat(tc.getHeader()).contains(JDK_IMPL);
             } else {
-              Assertions.assertThat(tc.getHeader()).endsWith(JDK_FALLBACK);
+              Assertions.assertThat(tc.getHeader()).contains(JDK_FALLBACK);
             }
           }
           return null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
@@ -60,16 +60,17 @@ public class TestApacheHttpClientFallback extends AbstractAbfsTestWithTimeout {
     Mockito.doAnswer(answer -> {
           answer.callRealMethod();
           AbfsHttpOperation op = answer.getArgument(0);
+          String httpOperationHeader = tc.getHeader().split(":", -1)[11];
           if (op instanceof AbfsAHCHttpOperation) {
-            Assertions.assertThat(tc.getHeader()).endsWith(APACHE_IMPL);
+            Assertions.assertThat(httpOperationHeader).isEqualTo(APACHE_IMPL);
             apacheCallsRegister[0]++;
           }
           if (op instanceof AbfsJdkHttpOperation) {
             jdkCallsRegister[0]++;
             if (AbfsApacheHttpClient.usable()) {
-              Assertions.assertThat(tc.getHeader()).endsWith(JDK_IMPL);
+              Assertions.assertThat(httpOperationHeader).isEqualTo(JDK_IMPL);
             } else {
-              Assertions.assertThat(tc.getHeader()).endsWith(JDK_FALLBACK);
+              Assertions.assertThat(httpOperationHeader).isEqualTo(JDK_FALLBACK);
             }
           }
           return null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
@@ -61,15 +61,15 @@ public class TestApacheHttpClientFallback extends AbstractAbfsTestWithTimeout {
           answer.callRealMethod();
           AbfsHttpOperation op = answer.getArgument(0);
           if (op instanceof AbfsAHCHttpOperation) {
-            Assertions.assertThat(tc.getHeader()).contains(APACHE_IMPL);
+            Assertions.assertThat(tc.getHeader()).endsWith(APACHE_IMPL);
             apacheCallsRegister[0]++;
           }
           if (op instanceof AbfsJdkHttpOperation) {
             jdkCallsRegister[0]++;
             if (AbfsApacheHttpClient.usable()) {
-              Assertions.assertThat(tc.getHeader()).contains(JDK_IMPL);
+              Assertions.assertThat(tc.getHeader()).endsWith(JDK_IMPL);
             } else {
-              Assertions.assertThat(tc.getHeader()).contains(JDK_FALLBACK);
+              Assertions.assertThat(tc.getHeader()).endsWith(JDK_FALLBACK);
             }
           }
           return null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestApacheHttpClientFallback.java
@@ -60,17 +60,16 @@ public class TestApacheHttpClientFallback extends AbstractAbfsTestWithTimeout {
     Mockito.doAnswer(answer -> {
           answer.callRealMethod();
           AbfsHttpOperation op = answer.getArgument(0);
-          String httpOperationHeader = tc.getHeader().split(":", -1)[11];
           if (op instanceof AbfsAHCHttpOperation) {
-            Assertions.assertThat(httpOperationHeader).isEqualTo(APACHE_IMPL);
+            Assertions.assertThat(tc.getHeader()).contains(APACHE_IMPL);
             apacheCallsRegister[0]++;
           }
           if (op instanceof AbfsJdkHttpOperation) {
             jdkCallsRegister[0]++;
             if (AbfsApacheHttpClient.usable()) {
-              Assertions.assertThat(httpOperationHeader).isEqualTo(JDK_IMPL);
+              Assertions.assertThat(tc.getHeader()).contains(JDK_IMPL);
             } else {
-              Assertions.assertThat(httpOperationHeader).isEqualTo(JDK_FALLBACK);
+              Assertions.assertThat(tc.getHeader()).contains(JDK_FALLBACK);
             }
           }
           return null;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs.utils;
 
 import org.assertj.core.api.Assertions;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 
@@ -61,6 +62,7 @@ public class TracingHeaderValidator implements Listener {
     tracingHeaderValidator.primaryRequestId = primaryRequestId;
     tracingHeaderValidator.ingressHandler = ingressHandler;
     tracingHeaderValidator.position = position;
+    tracingHeaderValidator.readType = readType;
     tracingHeaderValidator.operatedBlobCount = operatedBlobCount;
     return tracingHeaderValidator;
   }
@@ -83,45 +85,43 @@ public class TracingHeaderValidator implements Listener {
   }
 
   private void validateTracingHeader(String tracingContextHeader) {
-    String[] idList = tracingContextHeader.split(":");
+    String[] idList = tracingContextHeader.split(":", -1);
     validateBasicFormat(idList);
     if (format != TracingHeaderFormat.ALL_ID_FORMAT) {
       return;
     }
-    if (idList.length >= 8) {
-      if (operatedBlobCount != null) {
-        Assertions.assertThat(Integer.parseInt(idList[7]))
-                .describedAs("OperatedBlobCount is incorrect")
-                .isEqualTo(operatedBlobCount);
-      }
+
+    // Validate Operated Blob Count
+    if (operatedBlobCount != null) {
+      Assertions.assertThat(Integer.parseInt(idList[10]))
+          .describedAs("OperatedBlobCount is incorrect")
+          .isEqualTo(operatedBlobCount);
     }
-    if (!primaryRequestId.isEmpty() && !idList[3].isEmpty()) {
-      Assertions.assertThat(idList[3])
+
+    // Validate Primary Request ID
+    if (!primaryRequestId.isEmpty() && !idList[4].isEmpty()) {
+      Assertions.assertThat(idList[4])
           .describedAs("PrimaryReqID should be common for these requests")
           .isEqualTo(primaryRequestId);
     }
+
+    // Validate Stream ID
     if (!streamID.isEmpty()) {
-      Assertions.assertThat(idList[4])
+      Assertions.assertThat(idList[5])
           .describedAs("Stream id should be common for these requests")
           .isEqualTo(streamID);
     }
   }
 
   private void validateBasicFormat(String[] idList) {
+    // Validate Version and Number of fields in the header
+    Assertions.assertThat(idList[0]).describedAs("Version should be present")
+        .isEqualTo(AbfsHttpConstants.TracingHeaderVersion.getCurrentVersion().toString());
+    int expectedSize = 0;
     if (format == TracingHeaderFormat.ALL_ID_FORMAT) {
-      int expectedSize = 8;
-      if (operatedBlobCount != null) {
-        expectedSize += 1;
-      }
-      if (ingressHandler != null) {
-        expectedSize += 2;
-      }
-      Assertions.assertThat(idList)
-          .describedAs("header should have " + expectedSize + " elements")
-          .hasSize(expectedSize);
+      expectedSize = 13;
     } else if (format == TracingHeaderFormat.TWO_ID_FORMAT) {
-      Assertions.assertThat(idList)
-          .describedAs("header should have 2 elements").hasSize(2);
+      expectedSize = 3;
     } else {
       Assertions.assertThat(idList).describedAs("header should have 1 element")
           .hasSize(1);
@@ -129,36 +129,49 @@ public class TracingHeaderValidator implements Listener {
           .describedAs("Client request ID is a guid").matches(GUID_PATTERN);
       return;
     }
+    Assertions.assertThat(idList)
+        .describedAs("header should have " + expectedSize + " elements")
+        .hasSize(expectedSize);
 
+    // Validate Client Correlation ID
     if (clientCorrelationId.matches("[a-zA-Z0-9-]*")) {
-      Assertions.assertThat(idList[0])
+      Assertions.assertThat(idList[1])
           .describedAs("Correlation ID should match config")
           .isEqualTo(clientCorrelationId);
     } else {
-      Assertions.assertThat(idList[0])
+      Assertions.assertThat(idList[1])
           .describedAs("Invalid config should be replaced with empty string")
           .isEmpty();
     }
-    Assertions.assertThat(idList[1]).describedAs("Client request ID is a guid")
+
+    // Validate Client Request ID
+    Assertions.assertThat(idList[2]).describedAs("Client request ID is a guid")
         .matches(GUID_PATTERN);
 
     if (format != TracingHeaderFormat.ALL_ID_FORMAT) {
       return;
     }
 
-    Assertions.assertThat(idList[2]).describedAs("Filesystem ID incorrect")
+    // Validate FileSystem ID
+    Assertions.assertThat(idList[3]).describedAs("Filesystem ID incorrect")
         .isEqualTo(fileSystemId);
+
+    // Validate Primary Request ID
     if (needsPrimaryRequestId && !operation
         .equals(FSOperationType.READ)) {
-      Assertions.assertThat(idList[3]).describedAs("should have primaryReqId")
+      Assertions.assertThat(idList[4]).describedAs("should have primaryReqId")
           .isNotEmpty();
     }
-    Assertions.assertThat(idList[5]).describedAs("Operation name incorrect")
+
+    // Validate Operation Type
+    Assertions.assertThat(idList[6]).describedAs("Operation name incorrect")
         .isEqualTo(operation.toString());
-    if (idList[6].contains("_")) {
-      idList[6] = idList[6].split("_")[0];
+
+    // Validate Retry Header
+    if (idList[7].contains("_")) {
+      idList[7] = idList[7].split("_")[0];
     }
-    int retryCount = Integer.parseInt(idList[6]);
+    int retryCount = Integer.parseInt(idList[7]);
     Assertions.assertThat(retryCount)
         .describedAs("Retry was required due to issue on server side")
         .isEqualTo(retryNum);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -207,7 +207,7 @@ public class TracingHeaderValidator implements Listener {
   }
 
   /**
-   * Sets the value of the number of blobs operated on976345
+   * Sets the value of the number of blobs operated on.
    * @param operatedBlobCount number of blobs operated on
    */
   public void setOperatedBlobCount(Integer operatedBlobCount) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs.utils;
 import org.assertj.core.api.Assertions;
 
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
+import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 
@@ -41,6 +42,7 @@ public class TracingHeaderValidator implements Listener {
   private static final String GUID_PATTERN = "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$";
   private String ingressHandler = null;
   private String position = null;
+  private ReadType readType = null;
 
   private Integer operatedBlobCount = null;
 
@@ -184,6 +186,11 @@ public class TracingHeaderValidator implements Listener {
   @Override
   public void updatePosition(String position) {
     this.position = position;
+  }
+
+  @Override
+  public void updateReadType(ReadType readType) {
+    this.readType = readType;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.azurebfs.utils;
 
 import org.assertj.core.api.Assertions;
 
-import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -115,7 +115,7 @@ public class TracingHeaderValidator implements Listener {
   private void validateBasicFormat(String[] idList) {
     // Validate Version and Number of fields in the header
     Assertions.assertThat(idList[0]).describedAs("Version should be present")
-        .isEqualTo(TracingHeaderVersion.getCurrentVersion().getVersion());
+        .isEqualTo(TracingHeaderVersion.getCurrentVersion().toString());
     int expectedSize = 0;
     if (format == TracingHeaderFormat.ALL_ID_FORMAT) {
       expectedSize = TracingHeaderVersion.getCurrentVersion().getFieldCount();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -116,10 +116,10 @@ public class TracingHeaderValidator implements Listener {
   private void validateBasicFormat(String[] idList) {
     // Validate Version and Number of fields in the header
     Assertions.assertThat(idList[0]).describedAs("Version should be present")
-        .isEqualTo(AbfsHttpConstants.TracingHeaderVersion.getCurrentVersion().toString());
+        .isEqualTo(TracingHeaderVersion.getCurrentVersion().getVersion());
     int expectedSize = 0;
     if (format == TracingHeaderFormat.ALL_ID_FORMAT) {
-      expectedSize = 13;
+      expectedSize = TracingHeaderVersion.getCurrentVersion().getFieldCount();
     } else if (format == TracingHeaderFormat.TWO_ID_FORMAT) {
       expectedSize = 3;
     } else {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.ReadType;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.SPLIT_NO_LIMIT;
 
 /**
  * Used to validate correlation identifiers provided during testing against
@@ -41,8 +42,8 @@ public class TracingHeaderValidator implements Listener {
 
   private static final String GUID_PATTERN = "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$";
   private String ingressHandler = null;
-  private String position = null;
-  private ReadType readType = null;
+  private String position = String.valueOf(0);
+  private ReadType readType = ReadType.UNKNOWN_READ;
 
   private Integer operatedBlobCount = null;
 
@@ -84,7 +85,7 @@ public class TracingHeaderValidator implements Listener {
   }
 
   private void validateTracingHeader(String tracingContextHeader) {
-    String[] idList = tracingContextHeader.split(":", -1);
+    String[] idList = tracingContextHeader.split(":", SPLIT_NO_LIMIT);
     validateBasicFormat(idList);
     if (format != TracingHeaderFormat.ALL_ID_FORMAT) {
       return;
@@ -206,7 +207,7 @@ public class TracingHeaderValidator implements Listener {
   }
 
   /**
-   * Sets the value of the number of blobs operated on
+   * Sets the value of the number of blobs operated on976345
    * @param operatedBlobCount number of blobs operated on
    */
   public void setOperatedBlobCount(Integer operatedBlobCount) {


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HADOOP-19645

There are a number of ways in which ABFS driver can trigger a network call to read data. We need a way to identify what type of read call was made from client. Plan is to add an indication for this in already present ClientRequestId header.

Following are types of read we want to identify:
1. Direct Read: Read from a given position in remote file. This will be synchronous read
2. Normal Read: Read from current seeked position where read ahead was bypassed. This will be synchronous read.
3. Prefetch Read: Read triggered from background threads filling up in memory cache. This will be asynchronous read.
4. Missed Cache Read: Read triggered after nothing was received from read ahead. This will be synchronous read.
5. Footer Read: Read triggered as part of footer read optimization. This will be synchronous.
6. Small File Read: Read triggered as a part of small file read. This will be synchronous read.

We will add another field in the Tracing Header (Client Request Id) for each request. We can call this field "Operation Specific Header" very similar to how we have "Retry Header" today. As part of this we will only use it for read operations keeping it empty for other operations. Moving ahead f we need to publish any operation specific info, same header can be used.

### How was this patch tested?
New tests around changes in Tracing Header and intoduction of read specific header added.
Existing test suite ran across all combinations. Results added as comment