### PR TITLE
YARN-11843. Fix potential deadlock when auto-correction of container allocation is enabled

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/DrainDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/event/DrainDispatcher.java
@@ -96,7 +96,7 @@ public class DrainDispatcher extends AsyncDispatcher {
   }
 
   @Override
-  protected boolean isDrained() {
+  public boolean isDrained() {
     synchronized (mutex) {
       return drained;
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -722,7 +722,7 @@ public abstract class AbstractYarnScheduler
       if (allocatedContainers != null) {
         for (RMContainer rmContainer : allocatedContainers) {
           if (extraContainers > 0) {
-            // Change the state of the container from ALLOCATED to EXPIRED since it is not required.
+            // Change the state of the container from ALLOCATED to RELEASED since it is not required.
             LOG.debug("Removing extra container:{}", rmContainer.getContainer());
             asyncContainerRelease(rmContainer);
             application.newlyAllocatedContainers.remove(rmContainer);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -722,7 +722,8 @@ public abstract class AbstractYarnScheduler
       if (allocatedContainers != null) {
         for (RMContainer rmContainer : allocatedContainers) {
           if (extraContainers > 0) {
-            // Change the state of the container from ALLOCATED to RELEASED since it is not required.
+            // Change the state of the container from ALLOCATED to RELEASED
+            // since it is not required.
             LOG.debug("Removing extra container:{}", rmContainer.getContainer());
             asyncContainerRelease(rmContainer);
             application.newlyAllocatedContainers.remove(rmContainer);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -724,9 +724,7 @@ public abstract class AbstractYarnScheduler
           if (extraContainers > 0) {
             // Change the state of the container from ALLOCATED to EXPIRED since it is not required.
             LOG.debug("Removing extra container:{}", rmContainer.getContainer());
-            completedContainer(rmContainer, SchedulerUtils.createAbnormalContainerStatus(
-                rmContainer.getContainerId(), SchedulerUtils.EXPIRED_CONTAINER),
-                RMContainerEventType.EXPIRE);
+            asyncContainerRelease(rmContainer);
             application.newlyAllocatedContainers.remove(rmContainer);
             extraContainers--;
           }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/AbstractYarnScheduler.java
@@ -769,10 +769,10 @@ public abstract class AbstractYarnScheduler
     }
 
     // when auto correct container allocation is enabled, there can be a case when extra containers
-    // go to expired state from allocated state. When such scenario happens do not re-attempt the
+    // go to released state from allocated state. When such scenario happens do not re-attempt the
     // container request since this is expected.
     if (autoCorrectContainerAllocation &&
-        RMContainerState.EXPIRED.equals(rmContainer.getState())) {
+        RMContainerState.RELEASED.equals(rmContainer.getState())) {
       return;
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestAbstractYarnScheduler.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Sets;
 import org.apache.hadoop.util.Time;
@@ -86,6 +87,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNodeEventType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.ContainerRequest;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAddedSchedulerEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.AppAttemptAddedSchedulerEvent;
@@ -291,7 +293,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
    */
   @ParameterizedTest(name = "{0}")
   @MethodSource("getParameters")
-  public void testAutoCorrectContainerAllocation(SchedulerType type) throws IOException {
+  public void testAutoCorrectContainerAllocation(SchedulerType type) throws Exception {
     initTestAbstractYarnScheduler(type);
     Configuration conf = new Configuration(getConf());
     conf.setBoolean(YarnConfiguration.RM_SCHEDULER_AUTOCORRECT_CONTAINER_ALLOCATION, true);
@@ -372,7 +374,8 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
     Container container = mock(Container.class);
 
     // Mock the Container instance with the specified parameters
-    when(container.getResource()).thenReturn(Resource.newInstance(memory, 1));
+    Resource resource = Resource.newInstance(memory, 1);
+    when(container.getResource()).thenReturn(resource);
     when(container.getPriority()).thenReturn(priority);
     when(container.getId()).thenReturn(ContainerId.newContainerId(appAttemptId, containerId));
     when(container.getNodeId()).thenReturn(nodeId);
@@ -388,6 +391,10 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
     when(rmContainer.getContainer()).thenReturn(container);
     when(rmContainer.getContainerId()).thenReturn(
         ContainerId.newContainerId(appAttemptId, containerId));
+    ResourceRequest resourceRequest =
+        BuilderUtils.newResourceRequest(priority, "*", resource, 1);
+    when(rmContainer.getContainerRequest()).thenReturn(
+        new ContainerRequest(ImmutableList.of(resourceRequest)));
 
     return rmContainer;
   }
@@ -470,7 +477,7 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
    */
   private void testContainerAskZeroAndNewlyAllocatedContainerOne(AbstractYarnScheduler scheduler,
       SchedulerApplicationAttempt application, SchedulerNode schedulerNode, NodeId nodeId,
-      Priority priority, ApplicationAttemptId appAttemptId) {
+      Priority priority, ApplicationAttemptId appAttemptId) throws Exception {
     // Create a resource request with 0 containers, 1024 MB memory, and GUARANTEED execution type
     ResourceRequest resourceRequest = createResourceRequest(1024, 1,
         0, priority, 0L,
@@ -485,14 +492,29 @@ public class TestAbstractYarnScheduler extends ParameterizedSchedulerTestBase {
     // Add the RMContainer to the newly allocated containers of the application
     application.addToNewlyAllocatedContainers(schedulerNode, rmContainer1);
 
+    // Simulate the container is released and expect it won't be recovered
+    // when calling AbstractYarnScheduler#recoverResourceRequestForContainer
+    when(rmContainer1.getState()).thenReturn(RMContainerState.RELEASED);
+
     // Call the autoCorrectContainerAllocation method
     scheduler.autoCorrectContainerAllocation(containerAsk, application);
+
+    // Make sure all event is handled
+    Dispatcher dispatcher = scheduler.rmContext.getDispatcher();
+    if (dispatcher instanceof DrainDispatcher) {
+      GenericTestUtils.waitFor(
+          () -> ((DrainDispatcher) dispatcher).isDrained(),
+          500, 3000);
+    }
 
     // Assert that the container ask remains 0
     assertEquals(0, resourceRequest.getNumContainers());
 
     // Assert that there are no newly allocated containers
     assertEquals(0, application.pullNewlyAllocatedContainers().size());
+
+    // Assert that the next pending ask is null
+    assertNull(application.appSchedulingInfo.getNextPendingAsk());
   }
 
   /**


### PR DESCRIPTION
Details please refer to YARN-11843.

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

