### PR TITLE
HADOOP-19649. [ABFS] Fixing Test Failures and Assumptions Post Junit Upgrade

### DIFF
--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -360,11 +360,6 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -617,7 +617,7 @@ public abstract class AbstractAbfsIntegrationTest extends
    * @param path path to create. Can be relative or absolute.
    */
   protected void createAzCopyFolder(Path path) throws Exception {
-    assumeThat(getAbfsServiceType()).isEqualTo(AbfsServiceType.BLOB);
+    assumeBlobServiceType();
     assumeValidTestConfigPresent(getRawConfiguration(), FS_AZURE_TEST_FIXED_SAS_TOKEN);
     String sasToken = getRawConfiguration().get(FS_AZURE_TEST_FIXED_SAS_TOKEN);
     AzcopyToolHelper azcopyHelper = AzcopyToolHelper.getInstance(sasToken);
@@ -629,7 +629,7 @@ public abstract class AbstractAbfsIntegrationTest extends
    * @param path path to create. Can be relative or absolute.
    */
   protected void createAzCopyFile(Path path) throws Exception {
-    assumeThat(getAbfsServiceType()).isEqualTo(AbfsServiceType.BLOB);
+    assumeBlobServiceType();
     assumeValidTestConfigPresent(getRawConfiguration(), FS_AZURE_TEST_FIXED_SAS_TOKEN);
     String sasToken = getRawConfiguration().get(FS_AZURE_TEST_FIXED_SAS_TOKEN);
     AzcopyToolHelper azcopyHelper = AzcopyToolHelper.getInstance(sasToken);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -586,7 +586,7 @@ public abstract class AbstractAbfsIntegrationTest extends
     final AuthType currentAuthType = getAuthType();
     assumeThat(currentAuthType).
         as("SAS Based Authentication Not Allowed For Integration Tests").
-        isEqualTo(AuthType.SAS);
+        isNotEqualTo(AuthType.SAS);
     if (currentAuthType == AuthType.SharedKey) {
       assumeValidTestConfigPresent(getRawConfiguration(), FS_AZURE_ACCOUNT_KEY);
     } else {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
@@ -35,6 +35,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Test MsiTokenProvider.
@@ -49,13 +50,13 @@ public final class ITestAbfsMsiTokenProvider
   @Test
   public void test() throws IOException {
     AbfsConfiguration conf = getConfiguration();
-    assertThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT))
+    assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT))
         .isNotNull().isNotEmpty();
-    assertThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT))
+    assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT))
         .isNotNull().isNotEmpty();
-    assertThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID))
+    assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID))
         .isNotNull().isNotEmpty();
-    assertThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY))
+    assumeThat(conf.get(FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY))
         .isNotNull().isNotEmpty();
 
     String tenantGuid = conf

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -608,12 +608,12 @@ public class ITestAzureBlobFileSystemAppend extends
    **/
   @Test
   public void testRecreateAppendAndFlush() throws IOException {
+      assumeThat(isAppendBlobEnabled()).as("Not valid for APPEND BLOB").isFalse();
+      assumeThat(getIngressServiceType()).isEqualTo(AbfsServiceType.BLOB);
       assertThrows(IOException.class, () -> {
-          assumeThat(isAppendBlobEnabled()).as("Not valid for APPEND BLOB").isFalse();
           final AzureBlobFileSystem fs = getFileSystem();
           final Path filePath = path(TEST_FILE_PATH);
           fs.create(filePath);
-          assumeThat(getIngressServiceType()).isEqualTo(AbfsServiceType.BLOB);
           FSDataOutputStream outputStream = fs.append(filePath);
           outputStream.write(TEN);
           try (AzureBlobFileSystem fs1

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -123,9 +123,9 @@ public class ITestAzureBlobFileSystemCheckAccess
 
   @Test
   public void testCheckAccessForFileWithNullFsAction() throws Exception {
+    assumeThat(isHNSEnabled).as(FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT + " is false").isTrue();
+    assumeThat(isCheckAccessEnabled).as(FS_AZURE_ENABLE_CHECK_ACCESS + " is false").isTrue();
     assertThrows(NullPointerException.class, () -> {
-      assumeThat(isHNSEnabled).as(FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT + " is false").isTrue();
-      assumeThat(isCheckAccessEnabled).as(FS_AZURE_ENABLE_CHECK_ACCESS + " is false").isTrue();
       //  NPE when trying to convert null FsAction enum
       superUserFs.access(new Path("test.txt"), null);
     });
@@ -133,13 +133,13 @@ public class ITestAzureBlobFileSystemCheckAccess
 
   @Test
   public void testCheckAccessForNonExistentFile() throws Exception {
-      assertThrows(FileNotFoundException.class, () -> {
-          checkPrerequisites();
-          Path nonExistentFile = setupTestDirectoryAndUserAccess(
-        "/nonExistentFile1.txt", FsAction.ALL);
-          superUserFs.delete(nonExistentFile, true);
-          testUserFs.access(nonExistentFile, FsAction.READ);
-      });
+    checkPrerequisites();
+    assertThrows(FileNotFoundException.class, () -> {
+        Path nonExistentFile = setupTestDirectoryAndUserAccess(
+      "/nonExistentFile1.txt", FsAction.ALL);
+        superUserFs.delete(nonExistentFile, true);
+        testUserFs.access(nonExistentFile, FsAction.READ);
+    });
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
@@ -220,7 +220,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  @Timeout(value = TEST_EXECUTION_TIMEOUT, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = LONG_TEST_EXECUTION_TIMEOUT, unit = TimeUnit.MILLISECONDS)
   public void testTwoWritersCreateAppendWithInfiniteLeaseEnabled() throws Exception {
     final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);
@@ -294,7 +294,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  @Timeout(value = TEST_EXECUTION_TIMEOUT, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = LONG_TEST_EXECUTION_TIMEOUT, unit = TimeUnit.MILLISECONDS)
   public void testLeaseFreedAfterBreak() throws Exception {
     final Path testFilePath = new Path(path(methodName.getMethodName()), TEST_FILE);
     final AzureBlobFileSystem fs = getCustomFileSystem(testFilePath.getParent(), 1);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFilesystemAcl.java
@@ -56,33 +56,55 @@ import org.junit.jupiter.api.Assertions;
  * Test acl operations.
  */
 public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
+
   private static final FsAction ALL = FsAction.ALL;
+
   private static final FsAction NONE = FsAction.NONE;
+
   private static final FsAction READ = FsAction.READ;
+
   private static final FsAction EXECUTE = FsAction.EXECUTE;
+
   private static final FsAction READ_EXECUTE = FsAction.READ_EXECUTE;
+
   private static final FsAction READ_WRITE = FsAction.READ_WRITE;
 
   private static final short RW = 0600;
+
   private static final short RWX = 0700;
+
   private static final short RWX_R = 0740;
+
   private static final short RWX_RW = 0760;
+
   private static final short RWX_RWX = 0770;
+
   private static final short RWX_RX = 0750;
+
   private static final short RWX_RX_RX = 0755;
+
   private static final short RW_R = 0640;
+
   private static final short RW_X = 0610;
+
   private static final short RW_RW = 0660;
+
   private static final short RW_RWX = 0670;
+
   private static final short RW_R_R = 0644;
+
   private static final short STICKY_RWX_RWX = 01770;
 
   private static final String FOO = UUID.randomUUID().toString();
+
   private static final String BAR = UUID.randomUUID().toString();
+
   private static final String TEST_OWNER = UUID.randomUUID().toString();
+
   private static final String TEST_GROUP = UUID.randomUUID().toString();
 
   private static Path testRoot = new Path("/test");
+
   private Path path;
 
   public ITestAzureBlobFilesystemAcl() throws Exception {
@@ -111,11 +133,16 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
 
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, READ_EXECUTE),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, READ_EXECUTE), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
-       returned);
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, READ_EXECUTE),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
+        returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -138,7 +165,9 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(new AclEntry[]{
-        aclEntry(ACCESS, USER, FOO, READ_EXECUTE), aclEntry(ACCESS, GROUP, READ_EXECUTE)},
+            aclEntry(ACCESS, USER, FOO, READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -157,9 +186,13 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.modifyAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, READ_EXECUTE), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, READ_EXECUTE),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -177,7 +210,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(new AclEntry[]{
-        aclEntry(ACCESS, USER, FOO, READ_WRITE), aclEntry(ACCESS, GROUP, READ)},
+            aclEntry(ACCESS, USER, FOO, READ_WRITE), aclEntry(ACCESS, GROUP, READ)
+        },
         returned);
     assertPermission(fs, (short) RW_RW);
   }
@@ -195,8 +229,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.modifyAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -214,8 +250,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.modifyAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ)
+    }, returned);
     assertPermission(fs, (short) RW);
   }
 
@@ -238,41 +276,46 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.modifyAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, READ_EXECUTE),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, READ_EXECUTE), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, READ_EXECUTE),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) 01750);
   }
 
   @Test
   public void testModifyAclEntriesPathNotFound() throws Exception {
-      Assertions.assertThrows(FileNotFoundException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(ACCESS, USER, ALL),
-        aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE),
-        aclEntry(ACCESS, OTHER, NONE));
-          fs.modifyAclEntries(path, aclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(FileNotFoundException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(ACCESS, USER, ALL),
+          aclEntry(ACCESS, USER, FOO, ALL),
+          aclEntry(ACCESS, GROUP, READ_EXECUTE),
+          aclEntry(ACCESS, OTHER, NONE));
+      fs.modifyAclEntries(path, aclSpec);
+    });
   }
 
   @Test
   public void testModifyAclEntriesDefaultOnFile() throws Exception {
-      Assertions.assertThrows(Exception.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          fs.create(path).close();
-          fs.setPermission(path, FsPermission.createImmutable((short) RW_R));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(DEFAULT, USER, FOO, ALL));
-          fs.modifyAclEntries(path, aclSpec);
-      });
+    Assertions.assertThrows(Exception.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      assumeTrue(getIsNamespaceEnabled(fs));
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      fs.create(path).close();
+      fs.setPermission(path, FsPermission.createImmutable((short) RW_R));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(DEFAULT, USER, FOO, ALL));
+      fs.modifyAclEntries(path, aclSpec);
+    });
   }
 
   @Test
@@ -291,9 +334,12 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
 
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, READ_WRITE),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, MASK, EXECUTE),
-        aclEntry(DEFAULT, OTHER, NONE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(DEFAULT, USER, READ_WRITE),
+        aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+        aclEntry(DEFAULT, MASK, EXECUTE),
+        aclEntry(DEFAULT, OTHER, NONE)
+    }, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -313,25 +359,26 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
 
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, GROUP, READ_EXECUTE)},
+        returned);
     assertPermission(fs, (short) RW_X);
   }
 
   @Test
   public void testModifyAclEntriesWithDuplicateEntries() throws Exception {
-      Assertions.assertThrows(PathIOException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(ACCESS, MASK, EXECUTE));
-          fs.setAcl(path, aclSpec);
-          List<AclEntry> modifyAclSpec = Lists.newArrayList(
-        aclEntry(ACCESS, USER, READ_WRITE),
-        aclEntry(ACCESS, USER, READ_WRITE));
-          fs.modifyAclEntries(path, modifyAclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(PathIOException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(ACCESS, MASK, EXECUTE));
+      fs.setAcl(path, aclSpec);
+      List<AclEntry> modifyAclSpec = Lists.newArrayList(
+          aclEntry(ACCESS, USER, READ_WRITE),
+          aclEntry(ACCESS, USER, READ_WRITE));
+      fs.modifyAclEntries(path, modifyAclSpec);
+    });
   }
 
   @Test
@@ -353,9 +400,11 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, USER, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -379,8 +428,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, BAR, READ_WRITE),
-        aclEntry(ACCESS, GROUP, READ_WRITE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, BAR, READ_WRITE),
+        aclEntry(ACCESS, GROUP, READ_WRITE)
+    }, returned);
     assertPermission(fs, (short) RWX_RW);
   }
 
@@ -402,9 +453,13 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, BAR, READ_EXECUTE), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, BAR, READ_EXECUTE),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -428,7 +483,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RWX_RW);
   }
 
@@ -453,8 +508,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -478,70 +535,74 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAclEntries(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, USER, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) 01750);
   }
 
   @Test
   public void testRemoveAclEntriesPathNotFound() throws Exception {
-      Assertions.assertThrows(FileNotFoundException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          List<AclEntry> aclSpec = Lists.newArrayList(
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(FileNotFoundException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(ACCESS, USER, FOO));
-          fs.removeAclEntries(path, aclSpec);
-      });
+      fs.removeAclEntries(path, aclSpec);
+    });
   }
 
   @Test
   public void testRemoveAclEntriesAccessMask() throws Exception {
-      Assertions.assertThrows(PathIOException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
-          List<AclEntry> aclSpec = Lists.newArrayList(
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(PathIOException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
+      List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(ACCESS, MASK, EXECUTE),
         aclEntry(ACCESS, USER, FOO, ALL));
-          fs.setAcl(path, aclSpec);
-          fs.removeAclEntries(path, Lists.newArrayList(aclEntry(ACCESS, MASK, NONE)));
-      });
+      fs.setAcl(path, aclSpec);
+      fs.removeAclEntries(path,
+        Lists.newArrayList(aclEntry(ACCESS, MASK, NONE)));
+    });
   }
 
   @Test
   public void testRemoveAclEntriesDefaultMask() throws Exception {
-      Assertions.assertThrows(PathIOException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(DEFAULT, MASK, EXECUTE),
-        aclEntry(DEFAULT, USER, FOO, ALL));
-          fs.setAcl(path, aclSpec);
-          fs.removeAclEntries(path, Lists.newArrayList(aclEntry(DEFAULT, MASK, NONE)));
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(PathIOException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(DEFAULT, MASK, EXECUTE),
+          aclEntry(DEFAULT, USER, FOO, ALL));
+      fs.setAcl(path, aclSpec);
+      fs.removeAclEntries(path,
+          Lists.newArrayList(aclEntry(DEFAULT, MASK, NONE)));
+    });
   }
 
   @Test
   public void testRemoveAclEntriesWithDuplicateEntries() throws Exception {
-      Assertions.assertThrows(PathIOException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(DEFAULT, MASK, EXECUTE));
-          fs.setAcl(path, aclSpec);
-          List<AclEntry> removeAclSpec = Lists.newArrayList(
-        aclEntry(DEFAULT, USER, READ_WRITE),
-        aclEntry(DEFAULT, USER, READ_WRITE));
-          fs.removeAclEntries(path, removeAclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(PathIOException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(DEFAULT, MASK, EXECUTE));
+      fs.setAcl(path, aclSpec);
+      List<AclEntry> removeAclSpec = Lists.newArrayList(
+          aclEntry(DEFAULT, USER, READ_WRITE),
+          aclEntry(DEFAULT, USER, READ_WRITE));
+      fs.removeAclEntries(path, removeAclSpec);
+    });
   }
 
   @Test
@@ -560,8 +621,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeDefaultAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ_EXECUTE)
+    }, returned);
     assertPermission(fs, (short) RWX_RWX);
   }
 
@@ -581,8 +644,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeDefaultAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ_EXECUTE)
+    }, returned);
     assertPermission(fs, (short) RWX_RWX);
   }
 
@@ -598,7 +663,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeDefaultAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -611,7 +676,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeDefaultAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -631,21 +696,23 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeDefaultAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ_EXECUTE)
+    }, returned);
     assertPermission(fs, (short) STICKY_RWX_RWX);
   }
 
   @Test
   public void testRemoveDefaultAclPathNotFound() throws Exception {
-      Assertions.assertThrows(FileNotFoundException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          fs.removeDefaultAcl(path);
-      });
-  // Path has not been created.
-}
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(FileNotFoundException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      fs.removeDefaultAcl(path);
+    });
+    // Path has not been created.
+  }
 
   @Test
   public void testRemoveAcl() throws Exception {
@@ -665,7 +732,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
 
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -679,7 +746,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RW_R);
   }
 
@@ -699,7 +766,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) 01750);
   }
 
@@ -718,20 +785,20 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.removeAcl(path);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
   @Test
   public void testRemoveAclPathNotFound() throws Exception {
-      Assertions.assertThrows(FileNotFoundException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          fs.removeAcl(path);
-      });
-  // Path has not been created.
-}
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(FileNotFoundException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      fs.removeAcl(path);
+    });
+    // Path has not been created.
+  }
 
   @Test
   public void testSetAcl() throws Exception {
@@ -748,10 +815,15 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, ALL),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RWX);
   }
@@ -771,8 +843,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, READ),
-        aclEntry(ACCESS, GROUP, READ)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, READ),
+        aclEntry(ACCESS, GROUP, READ)
+    }, returned);
     assertPermission(fs, (short) RW_R);
   }
 
@@ -787,9 +861,13 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(DEFAULT, USER, ALL),
+        aclEntry(DEFAULT, USER, FOO, ALL),
+        aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+        aclEntry(DEFAULT, MASK, ALL),
+        aclEntry(DEFAULT, OTHER, NONE)
+    }, returned);
     assertPermission(fs, (short) RWX_RX);
   }
 
@@ -813,7 +891,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, (short) RW_R);
   }
 
@@ -830,8 +908,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX_RX);
   }
@@ -852,8 +932,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, READ),
-        aclEntry(ACCESS, GROUP, READ)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, READ),
+        aclEntry(ACCESS, GROUP, READ)
+    }, returned);
     assertPermission(fs, (short) RW_RWX);
   }
 
@@ -872,41 +954,46 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setAcl(path, aclSpec);
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, ALL),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) STICKY_RWX_RWX);
   }
 
   @Test
   public void testSetAclPathNotFound() throws Exception {
-      Assertions.assertThrows(FileNotFoundException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(ACCESS, USER, READ_WRITE),
-        aclEntry(ACCESS, USER, FOO, READ),
-        aclEntry(ACCESS, GROUP, READ),
-        aclEntry(ACCESS, OTHER, NONE));
-          fs.setAcl(path, aclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(FileNotFoundException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(ACCESS, USER, READ_WRITE),
+          aclEntry(ACCESS, USER, FOO, READ),
+          aclEntry(ACCESS, GROUP, READ),
+          aclEntry(ACCESS, OTHER, NONE));
+      fs.setAcl(path, aclSpec);
+    });
   }
 
   @Test
   public void testSetAclDefaultOnFile() throws Exception {
-      Assertions.assertThrows(Exception.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          fs.create(path).close();
-          fs.setPermission(path, FsPermission.createImmutable((short) RW_R));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(DEFAULT, USER, FOO, ALL));
-          fs.setAcl(path, aclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(Exception.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      fs.create(path).close();
+      fs.setPermission(path, FsPermission.createImmutable((short) RW_R));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(DEFAULT, USER, FOO, ALL));
+      fs.setAcl(path, aclSpec);
+    });
   }
 
   @Test
@@ -925,24 +1012,27 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     // get acl status and check result.
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, MASK, EXECUTE),
-        aclEntry(DEFAULT, OTHER, NONE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(DEFAULT, USER, ALL),
+        aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+        aclEntry(DEFAULT, MASK, EXECUTE),
+        aclEntry(DEFAULT, OTHER, NONE)
+    }, returned);
     assertPermission(fs, (short) RWX_RX_RX);
   }
 
   @Test
   public void testSetAclWithDuplicateEntries() throws Exception {
-      Assertions.assertThrows(PathIOException.class, () -> {
-          final AzureBlobFileSystem fs = this.getFileSystem();
-          assumeTrue(getIsNamespaceEnabled(fs));
-          path = new Path(testRoot, UUID.randomUUID().toString());
-          FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
-          List<AclEntry> aclSpec = Lists.newArrayList(
-        aclEntry(ACCESS, MASK, EXECUTE),
-        aclEntry(ACCESS, MASK, EXECUTE));
-          fs.setAcl(path, aclSpec);
-      });
+    assumeTrue(getIsNamespaceEnabled(getFileSystem()));
+    Assertions.assertThrows(PathIOException.class, () -> {
+      final AzureBlobFileSystem fs = this.getFileSystem();
+      path = new Path(testRoot, UUID.randomUUID().toString());
+      FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX));
+      List<AclEntry> aclSpec = Lists.newArrayList(
+          aclEntry(ACCESS, MASK, EXECUTE),
+          aclEntry(ACCESS, MASK, EXECUTE));
+      fs.setAcl(path, aclSpec);
+    });
   }
 
   @Test
@@ -961,10 +1051,15 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setPermission(path, FsPermission.createImmutable((short) RWX));
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, ALL),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX);
   }
@@ -985,8 +1080,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setPermission(path, FsPermission.createImmutable((short) RW));
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, READ),
-        aclEntry(ACCESS, GROUP, READ)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, READ),
+        aclEntry(ACCESS, GROUP, READ)
+    }, returned);
     assertPermission(fs, (short) RW);
   }
 
@@ -1005,9 +1102,13 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.setPermission(path, FsPermission.createImmutable((short) RWX));
     AclStatus s = fs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, (short) RWX);
   }
@@ -1026,8 +1127,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.create(filePath).close();
     AclStatus s = fs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ_EXECUTE)
+    }, returned);
     assertPermission(fs, filePath, (short) RW_R);
   }
 
@@ -1045,7 +1148,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.create(filePath).close();
     AclStatus s = fs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, filePath, (short) RW_R_R);
   }
 
@@ -1064,7 +1167,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.create(filePath).close();
     AclStatus s = fs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, filePath, (short) RW_R);
   }
 
@@ -1083,10 +1186,15 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
 
     AclStatus s = fs.getAclStatus(dirPath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, ALL),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, dirPath, (short) RWX_RWX);
   }
@@ -1105,7 +1213,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.mkdirs(dirPath);
     AclStatus s = fs.getAclStatus(dirPath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] { }, returned);
+    assertArrayEquals(new AclEntry[]{}, returned);
     assertPermission(fs, dirPath, (short) RWX_RX_RX);
   }
 
@@ -1124,8 +1232,10 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.mkdirs(dirPath);
     AclStatus s = fs.getAclStatus(dirPath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)
+        },
         returned);
     assertPermission(fs, dirPath, (short) RWX_RX);
   }
@@ -1136,19 +1246,22 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     assumeTrue(getIsNamespaceEnabled(fs));
     assumeTrue(getIngressServiceType() == AbfsServiceType.DFS);
     path = new Path(testRoot, UUID.randomUUID().toString());
-    FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX_RX));
+    FileSystem.mkdirs(fs, path,
+        FsPermission.createImmutable((short) RWX_RX_RX));
     List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(DEFAULT, USER, FOO, ALL));
     fs.setAcl(path, aclSpec);
     Path filePath = new Path(path, "file1");
-    int bufferSize =  4 * 1024 * 1024;
+    int bufferSize = 4 * 1024 * 1024;
     fs.create(filePath, new FsPermission((short) RWX_R), false, bufferSize,
-        fs.getDefaultReplication(filePath), fs.getDefaultBlockSize(path), null)
+            fs.getDefaultReplication(filePath), fs.getDefaultBlockSize(path), null)
         .close();
     AclStatus s = fs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE)}, returned);
+    assertArrayEquals(new AclEntry[]{
+        aclEntry(ACCESS, USER, FOO, ALL),
+        aclEntry(ACCESS, GROUP, READ_EXECUTE)
+    }, returned);
     assertPermission(fs, filePath, (short) RWX_R);
   }
 
@@ -1158,7 +1271,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     assumeTrue(getIsNamespaceEnabled(fs));
     assumeTrue(getIngressServiceType() == AbfsServiceType.DFS);
     path = new Path(testRoot, UUID.randomUUID().toString());
-    FileSystem.mkdirs(fs, path, FsPermission.createImmutable((short) RWX_RX_RX));
+    FileSystem.mkdirs(fs, path,
+        FsPermission.createImmutable((short) RWX_RX_RX));
     List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(DEFAULT, USER, FOO, ALL));
     fs.setAcl(path, aclSpec);
@@ -1166,10 +1280,15 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.mkdirs(dirPath, new FsPermission((short) RWX_R));
     AclStatus s = fs.getAclStatus(dirPath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, FOO, ALL),
-        aclEntry(ACCESS, GROUP, READ_EXECUTE), aclEntry(DEFAULT, USER, ALL),
-        aclEntry(DEFAULT, USER, FOO, ALL), aclEntry(DEFAULT, GROUP, READ_EXECUTE),
-        aclEntry(DEFAULT, MASK, ALL), aclEntry(DEFAULT, OTHER, READ_EXECUTE)},
+    assertArrayEquals(new AclEntry[]{
+            aclEntry(ACCESS, USER, FOO, ALL),
+            aclEntry(ACCESS, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, FOO, ALL),
+            aclEntry(DEFAULT, GROUP, READ_EXECUTE),
+            aclEntry(DEFAULT, MASK, ALL),
+            aclEntry(DEFAULT, OTHER, READ_EXECUTE)
+        },
         returned);
     assertPermission(fs, dirPath, (short) RWX_R);
   }
@@ -1180,7 +1299,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     assumeTrue(getIsNamespaceEnabled(fs));
     path = new Path(testRoot, UUID.randomUUID().toString());
     Path dirPath = new Path(path, "dir");
-    FileSystem.mkdirs(fs, dirPath, FsPermission.createImmutable((short) RWX_RX));
+    FileSystem.mkdirs(fs, dirPath,
+        FsPermission.createImmutable((short) RWX_RX));
     List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(DEFAULT, USER, FOO, ALL));
     fs.setAcl(dirPath, aclSpec);
@@ -1194,7 +1314,7 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
         fs.getFileSystemId(), FSOperationType.RENAME, true, 0));
     fs.rename(filePath, renamedFilePath);
     fs.registerListener(null);
-    AclEntry[] expected = new AclEntry[] { };
+    AclEntry[] expected = new AclEntry[]{};
     AclStatus s = fs.getAclStatus(renamedFilePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(expected, returned);
@@ -1207,15 +1327,17 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     assumeTrue(getIsNamespaceEnabled(fs));
     path = new Path(testRoot, UUID.randomUUID().toString());
     Path dirPath = new Path(path, "dir");
-    FileSystem.mkdirs(fs, dirPath, FsPermission.createImmutable((short) RWX_RX));
+    FileSystem.mkdirs(fs, dirPath,
+        FsPermission.createImmutable((short) RWX_RX));
     List<AclEntry> aclSpec = Lists.newArrayList(
         aclEntry(DEFAULT, USER, FOO, ALL));
     fs.setAcl(dirPath, aclSpec);
     Path subdirPath = new Path(path, "subdir");
-    FileSystem.mkdirs(fs, subdirPath, FsPermission.createImmutable((short) RWX_RX));
+    FileSystem.mkdirs(fs, subdirPath,
+        FsPermission.createImmutable((short) RWX_RX));
     Path renamedSubdirPath = new Path(dirPath, "subdir");
     fs.rename(subdirPath, renamedSubdirPath);
-    AclEntry[] expected = new AclEntry[] { };
+    AclEntry[] expected = new AclEntry[]{};
     AclStatus s = fs.getAclStatus(renamedSubdirPath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(expected, returned);
@@ -1284,7 +1406,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testSetPermissionForNonNamespaceEnabledAccount() throws Exception {
+  public void testSetPermissionForNonNamespaceEnabledAccount()
+      throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     assumeTrue(!getIsNamespaceEnabled(fs));
     final Path filePath = new Path(methodName.getMethodName());
@@ -1303,15 +1426,16 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testModifyAclEntriesForNonNamespaceEnabledAccount() throws Exception {
+  public void testModifyAclEntriesForNonNamespaceEnabledAccount()
+      throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     assumeTrue(!getIsNamespaceEnabled(fs));
     final Path filePath = new Path(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
-              aclEntry(DEFAULT, GROUP, FOO, ALL),
-              aclEntry(ACCESS, GROUP, BAR, ALL));
+          aclEntry(DEFAULT, GROUP, FOO, ALL),
+          aclEntry(ACCESS, GROUP, BAR, ALL));
       fs.modifyAclEntries(filePath, aclSpec);
       assertFalse(false, "UnsupportedOperationException is expected");
     } catch (UnsupportedOperationException ex) {
@@ -1320,15 +1444,16 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testRemoveAclEntriesEntriesForNonNamespaceEnabledAccount() throws Exception {
+  public void testRemoveAclEntriesEntriesForNonNamespaceEnabledAccount()
+      throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     assumeTrue(!getIsNamespaceEnabled(fs));
     final Path filePath = new Path(methodName.getMethodName());
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
-              aclEntry(DEFAULT, GROUP, FOO, ALL),
-              aclEntry(ACCESS, GROUP, BAR, ALL));
+          aclEntry(DEFAULT, GROUP, FOO, ALL),
+          aclEntry(ACCESS, GROUP, BAR, ALL));
       fs.removeAclEntries(filePath, aclSpec);
       assertFalse(false, "UnsupportedOperationException is expected");
     } catch (UnsupportedOperationException ex) {
@@ -1337,7 +1462,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
   }
 
   @Test
-  public void testRemoveDefaultAclForNonNamespaceEnabledAccount() throws Exception {
+  public void testRemoveDefaultAclForNonNamespaceEnabledAccount()
+      throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     assumeTrue(!getIsNamespaceEnabled(fs));
     final Path filePath = new Path(methodName.getMethodName());
@@ -1372,8 +1498,8 @@ public class ITestAzureBlobFilesystemAcl extends AbstractAbfsIntegrationTest {
     fs.create(filePath);
     try {
       List<AclEntry> aclSpec = Lists.newArrayList(
-              aclEntry(DEFAULT, GROUP, FOO, ALL),
-              aclEntry(ACCESS, GROUP, BAR, ALL));
+          aclEntry(DEFAULT, GROUP, FOO, ALL),
+          aclEntry(ACCESS, GROUP, BAR, ALL));
       fs.setAcl(filePath, aclSpec);
       assertFalse(false, "UnsupportedOperationException is expected");
     } catch (UnsupportedOperationException ex) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestOauthOverAbfsScheme.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestOauthOverAbfsScheme.java
@@ -38,7 +38,7 @@ public class ITestOauthOverAbfsScheme extends AbstractAbfsIntegrationTest {
   public ITestOauthOverAbfsScheme() throws Exception {
     assumeThat(getAuthType())
         .as("ITestOauthOverAbfsScheme is skipped because auth type is not OAuth")
-        .isNotEqualTo(AuthType.OAuth);
+        .isEqualTo(AuthType.OAuth);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestWasbAbfsCompatibility.java
@@ -161,7 +161,7 @@ public class ITestWasbAbfsCompatibility extends AbstractAbfsIntegrationTest {
         .as("Namespace enabled account does not support this test")
         .isFalse();
     assumeBlobServiceType();
-    assumeThat(isAppendBlobEnabled()).as("Not valid for APPEND BLOB");
+    assumeThat(isAppendBlobEnabled()).as("Not valid for APPEND BLOB").isFalse();
     NativeAzureFileSystem wasb = getWasbFileSystem();
 
     Path testFile = path("/testReadFile");

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsHttpClientRequestExecutor.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsHttpClientRequestExecutor.java
@@ -69,7 +69,7 @@ public class ITestAbfsHttpClientRequestExecutor extends
     if (isAppendBlobEnabled()) {
       assumeThat(getIngressServiceType())
           .as("Not valid for AppendBlob with blob endpoint")
-          .isEqualTo(AbfsServiceType.BLOB);
+          .isNotEqualTo(AbfsServiceType.BLOB);
     }
 
     Configuration conf = new Configuration(fs.getConf());


### PR DESCRIPTION
### Description of PR
After https://issues.apache.org/jira/browse/HADOOP-19425
most of the integration tests are getting skipped. All tests need to be fixed with this PR 

### How was this patch tested?
Test Suite ran.