### PR TITLE
HADOOP-19343: Remove JUnit 4 dependencies from hadoop-gcp.

### DIFF
--- a/hadoop-tools/hadoop-gcp/pom.xml
+++ b/hadoop-tools/hadoop-gcp/pom.xml
@@ -425,23 +425,23 @@
     </plugins>
   </build>
 
-<dependencyManagement>
-        <dependencies>
-          <dependency>
-            <!--
-      We're using a specific Protobuf version to ensure compatibility with the
-      Google Cloud Storage (GCS) client. The GCS client often relies on
-      particular Long-Term Support (LTS) versions of Protobuf. When we upgrade
-      the GCS client, we'll likely need to update Protobuf too. To prevent
-      dependency conflicts, Protobuf will be shaded within the GCS connector's
-      fat JAR.
-      -->
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-        </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!--
+        We're using a specific Protobuf version to ensure compatibility with the
+        Google Cloud Storage (GCS) client. The GCS client often relies on
+        particular Long-Term Support (LTS) versions of Protobuf. When we upgrade
+        the GCS client, we'll likely need to update Protobuf too. To prevent
+        dependency conflicts, Protobuf will be shaded within the GCS connector's
+        fat JAR.
+        -->
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.25.5</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -476,25 +476,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
     </dependency>
-        <dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -511,4 +501,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestStorageResourceId.java
+++ b/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestStorageResourceId.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.gs;
 
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestStringPaths.java
+++ b/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestStringPaths.java
@@ -18,9 +18,10 @@
 
 package org.apache.hadoop.fs.gs;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -42,29 +43,39 @@ public class TestStringPaths {
     assertEquals("another-bucket", StringPaths.validateBucketName("another-bucket/"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateBucketNameEmpty() {
-    StringPaths.validateBucketName("");
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateBucketName("");
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateBucketNameNull() {
-    StringPaths.validateBucketName(null);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateBucketName(null);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateBucketNameInvalidChars() {
-    StringPaths.validateBucketName("my bucket"); // Space
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateBucketName("my bucket"); // Space
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateBucketNameInvalidChars2() {
-    StringPaths.validateBucketName("my@bucket"); // @ symbol
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateBucketName("my@bucket"); // @ symbol
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateBucketNameUpperCase() {
-    StringPaths.validateBucketName("MyBucket"); // Uppercase
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateBucketName("MyBucket"); // Uppercase
+    });
   }
 
   @Test
@@ -84,14 +95,18 @@ public class TestStringPaths {
     assertEquals("object", StringPaths.validateObjectName("/object", false));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateObjectNameEmptyNotAllowed() {
-    StringPaths.validateObjectName("", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateObjectName("", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateObjectNameNullNotAllowed() {
-    StringPaths.validateObjectName(null, false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateObjectName(null, false);
+    });
   }
 
   @Test
@@ -101,19 +116,25 @@ public class TestStringPaths {
     assertEquals("", StringPaths.validateObjectName("/", true)); // Single slash becomes empty
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateObjectNameConsecutiveSlashes() {
-    StringPaths.validateObjectName("path//to/object", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateObjectName("path//to/object", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateObjectNameConsecutiveSlashesAtStart() {
-    StringPaths.validateObjectName("//path/to/object", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateObjectName("//path/to/object", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidateObjectNameConsecutiveSlashesAtEnd() {
-    StringPaths.validateObjectName("path/to/object//", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.validateObjectName("path/to/object//", false);
+    });
   }
 
   @Test
@@ -124,9 +145,11 @@ public class TestStringPaths {
     assertEquals("gs://my-bucket/", StringPaths.fromComponents("my-bucket", ""));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFromComponentsNullBucketNonNullObject() {
-    StringPaths.fromComponents(null, "path/to/object");
+    assertThrows(IllegalArgumentException.class, () -> {
+      StringPaths.fromComponents(null, "path/to/object");
+    });
   }
 
   @Test

--- a/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestUriPaths.java
+++ b/hadoop-tools/hadoop-gcp/src/test/java/org/apache/hadoop/fs/gs/TestUriPaths.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.fs.gs;
 
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestUriPaths {
   @Test
@@ -130,23 +131,31 @@ public class TestUriPaths {
         UriPaths.fromStringPathComponents("my-bucket", "", true));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFromStringPathComponentsNullBucketNameNotAllowed() {
-    UriPaths.fromStringPathComponents(null, "object", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriPaths.fromStringPathComponents(null, "object", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFromStringPathComponentsEmptyObjectNameNotAllowed() {
-    UriPaths.fromStringPathComponents("my-bucket", "", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriPaths.fromStringPathComponents("my-bucket", "", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFromStringPathComponentsConsecutiveSlashes() {
-    UriPaths.fromStringPathComponents("my-bucket", "path//to/object", false);
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriPaths.fromStringPathComponents("my-bucket", "path//to/object", false);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFromStringPathComponentsInvalidBucketName() {
-    UriPaths.fromStringPathComponents("MyBucket", "object", false); // Uppercase
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriPaths.fromStringPathComponents("MyBucket", "object", false); // Uppercase
+    });
   }
 }


### PR DESCRIPTION
### Description of PR

Remove JUnit 4 dependencies from hadoop-gcp. Some use of `@Test(expect = ...)` needed to be converted to `assertThrows`.

### How was this patch tested?

All existing unit tests and integration tests pass after removal of the JUnit 4 dependencies.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

