### PR TITLE
HADOOP-19617 - [JDK17] Remove JUnit4 Dependency - HuaWeiCloud.

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -117,12 +117,6 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
@@ -200,6 +194,11 @@
           <artifactId>mockito-core</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/pom.xml
@@ -195,10 +195,5 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSContractCreate.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSContractCreate.java
@@ -21,7 +21,8 @@ package org.apache.hadoop.fs.obs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.junit.Assume;
+
+import org.junit.jupiter.api.Disabled;
 
 /**
  * Create test cases on obs file system.
@@ -33,13 +34,13 @@ public class TestOBSContractCreate extends AbstractContractCreateTest {
     return new OBSContract(conf);
   }
 
+  @Disabled
   @Override
   public void testCreatedFileIsImmediatelyVisible() {
-    Assume.assumeTrue("unsupport.", false);
   }
 
+  @Disabled
   @Override
   public void testCreatedFileIsVisibleOnFlush() {
-    Assume.assumeTrue("unsupport", false);
   }
 }

--- a/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSContractRename.java
+++ b/hadoop-cloud-storage-project/hadoop-huaweicloud/src/test/java/org/apache/hadoop/fs/obs/TestOBSContractRename.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.obs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.junit.Assume;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * Rename test cases on obs file system.
@@ -33,13 +33,13 @@ public class TestOBSContractRename extends AbstractContractRenameTest {
     return new OBSContract(conf);
   }
 
+  @Disabled
   @Override
   public void testRenameFileUnderFileSubdir() {
-    Assume.assumeTrue("unsupport.", false);
   }
 
+  @Disabled
   @Override
   public void testRenameFileUnderFile() {
-    Assume.assumeTrue("unsupport.", false);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19617 - [JDK17] Remove JUnit4 Dependency - HuaWeiCloud.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

