### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part10.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
@@ -220,10 +220,10 @@ public class DataNodeTestUtils {
     }
     try {
       assertEquals(
-          dn.getConf().get(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY),
           dn.reconfigurePropertyImpl(
               DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
-              dnNewDataDirs.toString())
+              dnNewDataDirs.toString()),
+          dn.getConf().get(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY)
       );
     } catch (ReconfigurationException e) {
       // This can be thrown if reconfiguration tries to use a failed volume.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/DataNodeTestUtils.java
@@ -39,8 +39,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import java.util.function.Supplier;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * DO NOT ADD MOCKITO IMPORTS HERE Or Downstream projects may not
@@ -220,11 +219,12 @@ public class DataNodeTestUtils {
       dnNewDataDirs.append(newVol.getAbsolutePath());
     }
     try {
-      assertThat(
+      assertEquals(
+          dn.getConf().get(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY),
           dn.reconfigurePropertyImpl(
               DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
-              dnNewDataDirs.toString()),
-          is(dn.getConf().get(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY)));
+              dnNewDataDirs.toString())
+      );
     } catch (ReconfigurationException e) {
       // This can be thrown if reconfiguration tries to use a failed volume.
       // We need to swallow the exception, because some of our tests want to

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/InternalDataNodeTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +42,6 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.server.protocol.HeartbeatResponse;
 import org.apache.hadoop.hdfs.server.protocol.NNHAStatusHeartbeat;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -172,8 +172,8 @@ public class InternalDataNodeTestUtils {
       @Override
       DatanodeProtocolClientSideTranslatorPB connectToNN(
           InetSocketAddress nnAddr) throws IOException {
-        Assert.assertEquals(nnSocketAddr, nnAddr);
-        return namenode;
+            assertEquals(nnSocketAddr, nnAddr);
+            return namenode;
       }
     };
     // Trigger a heartbeat so that it acknowledges the NN as active.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBatchIbr.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBatchIbr.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCKREPORT_INCREMENTAL_INTERVAL_MSEC_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,7 +47,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -161,7 +162,7 @@ public class TestBatchIbr {
         });
       }
       for(int i = 0; i < NUM_FILES; i++) {
-        Assertions.assertTrue(verifyService.take().get());
+        assertTrue(verifyService.take().get());
       }
       final long testEndTime = Time.monotonicNow();
 
@@ -247,7 +248,7 @@ public class TestBatchIbr {
       for(int i = 0; i < numBlocks; i++) {
         in.read(computed);
         nextBytes(i, seed, expected);
-        Assertions.assertArrayEquals(expected, computed);
+        assertArrayEquals(expected, computed);
       }
       return true;
     } catch(Exception e) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockPoolManager.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -31,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -159,9 +160,9 @@ public class TestBlockPoolManager {
     bpm.refreshNamenodes(conf);
     assertEquals("create #1\n", log.toString());
     Map<String, BPOfferService> map = bpm.getBpByNameserviceId();
-    Assertions.assertFalse(map.containsKey("ns2"));
-    Assertions.assertFalse(map.containsKey("ns3"));
-    Assertions.assertTrue(map.containsKey("ns1"));
+    assertFalse(map.containsKey("ns2"));
+    assertFalse(map.containsKey("ns3"));
+    assertTrue(map.containsKey("ns1"));
     log.setLength(0);
   }
 
@@ -179,18 +180,18 @@ public class TestBlockPoolManager {
             "create #2\n" +
             "create #3\n", log.toString());
     Map<String, BPOfferService> map = bpm.getBpByNameserviceId();
-    Assertions.assertTrue(map.containsKey("ns1"));
-    Assertions.assertTrue(map.containsKey("ns2"));
-    Assertions.assertTrue(map.containsKey("ns3"));
-    Assertions.assertEquals(2, map.get("ns3").getBPServiceActors().size());
-    Assertions.assertEquals("ns3-" + MockDomainNameResolver.FQDN_1 + "-8020",
+    assertTrue(map.containsKey("ns1"));
+    assertTrue(map.containsKey("ns2"));
+    assertTrue(map.containsKey("ns3"));
+    assertEquals(2, map.get("ns3").getBPServiceActors().size());
+    assertEquals("ns3-" + MockDomainNameResolver.FQDN_1 + "-8020",
         map.get("ns3").getBPServiceActors().get(0).getNnId());
-    Assertions.assertEquals("ns3-" + MockDomainNameResolver.FQDN_2 + "-8020",
+    assertEquals("ns3-" + MockDomainNameResolver.FQDN_2 + "-8020",
         map.get("ns3").getBPServiceActors().get(1).getNnId());
-    Assertions.assertEquals(
+    assertEquals(
         new InetSocketAddress(MockDomainNameResolver.FQDN_1, 8020),
         map.get("ns3").getBPServiceActors().get(0).getNNSocketAddress());
-    Assertions.assertEquals(
+    assertEquals(
         new InetSocketAddress(MockDomainNameResolver.FQDN_2, 8020),
         map.get("ns3").getBPServiceActors().get(1).getNNSocketAddress());
     log.setLength(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery.java
@@ -21,8 +21,10 @@ package org.apache.hadoop.hdfs.server.datanode;
 import org.apache.hadoop.hdfs.AppendTestUtil;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -51,7 +53,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Iterators;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -93,12 +97,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -131,7 +133,8 @@ public class TestBlockRecovery {
   private final static ExtendedBlock block = new ExtendedBlock(POOL_ID,
       BLOCK_ID, BLOCK_LEN, GEN_STAMP);
 
-  @Rule
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName currentTestName = new TestName();
 
   private final int cellSize =
@@ -170,7 +173,7 @@ public class TestBlockRecovery {
    * Starts an instance of DataNode
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void startUp() throws IOException, URISyntaxException {
     tearDownDone = false;
     conf = new HdfsConfiguration();
@@ -228,8 +231,8 @@ public class TestBlockRecovery {
       @Override
       DatanodeProtocolClientSideTranslatorPB connectToNN(
           InetSocketAddress nnAddr) throws IOException {
-        Assert.assertEquals(NN_ADDR, nnAddr);
-        return namenode;
+            assertEquals(NN_ADDR, nnAddr);
+            return namenode;
       }
     };
     // Trigger a heartbeat so that it acknowledges the NN as active.
@@ -259,15 +262,14 @@ public class TestBlockRecovery {
     } catch (InterruptedException e) {
       LOG.warn("InterruptedException while waiting to see active NN", e);
     }
-    Assert.assertNotNull("Failed to get ActiveNN",
-        dn.getAllBpOs().get(0).getActiveNN());
+    assertNotNull(dn.getAllBpOs().get(0).getActiveNN(), "Failed to get ActiveNN");
   }
 
   /**
    * Cleans the resources and closes the instance of datanode
    * @throws IOException if an error occurred
    */
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (!tearDownDone && dn != null) {
       try {
@@ -277,8 +279,7 @@ public class TestBlockRecovery {
       } finally {
         File dir = new File(DATA_DIR);
         if (dir.exists())
-          Assert.assertTrue(
-              "Cannot delete data-node dirs", FileUtil.fullyDelete(dir));
+            assertTrue(FileUtil.fullyDelete(dir), "Cannot delete data-node dirs");
       }
       tearDownDone = true;
     }
@@ -317,7 +318,8 @@ public class TestBlockRecovery {
    * Two replicas are in Finalized state
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFinalizedReplicas () throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -344,9 +346,9 @@ public class TestBlockRecovery {
 
     try {
       testSyncReplicas(replica1, replica2, dn1, dn2);
-      Assert.fail("Two finalized replicas should not have different lengthes!");
+      fail("Two finalized replicas should not have different lengthes!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           "Inconsistent size of finalized replicas. "));
     }
   }
@@ -356,7 +358,8 @@ public class TestBlockRecovery {
    * One replica is Finalized and another is RBW.
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFinalizedRbwReplicas() throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -399,7 +402,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFinalizedRwrReplicas() throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -441,7 +445,8 @@ public class TestBlockRecovery {
    * Two replicas are RBW.
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRBWReplicas() throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -466,7 +471,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRBW_RWRReplicas() throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -491,7 +497,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRWRReplicas() throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -528,7 +535,8 @@ public class TestBlockRecovery {
    * @throws IOException
    *           in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRecoveryInProgressException()
     throws IOException, InterruptedException {
     if(LOG.isDebugEnabled()) {
@@ -553,7 +561,8 @@ public class TestBlockRecovery {
    * @throws IOException
    *           in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testErrorReplicas() throws IOException, InterruptedException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -580,7 +589,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testZeroLenReplicas() throws IOException, InterruptedException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -620,7 +630,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFailedReplicaUpdate() throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -642,7 +653,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testNoReplicaUnderRecovery() throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -667,7 +679,8 @@ public class TestBlockRecovery {
    *
    * @throws IOException in case of an error
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testNotMatchedReplicaID() throws IOException {
     if(LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -702,7 +715,8 @@ public class TestBlockRecovery {
    * throw an exception.
    * @throws Exception
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRURReplicas() throws Exception {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Running " + GenericTestUtils.getMethodName());
@@ -724,16 +738,18 @@ public class TestBlockRecovery {
     } catch (IOException e) {
       // expect IOException to be thrown here
       e.printStackTrace();
-      assertTrue("Wrong exception was thrown: " + e.getMessage(),
-          e.getMessage().contains("Found 1 replica(s) for block " + block +
-          " but none is in RWR or better state"));
+      assertTrue(
+          e.getMessage().contains(
+              "Found 1 replica(s) for block " + block + " but none is in RWR or better state"),
+          "Wrong exception was thrown: " + e.getMessage());
       exceptionThrown = true;
     } finally {
       assertTrue(exceptionThrown);
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSafeLength() throws Exception {
     // hard coded policy to work with hard coded test suite
     ErasureCodingPolicy ecPolicy = StripedFileTestUtil.getDefaultECPolicy();
@@ -752,8 +768,8 @@ public class TestBlockRecovery {
             blockLengths[id], 0, null);
         syncList.put((long) id, new BlockRecord(null, null, rInfo));
       }
-      Assert.assertEquals("BLOCK_LENGTHS_SUITE[" + i + "]", safeLength,
-          recoveryTask.getSafeLength(syncList));
+      assertEquals(safeLength, recoveryTask.getSafeLength(syncList),
+          "BLOCK_LENGTHS_SUITE[" + i + "]");
     }
   }
 
@@ -806,7 +822,8 @@ public class TestBlockRecovery {
     void run(RecoveringBlock recoveringBlock) throws Exception;
   }
 
-  @Test(timeout=90000)
+  @Test
+  @Timeout(value = 90)
   public void testInitReplicaRecoveryDoesNotHoldLock() throws Exception {
     testStopWorker(new TestStopWorkerRunnable() {
       @Override
@@ -827,7 +844,8 @@ public class TestBlockRecovery {
     });
   }
 
-  @Test(timeout=90000)
+  @Test
+  @Timeout(value = 90)
   public void testRecoverAppendDoesNotHoldLock() throws Exception {
     testStopWorker(new TestStopWorkerRunnable() {
       @Override
@@ -851,7 +869,8 @@ public class TestBlockRecovery {
     });
   }
 
-  @Test(timeout=90000)
+  @Test
+  @Timeout(value = 90)
   public void testRecoverCloseDoesNotHoldLock() throws Exception {
     testStopWorker(new TestStopWorkerRunnable() {
       @Override
@@ -885,8 +904,7 @@ public class TestBlockRecovery {
     // We need a long value for the data xceiver stop timeout.
     // Otherwise the timeout will trigger, and we will not have tested that
     // thread join was done locklessly.
-    Assert.assertEquals(
-        TEST_STOP_WORKER_XCEIVER_STOP_TIMEOUT_MILLIS,
+    assertEquals(TEST_STOP_WORKER_XCEIVER_STOP_TIMEOUT_MILLIS,
         dn.getDnConf().getXceiverStopTimeout());
     final TestStopWorkerSemaphore progressParent =
       new TestStopWorkerSemaphore();
@@ -966,7 +984,7 @@ public class TestBlockRecovery {
     // unit test framework, so we have to do it manually here.
     String failureReason = failure.get();
     if (failureReason != null) {
-      Assert.fail("Thread failure: " + failureReason);
+      fail("Thread failure: " + failureReason);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockRecovery2.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestName;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -77,6 +76,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_SIZE_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REPLICATION_MIN_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -168,7 +169,7 @@ public class TestBlockRecovery2 {
       @Override
       DatanodeProtocolClientSideTranslatorPB connectToNN(
           InetSocketAddress nnAddr) throws IOException {
-        Assertions.assertEquals(NN_ADDR, nnAddr);
+        assertEquals(NN_ADDR, nnAddr);
         return namenode;
       }
     };
@@ -192,7 +193,7 @@ public class TestBlockRecovery2 {
     } catch (InterruptedException e) {
       LOG.warn("InterruptedException while waiting to see active NN", e);
     }
-    Assertions.assertNotNull(dn.getAllBpOs().get(0).getActiveNN(),
+    assertNotNull(dn.getAllBpOs().get(0).getActiveNN(),
         "Failed to get ActiveNN");
   }
 
@@ -210,7 +211,7 @@ public class TestBlockRecovery2 {
       } finally {
         File dir = new File(DATA_DIR);
         if (dir.exists()) {
-          Assertions.assertTrue(FileUtil.fullyDelete(dir), "Cannot delete data-node dirs");
+          assertTrue(FileUtil.fullyDelete(dir), "Cannot delete data-node dirs");
         }
       }
       tearDownDone = true;
@@ -264,12 +265,12 @@ public class TestBlockRecovery2 {
       try {
         out.close();
       } catch (IOException e) {
-        Assertions.assertTrue(e.getMessage().contains("are bad. Aborting..."),
+        assertTrue(e.getMessage().contains("are bad. Aborting..."),
             "Writing should fail");
       } finally {
         recoveryThread.join();
       }
-      Assertions.assertTrue(recoveryInitResult.get(),
+      assertTrue(recoveryInitResult.get(),
           "Recovery should be initiated successfully");
 
       dataNode.updateReplicaUnderRecovery(block.getBlock(), block.getBlock()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockScanner.java
@@ -25,8 +25,8 @@ import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_
 import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_VOLUME_SCANNER_SCAN_RESULT_HANDLER;
 import static org.apache.hadoop.hdfs.server.datanode.BlockScanner.Conf.INTERNAL_DFS_BLOCK_SCANNER_CURSOR_SAVE_INTERVAL_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Closeable;
@@ -62,7 +62,6 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.hdfs.server.datanode.VolumeScanner.Statistics;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -704,36 +703,36 @@ public class TestBlockScanner {
     arr.add("3");
     arr.add("5");
     arr.add("7");
-    Assertions.assertEquals("3", FsVolumeImpl.nextSorted(arr, "2"));
-    Assertions.assertEquals("3", FsVolumeImpl.nextSorted(arr, "1"));
-    Assertions.assertEquals("1", FsVolumeImpl.nextSorted(arr, ""));
-    Assertions.assertEquals("1", FsVolumeImpl.nextSorted(arr, null));
-    Assertions.assertEquals(null, FsVolumeImpl.nextSorted(arr, "9"));
+    assertEquals("3", FsVolumeImpl.nextSorted(arr, "2"));
+    assertEquals("3", FsVolumeImpl.nextSorted(arr, "1"));
+    assertEquals("1", FsVolumeImpl.nextSorted(arr, ""));
+    assertEquals("1", FsVolumeImpl.nextSorted(arr, null));
+    assertEquals(null, FsVolumeImpl.nextSorted(arr, "9"));
   }
 
   @Test
   @Timeout(value = 120)
   public void testCalculateNeededBytesPerSec() throws Exception {
     // If we didn't check anything the last hour, we should scan now.
-    Assertions.assertTrue(
+    assertTrue(
         VolumeScanner.calculateShouldScan("test", 100, 0, 0, 60));
 
     // If, on average, we checked 101 bytes/s checked during the last hour,
     // stop checking now.
-    Assertions.assertFalse(VolumeScanner.
+    assertFalse(VolumeScanner.
         calculateShouldScan("test", 100, 101 * 3600, 1000, 5000));
 
     // Target is 1 byte / s, but we didn't scan anything in the last minute.
     // Should scan now.
-    Assertions.assertTrue(VolumeScanner.
+    assertTrue(VolumeScanner.
         calculateShouldScan("test", 1, 3540, 0, 60));
 
     // Target is 1000000 byte / s, but we didn't scan anything in the last
     // minute.  Should scan now.
-    Assertions.assertTrue(VolumeScanner.
+    assertTrue(VolumeScanner.
         calculateShouldScan("test", 100000L, 354000000L, 0, 60));
 
-    Assertions.assertFalse(VolumeScanner.
+    assertFalse(VolumeScanner.
         calculateShouldScan("test", 100000L, 365000000L, 0, 60));
   }
 
@@ -847,7 +846,7 @@ public class TestBlockScanner {
       // We should not have rescanned the "suspect block",
       // because it was recently rescanned by the suspect block system.
       // This is a test of the "suspect block" rate limiting.
-      Assertions.assertFalse(info.goodBlocks.contains(first), "We should not " +
+      assertFalse(info.goodBlocks.contains(first), "We should not " +
           "have rescanned block " + first + ", because it should have been " +
           "in recentSuspectBlocks.");
       info.blocksScanned = 0;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCachingStrategy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestCachingStrategy.java
@@ -42,8 +42,10 @@ import org.apache.hadoop.io.nativeio.NativeIO.POSIX.CacheManipulator;
 import org.apache.hadoop.io.nativeio.NativeIOException;
 
 import static org.apache.hadoop.io.nativeio.NativeIO.POSIX.POSIX_FADV_DONTNEED;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -241,7 +243,7 @@ public class TestCachingStrategy {
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, true);
       // verify that we dropped everything from the cache.
-      Assertions.assertNotNull(stats);
+      assertNotNull(stats);
       stats.assertDroppedInRange(0, TEST_PATH_LEN - WRITE_PACKET_SIZE);
     } finally {
       if (cluster != null) {
@@ -287,7 +289,7 @@ public class TestCachingStrategy {
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, null);
       // verify that we dropped everything from the cache.
-      Assertions.assertNotNull(stats);
+      assertNotNull(stats);
       stats.assertDroppedInRange(0, TEST_PATH_LEN - WRITE_PACKET_SIZE);
     } finally {
       if (cluster != null) {
@@ -366,7 +368,7 @@ public class TestCachingStrategy {
           TEST_PATH, 0, Long.MAX_VALUE).get(0).getBlock();
       String fadvisedFileName = cluster.getBlockFile(0, block).getName();
       Stats stats = tracker.getStats(fadvisedFileName);
-      Assertions.assertNull(stats);
+      assertNull(stats);
       
       // read file
       readHdfsFile(fs, new Path(TEST_PATH), Long.MAX_VALUE, false);
@@ -394,7 +396,7 @@ public class TestCachingStrategy {
       createHdfsFile(fs, new Path(TEST_PATH), TEST_PATH_LEN, false);
       // verify that we can seek after setDropBehind
       try (FSDataInputStream fis = fs.open(new Path(TEST_PATH))) {
-        Assertions.assertTrue(fis.read() != -1); // create BlockReader
+        assertTrue(fis.read() != -1); // create BlockReader
         fis.setDropBehind(false); // clear BlockReader
         fis.seek(2); // seek
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDNUsageReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDNUsageReport.java
@@ -21,10 +21,12 @@ import java.io.IOException;
 
 import org.apache.hadoop.hdfs.server.protocol.DataNodeUsageReport;
 import org.apache.hadoop.hdfs.server.protocol.DataNodeUsageReportUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class for {@link DataNodeUsageReport}.
@@ -40,12 +42,12 @@ public class TestDNUsageReport {
   private long readBlock;
   private long timeSinceLastReport;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     dnUsageUtil = new DataNodeUsageReportUtil();
   }
 
-  @After
+  @AfterEach
   public void clear() throws IOException {
     dnUsageUtil = null;
   }
@@ -54,13 +56,14 @@ public class TestDNUsageReport {
    * Ensure that storage type and storage state are propagated
    * in Storage Reports.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUsageReport() throws IOException {
 
     // Test1
     DataNodeUsageReport report = dnUsageUtil.getUsageReport(0,
         0, 0, 0, 0, 0, 0);
-    Assert.assertEquals(report, DataNodeUsageReport.EMPTY_REPORT);
+    assertEquals(report, DataNodeUsageReport.EMPTY_REPORT);
 
     // Test2
     bytesWritten = 200;
@@ -74,22 +77,18 @@ public class TestDNUsageReport {
         bytesRead, writeTime, readTime, writeBlock, readBlock,
         timeSinceLastReport);
 
-    Assert.assertEquals(bytesWritten / timeSinceLastReport,
-        report.getBytesWrittenPerSec());
-    Assert.assertEquals(bytesRead / timeSinceLastReport,
-        report.getBytesReadPerSec());
-    Assert.assertEquals(writeTime, report.getWriteTime());
-    Assert.assertEquals(readTime, report.getReadTime());
-    Assert.assertEquals(writeBlock / timeSinceLastReport,
-        report.getBlocksWrittenPerSec());
-    Assert.assertEquals(readBlock / timeSinceLastReport,
-        report.getBlocksReadPerSec());
+    assertEquals(bytesWritten / timeSinceLastReport, report.getBytesWrittenPerSec());
+    assertEquals(bytesRead / timeSinceLastReport, report.getBytesReadPerSec());
+    assertEquals(writeTime, report.getWriteTime());
+    assertEquals(readTime, report.getReadTime());
+    assertEquals(writeBlock / timeSinceLastReport, report.getBlocksWrittenPerSec());
+    assertEquals(readBlock / timeSinceLastReport, report.getBlocksReadPerSec());
 
     // Test3
     DataNodeUsageReport report2 = dnUsageUtil.getUsageReport(bytesWritten,
         bytesRead, writeTime, readTime, writeBlock, readBlock,
         0);
-    Assert.assertEquals(report, report2);
+    assertEquals(report, report2);
 
     // Test4
     long bytesWritten2 = 50000;
@@ -103,15 +102,15 @@ public class TestDNUsageReport {
         bytesRead2, writeTime2, readTime2, writeBlock2, readBlock2,
         timeSinceLastReport);
 
-    Assert.assertEquals((bytesWritten2 - bytesWritten) / timeSinceLastReport,
+    assertEquals((bytesWritten2 - bytesWritten) / timeSinceLastReport,
         report2.getBytesWrittenPerSec());
-    Assert.assertEquals((bytesRead2 - bytesRead) / timeSinceLastReport,
+    assertEquals((bytesRead2 - bytesRead) / timeSinceLastReport,
         report2.getBytesReadPerSec());
-    Assert.assertEquals(writeTime2 - writeTime, report2.getWriteTime());
-    Assert.assertEquals(readTime2 - readTime, report2.getReadTime());
-    Assert.assertEquals((writeBlock2 - writeBlock) / timeSinceLastReport,
+    assertEquals(writeTime2 - writeTime, report2.getWriteTime());
+    assertEquals(readTime2 - readTime, report2.getReadTime());
+    assertEquals((writeBlock2 - writeBlock) / timeSinceLastReport,
         report2.getBlocksWrittenPerSec());
-    Assert.assertEquals((readBlock2 - readBlock) / timeSinceLastReport,
+    assertEquals((readBlock2 - readBlock) / timeSinceLastReport,
         report2.getBlocksReadPerSec());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeECN.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeECN.java
@@ -21,11 +21,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.datatransfer.PipelineAck;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @Timeout(300)
 public class TestDataNodeECN {
@@ -38,7 +39,7 @@ public class TestDataNodeECN {
     try {
       cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
       PipelineAck.ECN ecn = cluster.getDataNodes().get(0).getECN();
-      Assertions.assertNotEquals(PipelineAck.ECN.DISABLED, ecn);
+      assertNotEquals(PipelineAck.ECN.DISABLED, ecn);
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeErasureCodingMetrics.java
@@ -38,11 +38,11 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounterWithoutCheck;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -92,26 +92,26 @@ public class TestDataNodeErasureCodingMetrics {
   @Test
   @Timeout(value = 120)
   public void testFullBlock() throws Exception {
-    Assertions.assertEquals(0, getLongMetric("EcReconstructionReadTimeMillis"));
-    Assertions.assertEquals(0, getLongMetric("EcReconstructionDecodingTimeMillis"));
-    Assertions.assertEquals(0, getLongMetric("EcReconstructionWriteTimeMillis"));
+    assertEquals(0, getLongMetric("EcReconstructionReadTimeMillis"));
+    assertEquals(0, getLongMetric("EcReconstructionDecodingTimeMillis"));
+    assertEquals(0, getLongMetric("EcReconstructionWriteTimeMillis"));
 
     doTest("/testEcMetrics", blockGroupSize, 0);
 
-    Assertions.assertEquals(1, getLongMetric("EcReconstructionTasks"),
+    assertEquals(1, getLongMetric("EcReconstructionTasks"),
         "EcReconstructionTasks should be ");
-    Assertions.assertEquals(0, getLongMetric("EcFailedReconstructionTasks"),
+    assertEquals(0, getLongMetric("EcFailedReconstructionTasks"),
         "EcFailedReconstructionTasks should be ");
-    Assertions.assertTrue(getLongMetric("EcDecodingTimeNanos") > 0);
-    Assertions.assertEquals(blockGroupSize, getLongMetric("EcReconstructionBytesRead"),
+    assertTrue(getLongMetric("EcDecodingTimeNanos") > 0);
+    assertEquals(blockGroupSize, getLongMetric("EcReconstructionBytesRead"),
         "EcReconstructionBytesRead should be ");
-    Assertions.assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
+    assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
         "EcReconstructionBytesWritten should be ");
-    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+    assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
         "EcReconstructionRemoteBytesRead should be ");
-    Assertions.assertTrue(getLongMetric("EcReconstructionReadTimeMillis") > 0);
-    Assertions.assertTrue(getLongMetric("EcReconstructionDecodingTimeMillis") > 0);
-    Assertions.assertTrue(getLongMetric("EcReconstructionWriteTimeMillis") > 0);
+    assertTrue(getLongMetric("EcReconstructionReadTimeMillis") > 0);
+    assertTrue(getLongMetric("EcReconstructionDecodingTimeMillis") > 0);
+    assertTrue(getLongMetric("EcReconstructionWriteTimeMillis") > 0);
   }
 
   // A partial block, reconstruct the partial block
@@ -121,11 +121,11 @@ public class TestDataNodeErasureCodingMetrics {
     final int fileLen = blockSize / 10;
     doTest("/testEcBytes", fileLen, 0);
 
-    Assertions.assertEquals(fileLen, getLongMetric("EcReconstructionBytesRead"),
+    assertEquals(fileLen, getLongMetric("EcReconstructionBytesRead"),
         "EcReconstructionBytesRead should be ");
-    Assertions.assertEquals(fileLen, getLongMetric("EcReconstructionBytesWritten"),
+    assertEquals(fileLen, getLongMetric("EcReconstructionBytesWritten"),
         "EcReconstructionBytesWritten should be ");
-    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+    assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
         "EcReconstructionRemoteBytesRead should be ");
   }
 
@@ -136,12 +136,12 @@ public class TestDataNodeErasureCodingMetrics {
     final int fileLen = cellSize * dataBlocks + cellSize + cellSize / 10;
     doTest("/testEcBytes", fileLen, 0);
 
-    Assertions.assertEquals(cellSize * dataBlocks
+    assertEquals(cellSize * dataBlocks
             + cellSize + cellSize / 10,
         getLongMetric("EcReconstructionBytesRead"), "ecReconstructionBytesRead should be ");
-    Assertions.assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
+    assertEquals(blockSize, getLongMetric("EcReconstructionBytesWritten"),
         "EcReconstructionBytesWritten should be ");
-    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+    assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
         "EcReconstructionRemoteBytesRead should be ");
   }
 
@@ -152,13 +152,13 @@ public class TestDataNodeErasureCodingMetrics {
     final int fileLen = cellSize * dataBlocks + cellSize + cellSize / 10;
     doTest("/testEcBytes", fileLen, 1);
 
-    Assertions.assertEquals(cellSize * dataBlocks + (cellSize / 10) * 2,
+    assertEquals(cellSize * dataBlocks + (cellSize / 10) * 2,
         getLongMetric("EcReconstructionBytesRead"),
         "ecReconstructionBytesRead should be ");
-    Assertions.assertEquals(cellSize + cellSize / 10,
+    assertEquals(cellSize + cellSize / 10,
         getLongMetric("EcReconstructionBytesWritten"),
         "ecReconstructionBytesWritten should be ");
-    Assertions.assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
+    assertEquals(0, getLongMetricWithoutCheck("EcReconstructionRemoteBytesRead"),
         "EcReconstructionRemoteBytesRead should be ");
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetrics.java
@@ -24,7 +24,10 @@ import static org.apache.hadoop.test.MetricsAsserts.assertInverseQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.Closeable;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetricsLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMetricsLogger.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_METRICS_LOGGER_PERIOD_SECONDS_KEY;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -44,17 +45,15 @@ import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.AsyncAppender;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
 /**
  * Test periodic logging of DataNode metrics.
  */
+@Timeout(300)
 public class TestDataNodeMetricsLogger {
   static final Logger LOG =
       LoggerFactory.getLogger(TestDataNodeMetricsLogger.class);
@@ -68,9 +67,6 @@ public class TestDataNodeMetricsLogger {
   private DataNode dn;
 
   static final Random random = new Random(System.currentTimeMillis());
-
-  @Rule
-  public Timeout timeout = new Timeout(300000);
 
   /**
    * Starts an instance of DataNode
@@ -96,7 +92,7 @@ public class TestDataNodeMetricsLogger {
    * @throws IOException
    *           if an error occurred
    */
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (dn != null) {
       try {
@@ -106,8 +102,7 @@ public class TestDataNodeMetricsLogger {
       } finally {
         File dir = new File(DATA_DIR);
         if (dir.exists())
-          Assert.assertTrue("Cannot delete data-node dirs",
-              FileUtil.fullyDelete(dir));
+          assertTrue(FileUtil.fullyDelete(dir), "Cannot delete data-node dirs");
       }
     }
     dn = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMultipleRegistrations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeMultipleRegistrations.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -44,7 +44,6 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -94,7 +93,7 @@ public class TestDataNodeMultipleRegistrations {
       // check number of volumes in fsdataset
       DataNode dn = cluster.getDataNodes().get(0);
       final Map<String, Object> volInfos = dn.data.getVolumeInfoMap();
-      Assertions.assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
+      assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
       int i = 0;
       for (Map.Entry<String, Object> e : volInfos.entrySet()) {
         LOG.info("vol " + i++ + ") " + e.getKey() + ": " + e.getValue());
@@ -158,7 +157,7 @@ public class TestDataNodeMultipleRegistrations {
       // check number of vlumes in fsdataset
       DataNode dn = cluster.getDataNodes().get(0);
       final Map<String, Object> volInfos = dn.data.getVolumeInfoMap();
-      Assertions.assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
+      assertTrue(volInfos.size() > 0, "No volumes in the fsdataset");
       int i = 0;
       for (Map.Entry<String, Object> e : volInfos.entrySet()) {
         LOG.info("vol " + i++ + ") " + e.getKey() + ": " + e.getValue());
@@ -205,14 +204,14 @@ public class TestDataNodeMultipleRegistrations {
       DataNode dn = cluster.getDataNodes().get(0);
       List<BPOfferService> bposs = dn.getAllBpOs();
       LOG.info("dn bpos len (should be 2):" + bposs.size());
-      Assertions.assertEquals(bposs.size(), 2, "should've registered with two namenodes");
+      assertEquals(bposs.size(), 2, "should've registered with two namenodes");
       
       // add another namenode
       cluster.addNameNode(conf, 9938);
       Thread.sleep(500);// lets wait for the registration to happen
       bposs = dn.getAllBpOs(); 
       LOG.info("dn bpos len (should be 3):" + bposs.size());
-      Assertions.assertEquals(bposs.size(), 3, "should've registered with three namenodes");
+      assertEquals(bposs.size(), 3, "should've registered with three namenodes");
       
       // change cluster id and another Namenode
       StartupOption.FORMAT.setClusterId("DifferentCID");
@@ -223,7 +222,7 @@ public class TestDataNodeMultipleRegistrations {
       Thread.sleep(500);// lets wait for the registration to happen
       bposs = dn.getAllBpOs(); 
       LOG.info("dn bpos len (still should be 3):" + bposs.size());
-      Assertions.assertEquals(3, bposs.size(), "should've registered with three namenodes");
+      assertEquals(3, bposs.size(), "should've registered with three namenodes");
     } finally {
         cluster.shutdown();
     }
@@ -322,12 +321,12 @@ public class TestDataNodeMultipleRegistrations {
     // add a node
     try {
       cluster.waitActive();
-      Assertions.assertEquals(2, cluster.getNumNameNodes(), "(1)Should be 2 namenodes");
+      assertEquals(2, cluster.getNumNameNodes(), "(1)Should be 2 namenodes");
 
       cluster.addNameNode(conf, 0);
-      Assertions.assertEquals(3, cluster.getNumNameNodes(), "(1)Should be 3 namenodes");
+      assertEquals(3, cluster.getNumNameNodes(), "(1)Should be 3 namenodes");
     } catch (IOException ioe) {
-      Assertions.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
+      fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
     } finally {
       cluster.shutdown();
     }
@@ -339,15 +338,15 @@ public class TestDataNodeMultipleRegistrations {
       .build();
     
     try {
-      Assertions.assertNotNull(cluster);
+      assertNotNull(cluster);
       cluster.waitActive();
-      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
+      assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
     
       // add a node
       cluster.addNameNode(conf, 0);
-      Assertions.assertEquals(2, cluster.getNumNameNodes(), "(2)Should be 2 namenodes");
+      assertEquals(2, cluster.getNumNameNodes(), "(2)Should be 2 namenodes");
     } catch (IOException ioe) {
-      Assertions.fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
+      fail("Failed to add NN to cluster:" + StringUtils.stringifyException(ioe));
     } finally {
       cluster.shutdown();
     }
@@ -359,15 +358,15 @@ public class TestDataNodeMultipleRegistrations {
     // add a node
     try {
       cluster.waitActive();
-      Assertions.assertNotNull(cluster);
-      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
+      assertNotNull(cluster);
+      assertEquals(1, cluster.getNumNameNodes(), "(2)Should be 1 namenodes");
 
       cluster.addNameNode(conf, 9929);
-      Assertions.fail("shouldn't be able to add another NN to non federated cluster");
+      fail("shouldn't be able to add another NN to non federated cluster");
     } catch (IOException e) {
       // correct 
-      Assertions.assertTrue(e.getMessage().startsWith("cannot add namenode"));
-      Assertions.assertEquals(1, cluster.getNumNameNodes(), "(3)Should be 1 namenodes");
+      assertTrue(e.getMessage().startsWith("cannot add namenode"));
+      assertEquals(1, cluster.getNumNameNodes(), "(3)Should be 1 namenodes");
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeReconfiguration.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DISK_BALANCER_PLAN_VALID_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -82,7 +83,6 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.BlockPoolSlice;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsVolumeImpl;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -114,7 +114,7 @@ public class TestDataNodeReconfiguration {
 
     File dir = new File(DATA_DIR);
     if (dir.exists())
-      Assertions.assertTrue(FileUtil.fullyDelete(dir),
+      assertTrue(FileUtil.fullyDelete(dir),
           "Cannot delete data-node dirs");
   }
 
@@ -260,7 +260,7 @@ public class TestDataNodeReconfiguration {
       // Attempt to set new maximum to 1
       final boolean success =
           dataNode.xserver.updateBalancerMaxConcurrentMovers(1);
-      Assertions.assertFalse(success);
+      assertFalse(success);
     } finally {
       dataNode.shutdown();
     }
@@ -272,7 +272,7 @@ public class TestDataNodeReconfiguration {
   @Test
   public void testFailedDecreaseConcurrentMoversReconfiguration()
       throws IOException, ReconfigurationException {
-    Assertions.assertThrows(ReconfigurationException.class, () -> {
+    assertThrows(ReconfigurationException.class, () -> {
       final DataNode[] dns = createDNsForTest(1);
       final DataNode dataNode = dns[0];
       try {
@@ -289,9 +289,9 @@ public class TestDataNodeReconfiguration {
         dataNode.reconfigurePropertyImpl(
             DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, "1");
       } catch (ReconfigurationException e) {
-        Assertions.assertEquals(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
+        assertEquals(DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY,
             e.getProperty());
-        Assertions.assertEquals("1", e.getNewValue());
+        assertEquals("1", e.getNewValue());
         throw e;
       } finally {
         dataNode.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeUUID.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeUUID.java
@@ -26,15 +26,16 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestDataNodeUUID {
 
@@ -68,7 +69,8 @@ public class TestDataNodeUUID {
     assertNotEquals(dn.getDatanodeUuid(), nullString);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testUUIDRegeneration() throws Exception {
     File baseDir = GenericTestUtils.getTestDir();
     File disk1 = new File(baseDir, "disk1");
@@ -96,19 +98,16 @@ public class TestDataNodeUUID {
       // on the second disk
       MiniDFSCluster.DataNodeProperties dn = cluster.stopDataNode(0);
       FileUtils.deleteDirectory(disk2);
-      assertTrue("Failed to recreate the data directory: " + disk2,
-              disk2.mkdirs());
+      assertTrue(disk2.mkdirs(), "Failed to recreate the data directory: " + disk2);
 
       // Restart and check if the UUID changed
-      assertTrue("DataNode failed to start up: " + dn,
-              cluster.restartDataNode(dn));
+      assertTrue(cluster.restartDataNode(dn), "DataNode failed to start up: " + dn);
       // We need to wait until the DN has completed registration
       while (!cluster.getDataNodes().get(0).isDatanodeFullyStarted()) {
         Thread.sleep(50);
       }
-      assertEquals(
-              "DN generated a new UUID despite disk1 having it intact",
-              originalUUID, cluster.getDataNodes().get(0).getDatanodeUuid());
+      assertEquals(originalUUID, cluster.getDataNodes().get(0).getDatanodeUuid(),
+          "DN generated a new UUID despite disk1 having it intact");
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureReporting.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -532,7 +531,7 @@ public class TestDataNodeVolumeFailureReporting {
         "Hadoop:service=DataNode,name=FSDatasetState-" + dn0.getDatanodeUuid());
     int numFailedVolumes = (int) mbs.getAttribute(mxbeanName,
         "NumFailedVolumes");
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, false, new String[] {});
 
     // Fail dn0Vol1 first.
@@ -541,8 +540,8 @@ public class TestDataNodeVolumeFailureReporting {
     DataNodeTestUtils.waitForDiskError(dn0,
         DataNodeTestUtils.getVolume(dn0, dn0Vol1));
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assertions.assertEquals(1, numFailedVolumes);
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
+    assertEquals(1, numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol1.getAbsolutePath()});
 
@@ -553,12 +552,12 @@ public class TestDataNodeVolumeFailureReporting {
           oldDataDirs);
       fail("Reconfigure with failed disk should throw exception.");
     } catch (ReconfigurationException e) {
-      Assertions.assertTrue(e.getCause().getMessage().contains(dn0Vol1.getAbsolutePath()),
+      assertTrue(e.getCause().getMessage().contains(dn0Vol1.getAbsolutePath()),
           "Reconfigure exception doesn't have expected path!");
     }
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assertions.assertEquals(1, numFailedVolumes);
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
+    assertEquals(1, numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(), numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol1.getAbsolutePath()});
 
@@ -568,8 +567,8 @@ public class TestDataNodeVolumeFailureReporting {
     dn0.reconfigurePropertyImpl(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
             dataDirs);
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assertions.assertEquals(0, numFailedVolumes);
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+    assertEquals(0, numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
         numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, true, new String[] {});
 
@@ -579,8 +578,8 @@ public class TestDataNodeVolumeFailureReporting {
     dn0.reconfigurePropertyImpl(DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY,
             oldDataDirs);
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assertions.assertEquals(0, numFailedVolumes);
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+    assertEquals(0, numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
         numFailedVolumes);
     checkFailuresAtDataNode(dn0, 0, true, new String[] {});
 
@@ -590,8 +589,8 @@ public class TestDataNodeVolumeFailureReporting {
     DataNodeTestUtils.waitForDiskError(dn0,
         DataNodeTestUtils.getVolume(dn0, dn0Vol2));
     numFailedVolumes = (int) mbs.getAttribute(mxbeanName, "NumFailedVolumes");
-    Assertions.assertEquals(1, numFailedVolumes);
-    Assertions.assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
+    assertEquals(1, numFailedVolumes);
+    assertEquals(dn0.getFSDataset().getNumFailedVolumes(),
         numFailedVolumes);
     checkFailuresAtDataNode(dn0, 1, true,
         new String[] {dn0Vol2.getAbsolutePath()});

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureToleration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailureToleration.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,15 +37,16 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test the ability of a DN to tolerate volume failures.
+ * specific the timeout for entire test class
  */
+@Timeout(120)
 public class TestDataNodeVolumeFailureToleration {
   private FileSystem fs;
   private MiniDFSCluster cluster;
@@ -59,11 +60,7 @@ public class TestDataNodeVolumeFailureToleration {
   // a datanode to be considered dead by the namenode.  
   final int WAIT_FOR_DEATH = 15000;
 
-  // specific the timeout for entire test class
-  @Rule
-  public Timeout timeout = new Timeout(120 * 1000);
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 512L);
@@ -81,7 +78,7 @@ public class TestDataNodeVolumeFailureToleration {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -122,14 +119,12 @@ public class TestDataNodeVolumeFailureToleration {
     cluster.waitActive();
 
     try {
-      assertTrue("The DN should have started up fine.",
-          cluster.isDataNodeUp());
+      assertTrue(cluster.isDataNodeUp(), "The DN should have started up fine.");
       DataNode dn = cluster.getDataNodes().get(0);
       String si = DataNodeTestUtils.getFSDataset(dn).getStorageInfo();
-      assertTrue("The DN should have started with this directory",
-          si.contains(dataDir1Actual.getPath()));
-      assertFalse("The DN shouldn't have a bad directory.",
-          si.contains(dataDir2Actual.getPath()));
+      assertTrue(si.contains(dataDir1Actual.getPath()),
+          "The DN should have started with this directory");
+      assertFalse(si.contains(dataDir2Actual.getPath()), "The DN shouldn't have a bad directory.");
     } finally {
       cluster.shutdownDataNodes();
       FileUtil.chmod(dataDir2.toString(), "755");
@@ -272,8 +267,7 @@ public class TestDataNodeVolumeFailureToleration {
   private void prepareDirToFail(File dir) throws IOException,
       InterruptedException {
     dir.mkdirs();
-    assertEquals("Couldn't chmod local vol", 0,
-        FileUtil.chmod(dir.toString(), "000"));
+    assertEquals(0, FileUtil.chmod(dir.toString(), "000"), "Couldn't chmod local vol");
   }
 
   /**
@@ -292,8 +286,8 @@ public class TestDataNodeVolumeFailureToleration {
       prepareDirToFail(dir);
       restartDatanodes(1, false);
       // The cluster is up..
-      assertEquals(true, cluster.getDataNodes().get(0)
-          .isBPServiceAlive(cluster.getNamesystem().getBlockPoolId()));
+      assertEquals(true,
+          cluster.getDataNodes().get(0).isBPServiceAlive(cluster.getNamesystem().getBlockPoolId()));
       // but there has been a single volume failure
       DFSTestUtil.waitForDatanodeStatus(dm, 1, 0, 1,
           origCapacity / 2, WAIT_FOR_HEARTBEATS);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataTransferThrottler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataTransferThrottler.java
@@ -22,11 +22,12 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.util.Time.monotonicNow;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_READ_BANDWIDTHPERSEC_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -54,10 +55,10 @@ public class TestDataTransferThrottler {
       DataNode dataNode = cluster.getDataNodes().get(0);
       // DataXceiverServer#readThrottler is null if
       // dfs.datanode.data.read.bandwidthPerSec default value is 0.
-      Assertions.assertNull(dataNode.xserver.getReadThrottler());
+      assertNull(dataNode.xserver.getReadThrottler());
 
       // Read file.
-      Assertions.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
+      assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
 
       // Set dfs.datanode.data.read.bandwidthPerSec.
       long bandwidthPerSec = 1024 * 1024 * 8;
@@ -67,11 +68,11 @@ public class TestDataTransferThrottler {
       cluster.stopDataNode(0);
       cluster.startDataNodes(conf, 1, true, null, null);
       dataNode = cluster.getDataNodes().get(0);
-      Assertions.assertEquals(bandwidthPerSec, dataNode.xserver.getReadThrottler().getBandwidth());
+      assertEquals(bandwidthPerSec, dataNode.xserver.getReadThrottler().getBandwidth());
 
       // Read file with throttler.
       long start = monotonicNow();
-      Assertions.assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
+      assertEquals(fileLength, DFSTestUtil.readFileAsBytes(fs, file).length);
       long elapsedTime = monotonicNow() - start;
       // Ensure throttler is effective, read 1024 * 1024 * 10 * 8 bytes,
       // should take approximately 10 seconds (1024 * 1024 * 8 bytes per second).

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverLazyPersistHint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataXceiverLazyPersistHint.java
@@ -29,17 +29,15 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.util.DataChecksum;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -54,9 +52,8 @@ import static org.mockito.Mockito.when;
  * Mock-based unit test to verify that the DataXceiver correctly handles the
  * LazyPersist hint from clients.
  */
+@Timeout(300)
 public class TestDataXceiverLazyPersistHint {
-  @Rule
-  public Timeout timeout = new Timeout(300000);
 
   private enum PeerLocality {
     LOCAL,
@@ -80,7 +77,7 @@ public class TestDataXceiverLazyPersistHint {
 
     for (Boolean lazyPersistSetting : Arrays.asList(true, false)) {
       issueWriteBlockCall(xceiver, lazyPersistSetting);
-      assertThat(captor.getValue(), is(lazyPersistSetting));
+      assertThat(captor.getValue()).isEqualTo(lazyPersistSetting);
     }
   }
 
@@ -95,7 +92,7 @@ public class TestDataXceiverLazyPersistHint {
 
     for (Boolean lazyPersistSetting : Arrays.asList(true, false)) {
       issueWriteBlockCall(xceiver, lazyPersistSetting);
-      assertThat(captor.getValue(), is(false));
+      assertThat(captor.getValue()).isEqualTo(false);
     }
   }
 
@@ -112,7 +109,7 @@ public class TestDataXceiverLazyPersistHint {
 
     for (Boolean lazyPersistSetting : Arrays.asList(true, false)) {
       issueWriteBlockCall(xceiver, lazyPersistSetting);
-      assertThat(captor.getValue(), is(lazyPersistSetting));
+      assertThat(captor.getValue()).isEqualTo(lazyPersistSetting);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeProtocolRetryPolicy.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hdfs.server.datanode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +53,6 @@ import org.apache.hadoop.hdfs.server.protocol.RegisterCommand;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -118,7 +119,7 @@ public class TestDatanodeProtocolRetryPolicy {
       } finally {
         File dir = new File(DATA_DIR);
         if (dir.exists())
-          Assertions.assertTrue(FileUtil.fullyDelete(dir),
+          assertTrue(FileUtil.fullyDelete(dir),
               "Cannot delete data-node dirs");
       }
       tearDownDone = true;
@@ -224,7 +225,7 @@ public class TestDatanodeProtocolRetryPolicy {
       @Override
       DatanodeProtocolClientSideTranslatorPB connectToNN(
           InetSocketAddress nnAddr) throws IOException {
-        Assertions.assertEquals(NN_ADDR, nnAddr);
+        assertEquals(NN_ADDR, nnAddr);
         return namenode;
       }
     };

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeRegister.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDatanodeRegister.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.VersionInfo;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -157,7 +156,7 @@ public class TestDatanodeRegister {
       localActor.stop();
       localActor.register(nsInfo);
     } catch (IOException e) {
-      Assertions.assertEquals("DN shut down before block pool registered", e.getMessage());
+      assertEquals("DN shut down before block pool registered", e.getMessage());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestFsDatasetCacheRevocation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestFsDatasetCacheRevocation.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -45,9 +45,10 @@ import org.apache.hadoop.io.nativeio.NativeIO.POSIX.NoMlockCacheManipulator;
 import org.apache.hadoop.net.unix.DomainSocket;
 import org.apache.hadoop.net.unix.TemporarySocketDirectory;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,7 @@ public class TestFsDatasetCacheRevocation {
 
   private static final int BLOCK_SIZE = 4096;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     prevCacheManipulator = NativeIO.POSIX.getCacheManipulator();
     NativeIO.POSIX.setCacheManipulator(new NoMlockCacheManipulator());
@@ -72,7 +73,7 @@ public class TestFsDatasetCacheRevocation {
     sockDir = new TemporarySocketDirectory();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     // Restore the original CacheManipulator
     NativeIO.POSIX.setCacheManipulator(prevCacheManipulator);
@@ -99,7 +100,8 @@ public class TestFsDatasetCacheRevocation {
    * replica for a reasonable amount of time, even if an uncache request
    * occurs.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testPinning() throws Exception {
     assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
     assumeNotWindows();
@@ -149,7 +151,8 @@ public class TestFsDatasetCacheRevocation {
    * Test that when we have an uncache request, and the client refuses to
    * release the replica for a long time, we will un-mlock it.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testRevocation() throws Exception {
     assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
     assumeNotWindows();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestIncrementalBlockReports.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -54,8 +54,9 @@ import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStatus;
 
 import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 /**
@@ -82,7 +83,7 @@ public class TestIncrementalBlockReports {
   private BPServiceActor actor;   // BPSA to use for block injection.
   private String storageUuid;     // DatanodeStorage to use for block injection.
 
-  @Before
+  @BeforeEach
   public void startCluster() throws IOException {
     conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(DN_COUNT).build();
@@ -135,7 +136,8 @@ public class TestIncrementalBlockReports {
    * @throws InterruptedException
    * @throws IOException
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportBlockReceived() throws InterruptedException, IOException {
     try {
       DatanodeProtocolClientSideTranslatorPB nnSpy = spyOnDnCallsToNn();
@@ -162,7 +164,8 @@ public class TestIncrementalBlockReports {
    * @throws InterruptedException
    * @throws IOException
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportBlockDeleted() throws InterruptedException, IOException {
     try {
       // Trigger a block report to reset the IBR timer.
@@ -207,7 +210,8 @@ public class TestIncrementalBlockReports {
    * @throws InterruptedException
    * @throws IOException
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReplaceReceivedBlock() throws InterruptedException, IOException {
     try {
       // Spy on calls from the DN to the NN
@@ -326,9 +330,9 @@ public class TestIncrementalBlockReports {
       cluster.transitionToActive(1);
       cluster.waitActive(1);
 
-      assertEquals("There should not be any corrupt replicas", 0,
-          nn2.getNamesystem().getBlockManager()
-              .numCorruptReplicas(block.getLocalBlock()));
+      assertEquals(0,
+          nn2.getNamesystem().getBlockManager().numCorruptReplicas(block.getLocalBlock()),
+          "There should not be any corrupt replicas");
     } finally {
       cluster.shutdown();
     }
@@ -409,9 +413,9 @@ public class TestIncrementalBlockReports {
       cluster.transitionToActive(1);
       cluster.waitActive(1);
 
-      assertEquals("There should not be any corrupt replicas", 0,
-          nn2.getNamesystem().getBlockManager()
-              .numCorruptReplicas(block.getLocalBlock()));
+      assertEquals(0,
+          nn2.getNamesystem().getBlockManager().numCorruptReplicas(block.getLocalBlock()),
+          "There should not be any corrupt replicas");
     } finally {
       cluster.shutdown();
     }
@@ -514,9 +518,9 @@ public class TestIncrementalBlockReports {
       cluster.transitionToActive(1);
       cluster.waitActive(1);
 
-      assertEquals("There should be 1 corrupt replica", 1,
-          nn2.getNamesystem().getBlockManager()
-              .numCorruptReplicas(block.getLocalBlock()));
+      assertEquals(1,
+          nn2.getNamesystem().getBlockManager().numCorruptReplicas(block.getLocalBlock()),
+          "There should be 1 corrupt replica");
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestProvidedReplicaImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestProvidedReplicaImpl.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.datanode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,8 +35,8 @@ import java.util.List;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystemTestHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +90,7 @@ public class TestProvidedReplicaImpl {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     createFileIfNotExists(new File(BASE_DIR).getAbsolutePath());
     createProvidedReplicas(new Configuration());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTransferRbw.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestTransferRbw.java
@@ -38,11 +38,13 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.ReplicaState;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetTestUtil;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_WRITE_BANDWIDTHPERSEC_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test transferring RBW between datanodes */
 public class TestTransferRbw {
@@ -68,9 +70,9 @@ public class TestTransferRbw {
       LOG.info("wait since replicas.size() == 0; i=" + i);
       Thread.sleep(1000);
     }
-    Assert.assertEquals(1, replicas.size());
+    assertEquals(1, replicas.size());
     final ReplicaInfo r = replicas.iterator().next();
-    Assert.assertEquals(expectedState, r.getState());
+    assertEquals(expectedState, r.getState());
     return (LocalReplicaInPipeline)r;
   }
 
@@ -106,7 +108,7 @@ public class TestTransferRbw {
         final DataNode oldnode = cluster.getDataNodes().get(0);
         // DataXceiverServer#writeThrottler is null if
         // dfs.datanode.data.write.bandwidthPerSec default value is 0.
-        Assert.assertNull(oldnode.xserver.getWriteThrottler());
+        assertNull(oldnode.xserver.getWriteThrottler());
         oldrbw = getRbw(oldnode, bpid);
         LOG.info("oldrbw = " + oldrbw);
         
@@ -118,17 +120,17 @@ public class TestTransferRbw {
         // DataXceiverServer#writeThrottler#balancer is equal to
         // dfs.datanode.data.write.bandwidthPerSec value if
         // dfs.datanode.data.write.bandwidthPerSec value is not zero.
-        Assert.assertEquals(1024 * 1024 * 8,
+        assertEquals(1024 * 1024 * 8,
             newnode.xserver.getWriteThrottler().getBandwidth());
         final DatanodeInfo oldnodeinfo;
         {
           final DatanodeInfo[] datatnodeinfos = cluster.getNameNodeRpc(
               ).getDatanodeReport(DatanodeReportType.LIVE);
-          Assert.assertEquals(2, datatnodeinfos.length);
+          assertEquals(2, datatnodeinfos.length);
           int i = 0;
           for(DatanodeRegistration dnReg = newnode.getDNRegistrationForBP(bpid);
               i < datatnodeinfos.length && !datatnodeinfos[i].equals(dnReg); i++);
-          Assert.assertTrue(i < datatnodeinfos.length);
+          assertTrue(i < datatnodeinfos.length);
           newnodeinfo = datatnodeinfos[i];
           oldnodeinfo = datatnodeinfos[1 - i];
         }
@@ -138,15 +140,15 @@ public class TestTransferRbw {
             oldrbw.getGenerationStamp());
         final BlockOpResponseProto s = DFSTestUtil.transferRbw(
             b, DFSClientAdapter.getDFSClient(fs), oldnodeinfo, newnodeinfo);
-        Assert.assertEquals(Status.SUCCESS, s.getStatus());
+        assertEquals(Status.SUCCESS, s.getStatus());
       }
 
       //check new rbw
       final ReplicaBeingWritten newrbw = getRbw(newnode, bpid);
       LOG.info("newrbw = " + newrbw);
-      Assert.assertEquals(oldrbw.getBlockId(), newrbw.getBlockId());
-      Assert.assertEquals(oldrbw.getGenerationStamp(), newrbw.getGenerationStamp());
-      Assert.assertEquals(oldrbw.getVisibleLength(), newrbw.getVisibleLength());
+      assertEquals(oldrbw.getBlockId(), newrbw.getBlockId());
+      assertEquals(oldrbw.getGenerationStamp(), newrbw.getGenerationStamp());
+      assertEquals(oldrbw.getVisibleLength(), newrbw.getVisibleLength());
 
       LOG.info("DONE");
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestDatasetVolumeCheckerTimeout.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestDatasetVolumeCheckerTimeout.java
@@ -23,14 +23,15 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeReference;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.FakeTimer;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,8 @@ public class TestDatasetVolumeCheckerTimeout {
   public static final org.slf4j.Logger LOG =
       LoggerFactory.getLogger(TestDatasetVolumeCheckerTimeout.class);
 
-  @Rule
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName testName = new TestName();
 
   static Configuration conf;
@@ -81,7 +83,8 @@ public class TestDatasetVolumeCheckerTimeout {
     return volume;
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDiskCheckTimeout() throws Exception {
     LOG.info("Executing {}", testName.getMethodName());
     final FsVolumeSpi volume = makeSlowVolume();
@@ -103,9 +106,9 @@ public class TestDatasetVolumeCheckerTimeout {
 
             // Assert that the disk check registers a failed volume due to
             // timeout
-            assertThat(healthyVolumes.size(), is(0));
-            assertThat(failedVolumes.size(), is(1));
-          }
+            assertThat(healthyVolumes.size()).isEqualTo(0);
+            assertThat(failedVolumes.size()).isEqualTo(1);
+            }
         });
 
     // Wait for the callback
@@ -116,6 +119,6 @@ public class TestDatasetVolumeCheckerTimeout {
 
     // Ensure that the check was invoked only once.
     verify(volume, times(1)).check(any());
-    assertThat(numCallbackInvocations.get(), is(1L));
+    assertThat(numCallbackInvocations.get()).isEqualTo(1L);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestThrottledAsyncChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestThrottledAsyncChecker.java
@@ -22,7 +22,8 @@ import java.util.function.Supplier;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.FakeTimer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,9 +33,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Verify functionality of {@link ThrottledAsyncChecker}.
@@ -48,7 +49,8 @@ public class TestThrottledAsyncChecker {
    * Test various scheduling combinations to ensure scheduling and
    * throttling behave as expected.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testScheduler() throws Exception {
     final NoOpCheckable target1 = new NoOpCheckable();
     final NoOpCheckable target2 = new NoOpCheckable();
@@ -88,7 +90,8 @@ public class TestThrottledAsyncChecker {
     waitTestCheckableCheckCount(target2, 2L);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testConcurrentChecks() throws Exception {
     final StalledCheckable target = new StalledCheckable();
     final FakeTimer timer = new FakeTimer();
@@ -112,7 +115,8 @@ public class TestThrottledAsyncChecker {
    * method.
    * @throws Exception
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testContextIsPassed() throws Exception {
     final NoOpCheckable target1 = new NoOpCheckable();
     final FakeTimer timer = new FakeTimer();
@@ -148,7 +152,8 @@ public class TestThrottledAsyncChecker {
    *
    * @throws Exception
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testExceptionIsPropagated() throws Exception {
     final ThrowingCheckable target = new ThrowingCheckable();
     final FakeTimer timer = new FakeTimer();
@@ -174,7 +179,8 @@ public class TestThrottledAsyncChecker {
    *
    * @throws Exception
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testExceptionCaching() throws Exception {
     final ThrowingCheckable target1 = new ThrowingCheckable();
     final FakeTimer timer = new FakeTimer();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestThrottledAsyncCheckerTimeout.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/checker/TestThrottledAsyncCheckerTimeout.java
@@ -17,16 +17,16 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.checker;
 
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.FutureCallback;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Futures;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.hadoop.util.FakeTimer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
@@ -37,22 +37,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@Timeout(300)
 public class TestThrottledAsyncCheckerTimeout {
   public static final org.slf4j.Logger LOG =
       LoggerFactory.getLogger(TestThrottledAsyncCheckerTimeout.class);
 
-  @Rule
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName testName = new TestName();
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   private static final long DISK_CHECK_TIMEOUT = 10;
   private ReentrantLock lock;
@@ -61,7 +60,7 @@ public class TestThrottledAsyncCheckerTimeout {
     return new ScheduledThreadPoolExecutor(1);
   }
 
-  @Before
+  @BeforeEach
   public void initializeLock() {
     lock = new ReentrantLock();
   }
@@ -111,8 +110,8 @@ public class TestThrottledAsyncCheckerTimeout {
 
     lock.unlock();
 
-    assertThat(numCallbackInvocationsFailure.get(), is(1L));
-    assertThat(numCallbackInvocationsSuccess.get(), is(0L));
+    assertThat(numCallbackInvocationsFailure.get()).isEqualTo(1L);
+    assertThat(numCallbackInvocationsSuccess.get()).isEqualTo(0L);
     assertTrue(throwable[0] instanceof TimeoutException);
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/TestExternalDataset.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/extdataset/TestExternalDataset.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdfs.server.datanode.Replica;
 import org.apache.hadoop.hdfs.server.datanode.ReplicaInPipeline;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the ability to create external FsDatasetSpi implementations.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/TestAvailableSpaceVolumeChoosingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/TestAvailableSpaceVolumeChoosingPolicy.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.datanode.fsdataset;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_AVAILABLE_SPACE_VOLUME_CHOOSING_POLICY_BALANCED_SPACE_THRESHOLD_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_AVAILABLE_SPACE_VOLUME_CHOOSING_POLICY_BALANCED_SPACE_PREFERENCE_FRACTION_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +29,8 @@ import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 public class TestAvailableSpaceVolumeChoosingPolicy {
@@ -55,7 +56,8 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
   
   // Test the Round-Robin block-volume fallback path when all volumes are within
   // the threshold.
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRR() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -66,7 +68,8 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
   
   // ChooseVolume should throw DiskOutOfSpaceException
   // with volume and block sizes in exception message.
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRRPolicyExceptionMessage() throws Exception {
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy
         = new AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi>();
@@ -74,7 +77,8 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     TestRoundRobinVolumeChoosingPolicy.testRRPolicyExceptionMessage(policy);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testTwoUnbalancedVolumes() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -91,15 +95,13 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     // than the threshold of 1MB.
     volumes.add(Mockito.mock(FsVolumeSpi.class));
     Mockito.when(volumes.get(1).getAvailable()).thenReturn(1024L * 1024L * 3);
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
   }
-  
-  @Test(timeout=60000)
+
+  @Test
+  @Timeout(value = 60)
   public void testThreeUnbalancedVolumes() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -123,29 +125,22 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     // We should alternate assigning between the two volumes with a lot of free
     // space.
     initPolicy(policy, BALANCED_SPACE_THRESHOLD, 1.0f);
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-        null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
 
     // All writes should be assigned to the volume with the least free space.
     initPolicy(policy, BALANCED_SPACE_THRESHOLD, 0.0f);
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-        null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
   }
 
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSameAvailableVolumeSpace() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy =
@@ -172,29 +167,22 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     // We should alternate assigning between all the above volumes
     // for they have the same available space
     initPolicy(policy, 0, 1.0f);
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100,
-            null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100, null));
 
     // We should alternate assigning between all the above volumes
     // for they have the same available space
     initPolicy(policy, 0, 0.0f);
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-            null));
-    Assert.assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100,
-            null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100, null));
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFourUnbalancedVolumes() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -222,29 +210,22 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     // We should alternate assigning between the two volumes with a lot of free
     // space.
     initPolicy(policy, BALANCED_SPACE_THRESHOLD, 1.0f);
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100,
-        null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(2), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(3), policy.chooseVolume(volumes, 100, null));
 
     // We should alternate assigning between the two volumes with less free
     // space.
     initPolicy(policy, BALANCED_SPACE_THRESHOLD, 0.0f);
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100,
-         null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100,
-        null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
   }
-  
-  @Test(timeout=60000)
+
+  @Test
+  @Timeout(value = 60)
   public void testNotEnoughSpaceOnSelectedVolume() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -266,11 +247,11 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
     // space to accept the replica size, and another volume does have enough
     // free space, that should be chosen instead.
     initPolicy(policy, BALANCED_SPACE_THRESHOLD, 0.0f);
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes,
-        1024L * 1024L * 2, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 1024L * 1024L * 2, null));
   }
-  
-  @Test(timeout=60000)
+
+  @Test
+  @Timeout(value = 60)
   public void testAvailableSpaceChanges() throws Exception {
     @SuppressWarnings("unchecked")
     final AvailableSpaceVolumeChoosingPolicy<FsVolumeSpi> policy = 
@@ -294,26 +275,29 @@ public class TestAvailableSpaceVolumeChoosingPolicy {
 
     // Should still be able to get a volume for the replica even though the
     // available space on the second volume changed.
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes,
-        100, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 100, null));
   }
-  
-  @Test(timeout=60000)
+
+  @Test
+  @Timeout(value = 60)
   public void randomizedTest1() throws Exception {
     doRandomizedTest(0.75f, 1, 1);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void randomizedTest2() throws Exception {
     doRandomizedTest(0.75f, 5, 1);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void randomizedTest3() throws Exception {
     doRandomizedTest(0.75f, 1, 5);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void randomizedTest4() throws Exception {
     doRandomizedTest(0.90f, 5, 1);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/TestRoundRobinVolumeChoosingPolicy.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdfs.server.datanode.fsdataset;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_ROUND_ROBIN_VOLUME_CHOOSING_POLICY_ADDITIONAL_AVAILABLE_SPACE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,8 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestRoundRobinVolumeChoosingPolicy {
@@ -55,20 +56,19 @@ public class TestRoundRobinVolumeChoosingPolicy {
     Mockito.when(volumes.get(1).getAvailable()).thenReturn(200L);
 
     // Test two rounds of round-robin choosing
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 0, null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
-    Assert.assertEquals(volumes.get(0), policy.chooseVolume(volumes, 0, null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 0, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
+    assertEquals(volumes.get(0), policy.chooseVolume(volumes, 0, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
 
     // The first volume has only 100L space, so the policy should
     // wisely choose the second one in case we ask for more.
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 150,
-        null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 150, null));
 
     // Fail if no volume can be chosen?
     try {
       policy.chooseVolume(volumes, Long.MAX_VALUE, null);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
       // Passed.
     }
@@ -103,15 +103,13 @@ public class TestRoundRobinVolumeChoosingPolicy {
 
     // The first volume has only 100L space, so the policy should choose
     // the second one with additional available space configured as 100L.
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0,
-        null));
-    Assert.assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0,
-        null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
+    assertEquals(volumes.get(1), policy.chooseVolume(volumes, 0, null));
 
     // Fail if no volume can be chosen?
     try {
       policy.chooseVolume(volumes, 100, null);
-      Assert.fail();
+      fail();
     } catch (IOException e) {
       // Passed.
     }
@@ -141,12 +139,13 @@ public class TestRoundRobinVolumeChoosingPolicy {
     int blockSize = 700;
     try {
       policy.chooseVolume(volumes, blockSize, null);
-      Assert.fail("expected to throw DiskOutOfSpaceException");
+      fail("expected to throw DiskOutOfSpaceException");
     } catch(DiskOutOfSpaceException e) {
-      Assert.assertEquals("Not returnig the expected message",
+      assertEquals(
           "Out of space: The volume with the most available space (=" + 600
               + " B) is less than the block size (=" + blockSize + " B).",
-          e.getMessage());
+          e.getMessage(),
+          "Unexpected exception message");
     }
   }
 
@@ -183,23 +182,18 @@ public class TestRoundRobinVolumeChoosingPolicy {
             .thenReturn(StorageType.SSD);
     Mockito.when(ssdVolumes.get(1).getAvailable()).thenReturn(100L);
 
-    Assert.assertEquals(diskVolumes.get(0),
-            policy.chooseVolume(diskVolumes, 0, null));
+    assertEquals(diskVolumes.get(0), policy.chooseVolume(diskVolumes, 0, null));
     // Independent Round-Robin for different storage type
-    Assert.assertEquals(ssdVolumes.get(0),
-            policy.chooseVolume(ssdVolumes, 0, null));
+    assertEquals(ssdVolumes.get(0), policy.chooseVolume(ssdVolumes, 0, null));
     // Take block size into consideration
-    Assert.assertEquals(ssdVolumes.get(0),
-            policy.chooseVolume(ssdVolumes, 150L, null));
+    assertEquals(ssdVolumes.get(0), policy.chooseVolume(ssdVolumes, 150L, null));
 
-    Assert.assertEquals(diskVolumes.get(1),
-            policy.chooseVolume(diskVolumes, 0, null));
-    Assert.assertEquals(diskVolumes.get(0),
-            policy.chooseVolume(diskVolumes, 50L, null));
+    assertEquals(diskVolumes.get(1), policy.chooseVolume(diskVolumes, 0, null));
+    assertEquals(diskVolumes.get(0), policy.chooseVolume(diskVolumes, 50L, null));
 
     try {
       policy.chooseVolume(diskVolumes, 200L, null);
-      Assert.fail("Should throw an DiskOutOfSpaceException before this!");
+      fail("Should throw an DiskOutOfSpaceException before this!");
     } catch (DiskOutOfSpaceException e) {
       // Pass.
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetTestUtil.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.hdfs.server.datanode.ReplicaNotFoundException;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FsDatasetTestUtil {
 
@@ -104,9 +104,9 @@ public class FsDatasetTestUtil {
     try (RandomAccessFile raf = new RandomAccessFile(lockFile, "rws");
         FileChannel channel = raf.getChannel()) {
       FileLock lock = channel.tryLock();
-      assertNotNull(String.format(
+      assertNotNull(lock, String.format(
           "Lock file at %s appears to be held by a different process.",
-          lockFile.getAbsolutePath()), lock);
+          lockFile.getAbsolutePath()));
       if (lock != null) {
         try {
           lock.release();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/LazyPersistTestCase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/LazyPersistTestCase.java
@@ -30,10 +30,9 @@ import static org.apache.hadoop.fs.StorageType.DEFAULT;
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
 import static org.apache.hadoop.util.Shell.getMemlockLimit;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +54,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -80,11 +80,10 @@ import org.apache.hadoop.io.nativeio.NativeIO;
 import org.apache.hadoop.net.unix.TemporarySocketDirectory;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.event.Level;
 
+@Timeout(300)
 public abstract class LazyPersistTestCase {
   static final byte LAZY_PERSIST_POLICY_ID = (byte) 15;
 
@@ -129,7 +128,7 @@ public abstract class LazyPersistTestCase {
   protected JMXGet jmx;
   protected TemporarySocketDirectory sockDir;
 
-  @After
+  @AfterEach
   public void shutDownCluster() throws Exception {
 
     // Dump all RamDisk JMX metrics before shutdown the cluster
@@ -155,15 +154,12 @@ public abstract class LazyPersistTestCase {
     sockDir = null;
   }
 
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
-
   protected final LocatedBlocks ensureFileReplicasOnStorageType(
       Path path, StorageType storageType)
       throws IOException, TimeoutException, InterruptedException {
     // Ensure that returned block locations returned are correct!
     LOG.info("Ensure path: {} is on StorageType: {}", path, storageType);
-    assertThat(fs.exists(path), is(true));
+    assertThat(fs.exists(path)).isEqualTo(true);
     long fileLength = client.getFileInfo(path.toString()).getLen();
 
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestAddBlockPoolException.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestAddBlockPoolException.java
@@ -17,14 +17,14 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests to ensure AddBlockPoolException behaves correctly when additional

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestCacheByPmemMappableBlockLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestCacheByPmemMappableBlockLoader.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PMEM_CACHE_DIRS_KEY;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,12 +54,12 @@ import org.apache.hadoop.io.nativeio.NativeIO.POSIX.NoMlockCacheManipulator;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
@@ -103,7 +103,7 @@ public class TestCacheByPmemMappableBlockLoader {
         LoggerFactory.getLogger(FsDatasetCache.class), Level.DEBUG);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     assumeTrue("Requires PMDK", NativeIO.POSIX.isPmdkAvailable());
 
@@ -121,12 +121,12 @@ public class TestCacheByPmemMappableBlockLoader {
     });
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception {
     DataNodeFaultInjector.set(oldInjector);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.setLong(
@@ -155,7 +155,7 @@ public class TestCacheByPmemMappableBlockLoader {
     cacheManager = ((FsDatasetImpl) dn.getFSDataset()).cacheManager;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (fs != null) {
       fs.close();
@@ -209,12 +209,13 @@ public class TestCacheByPmemMappableBlockLoader {
     return keys;
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCacheAndUncache() throws Exception {
     final int maxCacheBlocksNum =
         Ints.checkedCast(CACHE_CAPACITY / BLOCK_SIZE);
     BlockReaderTestUtil.enableHdfsCachingTracing();
-    Assert.assertEquals(0, CACHE_CAPACITY % BLOCK_SIZE);
+    assertEquals(0, CACHE_CAPACITY % BLOCK_SIZE);
     assertEquals(CACHE_CAPACITY, cacheManager.getCacheCapacity());
     // DRAM cache is expected to be disabled.
     assertEquals(0L, cacheManager.getMemCacheCapacity());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestCacheByPmemMappableBlockLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestCacheByPmemMappableBlockLoader.java
@@ -66,7 +66,7 @@ import java.util.function.Supplier;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_FSDATASETCACHE_MAX_THREADS_PER_VOLUME_KEY;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests HDFS persistent memory cache by PmemMappableBlockLoader.
@@ -105,7 +105,7 @@ public class TestCacheByPmemMappableBlockLoader {
 
   @BeforeAll
   public static void setUpClass() throws Exception {
-    assumeTrue("Requires PMDK", NativeIO.POSIX.isPmdkAvailable());
+    assumeTrue(NativeIO.POSIX.isPmdkAvailable(), "Requires PMDK");
 
     oldInjector = DataNodeFaultInjector.get();
     DataNodeFaultInjector.set(new DataNodeFaultInjector() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestDatanodeRestart.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestDatanodeRestart.java
@@ -41,8 +41,9 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test if a datanode can correctly upgrade itself */
 public class TestDatanodeRestart {
@@ -122,13 +123,13 @@ public class TestDatanodeRestart {
       // check volumeMap: one rwr replica
       String bpid = cluster.getNamesystem().getBlockPoolId();
       ReplicaMap replicas = dataset(dn).volumeMap;
-      Assert.assertEquals(1, replicas.size(bpid));
+      assertEquals(1, replicas.size(bpid));
       ReplicaInfo replica = replicas.replicas(bpid).iterator().next();
-      Assert.assertEquals(ReplicaState.RWR, replica.getState());
+      assertEquals(ReplicaState.RWR, replica.getState());
       if (isCorrupt) {
-        Assert.assertEquals((fileLen-1)/512*512, replica.getNumBytes());
+        assertEquals((fileLen - 1) / 512 * 512, replica.getNumBytes());
       } else {
-        Assert.assertEquals(fileLen, replica.getNumBytes());
+        assertEquals(fileLen, replica.getNumBytes());
       }
       dataset(dn).invalidate(bpid, new Block[]{replica});
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestFsVolumeList.java
@@ -42,9 +42,9 @@ import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -60,11 +60,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DU_RESERVED_PERCENTAGE_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -83,7 +83,7 @@ public class TestFsVolumeList {
   private final static int DEFAULT_BLOCK_SIZE = 102400;
   private final static int BUFFER_LENGTH = 1024;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     dataset = mock(FsDatasetImpl.class);
     baseDir = new FileSystemTestHelper().getTestRootDir();
@@ -94,7 +94,8 @@ public class TestFsVolumeList {
     conf = new Configuration();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testGetNextVolumeWithClosedVolume() throws IOException {
     FsVolumeList volumeList = new FsVolumeList(
         Collections.<VolumeFailureInfo>emptyList(),
@@ -138,7 +139,8 @@ public class TestFsVolumeList {
     }
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testReleaseVolumeRefIfNoBlockScanner() throws IOException {
     FsVolumeList volumeList = new FsVolumeList(
         Collections.<VolumeFailureInfo>emptyList(), null, blockChooser, conf, null);
@@ -172,7 +174,7 @@ public class TestFsVolumeList {
         .setStorageID("storage-id")
         .setConf(conf)
         .build();
-    assertEquals("", 100L, volume.getReserved());
+    assertEquals(100L, volume.getReserved(), "");
     // when storage type reserved is configured.
     conf.setLong(
         DFSConfigKeys.DFS_DATANODE_DU_RESERVED_KEY + "."
@@ -190,7 +192,7 @@ public class TestFsVolumeList {
         .setStorageID("storage-id")
         .setConf(conf)
         .build();
-    assertEquals("", 1L, volume1.getReserved());
+    assertEquals(1L, volume1.getReserved(), "");
     FsVolumeImpl volume2 = new FsVolumeImplBuilder().setDataset(dataset)
         .setStorageDirectory(
             new StorageDirectory(
@@ -198,7 +200,7 @@ public class TestFsVolumeList {
         .setStorageID("storage-id")
         .setConf(conf)
         .build();
-    assertEquals("", 2L, volume2.getReserved());
+    assertEquals(2L, volume2.getReserved(), "");
     FsVolumeImpl volume3 = new FsVolumeImplBuilder().setDataset(dataset)
         .setStorageDirectory(
             new StorageDirectory(
@@ -206,7 +208,7 @@ public class TestFsVolumeList {
         .setStorageID("storage-id")
         .setConf(conf)
         .build();
-    assertEquals("", 100L, volume3.getReserved());
+    assertEquals(100L, volume3.getReserved(), "");
     FsVolumeImpl volume4 = new FsVolumeImplBuilder().setDataset(dataset)
         .setStorageDirectory(
             new StorageDirectory(
@@ -214,7 +216,7 @@ public class TestFsVolumeList {
         .setStorageID("storage-id")
         .setConf(conf)
         .build();
-    assertEquals("", 100L, volume4.getReserved());
+    assertEquals(100L, volume4.getReserved(), "");
     FsVolumeImpl volume5 = new FsVolumeImplBuilder().setDataset(dataset)
         .setStorageDirectory(
             new StorageDirectory(
@@ -367,7 +369,8 @@ public class TestFsVolumeList {
     assertEquals(200, volume5.getAvailable());
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testAddRplicaProcessorForAddingReplicaInMap() throws Exception {
     BlockPoolSlice.reInitializeAddReplicaThreadPool();
     Configuration cnf = new Configuration();
@@ -414,13 +417,13 @@ public class TestFsVolumeList {
     // It will create BlockPoolSlice.AddReplicaProcessor task's and lunch in
     // ForkJoinPool recursively
     vol.getVolumeMap(bpid, volumeMap, ramDiskReplicaMap);
-    assertTrue("Failed to add all the replica to map", volumeMap.replicas(bpid)
-        .size() == 1000);
-    assertEquals("Fork pool should be initialize with configured pool size",
-        poolSize, BlockPoolSlice.getAddReplicaForkPoolSize());
+    assertTrue(volumeMap.replicas(bpid).size() == 1000, "Failed to add all the replica to map");
+    assertEquals(poolSize, BlockPoolSlice.getAddReplicaForkPoolSize(),
+        "Fork pool should be initialize with configured pool size");
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testInstanceOfAddReplicaThreadPool() throws Exception {
     // Start cluster with multiple namespace
     try (MiniDFSCluster cluster = new MiniDFSCluster.Builder(
@@ -436,9 +439,8 @@ public class TestFsVolumeList {
           cluster.getNamesystem(0).getBlockPoolId()).getAddReplicaThreadPool();
       ForkJoinPool threadPool2 = vol.getBlockPoolSlice(
           cluster.getNamesystem(1).getBlockPoolId()).getAddReplicaThreadPool();
-      assertEquals(
-          "Thread pool instance should be same in all the BlockPoolSlice",
-          threadPool1, threadPool2);
+      assertEquals(threadPool1, threadPool2,
+          "Thread pool instance should be same in all the BlockPoolSlice");
     }
   }
 
@@ -529,13 +531,11 @@ public class TestFsVolumeList {
 
     // 1) getVolumeRef should return correct reference.
     assertEquals(diskVolume,
-        volumeList.getMountVolumeMap()
-            .getVolumeRefByMountAndStorageType(
-            device, StorageType.DISK).getVolume());
+        volumeList.getMountVolumeMap().getVolumeRefByMountAndStorageType(device, StorageType.DISK)
+            .getVolume());
     assertEquals(archivalVolume,
         volumeList.getMountVolumeMap()
-            .getVolumeRefByMountAndStorageType(
-            device, StorageType.ARCHIVE).getVolume());
+            .getVolumeRefByMountAndStorageType(device, StorageType.ARCHIVE).getVolume());
 
     // 2) removeVolume should work as expected
     volumeList.removeVolume(diskVolume.getStorageLocation(), true);
@@ -543,8 +543,7 @@ public class TestFsVolumeList {
             .getVolumeRefByMountAndStorageType(
             device, StorageType.DISK));
     assertEquals(archivalVolume, volumeList.getMountVolumeMap()
-        .getVolumeRefByMountAndStorageType(
-        device, StorageType.ARCHIVE).getVolume());
+        .getVolumeRefByMountAndStorageType(device, StorageType.ARCHIVE).getVolume());
   }
 
   // Test dfs stats with same disk archival
@@ -619,10 +618,8 @@ public class TestFsVolumeList {
         .when(spyDiskVolume).getDfUsed();
     Mockito.doReturn(dfUsage)
         .when(spyArchivalVolume).getDfUsed();
-    assertEquals(expectedActualNonDfsUsage,
-        spyDiskVolume.getActualNonDfsUsed());
-    assertEquals(expectedActualNonDfsUsage,
-        spyArchivalVolume.getActualNonDfsUsed());
+    assertEquals(expectedActualNonDfsUsage, spyDiskVolume.getActualNonDfsUsed());
+    assertEquals(expectedActualNonDfsUsage, spyArchivalVolume.getActualNonDfsUsed());
 
     // 3) When there is only one volume on a disk mount,
     // we allocate the full disk capacity regardless of the default ratio.
@@ -714,14 +711,14 @@ public class TestFsVolumeList {
         DEFAULT_BLOCK_SIZE, (short) 3, 0, false, null);
 
     // Asserts that the number of blocks created on a slow disk is 0.
-    Assert.assertEquals(0, dn0.getVolumeReport().stream()
-        .filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn0)).collect(Collectors.toList()).get(0)
-        .getNumBlocks());
-    Assert.assertEquals(0, dn1.getVolumeReport().stream()
-        .filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn1)).collect(Collectors.toList()).get(0)
-        .getNumBlocks());
-    Assert.assertEquals(0, dn2.getVolumeReport().stream()
-        .filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn2)).collect(Collectors.toList()).get(0)
-        .getNumBlocks());
+    assertEquals(0,
+        dn0.getVolumeReport().stream().filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn0))
+            .collect(Collectors.toList()).get(0).getNumBlocks());
+    assertEquals(0,
+        dn1.getVolumeReport().stream().filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn1))
+            .collect(Collectors.toList()).get(0).getNumBlocks());
+    assertEquals(0,
+        dn2.getVolumeReport().stream().filter(v -> (v.getPath() + "/").equals(slowDisk0OnDn2))
+            .collect(Collectors.toList()).get(0).getNumBlocks());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
@@ -17,9 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -61,8 +63,7 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -117,8 +118,8 @@ public class TestInterDatanodeProtocol {
   public static void checkMetaInfo(ExtendedBlock b, DataNode dn) throws IOException {
     Block metainfo = DataNodeTestUtils.getFSDataset(dn).getStoredBlock(
         b.getBlockPoolId(), b.getBlockId());
-    Assert.assertEquals(b.getBlockId(), metainfo.getBlockId());
-    Assert.assertEquals(b.getNumBytes(), metainfo.getNumBytes());
+    assertEquals(b.getBlockId(), metainfo.getBlockId());
+    assertEquals(b.getNumBytes(), metainfo.getNumBytes());
   }
 
   public static LocatedBlock getLastLocatedBlock(
@@ -222,11 +223,11 @@ public class TestInterDatanodeProtocol {
     return new FinalizedReplica(b, new ExternalVolumeImpl(), null);
   }
 
-  private static void assertEquals(ReplicaInfo originalInfo, ReplicaRecoveryInfo recoveryInfo) {
-    Assert.assertEquals(originalInfo.getBlockId(), recoveryInfo.getBlockId());
-    Assert.assertEquals(originalInfo.getGenerationStamp(), recoveryInfo.getGenerationStamp());
-    Assert.assertEquals(originalInfo.getBytesOnDisk(), recoveryInfo.getNumBytes());
-    Assert.assertEquals(originalInfo.getState(), recoveryInfo.getOriginalReplicaState());
+  private static void assertReplicaEquals(ReplicaInfo originalInfo, ReplicaRecoveryInfo recoveryInfo) {
+    assertEquals(originalInfo.getBlockId(), recoveryInfo.getBlockId());
+    assertEquals(originalInfo.getGenerationStamp(), recoveryInfo.getGenerationStamp());
+    assertEquals(originalInfo.getBytesOnDisk(), recoveryInfo.getNumBytes());
+    assertEquals(originalInfo.getState(), recoveryInfo.getOriginalReplicaState());
   }
 
   /** Test 
@@ -255,28 +256,28 @@ public class TestInterDatanodeProtocol {
       final ReplicaRecoveryInfo recoveryInfo = FsDatasetImpl
           .initReplicaRecovery(bpid, map, blocks[0], recoveryid,
               DFSConfigKeys.DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT, manager);
-      assertEquals(originalInfo, recoveryInfo);
+      assertReplicaEquals(originalInfo, recoveryInfo);
 
       final ReplicaUnderRecovery updatedInfo = (ReplicaUnderRecovery)map.get(bpid, b);
-      Assert.assertEquals(originalInfo.getBlockId(), updatedInfo.getBlockId());
-      Assert.assertEquals(recoveryid, updatedInfo.getRecoveryID());
+      assertEquals(originalInfo.getBlockId(), updatedInfo.getBlockId());
+      assertEquals(recoveryid, updatedInfo.getRecoveryID());
 
       //recover one more time 
       final long recoveryid2 = gs + 2;
       final ReplicaRecoveryInfo recoveryInfo2 = FsDatasetImpl
           .initReplicaRecovery(bpid, map, blocks[0], recoveryid2,
               DFSConfigKeys.DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT, manager);
-      assertEquals(originalInfo, recoveryInfo2);
+      assertReplicaEquals(originalInfo, recoveryInfo2);
 
       final ReplicaUnderRecovery updatedInfo2 = (ReplicaUnderRecovery)map.get(bpid, b);
-      Assert.assertEquals(originalInfo.getBlockId(), updatedInfo2.getBlockId());
-      Assert.assertEquals(recoveryid2, updatedInfo2.getRecoveryID());
+      assertEquals(originalInfo.getBlockId(), updatedInfo2.getBlockId());
+      assertEquals(recoveryid2, updatedInfo2.getRecoveryID());
       
       //case RecoveryInProgressException
       try {
         FsDatasetImpl.initReplicaRecovery(bpid, map, b, recoveryid,
             DFSConfigKeys.DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT, manager);
-        Assert.fail();
+        fail();
       }
       catch(RecoveryInProgressException ripe) {
         System.out.println("GOOD: getting " + ripe);
@@ -289,7 +290,7 @@ public class TestInterDatanodeProtocol {
       ReplicaRecoveryInfo r = FsDatasetImpl.initReplicaRecovery(bpid, map, b,
           recoveryid,
           DFSConfigKeys.DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT, manager);
-      Assert.assertNull("Data-node should not have this replica.", r);
+      assertNull(r, "Data-node should not have this replica.");
     }
     
     { // BlockRecoveryFI_02: "THIS IS NOT SUPPOSED TO HAPPEN" with recovery id < gs  
@@ -298,7 +299,7 @@ public class TestInterDatanodeProtocol {
       try {
         FsDatasetImpl.initReplicaRecovery(bpid, map, b, recoveryid,
             DFSConfigKeys.DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT, manager);
-        Assert.fail();
+        fail();
       }
       catch(IOException ioe) {
         System.out.println("GOOD: getting " + ioe);
@@ -347,11 +348,11 @@ public class TestInterDatanodeProtocol {
       final LocatedBlock locatedblock = getLastLocatedBlock(
           DFSClientAdapter.getDFSClient(dfs).getNamenode(), filestr);
       final DatanodeInfo[] datanodeinfo = locatedblock.getLocations();
-      Assert.assertTrue(datanodeinfo.length > 0);
+      assertTrue(datanodeinfo.length > 0);
 
       //get DataNode and FSDataset objects
       final DataNode datanode = cluster.getDataNode(datanodeinfo[0].getIpcPort());
-      Assert.assertTrue(datanode != null);
+      assertTrue(datanode != null);
 
       //initReplicaRecovery
       final ExtendedBlock b = locatedblock.getBlock();
@@ -364,7 +365,7 @@ public class TestInterDatanodeProtocol {
       //check replica
       final Replica replica =
           cluster.getFsDatasetTestUtils(datanode).fetchReplica(b);
-      Assert.assertEquals(ReplicaState.RUR, replica.getState());
+      assertEquals(ReplicaState.RUR, replica.getState());
 
       //check meta data before update
       cluster.getFsDatasetTestUtils(datanode).checkStoredReplica(replica);
@@ -379,7 +380,7 @@ public class TestInterDatanodeProtocol {
           //update should fail
           fsdataset.updateReplicaUnderRecovery(tmp, recoveryid,
               tmp.getBlockId(), newlength);
-          Assert.fail();
+          fail();
         } catch(IOException ioe) {
           System.out.println("GOOD: getting " + ioe);
         }
@@ -400,28 +401,29 @@ public class TestInterDatanodeProtocol {
   /** Test to verify that InterDatanode RPC timesout as expected when
    *  the server DN does not respond.
    */
-  @Test(expected=SocketTimeoutException.class)
+  @Test
   public void testInterDNProtocolTimeout() throws Throwable {
-    final Server server = new TestServer(1, true);
-    server.start();
-
-    final InetSocketAddress addr = NetUtils.getConnectAddress(server);
-    DatanodeID fakeDnId = DFSTestUtil.getLocalDatanodeID(addr.getPort());
-    DatanodeInfo dInfo = new DatanodeInfoBuilder().setNodeID(fakeDnId)
-        .build();
-    InterDatanodeProtocol proxy = null;
-
-    try {
-      proxy = DataNode.createInterDataNodeProtocolProxy(
-          dInfo, conf, 500, false);
-      proxy.initReplicaRecovery(new RecoveringBlock(
-          new ExtendedBlock("bpid", 1), null, 100));
-      fail ("Expected SocketTimeoutException exception, but did not get.");
-    } finally {
-      if (proxy != null) {
-        RPC.stopProxy(proxy);
+    assertThrows(SocketTimeoutException.class, () -> {
+      final Server server = new TestServer(1, true);
+      server.start();
+      final InetSocketAddress addr = NetUtils.getConnectAddress(server);
+      DatanodeID fakeDnId = DFSTestUtil.getLocalDatanodeID(addr.getPort());
+      DatanodeInfo dInfo = new DatanodeInfoBuilder().setNodeID(fakeDnId)
+          .build();
+      InterDatanodeProtocol proxy = null;
+      try {
+        proxy = DataNode.createInterDataNodeProtocolProxy(
+            dInfo, conf, 500, false);
+        proxy.initReplicaRecovery(new RecoveringBlock(
+            new ExtendedBlock("bpid", 1), null, 100));
+        fail("Expected SocketTimeoutException exception, but did not get.");
+      } finally {
+        if (proxy != null) {
+          RPC.stopProxy(proxy);
+        }
+        server.stop();
       }
-      server.stop();
-    }
+    });
+
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
@@ -223,7 +223,8 @@ public class TestInterDatanodeProtocol {
     return new FinalizedReplica(b, new ExternalVolumeImpl(), null);
   }
 
-  private static void assertReplicaEquals(ReplicaInfo originalInfo, ReplicaRecoveryInfo recoveryInfo) {
+  private static void assertReplicaEquals(ReplicaInfo originalInfo, ReplicaRecoveryInfo
+      recoveryInfo) {
     assertEquals(originalInfo.getBlockId(), recoveryInfo.getBlockId());
     assertEquals(originalInfo.getGenerationStamp(), recoveryInfo.getGenerationStamp());
     assertEquals(originalInfo.getBytesOnDisk(), recoveryInfo.getNumBytes());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestInterDatanodeProtocol.java
@@ -65,7 +65,7 @@ import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.net.NetUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * This tests InterDataNodeProtocol for block handling. 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistFiles.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ThreadUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -36,9 +36,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestLazyPersistFiles extends LazyPersistTestCase {
   private static final int THREADPOOL_SIZE = 10;
@@ -101,7 +102,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
 
     // Stop the DataNode.
     shutdownDataNodes();
-    assertThat(cluster.getNamesystem().getNumDeadDataNodes(), is(1));
+    assertThat(cluster.getNamesystem().getNumDeadDataNodes()).isEqualTo(1);
 
     // Next, wait for the redundancy monitor to mark the file as corrupt.
     waitForRedundancyMonitorCycle();
@@ -140,7 +141,8 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
  /**
   * If NN restarted then lazyPersist files should not deleted
   */
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testFileShouldNotDiscardedIfNNRestarted()
       throws IOException, InterruptedException, TimeoutException {
     getClusterBuilder().setRamDiskReplicaCapacity(2).build();
@@ -182,7 +184,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
       @Override
       public void run() {
         try {
-          Assert.assertTrue(verifyReadRandomFile(path1, BLOCK_SIZE, SEED));
+          assertTrue(verifyReadRandomFile(path1, BLOCK_SIZE, SEED));
         } catch (Throwable e) {
           LOG.error("readerRunnable error", e);
           testFailed.set(true);
@@ -201,7 +203,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
     for (int i = 0; i < NUM_TASKS; i++) {
       ThreadUtil.joinUninterruptibly(threads[i]);
     }
-    Assert.assertFalse(testFailed.get());
+    assertFalse(testFailed.get());
   }
 
   /**
@@ -244,7 +246,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
     // Stop executor from adding new tasks to finish existing threads in queue
     latch.await();
 
-    assertThat(testFailed.get(), is(false));
+    assertThat(testFailed.get()).isEqualTo(false);
   }
 
   class WriterRunnable implements Runnable {
@@ -284,7 +286,8 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testReleaseVolumeRefIfExceptionThrown()
       throws IOException, InterruptedException {
     getClusterBuilder().setRamDiskReplicaCapacity(2).build();
@@ -313,8 +316,7 @@ public class TestLazyPersistFiles extends LazyPersistTestCase {
       // asyncLazyPersistService is already shutdown.
       // If we do not release references, the number of
       // references will increase infinitely.
-      Assert.assertTrue(
-          beforeCnts[i] == afterCnt || beforeCnts[i] == (afterCnt - 1));
+      assertTrue(beforeCnts[i] == afterCnt || beforeCnts[i] == (afterCnt - 1));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistLockedMemory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistLockedMemory.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerTestUtil;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -40,8 +40,7 @@ import static org.apache.hadoop.fs.CreateFlag.CREATE;
 import static org.apache.hadoop.fs.CreateFlag.LAZY_PERSIST;
 import static org.apache.hadoop.fs.StorageType.DEFAULT;
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verify that locked memory is used correctly when writing to replicas in
@@ -77,7 +76,7 @@ public class TestLazyPersistLockedMemory extends LazyPersistTestCase {
     Path path = new Path("/" + METHOD_NAME + ".dat");
     makeTestFile(path, BLOCK_SIZE, true);
     ensureFileReplicasOnStorageType(path, RAM_DISK);
-    assertThat(fsd.getCacheUsed(), is((long) BLOCK_SIZE));
+    assertThat(fsd.getCacheUsed()).isEqualTo((long) BLOCK_SIZE);
   }
 
   @Test
@@ -91,7 +90,7 @@ public class TestLazyPersistLockedMemory extends LazyPersistTestCase {
     Path path = new Path("/" + METHOD_NAME + ".dat");
     makeTestFile(path, BLOCK_SIZE, true);
     ensureFileReplicasOnStorageType(path, RAM_DISK);
-    assertThat(fsd.getCacheUsed(), is((long) BLOCK_SIZE));
+    assertThat(fsd.getCacheUsed()).isEqualTo((long) BLOCK_SIZE);
 
     // Delete the file and ensure that the locked memory is released.
     fs.delete(path, false);
@@ -114,7 +113,7 @@ public class TestLazyPersistLockedMemory extends LazyPersistTestCase {
 
     Path path1 = new Path("/" + METHOD_NAME + ".01.dat");
     makeTestFile(path1, BLOCK_SIZE, true);
-    assertThat(fsd.getCacheUsed(), is((long) BLOCK_SIZE));
+    assertThat(fsd.getCacheUsed()).isEqualTo((long) BLOCK_SIZE);
 
     // Wait until the replica is written to persistent storage.
     waitForMetric("RamDiskBlocksLazyPersisted", 1);
@@ -138,7 +137,7 @@ public class TestLazyPersistLockedMemory extends LazyPersistTestCase {
 
     Path path = new Path("/" + METHOD_NAME + ".dat");
     makeTestFile(path, 1, true);
-    assertThat(fsd.getCacheUsed(), is(osPageSize));
+    assertThat(fsd.getCacheUsed()).isEqualTo(osPageSize);
 
     // Delete the file and ensure locked RAM usage goes to zero.
     fs.delete(path, false);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistPolicy.java
@@ -22,14 +22,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLazyPersistPolicy extends LazyPersistTestCase {
   @Test
@@ -42,7 +39,7 @@ public class TestLazyPersistPolicy extends LazyPersistTestCase {
     // Stat the file and check that the LAZY_PERSIST policy is not
     // returned back.
     HdfsFileStatus status = client.getFileInfo(path.toString());
-    assertThat(status.getStoragePolicy(), not(LAZY_PERSIST_POLICY_ID));
+    assertThat(status.getStoragePolicy()).isNotEqualTo(LAZY_PERSIST_POLICY_ID);
   }
 
   @Test
@@ -54,7 +51,7 @@ public class TestLazyPersistPolicy extends LazyPersistTestCase {
     makeTestFile(path, 0, true);
     // Stat the file and check that the lazyPersist flag is returned back.
     HdfsFileStatus status = client.getFileInfo(path.toString());
-    assertThat(status.getStoragePolicy(), is(LAZY_PERSIST_POLICY_ID));
+    assertThat(status.getStoragePolicy()).isEqualTo(LAZY_PERSIST_POLICY_ID);
   }
 
   @Test
@@ -68,7 +65,7 @@ public class TestLazyPersistPolicy extends LazyPersistTestCase {
 
     // Stat the file and check that the lazyPersist flag is returned back.
     HdfsFileStatus status = client.getFileInfo(path.toString());
-    assertThat(status.getStoragePolicy(), is(LAZY_PERSIST_POLICY_ID));
+    assertThat(status.getStoragePolicy()).isEqualTo(LAZY_PERSIST_POLICY_ID);
   }
 
   @Test
@@ -86,6 +83,6 @@ public class TestLazyPersistPolicy extends LazyPersistTestCase {
 
     // Stat the file and check that the lazyPersist flag is returned back.
     HdfsFileStatus status = client.getFileInfo(path.toString());
-    assertThat(status.getStoragePolicy(), is(LAZY_PERSIST_POLICY_ID));
+    assertThat(status.getStoragePolicy()).isEqualTo(LAZY_PERSIST_POLICY_ID);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistReplicaPlacement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistReplicaPlacement.java
@@ -23,16 +23,15 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.StorageType.DEFAULT;
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestLazyPersistReplicaPlacement extends LazyPersistTestCase {
   @Test
@@ -147,8 +146,8 @@ public class TestLazyPersistReplicaPlacement extends LazyPersistTestCase {
 
     // Since eviction is asynchronous, depending on the timing of eviction
     // wrt writes, we may get 2 or less blocks on RAM disk.
-    assertThat(numBlocksOnRamDisk, is(2));
-    assertThat(numBlocksOnDisk, is(3));
+    assertThat(numBlocksOnRamDisk).isEqualTo(2);
+    assertThat(numBlocksOnDisk).isEqualTo(3);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistReplicaRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyPersistReplicaRecovery.java
@@ -27,14 +27,14 @@ import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.StorageType.DEFAULT;
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLazyPersistReplicaRecovery extends LazyPersistTestCase {
   @Test
@@ -61,8 +61,7 @@ public class TestLazyPersistReplicaRecovery extends LazyPersistTestCase {
     ensureFileReplicasOnStorageType(path1, RAM_DISK);
 
     LOG.info("Restarting the DataNode");
-    assertTrue("DN did not restart properly",
-        cluster.restartDataNode(0, true));
+    assertTrue(cluster.restartDataNode(0, true), "DN did not restart properly");
     // wait for blockreport
     waitForBlockReport(dn, dnd);
     // Ensure that the replica is now on persistent storage.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestLazyWriter.java
@@ -23,8 +23,7 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,9 +32,9 @@ import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.StorageType.DEFAULT;
 import static org.apache.hadoop.fs.StorageType.RAM_DISK;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLazyWriter extends LazyPersistTestCase {
   @Test
@@ -192,9 +191,9 @@ public class TestLazyWriter extends LazyPersistTestCase {
         ensureFileReplicasOnStorageType(path, RAM_DISK);
     // Delete before persist
     client.delete(path.toString(), false);
-    Assert.assertFalse(fs.exists(path));
+    assertFalse(fs.exists(path));
 
-    assertThat(verifyDeletedBlocks(locatedBlocks), is(true));
+    assertThat(verifyDeletedBlocks(locatedBlocks)).isEqualTo(true);
 
     verifyRamDiskJMXMetric("RamDiskBlocksDeletedBeforeLazyPersisted", 1);
   }
@@ -218,9 +217,9 @@ public class TestLazyWriter extends LazyPersistTestCase {
 
     // Delete after persist
     client.delete(path.toString(), false);
-    Assert.assertFalse(fs.exists(path));
+    assertFalse(fs.exists(path));
 
-    assertThat(verifyDeletedBlocks(locatedBlocks), is(true));
+    assertThat(verifyDeletedBlocks(locatedBlocks)).isEqualTo(true);
     verifyRamDiskJMXMetric("RamDiskBlocksLazyPersisted", 1);
     verifyRamDiskJMXMetric("RamDiskBytesLazyPersisted", BLOCK_SIZE);
   }
@@ -243,17 +242,17 @@ public class TestLazyWriter extends LazyPersistTestCase {
     makeTestFile(path, BLOCK_SIZE, true);
     long usedAfterCreate = fs.getUsed();
 
-    assertThat(usedAfterCreate, is((long) BLOCK_SIZE));
+    assertThat(usedAfterCreate).isEqualTo((long) BLOCK_SIZE);
 
     waitForMetric("RamDiskBlocksLazyPersisted", 1);
 
     long usedAfterPersist = fs.getUsed();
-    assertThat(usedAfterPersist, is((long) BLOCK_SIZE));
+    assertThat(usedAfterPersist).isEqualTo((long) BLOCK_SIZE);
 
     // Delete after persist
     client.delete(path.toString(), false);
     long usedAfterDelete = fs.getUsed();
 
-    assertThat(usedBeforeCreate, is(usedAfterDelete));
+    assertThat(usedBeforeCreate).isEqualTo(usedAfterDelete);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestPmemCacheRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestPmemCacheRecovery.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,7 +104,7 @@ public class TestPmemCacheRecovery {
 
   @BeforeAll
   public static void setUpClass() throws Exception {
-    assumeTrue("Requires PMDK", NativeIO.POSIX.isPmdkAvailable());
+    assumeTrue(NativeIO.POSIX.isPmdkAvailable(), "Requires PMDK");
 
     oldInjector = DataNodeFaultInjector.get();
     DataNodeFaultInjector.set(new DataNodeFaultInjector() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestPmemCacheRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestPmemCacheRecovery.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.hdfs.server.datanode.DataNodeFaultInjector;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -55,12 +55,12 @@ import org.apache.hadoop.io.nativeio.NativeIO.POSIX.NoMlockCacheManipulator;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
@@ -102,7 +102,7 @@ public class TestPmemCacheRecovery {
         LoggerFactory.getLogger(FsDatasetCache.class), Level.DEBUG);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     assumeTrue("Requires PMDK", NativeIO.POSIX.isPmdkAvailable());
 
@@ -120,12 +120,12 @@ public class TestPmemCacheRecovery {
     });
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception {
     DataNodeFaultInjector.set(oldInjector);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.setBoolean(DFS_DATANODE_PMEM_CACHE_RECOVERY_KEY, true);
@@ -155,7 +155,7 @@ public class TestPmemCacheRecovery {
     cacheManager = ((FsDatasetImpl) dn.getFSDataset()).cacheManager;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (fs != null) {
       fs.close();
@@ -215,12 +215,13 @@ public class TestPmemCacheRecovery {
     return keys;
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCacheRecovery() throws Exception {
     final int cacheBlocksNum =
         Ints.checkedCast(CACHE_AMOUNT / BLOCK_SIZE);
     BlockReaderTestUtil.enableHdfsCachingTracing();
-    Assert.assertEquals(0, CACHE_AMOUNT % BLOCK_SIZE);
+    assertEquals(0, CACHE_AMOUNT % BLOCK_SIZE);
 
     final Path testFile = new Path("/testFile");
     final long testFileLen = cacheBlocksNum * BLOCK_SIZE;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestProvidedImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestProvidedImpl.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_SCAN_PERIOD_HOURS_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,8 +82,8 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi.BlockIterator;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,7 +313,7 @@ public class TestProvidedImpl {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     datanode = mock(DataNode.class);
     storage = mock(DataStorage.class);
@@ -367,8 +367,7 @@ public class TestProvidedImpl {
   @Test
   public void testProvidedVolumeImpl() throws IOException {
 
-    assertEquals(NUM_LOCAL_INIT_VOLUMES + NUM_PROVIDED_INIT_VOLUMES,
-        getNumVolumes());
+    assertEquals(NUM_LOCAL_INIT_VOLUMES + NUM_PROVIDED_INIT_VOLUMES, getNumVolumes());
     assertEquals(NUM_PROVIDED_INIT_VOLUMES, providedVolumes.size());
     assertEquals(0, dataset.getNumFailedVolumes());
 
@@ -376,8 +375,7 @@ public class TestProvidedImpl {
       // check basic information about provided volume
       assertEquals(DFSConfigKeys.DFS_PROVIDER_STORAGEUUID_DEFAULT,
           providedVolumes.get(i).getStorageID());
-      assertEquals(StorageType.PROVIDED,
-          providedVolumes.get(i).getStorageType());
+      assertEquals(StorageType.PROVIDED, providedVolumes.get(i).getStorageType());
 
       long space = providedVolumes.get(i).getBlockPoolUsed(
               BLOCK_POOL_IDS[CHOSEN_BP_ID]);
@@ -388,9 +386,9 @@ public class TestProvidedImpl {
       providedVolumes.get(i).shutdownBlockPool(
           BLOCK_POOL_IDS[1 - CHOSEN_BP_ID], null);
       try {
-        assertEquals(0, providedVolumes.get(i)
-            .getBlockPoolUsed(BLOCK_POOL_IDS[1 - CHOSEN_BP_ID]));
-        // should not be triggered
+        assertEquals(0,
+            providedVolumes.get(i).getBlockPoolUsed(BLOCK_POOL_IDS[1 - CHOSEN_BP_ID]));
+          // should not be triggered
         assertTrue(false);
       } catch (IOException e) {
         LOG.info("Expected exception: " + e);
@@ -413,8 +411,7 @@ public class TestProvidedImpl {
           assertEquals(null, volumeMap.replicas(BLOCK_POOL_IDS[j]));
         }
       }
-      assertEquals(NUM_PROVIDED_BLKS,
-          volumeMap.replicas(BLOCK_POOL_IDS[CHOSEN_BP_ID]).size());
+      assertEquals(NUM_PROVIDED_BLKS, volumeMap.replicas(BLOCK_POOL_IDS[CHOSEN_BP_ID]).size());
     }
   }
 
@@ -499,48 +496,37 @@ public class TestProvidedImpl {
     // all these blocks can belong to the provided volume
     int blocksFound = getBlocksInProvidedVolumes(providedBasePath + "/test1/",
         expectedBlocks, minId);
-    assertEquals(
-        "Number of blocks in provided volumes should be " + expectedBlocks,
-        expectedBlocks, blocksFound);
+    assertEquals(expectedBlocks, blocksFound,
+        "Number of blocks in provided volumes should be " + expectedBlocks);
     blocksFound = getBlocksInProvidedVolumes(
         "file:/" + providedBasePath + "/test1/", expectedBlocks, minId);
-    assertEquals(
-        "Number of blocks in provided volumes should be " + expectedBlocks,
-        expectedBlocks, blocksFound);
+    assertEquals(expectedBlocks, blocksFound,
+        "Number of blocks in provided volumes should be " + expectedBlocks);
     // use a path that is entirely different from the providedBasePath
     // none of these blocks can belong to the volume
     blocksFound =
         getBlocksInProvidedVolumes("randomtest1/", expectedBlocks, minId);
-    assertEquals("Number of blocks in provided volumes should be 0", 0,
-        blocksFound);
+    assertEquals(0, blocksFound, "Number of blocks in provided volumes should be 0");
   }
 
   @Test
   public void testProvidedVolumeContainsBlock() throws URISyntaxException {
     assertEquals(true, ProvidedVolumeImpl.containsBlock(null, null));
+    assertEquals(false, ProvidedVolumeImpl.containsBlock(new URI("file:/a"), null));
+    assertEquals(true,
+        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/c/"), new URI("file:/a/b/c/d/e.file")));
+    assertEquals(true,
+        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c/"), new URI("file:/a/b/c/d/e.file")));
+    assertEquals(true,
+        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c"), new URI("file:/a/b/c/d/e.file")));
+    assertEquals(true,
+        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c/"), new URI("/a/b/c/d/e.file")));
+    assertEquals(true,
+        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/c/"), new URI("/a/b/c/d/e.file")));
     assertEquals(false,
-        ProvidedVolumeImpl.containsBlock(new URI("file:/a"), null));
-    assertEquals(true,
-        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/c/"),
-            new URI("file:/a/b/c/d/e.file")));
-    assertEquals(true,
-        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c/"),
-            new URI("file:/a/b/c/d/e.file")));
-    assertEquals(true,
-        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c"),
-            new URI("file:/a/b/c/d/e.file")));
-    assertEquals(true,
-        ProvidedVolumeImpl.containsBlock(new URI("/a/b/c/"),
-            new URI("/a/b/c/d/e.file")));
-    assertEquals(true,
-        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/c/"),
-            new URI("/a/b/c/d/e.file")));
+        ProvidedVolumeImpl.containsBlock(new URI("/a/b/e"), new URI("file:/a/b/c/d/e.file")));
     assertEquals(false,
-        ProvidedVolumeImpl.containsBlock(new URI("/a/b/e"),
-            new URI("file:/a/b/c/d/e.file")));
-    assertEquals(false,
-        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/e"),
-            new URI("file:/a/b/c/d/e.file")));
+        ProvidedVolumeImpl.containsBlock(new URI("file:/a/b/e"), new URI("file:/a/b/c/d/e.file")));
     assertEquals(true,
         ProvidedVolumeImpl.containsBlock(new URI("s3a:/bucket1/dir1/"),
             new URI("s3a:/bucket1/dir1/temp.txt")));
@@ -557,31 +543,28 @@ public class TestProvidedImpl {
 
   @Test
   public void testProvidedReplicaSuffixExtraction() {
-    assertEquals("B.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("file:///A/"), new Path("file:///A/B.txt")));
-    assertEquals("B/C.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("file:///A/"), new Path("file:///A/B/C.txt")));
-    assertEquals("B/C/D.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("file:///A/"), new Path("file:///A/B/C/D.txt")));
-    assertEquals("D.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("file:///A/B/C/"), new Path("file:///A/B/C/D.txt")));
-    assertEquals("file:/A/B/C/D.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("file:///X/B/C/"), new Path("file:///A/B/C/D.txt")));
-    assertEquals("D.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("/A/B/C"), new Path("/A/B/C/D.txt")));
-    assertEquals("D.txt", ProvidedVolumeImpl.getSuffix(
-        new Path("/A/B/C/"), new Path("/A/B/C/D.txt")));
+    assertEquals("B.txt",
+        ProvidedVolumeImpl.getSuffix(new Path("file:///A/"), new Path("file:///A/B.txt")));
+    assertEquals("B/C.txt",
+        ProvidedVolumeImpl.getSuffix(new Path("file:///A/"), new Path("file:///A/B/C.txt")));
+    assertEquals("B/C/D.txt",
+        ProvidedVolumeImpl.getSuffix(new Path("file:///A/"), new Path("file:///A/B/C/D.txt")));
+    assertEquals("D.txt", ProvidedVolumeImpl.getSuffix(new Path("file:///A/B/C/"),
+        new Path("file:///A/B/C/D.txt")));
+    assertEquals("file:/A/B/C/D.txt", ProvidedVolumeImpl.getSuffix(new Path("file:///X/B/C/"),
+        new Path("file:///A/B/C/D.txt")));
+    assertEquals("D.txt",
+        ProvidedVolumeImpl.getSuffix(new Path("/A/B/C"), new Path("/A/B/C/D.txt")));
+    assertEquals("D.txt",
+        ProvidedVolumeImpl.getSuffix(new Path("/A/B/C/"), new Path("/A/B/C/D.txt")));
 
     assertEquals("data/current.csv", ProvidedVolumeImpl.getSuffix(
-        new Path("wasb:///users/alice/"),
-        new Path("wasb:///users/alice/data/current.csv")));
-    assertEquals("current.csv", ProvidedVolumeImpl.getSuffix(
-        new Path("wasb:///users/alice/data"),
+        new Path("wasb:///users/alice/"), new Path("wasb:///users/alice/data/current.csv")));
+    assertEquals("current.csv", ProvidedVolumeImpl.getSuffix(new Path("wasb:///users/alice/data"),
         new Path("wasb:///users/alice/data/current.csv")));
 
     assertEquals("wasb:/users/alice/data/current.csv",
-        ProvidedVolumeImpl.getSuffix(
-            new Path("wasb:///users/bob/"),
+        ProvidedVolumeImpl.getSuffix(new Path("wasb:///users/bob/"),
             new Path("wasb:///users/alice/data/current.csv")));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaCachingGetSpaceUsed.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaCachingGetSpaceUsed.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.Replica;
 import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsDatasetSpi;
 import org.apache.hadoop.io.IOUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -44,7 +44,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DU_INTERVAL_KEY;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for ReplicaCachingGetSpaceUsed class.
@@ -55,7 +56,7 @@ public class TestReplicaCachingGetSpaceUsed {
   private DistributedFileSystem fs;
   private DataNode dataNode;
 
-  @Before
+  @BeforeEach
   public void setUp()
       throws IOException, NoSuchMethodException, InterruptedException {
     conf = new Configuration();
@@ -70,7 +71,7 @@ public class TestReplicaCachingGetSpaceUsed {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -104,8 +105,7 @@ public class TestReplicaCachingGetSpaceUsed {
     // Guarantee ReplicaCachingGetSpaceUsed#refresh() is called after replica
     // has been written to disk.
     Thread.sleep(2000);
-    assertEquals(blockLength + metaLength,
-        dataNode.getFSDataset().getDfsUsed());
+    assertEquals(blockLength + metaLength, dataNode.getFSDataset().getDfsUsed());
 
     fs.delete(new Path("/testReplicaCachingGetSpaceUsedByFINALIZEDReplica"),
         true);
@@ -137,8 +137,7 @@ public class TestReplicaCachingGetSpaceUsed {
     // Guarantee ReplicaCachingGetSpaceUsed#refresh() is called after replica
     // has been written to disk.
     Thread.sleep(2000);
-    assertEquals(blockLength + metaLength,
-        dataNode.getFSDataset().getDfsUsed());
+    assertEquals(blockLength + metaLength, dataNode.getFSDataset().getDfsUsed());
 
     os.close();
 
@@ -148,13 +147,13 @@ public class TestReplicaCachingGetSpaceUsed {
     // After close operation, the replica state will be transformed from RBW to
     // finalized. But the space used of these replicas are all included and the
     // dfsUsed value should be same.
-    assertEquals(blockLength + metaLength,
-        dataNode.getFSDataset().getDfsUsed());
+    assertEquals(blockLength + metaLength, dataNode.getFSDataset().getDfsUsed());
 
     fs.delete(new Path("/testReplicaCachingGetSpaceUsedByRBWReplica"), true);
   }
 
-  @Test(timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testFsDatasetImplDeepCopyReplica() {
     FsDatasetSpi<?> fsDataset = dataNode.getFSDataset();
     ModifyThread modifyThread = new ModifyThread();
@@ -170,7 +169,7 @@ public class TestReplicaCachingGetSpaceUsed {
         }
       } catch (IOException e) {
         modifyThread.setShouldRun(false);
-        Assert.fail("Encounter IOException when deep copy replica.");
+        fail("Encounter IOException when deep copy replica.");
       }
     }
     modifyThread.setShouldRun(false);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReplicaMap.java
@@ -17,15 +17,14 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.datanode.FinalizedReplica;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for ReplicasMap class
@@ -35,7 +34,7 @@ public class TestReplicaMap {
   private final String bpid = "BP-TEST";
   private final  Block block = new Block(1234, 1234, 1234);
   
-  @Before
+  @BeforeEach
   public void setup() {
     map.add(bpid, new FinalizedReplica(block, null, null));
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReservedSpaceCalculator.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestReservedSpaceCalculator.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DF;
 import org.apache.hadoop.fs.StorageType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DU_RESERVED_KEY;
@@ -31,7 +31,8 @@ import static org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.ReservedSpac
 import static org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.ReservedSpaceCalculator.ReservedSpaceCalculatorAggressive;
 import static org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.ReservedSpaceCalculator.ReservedSpaceCalculatorConservative;
 import static org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.ReservedSpaceCalculator.ReservedSpaceCalculatorPercentage;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,7 +44,7 @@ public class TestReservedSpaceCalculator {
   private DF usage;
   private ReservedSpaceCalculator reserved;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new Configuration();
     usage = Mockito.mock(DF.class);
@@ -217,13 +218,15 @@ public class TestReservedSpaceCalculator {
     checkReserved(StorageType.DISK, 10000, 4000, dir3);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testInvalidCalculator() {
-    conf.set(DFS_DATANODE_DU_RESERVED_CALCULATOR_KEY, "INVALIDTYPE");
-    reserved = new ReservedSpaceCalculator.Builder(conf)
-        .setUsage(usage)
-        .setStorageType(StorageType.DISK)
-        .build();
+    assertThrows(IllegalStateException.class, () -> {
+      conf.set(DFS_DATANODE_DU_RESERVED_CALCULATOR_KEY, "INVALIDTYPE");
+      reserved = new ReservedSpaceCalculator.Builder(conf)
+          .setUsage(usage)
+          .setStorageType(StorageType.DISK)
+          .build();
+    });
   }
 
   private void checkReserved(StorageType storageType,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestWriteToReplica.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/TestWriteToReplica.java
@@ -17,9 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.fsdataset.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,8 +49,7 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test if FSDataset#append, writeToRbw, and writeToTmp */
 public class TestWriteToReplica {
@@ -187,9 +187,9 @@ public class TestWriteToReplica {
         fvi.onBlockFileDeletion(bpid, -available);
         blocks[FINALIZED].setNumBytes(expectedLen + 100);
         dataSet.append(blocks[FINALIZED], newGS, expectedLen);
-        Assert.fail("Should not have space to append to an RWR replica" + blocks[RWR]);
+        fail("Should not have space to append to an RWR replica" + blocks[RWR]);
       } catch (DiskOutOfSpaceException e) {
-        Assert.assertTrue(e.getMessage().startsWith(
+        assertTrue(e.getMessage().startsWith(
             "Insufficient space for appending to "));
       }
       fvi.onBlockFileDeletion(bpid, available);
@@ -204,51 +204,51 @@ public class TestWriteToReplica {
     try {
       dataSet.append(blocks[TEMPORARY], blocks[TEMPORARY].getGenerationStamp()+1, 
           blocks[TEMPORARY].getNumBytes());
-      Assert.fail("Should not have appended to a temporary replica " 
+      fail("Should not have appended to a temporary replica "
           + blocks[TEMPORARY]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA +
-          blocks[TEMPORARY], e.getMessage());
+      assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA + blocks[TEMPORARY],
+          e.getMessage());
     }
 
     try {
       dataSet.append(blocks[RBW], blocks[RBW].getGenerationStamp()+1,
           blocks[RBW].getNumBytes());
-      Assert.fail("Should not have appended to an RBW replica" + blocks[RBW]);
+      fail("Should not have appended to an RBW replica" + blocks[RBW]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA +
-          blocks[RBW], e.getMessage());
+      assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA + blocks[RBW],
+          e.getMessage());
     }
 
     try {
       dataSet.append(blocks[RWR], blocks[RWR].getGenerationStamp()+1,
           blocks[RBW].getNumBytes());
-      Assert.fail("Should not have appended to an RWR replica" + blocks[RWR]);
+      fail("Should not have appended to an RWR replica" + blocks[RWR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA +
-          blocks[RWR], e.getMessage());
+      assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA + blocks[RWR],
+          e.getMessage());
     }
 
     try {
       dataSet.append(blocks[RUR], blocks[RUR].getGenerationStamp()+1,
           blocks[RUR].getNumBytes());
-      Assert.fail("Should not have appended to an RUR replica" + blocks[RUR]);
+      fail("Should not have appended to an RUR replica" + blocks[RUR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA +
-          blocks[RUR], e.getMessage());
+      assertEquals(ReplicaNotFoundException.UNFINALIZED_REPLICA + blocks[RUR],
+          e.getMessage());
     }
 
     try {
       dataSet.append(blocks[NON_EXISTENT], 
           blocks[NON_EXISTENT].getGenerationStamp(), 
           blocks[NON_EXISTENT].getNumBytes());
-      Assert.fail("Should not have appended to a non-existent replica " + 
+      fail("Should not have appended to a non-existent replica " +
           blocks[NON_EXISTENT]);
     } catch (ReplicaNotFoundException e) {
       String expectMessage = ReplicaNotFoundException.NON_EXISTENT_REPLICA
           + blocks[NON_EXISTENT].getBlockPoolId() + ":"
           + blocks[NON_EXISTENT].getBlockId();
-      Assert.assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectMessage, e.getMessage());
     }
     
     newGS = blocks[FINALIZED].getGenerationStamp()+1;
@@ -259,10 +259,10 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverAppend(blocks[TEMPORARY], blocks[TEMPORARY].getGenerationStamp()+1, 
           blocks[TEMPORARY].getNumBytes());
-      Assert.fail("Should not have appended to a temporary replica " 
+      fail("Should not have appended to a temporary replica "
           + blocks[TEMPORARY]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
@@ -273,18 +273,18 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverAppend(blocks[RWR], blocks[RWR].getGenerationStamp()+1,
           blocks[RBW].getNumBytes());
-      Assert.fail("Should not have appended to an RWR replica" + blocks[RWR]);
+      fail("Should not have appended to an RWR replica" + blocks[RWR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
     try {
       dataSet.recoverAppend(blocks[RUR], blocks[RUR].getGenerationStamp()+1,
           blocks[RUR].getNumBytes());
-      Assert.fail("Should not have appended to an RUR replica" + blocks[RUR]);
+      fail("Should not have appended to an RUR replica" + blocks[RUR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
@@ -292,10 +292,10 @@ public class TestWriteToReplica {
       dataSet.recoverAppend(blocks[NON_EXISTENT], 
           blocks[NON_EXISTENT].getGenerationStamp(), 
           blocks[NON_EXISTENT].getNumBytes());
-      Assert.fail("Should not have appended to a non-existent replica " + 
+      fail("Should not have appended to a non-existent replica " +
           blocks[NON_EXISTENT]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_EXISTENT_REPLICA));
     }
   }
@@ -309,10 +309,10 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverClose(blocks[TEMPORARY], blocks[TEMPORARY].getGenerationStamp()+1, 
           blocks[TEMPORARY].getNumBytes());
-      Assert.fail("Should not have recovered close a temporary replica " 
+      fail("Should not have recovered close a temporary replica "
           + blocks[TEMPORARY]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
@@ -323,18 +323,18 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverClose(blocks[RWR], blocks[RWR].getGenerationStamp()+1,
           blocks[RBW].getNumBytes());
-      Assert.fail("Should not have recovered close an RWR replica" + blocks[RWR]);
+      fail("Should not have recovered close an RWR replica" + blocks[RWR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
     try {
       dataSet.recoverClose(blocks[RUR], blocks[RUR].getGenerationStamp()+1,
           blocks[RUR].getNumBytes());
-      Assert.fail("Should not have recovered close an RUR replica" + blocks[RUR]);
+      fail("Should not have recovered close an RUR replica" + blocks[RUR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.UNFINALIZED_AND_NONRBW_REPLICA));
     }
 
@@ -342,10 +342,10 @@ public class TestWriteToReplica {
       dataSet.recoverClose(blocks[NON_EXISTENT], 
           blocks[NON_EXISTENT].getGenerationStamp(), 
           blocks[NON_EXISTENT].getNumBytes());
-      Assert.fail("Should not have recovered close a non-existent replica " + 
+      fail("Should not have recovered close a non-existent replica " +
           blocks[NON_EXISTENT]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_EXISTENT_REPLICA));
     }
   }
@@ -355,16 +355,16 @@ public class TestWriteToReplica {
       dataSet.recoverRbw(blocks[FINALIZED],
           blocks[FINALIZED].getGenerationStamp()+1,
           0L, blocks[FINALIZED].getNumBytes());
-      Assert.fail("Should not have recovered a finalized replica " +
+      fail("Should not have recovered a finalized replica " +
           blocks[FINALIZED]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_RBW_REPLICA));
     }
  
     try {
       dataSet.createRbw(StorageType.DEFAULT, null, blocks[FINALIZED], false);
-      Assert.fail("Should not have created a replica that's already " +
+      fail("Should not have created a replica that's already " +
       		"finalized " + blocks[FINALIZED]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -373,16 +373,16 @@ public class TestWriteToReplica {
       dataSet.recoverRbw(blocks[TEMPORARY], 
           blocks[TEMPORARY].getGenerationStamp()+1, 
           0L, blocks[TEMPORARY].getNumBytes());
-      Assert.fail("Should not have recovered a temporary replica " +
+      fail("Should not have recovered a temporary replica " +
           blocks[TEMPORARY]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_RBW_REPLICA));
     }
 
     try {
       dataSet.createRbw(StorageType.DEFAULT, null, blocks[TEMPORARY], false);
-      Assert.fail("Should not have created a replica that had created as " +
+      fail("Should not have created a replica that had created as " +
       		"temporary " + blocks[TEMPORARY]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -392,7 +392,7 @@ public class TestWriteToReplica {
     
     try {
       dataSet.createRbw(StorageType.DEFAULT, null, blocks[RBW], false);
-      Assert.fail("Should not have created a replica that had created as RBW " +
+      fail("Should not have created a replica that had created as RBW " +
           blocks[RBW]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -400,15 +400,15 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverRbw(blocks[RWR], blocks[RWR].getGenerationStamp()+1,
           0L, blocks[RWR].getNumBytes());
-      Assert.fail("Should not have recovered a RWR replica " + blocks[RWR]);
+      fail("Should not have recovered a RWR replica " + blocks[RWR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_RBW_REPLICA));
     }
 
     try {
       dataSet.createRbw(StorageType.DEFAULT, null, blocks[RWR], false);
-      Assert.fail("Should not have created a replica that was waiting to be " +
+      fail("Should not have created a replica that was waiting to be " +
       		"recovered " + blocks[RWR]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -416,15 +416,15 @@ public class TestWriteToReplica {
     try {
       dataSet.recoverRbw(blocks[RUR], blocks[RUR].getGenerationStamp()+1,
           0L, blocks[RUR].getNumBytes());
-      Assert.fail("Should not have recovered a RUR replica " + blocks[RUR]);
+      fail("Should not have recovered a RUR replica " + blocks[RUR]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(e.getMessage().startsWith(
+      assertTrue(e.getMessage().startsWith(
           ReplicaNotFoundException.NON_RBW_REPLICA));
     }
 
     try {
       dataSet.createRbw(StorageType.DEFAULT, null, blocks[RUR], false);
-      Assert.fail("Should not have created a replica that was under recovery " +
+      fail("Should not have created a replica that was under recovery " +
           blocks[RUR]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -433,10 +433,10 @@ public class TestWriteToReplica {
       dataSet.recoverRbw(blocks[NON_EXISTENT],
           blocks[NON_EXISTENT].getGenerationStamp()+1,
           0L, blocks[NON_EXISTENT].getNumBytes());
-      Assert.fail("Cannot recover a non-existent replica " +
+      fail("Cannot recover a non-existent replica " +
           blocks[NON_EXISTENT]);
     } catch (ReplicaNotFoundException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains(ReplicaNotFoundException.NON_EXISTENT_REPLICA));
     }
     
@@ -447,7 +447,7 @@ public class TestWriteToReplica {
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[FINALIZED],
           false);
-      Assert.fail("Should not have created a temporary replica that was " +
+      fail("Should not have created a temporary replica that was " +
       		"finalized " + blocks[FINALIZED]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -455,28 +455,28 @@ public class TestWriteToReplica {
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[TEMPORARY],
           false);
-      Assert.fail("Should not have created a replica that had created as" +
+      fail("Should not have created a replica that had created as" +
       		"temporary " + blocks[TEMPORARY]);
     } catch (ReplicaAlreadyExistsException e) {
     }
     
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[RBW], false);
-      Assert.fail("Should not have created a replica that had created as RBW " +
+      fail("Should not have created a replica that had created as RBW " +
           blocks[RBW]);
     } catch (ReplicaAlreadyExistsException e) {
     }
     
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[RWR], false);
-      Assert.fail("Should not have created a replica that was waiting to be " +
+      fail("Should not have created a replica that was waiting to be " +
       		"recovered " + blocks[RWR]);
     } catch (ReplicaAlreadyExistsException e) {
     }
     
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[RUR], false);
-      Assert.fail("Should not have created a replica that was under recovery " +
+      fail("Should not have created a replica that was under recovery " +
           blocks[RUR]);
     } catch (ReplicaAlreadyExistsException e) {
     }
@@ -487,12 +487,12 @@ public class TestWriteToReplica {
     try {
       dataSet.createTemporary(StorageType.DEFAULT, null, blocks[NON_EXISTENT],
           false);
-      Assert.fail("Should not have created a replica that had already been "
+      fail("Should not have created a replica that had already been "
           + "created " + blocks[NON_EXISTENT]);
     } catch (Exception e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains(blocks[NON_EXISTENT].getBlockName()));
-      Assert.assertTrue(e instanceof ReplicaAlreadyExistsException);
+      assertTrue(e instanceof ReplicaAlreadyExistsException);
     }
 
     long newGenStamp = blocks[NON_EXISTENT].getGenerationStamp() * 10;
@@ -501,11 +501,11 @@ public class TestWriteToReplica {
       ReplicaInPipeline replicaInfo =
           dataSet.createTemporary(StorageType.DEFAULT, null,
               blocks[NON_EXISTENT], false).getReplica();
-      Assert.assertTrue(replicaInfo.getGenerationStamp() == newGenStamp);
-      Assert.assertTrue(
+      assertTrue(replicaInfo.getGenerationStamp() == newGenStamp);
+      assertTrue(
           replicaInfo.getBlockId() == blocks[NON_EXISTENT].getBlockId());
     } catch (ReplicaAlreadyExistsException e) {
-      Assert.fail("createTemporary should have allowed the block with newer "
+      fail("createTemporary should have allowed the block with newer "
           + " generation stamp to be created " + blocks[NON_EXISTENT]);
     }
   }
@@ -526,8 +526,8 @@ public class TestWriteToReplica {
       cluster.waitActive();
       NameNode nn1 = cluster.getNameNode(0);
       NameNode nn2 = cluster.getNameNode(1);
-      assertNotNull("cannot create nn1", nn1);
-      assertNotNull("cannot create nn2", nn2);
+      assertNotNull(nn1, "cannot create nn1");
+      assertNotNull(nn2, "cannot create nn2");
       
       // check number of volumes in fsdataset
       DataNode dn = cluster.getDataNodes().get(0);
@@ -537,7 +537,7 @@ public class TestWriteToReplica {
       List<FsVolumeSpi> volumes = null;
       try (FsDatasetSpi.FsVolumeReferences referredVols = dataSet.getFsVolumeReferences()) {
         // number of volumes should be 2 - [data1, data2]
-        assertEquals("number of volumes is wrong", 2, referredVols.size());
+        assertEquals(2, referredVols.size(), "number of volumes is wrong");
         volumes = new ArrayList<>(referredVols.size());
         for (FsVolumeSpi vol : referredVols) {
           volumes.add(vol);
@@ -547,8 +547,7 @@ public class TestWriteToReplica {
           cluster.getNamesystem(0).getBlockPoolId(),
           cluster.getNamesystem(1).getBlockPoolId()));
       
-      Assert.assertTrue("Cluster should have 2 block pools", 
-          bpList.size() == 2);
+      assertTrue(bpList.size() == 2, "Cluster should have 2 block pools");
       
       createReplicas(bpList, volumes, cluster.getFsDatasetTestUtils(dn));
       ReplicaMap oldReplicaMap = new ReplicaMap();
@@ -592,7 +591,7 @@ public class TestWriteToReplica {
     fsDataset.recoverRbw(blocks[RBW], blocks[RBW].getGenerationStamp(), 0L,
         rbw.getNumBytes());
     // after the recovery, on disk length should equal acknowledged length.
-    Assert.assertTrue(rbw.getBytesOnDisk() == rbw.getBytesAcked());
+    assertTrue(rbw.getBytesOnDisk() == rbw.getBytesAcked());
 
     // reduce on disk length again; this time actually truncate the file to
     // simulate the data not being present
@@ -619,14 +618,14 @@ public class TestWriteToReplica {
     // replicaInfo from oldReplicaMap.
     for (String bpid: bpidList) {
       for (ReplicaInfo info: newReplicaMap.replicas(bpid)) {
-        assertNotNull("Volume map before restart didn't contain the "
-            + "blockpool: " + bpid, oldReplicaMap.replicas(bpid));
+        assertNotNull(oldReplicaMap.replicas(bpid),
+            "Volume map before restart didn't contain the " + "blockpool: " + bpid);
         
         ReplicaInfo oldReplicaInfo = oldReplicaMap.get(bpid, 
             info.getBlockId());
         // Volume map after restart contains a blockpool id which 
-        assertNotNull("Old Replica Map didnt't contain block with blockId: " +
-            info.getBlockId(), oldReplicaInfo);
+        assertNotNull(oldReplicaInfo,
+            "Old Replica Map didnt't contain block with blockId: " + info.getBlockId());
         
         ReplicaState oldState = oldReplicaInfo.getState();
         // Since after restart, all the RWR, RBW and RUR blocks gets 
@@ -649,8 +648,8 @@ public class TestWriteToReplica {
     for (String bpid: bpidList) {
       for (ReplicaInfo replicaInfo: oldReplicaMap.replicas(bpid)) {
         if (replicaInfo.getState() != ReplicaState.TEMPORARY) {
-          Assert.fail("After datanode restart we lost the block with blockId: "
-              +  replicaInfo.getBlockId());
+          fail("After datanode restart we lost the block with blockId: "
+              + replicaInfo.getBlockId());
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestDataNodeOutlierDetectionViaMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestDataNodeOutlierDetectionViaMetrics.java
@@ -24,10 +24,9 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.protocol.OutlierMetrics;
 import org.apache.hadoop.metrics2.lib.MetricsTestHelper;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -36,24 +35,18 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test that the {@link DataNodePeerMetrics} class is able to detect
  * outliers i.e. slow nodes via the metrics it maintains.
+ * Set a timeout for every test case.
  */
+@Timeout(300)
 public class TestDataNodeOutlierDetectionViaMetrics {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestDataNodeOutlierDetectionViaMetrics.class);
-
-  /**
-   * Set a timeout for every test case.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   // A few constants to keep the test run time short.
   private static final int WINDOW_INTERVAL_SECONDS = 3;
@@ -66,7 +59,7 @@ public class TestDataNodeOutlierDetectionViaMetrics {
 
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     GenericTestUtils.setLogLevel(DataNodePeerMetrics.LOG, Level.TRACE);
     GenericTestUtils.setLogLevel(OutlierDetector.LOG, Level.TRACE);
@@ -103,7 +96,7 @@ public class TestDataNodeOutlierDetectionViaMetrics {
 
     final Map<String, OutlierMetrics> outliers = peerMetrics.getOutliers();
     LOG.info("Got back outlier nodes: {}", outliers);
-    assertThat(outliers.size(), is(1));
+    assertThat(outliers.size()).isEqualTo(1);
     assertTrue(outliers.containsKey(slowNodeName));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestSlowNodeDetector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/metrics/TestSlowNodeDetector.java
@@ -23,10 +23,9 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -37,20 +36,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link OutlierDetector}.
+ * Set a timeout for every test case.
  */
+@Timeout(300)
 public class TestSlowNodeDetector {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestSlowNodeDetector.class);
-
-  /**
-   * Set a timeout for every test case.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   private final static double LOW_THRESHOLD = 1000;
   private final static long MIN_OUTLIER_DETECTION_PEERS = 3;
@@ -235,7 +231,7 @@ public class TestSlowNodeDetector {
 
   private OutlierDetector slowNodeDetector;
 
-  @Before
+  @BeforeEach
   public void setup() {
     slowNodeDetector = new OutlierDetector(MIN_OUTLIER_DETECTION_PEERS,
         (long) LOW_THRESHOLD);
@@ -251,10 +247,10 @@ public class TestSlowNodeDetector {
       final Set<String> outliers =
           slowNodeDetector.getOutliers(entry.getKey()).keySet();
       assertTrue(
+          outliers.equals(entry.getValue()),
           "Running outlier detection on " + entry.getKey() +
               " was expected to yield set " + entry.getValue() + ", but " +
-              " we got set " + outliers,
-          outliers.equals(entry.getValue()));
+              " we got set " + outliers);
     }
   }
 
@@ -276,9 +272,9 @@ public class TestSlowNodeDetector {
           Math.abs(median - expectedMedian) * 100.0 / expectedMedian;
 
       assertTrue(
-          "Set " + inputList + "; Expected median: " +
-              expectedMedian + ", got: " + median,
-          errorPercent < 0.001);
+          errorPercent < 0.001,
+          "Set " + inputList + "; Expected median: "
+              + expectedMedian + ", got: " + median);
     }
   }
 
@@ -301,16 +297,16 @@ public class TestSlowNodeDetector {
             Math.abs(mad - expectedMad) * 100.0 / expectedMad;
 
         assertTrue(
-            "Set " + entry.getKey() + "; Expected M.A.D.: " +
-                expectedMad + ", got: " + mad,
-            errorPercent < 0.001);
+            errorPercent < 0.001,
+            "Set " + entry.getKey() + "; Expected M.A.D.: "
+                + expectedMad + ", got: " + mad);
       } else {
         // For an input list of size 1, the MAD should be 0.0.
         final Double epsilon = 0.000001; // Allow for some FP math error.
         assertTrue(
-            "Set " + entry.getKey() + "; Expected M.A.D.: " +
-                expectedMad + ", got: " + mad,
-            mad < epsilon);
+            mad < epsilon,
+            "Set " + entry.getKey() + "; Expected M.A.D.: "
+                + expectedMad + ", got: " + mad);
       }
     }
   }
@@ -319,17 +315,21 @@ public class TestSlowNodeDetector {
    * Verify that {@link OutlierDetector#computeMedian(List)} throws when
    * passed an empty list.
    */
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testMedianOfEmptyList() {
-    OutlierDetector.computeMedian(Collections.emptyList());
+    assertThrows(IllegalArgumentException.class, () -> {
+      OutlierDetector.computeMedian(Collections.emptyList());
+    });
   }
 
   /**
    * Verify that {@link OutlierDetector#computeMad(List)} throws when
    * passed an empty list.
    */
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testMadOfEmptyList() {
-    OutlierDetector.computeMedian(Collections.emptyList());
+    assertThrows(IllegalArgumentException.class, () -> {
+      OutlierDetector.computeMedian(Collections.emptyList());
+    });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpXFrame.java
@@ -23,15 +23,17 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.http.HttpServer2;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test that X-Frame-Options works correctly with DatanodeHTTPServer.
@@ -40,10 +42,7 @@ public class TestDatanodeHttpXFrame {
 
   private MiniDFSCluster cluster = null;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @After
+  @AfterEach
   public void cleanUp() {
     if (cluster != null) {
       cluster.shutdown();
@@ -57,8 +56,8 @@ public class TestDatanodeHttpXFrame {
     cluster = createCluster(xFrameEnabled, null);
     HttpURLConnection conn = getConn(cluster);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertNotNull("X-FRAME-OPTIONS is absent in the header", xfoHeader);
-    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
+    assertNotNull(xfoHeader, "X-FRAME-OPTIONS is absent in the header");
+    assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
         .SAMEORIGIN.toString()));
   }
 
@@ -68,13 +67,14 @@ public class TestDatanodeHttpXFrame {
     cluster = createCluster(xFrameEnabled, null);
     HttpURLConnection conn = getConn(cluster);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertNull("unexpected X-FRAME-OPTION in header", xfoHeader);
+    assertNull(xfoHeader, "unexpected X-FRAME-OPTION in header");
   }
 
   @Test
   public void testDataNodeXFramewithInvalidOptions() throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    cluster = createCluster(false, "Hadoop");
+    assertThrows(IllegalArgumentException.class, () -> {
+      cluster = createCluster(false, "Hadoop");
+    });
   }
 
   private static MiniDFSCluster createCluster(boolean enabled, String

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestHostRestrictingAuthorizationFilterHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestHostRestrictingAuthorizationFilterHandler.java
@@ -28,15 +28,15 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.common.HostRestrictingAuthorizationFilter;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHostRestrictingAuthorizationFilterHandler {
 
@@ -56,11 +56,11 @@ public class TestHostRestrictingAuthorizationFilterHandler {
             HttpMethod.GET,
             WebHdfsFileSystem.PATH_PREFIX + "/user/myName/fooFile?op=OPEN");
     // we will send back an error so ensure our write returns false
-    assertFalse("Should get error back from handler for rejected request",
-        channel.writeInbound(httpRequest));
+    assertFalse(channel.writeInbound(httpRequest),
+        "Should get error back from handler for rejected request");
     DefaultHttpResponse channelResponse =
         (DefaultHttpResponse) channel.outboundMessages().poll();
-    assertNotNull("Expected response to exist.", channelResponse);
+    assertNotNull(channelResponse, "Expected response to exist.");
     assertEquals(HttpResponseStatus.FORBIDDEN, channelResponse.status());
     assertFalse(channel.isOpen());
   }
@@ -89,12 +89,11 @@ public class TestHostRestrictingAuthorizationFilterHandler {
         new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
             HttpMethod.GET,
             WebHdfsFileSystem.PATH_PREFIX + "/allowed/file_three?op=OPEN");
-    assertTrue("Should successfully accept request",
-        channel.writeInbound(allowedHttpRequest));
-    assertTrue("Should successfully accept request, second time",
-        channel.writeInbound(allowedHttpRequest2));
-    assertTrue("Should successfully accept request, third time",
-        channel.writeInbound(allowedHttpRequest3));
+    assertTrue(channel.writeInbound(allowedHttpRequest), "Should successfully accept request");
+    assertTrue(channel.writeInbound(allowedHttpRequest2),
+        "Should successfully accept request, second time");
+    assertTrue(channel.writeInbound(allowedHttpRequest3),
+        "Should successfully accept request, third time");
   }
 
   /*
@@ -125,15 +124,14 @@ public class TestHostRestrictingAuthorizationFilterHandler {
         new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
             HttpMethod.GET,
             WebHdfsFileSystem.PATH_PREFIX + "/allowed/file_three?op=OPEN");
-    assertTrue("Should successfully accept request",
-        channel1.writeInbound(allowedHttpRequest));
-    assertTrue("Should successfully accept request, second time",
-        channel2.writeInbound(allowedHttpRequest2));
+    assertTrue(channel1.writeInbound(allowedHttpRequest), "Should successfully accept request");
+    assertTrue(channel2.writeInbound(allowedHttpRequest2),
+        "Should successfully accept request, second time");
 
     // verify closing one channel does not affect remaining channels
     channel1.close();
-    assertTrue("Should successfully accept request, third time",
-        channel3.writeInbound(allowedHttpRequest3));
+    assertTrue(channel3.writeInbound(allowedHttpRequest3),
+        "Should successfully accept request, third time");
   }
 
   /*
@@ -148,8 +146,7 @@ public class TestHostRestrictingAuthorizationFilterHandler {
             HttpMethod.GET,
             WebHdfsFileSystem.PATH_PREFIX + "/user/myName/fooFile?op" +
                 "=GETFILECHECKSUM");
-    assertTrue("Should successfully accept request",
-        channel.writeInbound(httpRequest));
+    assertTrue(channel.writeInbound(httpRequest), "Should successfully accept request");
   }
 
   /*

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestDataNodeUGIProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestDataNodeUGIProvider.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.hdfs.server.datanode.web.webhdfs;
 
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -52,10 +54,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Lists;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDataNodeUGIProvider {
   private final URI uri = URI.create(WebHdfsConstants.WEBHDFS_SCHEME + "://"
@@ -65,7 +65,8 @@ public class TestDataNodeUGIProvider {
   private final int LENGTH = 512;
   private final static int EXPIRE_AFTER_ACCESS = 5*1000;
   private Configuration conf;
-  @Before
+
+  @BeforeEach
   public void setUp(){
     conf = WebHdfsTestUtil.createConf();
     conf.setInt(DFSConfigKeys.DFS_WEBHDFS_UGI_EXPIRE_AFTER_ACCESS_KEY,
@@ -107,22 +108,19 @@ public class TestDataNodeUGIProvider {
     UserGroupInformation ugi11 = ugiProvider1.ugi();
     UserGroupInformation ugi12 = ugiProvider1.ugi();
 
-    Assert.assertEquals(
-        "With UGI cache, two UGIs returned by the same token should be same",
-        ugi11, ugi12);
+    assertEquals(ugi11, ugi12,
+        "With UGI cache, two UGIs returned by the same token should be same");
 
     DataNodeUGIProvider ugiProvider2 = new DataNodeUGIProvider(
         new ParameterParser(new QueryStringDecoder(URI.create(uri2)), conf));
     UserGroupInformation url21 = ugiProvider2.ugi();
     UserGroupInformation url22 = ugiProvider2.ugi();
 
-    Assert.assertEquals(
-        "With UGI cache, two UGIs returned by the same token should be same",
-        url21, url22);
+    assertEquals(url21, url22,
+        "With UGI cache, two UGIs returned by the same token should be same");
 
-    Assert.assertNotEquals(
-        "With UGI cache, two UGIs for the different token should not be same",
-        ugi11, url22);
+    assertNotEquals(ugi11, url22,
+        "With UGI cache, two UGIs for the different token should not be same");
 
     ugiProvider2.clearCache();
     awaitCacheEmptyDueToExpiration();
@@ -131,12 +129,11 @@ public class TestDataNodeUGIProvider {
 
     String msg = "With cache eviction, two UGIs returned" +
     " by the same token should not be same";
-    Assert.assertNotEquals(msg, ugi11, ugi12);
-    Assert.assertNotEquals(msg, url21, url22);
+    assertNotEquals(ugi11, ugi12, msg);
+    assertNotEquals(url21, url22, msg);
 
-    Assert.assertNotEquals(
-        "With UGI cache, two UGIs for the different token should not be same",
-        ugi11, url22);
+    assertNotEquals(ugi11, url22,
+        "With UGI cache, two UGIs for the different token should not be same");
   }
 
   @Test
@@ -158,22 +155,19 @@ public class TestDataNodeUGIProvider {
     UserGroupInformation ugi11 = ugiProvider1.ugi();
     UserGroupInformation ugi12 = ugiProvider1.ugi();
 
-    Assert.assertEquals(
-        "With UGI cache, two UGIs for the same user should be same", ugi11,
-        ugi12);
+    assertEquals(ugi11, ugi12,
+        "With UGI cache, two UGIs for the same user should be same");
 
     DataNodeUGIProvider ugiProvider2 = new DataNodeUGIProvider(
         new ParameterParser(new QueryStringDecoder(URI.create(uri2)), conf));
     UserGroupInformation url21 = ugiProvider2.ugi();
     UserGroupInformation url22 = ugiProvider2.ugi();
 
-    Assert.assertEquals(
-        "With UGI cache, two UGIs for the same user should be same", url21,
-        url22);
+    assertEquals(url21, url22,
+        "With UGI cache, two UGIs for the same user should be same");
 
-    Assert.assertNotEquals(
-        "With UGI cache, two UGIs for the different user should not be same",
-        ugi11, url22);
+    assertNotEquals(ugi11, url22,
+        "With UGI cache, two UGIs for the different user should not be same");
 
     awaitCacheEmptyDueToExpiration();
     ugi12 = ugiProvider1.ugi();
@@ -181,12 +175,11 @@ public class TestDataNodeUGIProvider {
 
     String msg = "With cache eviction, two UGIs returned by" +
     " the same user should not be same";
-    Assert.assertNotEquals(msg, ugi11, ugi12);
-    Assert.assertNotEquals(msg, url21, url22);
+    assertNotEquals(ugi11, ugi12, msg);
+    assertNotEquals(url21, url22, msg);
 
-    Assert.assertNotEquals(
-        "With UGI cache, two UGIs for the different user should not be same",
-        ugi11, url22);
+    assertNotEquals(ugi11, url22,
+        "With UGI cache, two UGIs for the different user should not be same");
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestParameterParser.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/webhdfs/TestParameterParser.java
@@ -27,10 +27,12 @@ import org.apache.hadoop.hdfs.web.resources.NamenodeAddressParam;
 import org.apache.hadoop.hdfs.web.resources.OffsetParam;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 
@@ -52,7 +54,7 @@ public class TestParameterParser {
       + DelegationParam.NAME + "=" + token.encodeToUrlString());
     ParameterParser testParser = new ParameterParser(decoder, conf);
     final Token<DelegationTokenIdentifier> tok2 = testParser.delegationToken();
-    Assert.assertTrue(HAUtilClient.isTokenForLogicalUri(tok2));
+    assertTrue(HAUtilClient.isTokenForLogicalUri(tok2));
   }
 
   @Test
@@ -61,7 +63,7 @@ public class TestParameterParser {
     QueryStringDecoder decoder = new QueryStringDecoder(
             WebHdfsHandler.WEBHDFS_PREFIX + "/test");
     ParameterParser testParser = new ParameterParser(decoder, conf);
-    Assert.assertNull(testParser.delegationToken());
+    assertNull(testParser.delegationToken());
   }
 
   @Test
@@ -73,7 +75,7 @@ public class TestParameterParser {
     QueryStringDecoder decoder = new QueryStringDecoder(
       WebHdfsHandler.WEBHDFS_PREFIX + ESCAPED_PATH);
     ParameterParser testParser = new ParameterParser(decoder, conf);
-    Assert.assertEquals(EXPECTED_PATH, testParser.path());
+    assertEquals(EXPECTED_PATH, testParser.path());
   }
 
   @Test
@@ -86,8 +88,7 @@ public class TestParameterParser {
     EnumSet<CreateFlag> actual = testParser.createFlag();
     EnumSet<CreateFlag> expected = EnumSet.of(CreateFlag.APPEND,
         CreateFlag.SYNC_BLOCK);
-    Assert.assertEquals(expected.toString(), actual.toString());
-
+    assertEquals(expected.toString(), actual.toString());
 
     final String path1 = "/test1?createflag=append";
     decoder = new QueryStringDecoder(
@@ -96,14 +97,14 @@ public class TestParameterParser {
 
     actual = testParser.createFlag();
     expected = EnumSet.of(CreateFlag.APPEND);
-    Assert.assertEquals(expected, actual);
+    assertEquals(expected, actual);
 
     final String path2 = "/test1";
     decoder = new QueryStringDecoder(
         WebHdfsHandler.WEBHDFS_PREFIX + path2);
     testParser = new ParameterParser(decoder, conf);
     actual = testParser.createFlag();
-    Assert.assertEquals(0, actual.size());
+    assertEquals(0, actual.size());
 
     final String path3 = "/test1?createflag=create,overwrite";
     decoder = new QueryStringDecoder(
@@ -112,15 +113,14 @@ public class TestParameterParser {
     actual = testParser.createFlag();
     expected = EnumSet.of(CreateFlag.CREATE, CreateFlag
         .OVERWRITE);
-    Assert.assertEquals(expected.toString(), actual.toString());
-
+    assertEquals(expected.toString(), actual.toString());
 
     final String path4 = "/test1?createflag=";
     decoder = new QueryStringDecoder(
         WebHdfsHandler.WEBHDFS_PREFIX + path4);
     testParser = new ParameterParser(decoder, conf);
     actual = testParser.createFlag();
-    Assert.assertEquals(0, actual.size());
+    assertEquals(0, actual.size());
 
     //Incorrect value passed to createflag
     try {
@@ -156,14 +156,14 @@ public class TestParameterParser {
     final long X = 42;
 
     long offset = new OffsetParam(Long.toString(X)).getOffset();
-    Assert.assertEquals("OffsetParam: ", X, offset);
+    assertEquals(X, offset, "OffsetParam: ");
 
     offset = new OffsetParam((String) null).getOffset();
-    Assert.assertEquals("OffsetParam with null should have defaulted to 0", 0, offset);
+    assertEquals(0, offset, "OffsetParam with null should have defaulted to 0");
 
     try {
       offset = new OffsetParam("abc").getValue();
-      Assert.fail("OffsetParam with nondigit value should have thrown IllegalArgumentException");
+      fail("OffsetParam with nondigit value should have thrown IllegalArgumentException");
     } catch (IllegalArgumentException iae) {
       // Ignore
     }


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part10.

### How was this patch tested?
Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

