### PR TITLE
HADOOP-19646. [JDK17] Migrate hadoop-aws module from JUnit4 Assume to JUnit5 Assumptions.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.junit.jupiter.api.Assumptions;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Use {@link Constants#FAST_UPLOAD_BUFFER_DISK} for buffering.
@@ -36,7 +36,9 @@ public class ITestS3ABlockOutputDisk extends ITestS3ABlockOutputArray {
    * @return null
    */
   protected S3ADataBlocks.BlockFactory createFactory(S3AFileSystem fileSystem) {
-    Assumptions.assumeTrue(false, "mark/reset not supported");
+    assumeThat(false)
+        .as("mark/reset not supported")
+        .isTrue();
     return null;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputDisk.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 
 /**
  * Use {@link Constants#FAST_UPLOAD_BUFFER_DISK} for buffering.
@@ -36,7 +36,7 @@ public class ITestS3ABlockOutputDisk extends ITestS3ABlockOutputArray {
    * @return null
    */
   protected S3ADataBlocks.BlockFactory createFactory(S3AFileSystem fileSystem) {
-    Assume.assumeTrue("mark/reset not supported", false);
+    Assumptions.assumeTrue(false, "mark/reset not supported");
     return null;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.test.LambdaTestUtils;
 
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
@@ -36,6 +35,7 @@ import static org.apache.hadoop.fs.s3a.Constants.CHANGE_DETECT_SOURCE;
 import static org.apache.hadoop.fs.s3a.Constants.RETRY_INTERVAL;
 import static org.apache.hadoop.fs.s3a.Constants.RETRY_LIMIT;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests behavior of a FileNotFound error that happens after open(), i.e. on
@@ -68,8 +68,9 @@ public class ITestS3ADelayedFNF extends AbstractS3ATestBase {
     S3AFileSystem fs = getFileSystem();
     ChangeDetectionPolicy changeDetectionPolicy =
         fs.getChangeDetectionPolicy();
-    Assumptions.assumeFalse(changeDetectionPolicy.getSource() == Source.VersionId,
-        "FNF not expected when using a bucket with object versioning");
+    assumeThat(changeDetectionPolicy.getSource())
+        .as("FNF not expected when using a bucket with object versioning")
+        .isNotEqualTo(Source.VersionId);
 
     Path p = path("some-file");
     ContractTestUtils.createFile(fs, p, false, new byte[] {20, 21, 22});

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ADelayedFNF.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy;
 import org.apache.hadoop.fs.s3a.impl.ChangeDetectionPolicy.Source;
 import org.apache.hadoop.test.LambdaTestUtils;
 
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
@@ -68,9 +68,8 @@ public class ITestS3ADelayedFNF extends AbstractS3ATestBase {
     S3AFileSystem fs = getFileSystem();
     ChangeDetectionPolicy changeDetectionPolicy =
         fs.getChangeDetectionPolicy();
-    Assume.assumeFalse("FNF not expected when using a bucket with"
-            + " object versioning",
-        changeDetectionPolicy.getSource() == Source.VersionId);
+    Assumptions.assumeFalse(changeDetectionPolicy.getSource() == Source.VersionId,
+        "FNF not expected when using a bucket with object versioning");
 
     Path p = path("some-file");
     ContractTestUtils.createFile(fs, p, false, new byte[] {20, 21, 22});

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -71,7 +71,6 @@ import org.apache.hadoop.util.functional.FutureIO;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
-import org.junit.Assume;
 import org.opentest4j.TestAbortedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -234,8 +233,7 @@ public final class S3ATestUtils {
     }
     // This doesn't work with our JUnit 3 style test cases, so instead we'll
     // make this whole class not run by default
-    Assume.assumeTrue("No test filesystem in " + TEST_FS_S3A_NAME,
-        liveTest);
+    Assumptions.assumeThat(liveTest).isTrue().as("No test filesystem in " + TEST_FS_S3A_NAME);
 
     S3AFileSystem fs1 = new S3AFileSystem();
     //enable purging in tests
@@ -276,8 +274,7 @@ public final class S3ATestUtils {
     }
     // This doesn't work with our JUnit 3 style test cases, so instead we'll
     // make this whole class not run by default
-    Assume.assumeTrue("No test filesystem in " + TEST_FS_S3A_NAME,
-        liveTest);
+    Assumptions.assumeThat(liveTest).isTrue().as("No test filesystem in " + TEST_FS_S3A_NAME);
     FileContext fc = FileContext.getFileContext(testURI, conf);
     return fc;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -126,6 +126,7 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.util.functional.FunctionalIO.uncheckIOExceptions;
 import static org.apache.hadoop.util.functional.RemoteIterators.mappingRemoteIterator;
 import static org.apache.hadoop.util.functional.RemoteIterators.toList;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -233,7 +234,9 @@ public final class S3ATestUtils {
     }
     // This doesn't work with our JUnit 3 style test cases, so instead we'll
     // make this whole class not run by default
-    Assumptions.assumeThat(liveTest).isTrue().as("No test filesystem in " + TEST_FS_S3A_NAME);
+    assumeThat(liveTest)
+        .as("No test filesystem in " + TEST_FS_S3A_NAME)
+        .isTrue();
 
     S3AFileSystem fs1 = new S3AFileSystem();
     //enable purging in tests
@@ -274,7 +277,9 @@ public final class S3ATestUtils {
     }
     // This doesn't work with our JUnit 3 style test cases, so instead we'll
     // make this whole class not run by default
-    Assumptions.assumeThat(liveTest).isTrue().as("No test filesystem in " + TEST_FS_S3A_NAME);
+    assumeThat(liveTest)
+        .as("No test filesystem in " + TEST_FS_S3A_NAME)
+        .isTrue();
     FileContext fc = FileContext.getFileContext(testURI, conf);
     return fc;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,8 +212,7 @@ public final class RoleTestUtils {
    */
   public static String probeForAssumedRoleARN(Configuration conf) {
     String arn = conf.getTrimmed(ASSUMED_ROLE_ARN, "");
-    Assume.assumeTrue("No ARN defined in " + ASSUMED_ROLE_ARN,
-        !arn.isEmpty());
+    Assumptions.assumeTrue(!arn.isEmpty(), "No ARN defined in " + ASSUMED_ROLE_ARN);
     return arn;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/RoleTestUtils.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.jupiter.api.Assumptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +45,7 @@ import static org.apache.hadoop.fs.s3a.auth.RoleModel.*;
 import static org.apache.hadoop.fs.s3a.auth.RolePolicies.*;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.DELEGATION_TOKEN_BINDING;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -212,7 +212,9 @@ public final class RoleTestUtils {
    */
   public static String probeForAssumedRoleARN(Configuration conf) {
     String arn = conf.getTrimmed(ASSUMED_ROLE_ARN, "");
-    Assumptions.assumeTrue(!arn.isEmpty(), "No ARN defined in " + ASSUMED_ROLE_ARN);
+    assumeThat(arn)
+        .as("No ARN defined in " + ASSUMED_ROLE_ARN)
+        .isNotEmpty();
     return arn;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.test;
 
-import org.junit.jupiter.api.Assumptions;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -29,6 +27,7 @@ import org.apache.hadoop.fs.s3a.S3ATestUtils;
 
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_BUCKET_WITH_MANY_OBJECTS;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_REQUESTER_PAYS_FILE;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Provides S3A filesystem URIs for public data sets for specific use cases.
@@ -128,8 +127,9 @@ public final class PublicDatasetTestUtils {
    */
   public static String requireDefaultExternalDataFile(Configuration conf) {
     String filename = getExternalData(conf).toUri().toString();
-    Assumptions.assumeTrue(DEFAULT_EXTERNAL_FILE.equals(filename),
-        "External test file is not the default");
+    assumeThat(filename)
+        .as("External test file is not the default")
+        .isEqualTo(DEFAULT_EXTERNAL_FILE);
     return filename;
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/PublicDatasetTestUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.s3a.test;
 
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -128,8 +128,8 @@ public final class PublicDatasetTestUtils {
    */
   public static String requireDefaultExternalDataFile(Configuration conf) {
     String filename = getExternalData(conf).toUri().toString();
-    Assume.assumeTrue("External test file is not the default",
-        DEFAULT_EXTERNAL_FILE.equals(filename));
+    Assumptions.assumeTrue(DEFAULT_EXTERNAL_FILE.equals(filename),
+        "External test file is not the default");
     return filename;
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19646. [JDK17] Migrate hadoop-aws module from JUnit4 Assume to JUnit5 Assumptions.

### How was this patch tested?

mvn clean test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

