### PR TITLE
HADOOP-19617 - [JDK17] Remove JUnit4 Dependency - Common.

### DIFF
--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -42,11 +42,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.11.0</version>

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -163,11 +163,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractEtagTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/AbstractContractEtagTest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.contract;
 import java.nio.charset.StandardCharsets;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +33,7 @@ import org.apache.hadoop.fs.Path;
 
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * For filesystems which support etags, validate correctness
@@ -132,9 +132,9 @@ public abstract class AbstractContractEtagTest extends
     describe("Verify that when a file is renamed, the etag remains unchanged");
     final Path path = methodPath();
     final FileSystem fs = getFileSystem();
-    Assume.assumeTrue(
-        "Filesystem does not declare that etags are preserved across renames",
-        fs.hasPathCapability(path, ETAGS_PRESERVED_IN_RENAME));
+    assumeThat(fs.hasPathCapability(path, ETAGS_PRESERVED_IN_RENAME))
+        .withFailMessage("Filesystem does not declare that etags are preserved across renames")
+        .isTrue();
     Path src = new Path(path, "src");
     Path dest = new Path(path, "dest");
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractAppend.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/contract/rawlocal/TestRawlocalContractAppend.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.fs.contract.rawlocal;
 
-import org.junit.Assume;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractContractAppendTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class TestRawlocalContractAppend extends AbstractContractAppendTest {
 
@@ -36,7 +36,7 @@ public class TestRawlocalContractAppend extends AbstractContractAppendTest {
   public void testRenameFileBeingAppended() throws Throwable {
     // Renaming a file while its handle is open is not supported on Windows.
     // Thus, this test should be skipped on Windows.
-    Assume.assumeFalse(Path.WINDOWS);
+    assumeThat(Path.WINDOWS).isFalse();
 
     super.testRenameFileBeingAppended();
   }

--- a/hadoop-common-project/hadoop-kms/pom.xml
+++ b/hadoop-common-project/hadoop-kms/pom.xml
@@ -39,11 +39,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
+++ b/hadoop-common-project/hadoop-kms/src/test/java/org/apache/hadoop/crypto/key/kms/server/TestKMSAudit.java
@@ -118,7 +118,10 @@ public class TestKMSAudit {
     kmsAudit.evictCacheForTesting();
     String out = getAndResetLogOutput();
     System.out.println(out);
-    boolean doesMatch = out.matches(
+    String cleanedOut =
+        out.replaceAll("fs\\.default\\.name in core-default\\.xml is deprecated\\. " +
+        "Instead, use fs\\.defaultFS", "");
+    boolean doesMatch = cleanedOut.matches(
         "OK\\[op=DECRYPT_EEK, key=k1, user=luser@REALM, accessCount=1, "
             + "interval=[^m]{1,4}ms\\] testmsg"
             // Not aggregated !!
@@ -156,11 +159,14 @@ public class TestKMSAudit {
     kmsAudit.evictCacheForTesting();
     String out = getAndResetLogOutput();
     System.out.println(out);
+    String cleanedOut =
+        out.replaceAll("fs\\.default\\.name in core-default\\.xml is deprecated\\. " +
+        "Instead, use fs\\.defaultFS", "");
 
     // The UNAUTHORIZED will trigger cache invalidation, which then triggers
     // the aggregated OK (accessCount=5). But the order of the UNAUTHORIZED and
     // the aggregated OK is arbitrary - no correctness concerns, but flaky here.
-    boolean doesMatch = out.matches(
+    boolean doesMatch = cleanedOut.matches(
         "UNAUTHORIZED\\[op=GENERATE_EEK, key=k2, user=luser@REALM\\] "
             + "OK\\[op=GENERATE_EEK, key=k3, user=luser@REALM, accessCount=1,"
             + " interval=[^m]{1,4}ms\\] testmsg"
@@ -169,7 +175,7 @@ public class TestKMSAudit {
             + "UNAUTHORIZED\\[op=GENERATE_EEK, key=k3, user=luser@REALM\\] "
             + "OK\\[op=GENERATE_EEK, key=k3, user=luser@REALM, accessCount=1,"
             + " interval=[^m]{1,4}ms\\] testmsg");
-    doesMatch = doesMatch || out.matches(
+    doesMatch = doesMatch || cleanedOut.matches(
         "UNAUTHORIZED\\[op=GENERATE_EEK, key=k2, user=luser@REALM\\] "
             + "OK\\[op=GENERATE_EEK, key=k3, user=luser@REALM, accessCount=1,"
             + " interval=[^m]{1,4}ms\\] testmsg"

--- a/hadoop-common-project/hadoop-minikdc/pom.xml
+++ b/hadoop-common-project/hadoop-minikdc/pom.xml
@@ -69,11 +69,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>provided</scope>

--- a/hadoop-common-project/hadoop-nfs/pom.xml
+++ b/hadoop-common-project/hadoop-nfs/pom.xml
@@ -92,6 +92,31 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-nfs/pom.xml
+++ b/hadoop-common-project/hadoop-nfs/pom.xml
@@ -54,11 +54,6 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
@@ -208,17 +208,17 @@ public class TestNfsExports {
 
   @Test
   public void testInvalidHost() {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-          NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
-        "foo#bar");
-      });
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
+      "foo#bar");
+    });
   }
 
   @Test
   public void testInvalidSeparator() {
-      Assertions.assertThrows(IllegalArgumentException.class, () -> {
-          NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
-        "foo ro : bar rw");
-      });
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
+      "foo ro : bar rw");
+    });
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
@@ -209,16 +209,14 @@ public class TestNfsExports {
   @Test
   public void testInvalidHost() {
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
-      "foo#bar");
+      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, "foo#bar");
     });
   }
 
   @Test
   public void testInvalidSeparator() {
     Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
-      "foo ro : bar rw");
+      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, "foo ro : bar rw");
     });
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsExports.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.nfs;
 
 import org.apache.hadoop.nfs.nfs3.Nfs3Constant;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestNfsExports {
 
@@ -37,14 +37,14 @@ public class TestNfsExports {
   @Test
   public void testWildcardRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, "* rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
   }
 
   @Test
   public void testWildcardRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, "* ro");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
   }
 
@@ -52,33 +52,32 @@ public class TestNfsExports {
   public void testExactAddressRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, address1
         + " rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertFalse(AccessPrivilege.READ_WRITE == matcher
+    Assertions.assertFalse(AccessPrivilege.READ_WRITE == matcher
         .getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testExactAddressRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, address1);
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testExactHostRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, hostname1
         + " rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
   }
 
   @Test
   public void testExactHostRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, hostname1);
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
   }
 
@@ -86,70 +85,64 @@ public class TestNfsExports {
   public void testCidrShortRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "192.168.0.0/22 rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testCidrShortRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "192.168.0.0/22");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testCidrLongRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, 
         "192.168.0.0/255.255.252.0 rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testCidrLongRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod, 
         "192.168.0.0/255.255.252.0");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testRegexIPRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "192.168.0.[0-9]+ rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testRegexIPRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "192.168.0.[0-9]+");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.NONE,
-        matcher.getAccessPrivilege(address2, hostname1));
+    Assertions.assertEquals(AccessPrivilege.NONE, matcher.getAccessPrivilege(address2, hostname1));
   }
 
   @Test
   public void testRegexHostRW() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "[a-z]+.b.com rw");
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname1));
     // address1 will hit the cache
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address1, hostname2));
   }
 
@@ -157,10 +150,10 @@ public class TestNfsExports {
   public void testRegexHostRO() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "[a-z]+.b.com");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
     // address1 will hit the cache
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname2));
   }
   
@@ -168,17 +161,17 @@ public class TestNfsExports {
   public void testRegexGrouping() {
     NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "192.168.0.(12|34)");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
     // address1 will hit the cache
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname2));
 
     matcher = new NfsExports(CacheSize, ExpirationPeriod, "\\w*.a.b.com");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege("1.2.3.4", "web.a.b.com"));
     // address "1.2.3.4" will hit the cache
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege("1.2.3.4", "email.a.b.org"));
   }
   
@@ -187,16 +180,16 @@ public class TestNfsExports {
     long shortExpirationPeriod = 1 * 1000 * 1000 * 1000; // 1s
     NfsExports matcher = new NfsExports(CacheSize, shortExpirationPeriod, 
         "192.168.0.[0-9]+;[a-z]+.b.com rw");
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname2));
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, address1));
-    Assert.assertEquals(AccessPrivilege.READ_ONLY,
+    Assertions.assertEquals(AccessPrivilege.READ_ONLY,
         matcher.getAccessPrivilege(address1, hostname1));
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address2, hostname1));
     // address2 will hit the cache
-    Assert.assertEquals(AccessPrivilege.READ_WRITE,
+    Assertions.assertEquals(AccessPrivilege.READ_WRITE,
         matcher.getAccessPrivilege(address2, hostname2));
     
     Thread.sleep(1000);
@@ -210,18 +203,22 @@ public class TestNfsExports {
       }
       Thread.sleep(500);
     } while ((System.nanoTime() - startNanos) / NanosPerMillis < 5000);
-    Assert.assertEquals(AccessPrivilege.NONE, ap);
+    Assertions.assertEquals(AccessPrivilege.NONE, ap);
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInvalidHost() {
-      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "foo#bar");
+      });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testInvalidSeparator() {
-      NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
+      Assertions.assertThrows(IllegalArgumentException.class, () -> {
+          NfsExports matcher = new NfsExports(CacheSize, ExpirationPeriod,
         "foo ro : bar rw");
+      });
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/TestNfsTime.java
@@ -17,18 +17,18 @@
  */
 package org.apache.hadoop.nfs;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.nfs.NfsTime;
 import org.apache.hadoop.oncrpc.XDR;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNfsTime {
   @Test
   public void testConstructor() {
     NfsTime nfstime = new NfsTime(1001);
-    Assert.assertEquals(1, nfstime.getSeconds());
-    Assert.assertEquals(1000000, nfstime.getNseconds());
+    Assertions.assertEquals(1, nfstime.getSeconds());
+    Assertions.assertEquals(1000000, nfstime.getNseconds());
   }
   
   @Test
@@ -42,6 +42,6 @@ public class TestNfsTime {
     NfsTime t2 = NfsTime.deserialize(xdr.asReadOnlyWrap());
     
     // Ensure the NfsTimes are equal
-    Assert.assertEquals(t1, t2);
+    Assertions.assertEquals(t1, t2);
   }
 }

--- a/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/nfs3/TestFileHandle.java
+++ b/hadoop-common-project/hadoop-nfs/src/test/java/org/apache/hadoop/nfs/nfs3/TestFileHandle.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.nfs.nfs3;
 
 import org.apache.hadoop.oncrpc.XDR;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hadoop-common-project/hadoop-registry/pom.xml
+++ b/hadoop-common-project/hadoop-registry/pom.xml
@@ -65,12 +65,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>
@@ -159,11 +153,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19617 - [JDK17] Remove JUnit4 Dependency - Common.

### How was this patch tested?

Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

