### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part12.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlock.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -33,9 +33,9 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsDataOutputStream.SyncFlag;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfo;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test AddBlockOp is written and read correctly
@@ -47,7 +47,7 @@ public class TestAddBlock {
   private MiniDFSCluster cluster;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -56,7 +56,7 @@ public class TestAddBlock {
     cluster.waitActive();
   }
   
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -147,8 +147,7 @@ public class TestAddBlock {
       assertEquals(BLOCKSIZE, fileBlocks[0].getNumBytes());
       assertEquals(BlockUCState.COMPLETE, fileBlocks[0].getBlockUCState());
       assertEquals(appendContent.length() - 1, fileBlocks[1].getNumBytes());
-      assertEquals(BlockUCState.UNDER_CONSTRUCTION,
-          fileBlocks[1].getBlockUCState());
+      assertEquals(BlockUCState.UNDER_CONSTRUCTION, fileBlocks[1].getBlockUCState());
     } finally {
       if (out != null) {
         out.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlockRetry.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddBlockRetry.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.EnumSet;
 
@@ -38,9 +38,9 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.io.EnumSetWritable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -56,7 +56,7 @@ public class TestAddBlockRetry {
   private Configuration conf;
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -65,7 +65,7 @@ public class TestAddBlockRetry {
     cluster.waitActive();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -105,18 +105,17 @@ public class TestAddBlockRetry {
     }
     DatanodeStorageInfo targets[] = FSDirWriteFileOp.chooseTargetForNewBlock(
         ns.getBlockManager(), src, null, null, null, r);
-    assertNotNull("Targets must be generated", targets);
+    assertNotNull(targets, "Targets must be generated");
 
     // run second addBlock()
     LOG.info("Starting second addBlock for " + src);
     nn.addBlock(src, "clientName", null, null,
                 HdfsConstants.GRANDFATHER_INODE_ID, null, null);
-    assertTrue("Penultimate block must be complete",
-               checkFileProgress(src, false));
+    assertTrue(checkFileProgress(src, false), "Penultimate block must be complete");
     LocatedBlocks lbs = nn.getBlockLocations(src, 0, Long.MAX_VALUE);
-    assertEquals("Must be one block", 1, lbs.getLocatedBlocks().size());
+    assertEquals(1, lbs.getLocatedBlocks().size(), "Must be one block");
     LocatedBlock lb2 = lbs.get(0);
-    assertEquals("Wrong replication", REPLICATION, lb2.getLocations().length);
+    assertEquals(REPLICATION, lb2.getLocations().length, "Wrong replication");
 
     // continue first addBlock()
     ns.writeLock(RwLockMode.GLOBAL);
@@ -127,14 +126,14 @@ public class TestAddBlockRetry {
     } finally {
       ns.writeUnlock(RwLockMode.GLOBAL, "testRetryAddBlockWhileInChooseTarget");
     }
-    assertEquals("Blocks are not equal", lb2.getBlock(), newBlock.getBlock());
+    assertEquals(lb2.getBlock(), newBlock.getBlock(), "Blocks are not equal");
 
     // check locations
     lbs = nn.getBlockLocations(src, 0, Long.MAX_VALUE);
-    assertEquals("Must be one block", 1, lbs.getLocatedBlocks().size());
+    assertEquals(1, lbs.getLocatedBlocks().size(), "Must be one block");
     LocatedBlock lb1 = lbs.get(0);
-    assertEquals("Wrong replication", REPLICATION, lb1.getLocations().length);
-    assertEquals("Blocks are not equal", lb1.getBlock(), lb2.getBlock());
+    assertEquals(REPLICATION, lb1.getLocations().length, "Wrong replication");
+    assertEquals(lb1.getBlock(), lb2.getBlock(), "Blocks are not equal");
   }
 
   boolean checkFileProgress(String src, boolean checkall) throws IOException {
@@ -165,14 +164,14 @@ public class TestAddBlockRetry {
     LOG.info("Starting first addBlock for " + src);
     LocatedBlock lb1 = nameNodeRpc.addBlock(src, "clientName", null, null,
         HdfsConstants.GRANDFATHER_INODE_ID, null, null);
-    assertTrue("Block locations should be present",
-        lb1.getLocations().length > 0);
+    assertTrue(lb1.getLocations().length > 0,
+        "Block locations should be present");
 
     cluster.restartNameNode();
     nameNodeRpc = cluster.getNameNodeRpc();
     LocatedBlock lb2 = nameNodeRpc.addBlock(src, "clientName", null, null,
         HdfsConstants.GRANDFATHER_INODE_ID, null, null);
-    assertEquals("Blocks are not equal", lb1.getBlock(), lb2.getBlock());
-    assertTrue("Wrong locations with retry", lb2.getLocations().length > 0);
+    assertEquals(lb1.getBlock(), lb2.getBlock(), "Blocks are not equal");
+    assertTrue(lb2.getLocations().length > 0, "Wrong locations with retry");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -47,6 +46,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(300)
@@ -235,7 +235,7 @@ public class TestAddOverReplicatedStripedBlocks {
     for (byte index : bg.getBlockIndices()) {
       set.set(index);
     }
-    Assertions.assertFalse(set.get(0));
+    assertFalse(set.get(0));
     for (int i = 1; i < groupSize; i++) {
       assertTrue(set.get(i));
     }
@@ -292,7 +292,7 @@ public class TestAddOverReplicatedStripedBlocks {
     for (byte index : bg.getBlockIndices()) {
       set.set(index);
     }
-    Assertions.assertFalse(set.get(groupSize - 1));
+    assertFalse(set.get(groupSize - 1));
     for (int i = 0; i < groupSize - 1; i++) {
       assertTrue(set.get(i));
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
@@ -34,22 +34,22 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(300)
 public class TestAddOverReplicatedStripedBlocks {
 
   private MiniDFSCluster cluster;
@@ -66,10 +66,7 @@ public class TestAddOverReplicatedStripedBlocks {
   private final int blockSize = stripesPerBlock * cellSize;
   private final int numDNs = groupSize + 3;
 
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     Configuration conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
@@ -87,7 +84,7 @@ public class TestAddOverReplicatedStripedBlocks {
         ecPolicy.getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -238,7 +235,7 @@ public class TestAddOverReplicatedStripedBlocks {
     for (byte index : bg.getBlockIndices()) {
       set.set(index);
     }
-    Assert.assertFalse(set.get(0));
+    Assertions.assertFalse(set.get(0));
     for (int i = 1; i < groupSize; i++) {
       assertTrue(set.get(i));
     }
@@ -246,7 +243,7 @@ public class TestAddOverReplicatedStripedBlocks {
 
   // This test is going to be rewritten in HDFS-10854. Ignoring this test
   // temporarily as it fails with the fix for HDFS-10301.
-  @Ignore
+  @Disabled
   @Test
   public void testProcessOverReplicatedAndMissingStripedBlock()
       throws Exception {
@@ -295,7 +292,7 @@ public class TestAddOverReplicatedStripedBlocks {
     for (byte index : bg.getBlockIndices()) {
       set.set(index);
     }
-    Assert.assertFalse(set.get(groupSize - 1));
+    Assertions.assertFalse(set.get(groupSize - 1));
     for (int i = 0; i < groupSize - 1; i++) {
       assertTrue(set.get(i));
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddStripedBlockInFBR.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddStripedBlockInFBR.java
@@ -33,17 +33,17 @@ import org.apache.hadoop.hdfs.server.blockmanagement.NumberReplicas;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.util.function.Supplier;
 
 import java.io.IOException;
 
+@Timeout(300)
 public class TestAddStripedBlockInFBR {
   private final ErasureCodingPolicy ecPolicy =
       StripedFileTestUtil.getDefaultECPolicy();
@@ -55,10 +55,7 @@ public class TestAddStripedBlockInFBR {
   private MiniDFSCluster cluster;
   private DistributedFileSystem dfs;
 
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     Configuration conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(groupSize).build();
@@ -68,7 +65,7 @@ public class TestAddStripedBlockInFBR {
         StripedFileTestUtil.getDefaultECPolicy().getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddStripedBlocks.java
@@ -51,11 +51,10 @@ import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo.BlockStat
 import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
 import org.apache.hadoop.io.IOUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,11 +62,12 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_DEFAULT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+@Timeout(300)
 public class TestAddStripedBlocks {
   private final ErasureCodingPolicy ecPolicy =
       StripedFileTestUtil.getDefaultECPolicy();
@@ -80,10 +80,7 @@ public class TestAddStripedBlocks {
   private MiniDFSCluster cluster;
   private DistributedFileSystem dfs;
 
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     HdfsConfiguration conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(groupSize).build();
@@ -93,7 +90,7 @@ public class TestAddStripedBlocks {
     dfs.getClient().setErasureCodingPolicy("/", ecPolicy.getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -163,7 +160,8 @@ public class TestAddStripedBlocks {
     DFSTestUtil.flushInternal(out);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAddStripedBlock() throws Exception {
     final Path file = new Path("/file1");
     // create an empty file
@@ -485,17 +483,17 @@ public class TestAddStripedBlocks {
       out.write("this is a replicated file".getBytes());
     }
     BlockLocation[] locations = dfs.getFileBlockLocations(replicated, 0, 100);
-    assertEquals("There should be exactly one Block present",
-        1, locations.length);
-    assertFalse("The file is Striped", locations[0].isStriped());
+    assertEquals(1, locations.length,
+        "There should be exactly one Block present");
+    assertFalse(locations[0].isStriped(), "The file is Striped");
 
     Path striped = new Path("/blockLocation/striped");
     try (FSDataOutputStream out = dfs.createFile(striped).recursive().build()) {
       out.write("this is a striped file".getBytes());
     }
     locations = dfs.getFileBlockLocations(striped, 0, 100);
-    assertEquals("There should be exactly one Block present",
-        1, locations.length);
-    assertTrue("The file is not Striped", locations[0].isStriped());
+    assertEquals(1, locations.length,
+        "There should be exactly one Block present");
+    assertTrue(locations[0].isStriped(), "The file is not Striped");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogAtDebug.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogAtDebug.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -27,9 +28,7 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem.FSNamesystemAuditLogger;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.net.Inet4Address;
@@ -44,11 +43,9 @@ import static org.mockito.Mockito.*;
 /**
  * Test that the HDFS Audit logger respects DFS_NAMENODE_AUDIT_LOG_DEBUG_CMDLIST. 
  */
+@Timeout(300)
 public class TestAuditLogAtDebug {
   static final Logger LOG = LoggerFactory.getLogger(TestAuditLogAtDebug.class);
-
-  @Rule
-  public Timeout timeout = new Timeout(300000);
   
   private static final String DUMMY_COMMAND_1 = "dummycommand1";
   private static final String DUMMY_COMMAND_2 = "dummycommand2";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogger.java
@@ -40,8 +40,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.mockito.Mockito;
 
@@ -72,11 +73,11 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_KEY
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AUDIT_LOGGERS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AUDIT_LOG_WITH_REMOTE_PORT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.NNTOP_ENABLED_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
@@ -106,7 +107,7 @@ public class TestAuditLogger {
       "proto=.*?" +
       "callerContext=.*?clientPort\\:(\\d{0,9}).*?");
 
-  @Before
+  @BeforeEach
   public void setup() {
     DummyAuditLogger.initialized = false;
     DummyAuditLogger.logCount = 0;
@@ -155,8 +156,8 @@ public class TestAuditLogger {
           cluster.getNameNode().getNamesystem().getAuditLoggers();
       for (AuditLogger auditLogger : auditLoggers) {
         assertFalse(
-            "top audit logger is still hooked in after it is disabled",
-            auditLogger instanceof TopAuditLogger);
+            auditLogger instanceof TopAuditLogger,
+            "top audit logger is still hooked in after it is disabled");
       }
     } finally {
       cluster.shutdown();
@@ -475,7 +476,8 @@ public class TestAuditLogger {
    * Verify Audit log entries for the successful ACL API calls and ACL commands
    * over FS Shell.
    */
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAuditLogForAcls() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     conf.setBoolean(DFS_NAMENODE_ACLS_ENABLED_KEY, true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLoggerWithCommands.java
@@ -46,14 +46,14 @@ import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_ALWAYS_USE_KEY;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +76,7 @@ public class TestAuditLoggerWithCommands {
   static UserGroupInformation user2;
   private static NamenodeProtocols proto;
 
-  @Before
+  @BeforeEach
   public void initialize() throws Exception {
     // start a cluster
     conf = new HdfsConfiguration();
@@ -101,7 +101,7 @@ public class TestAuditLoggerWithCommands {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     Server.getCurCall().set(null);
     fs.close();
@@ -131,8 +131,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log from getContentSummary",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log from getContentSummary");
   }
 
   @Test
@@ -188,8 +188,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log from Concat",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log from Concat");
   }
 
   @Test
@@ -226,8 +226,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -253,8 +253,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length+1 == auditlog.getOutput().split("\n").length);
+    assertTrue(length + 1 == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -334,8 +334,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -400,8 +400,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -429,8 +429,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -452,8 +452,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -476,8 +476,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -501,8 +501,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -520,16 +520,16 @@ public class TestAuditLoggerWithCommands {
     String aceRemoveCachePoolPattern =
         ".*allowed=false.*ugi=theDoctor.*cmd=removeCachePool.*";
     int length = verifyAuditLogs(aceRemoveCachePoolPattern);
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
     try {
       fileSys.close();
       ((DistributedFileSystem) fileSys).removeCachePool("pool1");
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -551,8 +551,7 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e){
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length, "Unexpected log!");
   }
 
   @Test
@@ -574,8 +573,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -597,8 +596,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException e) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
   }
 
   @Test
@@ -639,8 +638,8 @@ public class TestAuditLoggerWithCommands {
       fail("The operation should have failed with IOException");
     } catch (IOException ace) {
     }
-    assertTrue("Unexpected log!",
-        length == auditlog.getOutput().split("\n").length);
+    assertTrue(length == auditlog.getOutput().split("\n").length,
+        "Unexpected log!");
     cluster.getNamesystem().setFSDirectory(dir);
   }
 
@@ -1246,8 +1245,8 @@ public class TestAuditLoggerWithCommands {
       fail(
           "RestoreFailedStorage should have thrown AccessControlException!");
     } catch (IOException ace) {
-      assertEquals("Unexpected Exception!",
-          ace.getClass(), AccessControlException.class);
+      assertEquals(ace.getClass(), AccessControlException.class,
+          "Unexpected Exception!");
       String auditLogString =
           ".*allowed=false.*cmd=" + operationName + ".*";
       verifyAuditLogs(auditLogString);
@@ -1300,7 +1299,8 @@ public class TestAuditLoggerWithCommands {
     int length = auditlog.getOutput().split(System.lineSeparator()).length;
     String lastAudit = auditlog.getOutput()
         .split(System.lineSeparator())[length - 1];
-    assertTrue("Unexpected log!", lastAudit.matches(pattern));
+    assertTrue(lastAudit.matches(pattern),
+        "Unexpected log!");
     return length;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
@@ -132,7 +132,7 @@ public class TestAuditLogs {
     userGroupInfo = UserGroupInformation.createUserForTesting(username, groups);
  }
 
- @AfterEach
+  @AfterEach
   public void teardownCluster() throws Exception {
     util.cleanup(fs, "/srcdat");
     if (fs != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -46,20 +46,20 @@ import org.apache.log4j.Appender;
 import org.apache.log4j.AsyncAppender;
 import org.apache.log4j.Logger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.LoggerFactory;
 
 /**
  * A JUnit test that audit logs are generated
  */
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestAuditLogs {
 
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(TestAuditLogs.class);
@@ -68,7 +68,6 @@ public class TestAuditLogs {
 
   private static LogCapturer auditLogCapture;
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<>();
     params.add(new Object[]{Boolean.FALSE});
@@ -106,7 +105,7 @@ public class TestAuditLogs {
   Configuration conf;
   UserGroupInformation userGroupInfo;
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     // must configure prior to instantiating the namesystem because it
     // will reconfigure the logger if async is enabled
@@ -133,7 +132,7 @@ public class TestAuditLogs {
     userGroupInfo = UserGroupInformation.createUserForTesting(username, groups);
  }
 
-  @After
+ @AfterEach
   public void teardownCluster() throws Exception {
     util.cleanup(fs, "/srcdat");
     if (fs != null) {
@@ -146,12 +145,12 @@ public class TestAuditLogs {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     auditLogCapture = LogCapturer.captureLogs(FSNamesystem.AUDIT_LOG);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     auditLogCapture.stopCapturing();
   }
@@ -167,7 +166,7 @@ public class TestAuditLogs {
     int val = istream.read();
     istream.close();
     verifySuccessCommandsAuditLogs(2, fnames[0], "cmd=open");
-    assertTrue("failed to read from file", val >= 0);
+    assertTrue(val >= 0, "failed to read from file");
   }
 
   /** test that allowed stat puts proper entry in audit log */
@@ -178,7 +177,7 @@ public class TestAuditLogs {
 
     FileStatus st = userfs.getFileStatus(file);
     verifySuccessCommandsAuditLogs(2, fnames[0], "cmd=getfileinfo");
-    assertTrue("failed to stat file", st != null && st.isFile());
+    assertTrue(st != null && st.isFile(), "failed to stat file");
   }
 
   /** test that denied operation puts proper entry in audit log */
@@ -213,7 +212,7 @@ public class TestAuditLogs {
     istream.close();
 
     verifySuccessCommandsAuditLogs(3, fnames[0], "cmd=open");
-    assertTrue("failed to read from file", val >= 0);
+    assertTrue(val >= 0, "failed to read from file");
   }
 
   /** test that stat via webhdfs puts proper entry in audit log */
@@ -228,7 +227,7 @@ public class TestAuditLogs {
     FileStatus st = webfs.getFileStatus(file);
 
     verifySuccessCommandsAuditLogs(2, fnames[0], "cmd=getfileinfo");
-    assertTrue("failed to stat file", st != null && st.isFile());
+    assertTrue(st != null && st.isFile(), "failed to stat file");
   }
 
   /** test that denied access via webhdfs puts proper entry in audit log */
@@ -282,8 +281,8 @@ public class TestAuditLogs {
       String line = "allowed=" + auditLogLine.split("allowed=")[1];
       LOG.info("Line: {}", line);
       if (SUCCESS_PATTERN.matcher(line).matches() && line.contains(file) && line.contains(cmd)) {
-        assertTrue("Expected audit event not found in audit log",
-            AUDIT_PATTERN.matcher(line).matches());
+        assertTrue(AUDIT_PATTERN.matcher(line).matches(),
+            "Expected audit event not found in audit log");
         LOG.info("Successful verification. Log line: {}", line);
         success++;
       }
@@ -305,14 +304,14 @@ public class TestAuditLogs {
       LOG.info("Line: {}", line);
       if (FAILURE_PATTERN.matcher(line).matches() && line.contains(file) && line.contains(
           cmd)) {
-        assertTrue("Expected audit event not found in audit log",
-            AUDIT_PATTERN.matcher(line).matches());
+        assertTrue(AUDIT_PATTERN.matcher(line).matches(),
+            "Expected audit event not found in audit log");
         LOG.info("Failure verification. Log line: {}", line);
         success++;
       }
     }
-    assertEquals("Expected: " + expected + ". Actual failure: " + success, expected,
-        success);
+    assertEquals(expected, success, "Expected: " + expected
+        + ". Actual failure: " + success);
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuthorizationContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuthorizationContext.java
@@ -19,12 +19,12 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -45,7 +45,7 @@ public class TestAuthorizationContext {
   private String path = "";
   private int ancestorIndex = inodes.length - 2;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     when(iip.getPathSnapshotId()).thenReturn(snapshotId);
     when(iip.getINodesArray()).thenReturn(inodes);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockPlacementPolicyRackFaultTolerant.java
@@ -41,17 +41,17 @@ import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.net.StaticMapping;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBlockPlacementPolicyRackFaultTolerant {
 
@@ -61,7 +61,7 @@ public class TestBlockPlacementPolicyRackFaultTolerant {
   private FSNamesystem namesystem = null;
   private PermissionStatus perm = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     StaticMapping.resetMap();
     Configuration conf = new HdfsConfiguration();
@@ -90,7 +90,7 @@ public class TestBlockPlacementPolicyRackFaultTolerant {
         FsPermission.getDefault());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -273,12 +273,11 @@ public class TestBlockPlacementPolicyRackFaultTolerant {
     LocatedBlocks locatedBlocks =
         cluster.getFileSystem().getClient().getLocatedBlocks(
             src, 0, DEFAULT_BLOCK_SIZE);
-    assertEquals(4, bm.getDatanodeManager().
-        getNetworkTopology().getNumOfNonEmptyRacks());
+    assertEquals(4, bm.getDatanodeManager().getNetworkTopology().getNumOfNonEmptyRacks());
     for (LocatedBlock block : locatedBlocks.getLocatedBlocks()) {
       BlockPlacementStatus status = bm.getStriptedBlockPlacementPolicy()
               .verifyBlockPlacement(block.getLocations(), 5);
-      Assert.assertTrue(status.isPlacementPolicySatisfied());
+      Assertions.assertTrue(status.isPlacementPolicySatisfied());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockPlacementPolicyRackFaultTolerant.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockPlacementPolicyRackFaultTolerant.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.net.StaticMapping;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -277,7 +276,7 @@ public class TestBlockPlacementPolicyRackFaultTolerant {
     for (LocatedBlock block : locatedBlocks.getLocatedBlocks()) {
       BlockPlacementStatus status = bm.getStriptedBlockPlacementPolicy()
               .verifyBlockPlacement(block.getLocations(), 5);
-      Assertions.assertTrue(status.isPlacementPolicySatisfied());
+      assertTrue(status.isPlacementPolicySatisfied());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockUnderConstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockUnderConstruction.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,9 +41,9 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockUnderConstructionFeature;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestBlockUnderConstruction {
   static final String BASE_DIR = "/test/TestBlockUnderConstruction";
@@ -53,7 +53,7 @@ public class TestBlockUnderConstruction {
   private static MiniDFSCluster cluster;
   private static DistributedFileSystem hdfs;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Configuration conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3).build();
@@ -61,7 +61,7 @@ public class TestBlockUnderConstruction {
     hdfs = cluster.getFileSystem();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if(hdfs != null) hdfs.close();
     if(cluster != null) cluster.shutdown();
@@ -89,49 +89,45 @@ public class TestBlockUnderConstruction {
                                 boolean isFileOpen) throws IOException {
     FSNamesystem ns = cluster.getNamesystem();
     final INodeFile inode = INodeFile.valueOf(ns.dir.getINode(file), file);
-    assertTrue("File " + inode.toString() +
+    assertTrue(inode.isUnderConstruction() == isFileOpen, "File " + inode.toString() +
         " isUnderConstruction = " + inode.isUnderConstruction() +
-        " expected to be " + isFileOpen,
-        inode.isUnderConstruction() == isFileOpen);
+        " expected to be " + isFileOpen);
     BlockInfo[] blocks = inode.getBlocks();
-    assertTrue("File does not have blocks: " + inode.toString(),
-        blocks != null && blocks.length > 0);
+    assertTrue(blocks != null && blocks.length > 0,
+        "File does not have blocks: " + inode.toString());
     
     int idx = 0;
     BlockInfo curBlock;
     // all blocks but the last two should be regular blocks
     for(; idx < blocks.length - 2; idx++) {
       curBlock = blocks[idx];
-      assertTrue("Block is not complete: " + curBlock,
-          curBlock.isComplete());
-      assertTrue("Block is not in BlocksMap: " + curBlock,
-          ns.getBlockManager().getStoredBlock(curBlock) == curBlock);
+      assertTrue(curBlock.isComplete(), "Block is not complete: " + curBlock);
+      assertTrue(ns.getBlockManager().getStoredBlock(curBlock) == curBlock,
+          "Block is not in BlocksMap: " + curBlock);
     }
 
     // the penultimate block is either complete or
     // committed if the file is not closed
     if(idx > 0) {
       curBlock = blocks[idx-1]; // penultimate block
-      assertTrue("Block " + curBlock +
-          " isUnderConstruction = " + inode.isUnderConstruction() +
-          " expected to be " + isFileOpen,
-          (isFileOpen && curBlock.isComplete()) ||
+      assertTrue((isFileOpen && curBlock.isComplete()) ||
           (!isFileOpen && !curBlock.isComplete() == 
             (curBlock.getBlockUCState() ==
-              BlockUCState.COMMITTED)));
-      assertTrue("Block is not in BlocksMap: " + curBlock,
-          ns.getBlockManager().getStoredBlock(curBlock) == curBlock);
+                  BlockUCState.COMMITTED)),
+          "Block " + curBlock + " isUnderConstruction = " + inode.isUnderConstruction()
+              + " expected to be " + isFileOpen);
+      assertTrue(ns.getBlockManager().getStoredBlock(curBlock) == curBlock,
+          "Block is not in BlocksMap: " + curBlock);
     }
 
     // The last block is complete if the file is closed.
     // If the file is open, the last block may be complete or not. 
     curBlock = blocks[idx]; // last block
     if (!isFileOpen) {
-      assertTrue("Block " + curBlock + ", isFileOpen = " + isFileOpen,
-          curBlock.isComplete());
+        assertTrue(curBlock.isComplete(), "Block " + curBlock + ", isFileOpen = " + isFileOpen);
     }
-    assertTrue("Block is not in BlocksMap: " + curBlock,
-        ns.getBlockManager().getStoredBlock(curBlock) == curBlock);
+    assertTrue(ns.getBlockManager().getStoredBlock(curBlock) == curBlock,
+        "Block is not in BlocksMap: " + curBlock);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockUnderConstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestBlockUnderConstruction.java
@@ -124,7 +124,7 @@ public class TestBlockUnderConstruction {
     // If the file is open, the last block may be complete or not. 
     curBlock = blocks[idx]; // last block
     if (!isFileOpen) {
-        assertTrue(curBlock.isComplete(), "Block " + curBlock + ", isFileOpen = " + isFileOpen);
+      assertTrue(curBlock.isComplete(), "Block " + curBlock + ", isFileOpen = " + isFileOpen);
     }
     assertTrue(ns.getBlockManager().getStoredBlock(curBlock) == curBlock,
         "Block is not in BlocksMap: " + curBlock);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestClusterId.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestClusterId.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -49,9 +49,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestClusterId {
   private static final Logger LOG =
@@ -77,7 +77,7 @@ public class TestClusterId {
     return cid;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     ExitUtil.disableSystemExit();
 
@@ -98,7 +98,7 @@ public class TestClusterId {
     config.set(DFS_NAMENODE_NAME_DIR_KEY, hdfsDir.getPath());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (hdfsDir.exists() && !FileUtil.fullyDelete(hdfsDir)) {
       throw new IOException("Could not tearDown test directory '" + hdfsDir
@@ -114,21 +114,21 @@ public class TestClusterId {
     NameNode.format(config);
     // see if cluster id not empty.
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")) );
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
 
     // 2. successful format with given clusterid
     StartupOption.FORMAT.setClusterId("mycluster");
     NameNode.format(config);
     // see if cluster id matches with given clusterid.
     cid = getClusterId(config);
-    assertTrue("ClusterId didn't match", cid.equals("mycluster"));
+    assertTrue(cid.equals("mycluster"), "ClusterId didn't match");
 
     // 3. format without any clusterid again. It should generate new
     //clusterid.
     StartupOption.FORMAT.setClusterId("");
     NameNode.format(config);
     String newCid = getClusterId(config);
-    assertFalse("ClusterId should not be the same", newCid.equals(cid));
+    assertFalse(newCid.equals(cid), "ClusterId should not be the same");
   }
 
   /**
@@ -143,11 +143,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -168,11 +168,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -193,11 +193,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -219,11 +219,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cId = getClusterId(config);
-    assertEquals("ClusterIds do not match", myId, cId);
+    assertEquals(myId, cId, "ClusterIds do not match");
   }
 
   /**
@@ -251,7 +251,7 @@ public class TestClusterId {
 
     // check if the version file does not exists.
     File version = new File(hdfsDir, "current/VERSION");
-    assertFalse("Check version should not exist", version.exists());
+    assertFalse(version.exists(), "Check version should not exist");
   }
 
   /**
@@ -279,7 +279,7 @@ public class TestClusterId {
 
     // check if the version file does not exists.
     File version = new File(hdfsDir, "current/VERSION");
-    assertFalse("Check version should not exist", version.exists());
+    assertFalse(version.exists(), "Check version should not exist");
   }
 
   /**
@@ -308,7 +308,7 @@ public class TestClusterId {
 
     // check if the version file does not exists.
     File version = new File(hdfsDir, "current/VERSION");
-    assertFalse("Check version should not exist", version.exists());
+    assertFalse(version.exists(), "Check version should not exist");
   }
 
   /**
@@ -331,13 +331,12 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have been aborted with exit code 1", 1,
-          e.status);
+        assertEquals(1, e.status, "Format should have been aborted with exit code 1");
     }
 
     // check if the version file does not exists.
     File version = new File(hdfsDir, "current/VERSION");
-    assertFalse("Check version should not exist", version.exists());
+    assertFalse(version.exists(), "Check version should not exist");
   }
 
   /**
@@ -355,11 +354,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -380,11 +379,11 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -415,13 +414,13 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should have succeeded", 0, e.status);
+        assertEquals(0, e.status, "Format should have succeeded");
     }
 
     System.setIn(origIn);
 
     String cid = getClusterId(config);
-    assertTrue("Didn't get new ClusterId", (cid != null && !cid.equals("")));
+    assertTrue((cid != null && !cid.equals("")), "Didn't get new ClusterId");
   }
 
   /**
@@ -451,14 +450,14 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-      assertEquals("Format should not have succeeded", 1, e.status);
+        assertEquals(1, e.status, "Format should not have succeeded");
     }
 
     System.setIn(origIn);
 
     // check if the version file does not exists.
     File version = new File(hdfsDir, "current/VERSION");
-    assertFalse("Check version should not exist", version.exists());
+    assertFalse(version.exists(), "Check version should not exist");
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestClusterId.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestClusterId.java
@@ -143,7 +143,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
@@ -168,7 +168,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
@@ -193,7 +193,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
@@ -219,7 +219,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cId = getClusterId(config);
@@ -331,7 +331,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(1, e.status, "Format should have been aborted with exit code 1");
+      assertEquals(1, e.status, "Format should have been aborted with exit code 1");
     }
 
     // check if the version file does not exists.
@@ -354,7 +354,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
@@ -379,7 +379,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     String cid = getClusterId(config);
@@ -414,7 +414,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(0, e.status, "Format should have succeeded");
+      assertEquals(0, e.status, "Format should have succeeded");
     }
 
     System.setIn(origIn);
@@ -450,7 +450,7 @@ public class TestClusterId {
       NameNode.createNameNode(argv, config);
       fail("createNameNode() did not call System.exit()");
     } catch (ExitException e) {
-        assertEquals(1, e.status, "Format should not have succeeded");
+      assertEquals(1, e.status, "Format should not have succeeded");
     }
 
     System.setIn(origIn);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockSynchronization.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockSynchronization.java
@@ -27,11 +27,11 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockInfoContiguous;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockWithInvalidGenStamp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockWithInvalidGenStamp.java
@@ -28,11 +28,13 @@ import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class TestCommitBlockWithInvalidGenStamp {
@@ -81,17 +83,17 @@ public class TestCommitBlockWithInvalidGenStamp {
       try{
         dfs.getClient().getNamenode().complete(file.toString(),
             dfs.getClient().getClientName(), previous, fileNode.getId());
-        Assertions.fail("should throw exception because invalid genStamp");
+        fail("should throw exception because invalid genStamp");
       } catch (IOException e) {
-        Assertions.assertTrue(e.toString().contains(
+        assertTrue(e.toString().contains(
             "Commit block with mismatching GS. NN has " +
-            newBlock + ", client submits " + newBlockClone));
+                newBlock + ", client submits " + newBlockClone));
       }
       previous = new ExtendedBlock(cluster.getNamesystem().getBlockPoolId(),
           newBlock);
       boolean complete =  dfs.getClient().getNamenode().complete(file.toString(),
       dfs.getClient().getClientName(), previous, fileNode.getId());
-      Assertions.assertTrue(complete, "should complete successfully");
+      assertTrue(complete, "should complete successfully");
     } finally {
       IOUtils.cleanupWithLogger(null, out);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockWithInvalidGenStamp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCommitBlockWithInvalidGenStamp.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.io.IOUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -41,7 +41,7 @@ public class TestCommitBlockWithInvalidGenStamp {
   private FSDirectory dir;
   private DistributedFileSystem dfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     final Configuration conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
@@ -52,7 +52,7 @@ public class TestCommitBlockWithInvalidGenStamp {
     dfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -81,9 +81,9 @@ public class TestCommitBlockWithInvalidGenStamp {
       try{
         dfs.getClient().getNamenode().complete(file.toString(),
             dfs.getClient().getClientName(), previous, fileNode.getId());
-        Assert.fail("should throw exception because invalid genStamp");
+        Assertions.fail("should throw exception because invalid genStamp");
       } catch (IOException e) {
-        Assert.assertTrue(e.toString().contains(
+        Assertions.assertTrue(e.toString().contains(
             "Commit block with mismatching GS. NN has " +
             newBlock + ", client submits " + newBlockClone));
       }
@@ -91,7 +91,7 @@ public class TestCommitBlockWithInvalidGenStamp {
           newBlock);
       boolean complete =  dfs.getClient().getNamenode().complete(file.toString(),
       dfs.getClient().getClientName(), previous, fileNode.getId());
-      Assert.assertTrue("should complete successfully", complete);
+      Assertions.assertTrue(complete, "should complete successfully");
     } finally {
       IOUtils.cleanupWithLogger(null, out);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCreateEditsLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCreateEditsLog.java
@@ -17,15 +17,16 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY;
 
 import java.io.File;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
@@ -48,13 +49,13 @@ public class TestCreateEditsLog {
 
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     deleteIfExists(HDFS_DIR);
     deleteIfExists(TEST_DIR);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -68,7 +69,8 @@ public class TestCreateEditsLog {
    * Tests that an edits log created using CreateEditsLog is valid and can be
    * loaded successfully by a namenode.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCanLoadCreatedEditsLog() throws Exception {
     // Format namenode.
     HdfsConfiguration conf = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.util.function.Supplier;
 import org.apache.hadoop.hdfs.server.protocol.SlowDiskReports;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -56,8 +56,8 @@ import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test to ensure requests from dead datnodes are rejected by namenode with
@@ -68,7 +68,7 @@ public class TestDeadDatanode {
       LoggerFactory.getLogger(TestDeadDatanode.class);
   private MiniDFSCluster cluster;
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (cluster != null) {
       cluster.shutdown();
@@ -143,8 +143,7 @@ public class TestDeadDatanode {
             SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT)
         .getCommands();
     assertEquals(1, cmd.length);
-    assertEquals(cmd[0].getAction(), RegisterCommand.REGISTER
-        .getAction());
+    assertEquals(cmd[0].getAction(), RegisterCommand.REGISTER.getAction());
   }
 
   @Test
@@ -179,8 +178,8 @@ public class TestDeadDatanode {
         clientNode, new HashSet<>(), 256 * 1024 * 1024L, null, (byte) 7,
         BlockType.CONTIGUOUS, null, null);
     for (DatanodeStorageInfo datanodeStorageInfo : results) {
-      assertFalse("Dead node should not be chosen", datanodeStorageInfo
-          .getDatanodeDescriptor().equals(clientNode));
+        assertFalse(datanodeStorageInfo.getDatanodeDescriptor().equals(clientNode),
+            "Dead node should not be chosen");
     }
   }
 
@@ -206,11 +205,12 @@ public class TestDeadDatanode {
           .getDatanode(dn2.getDatanodeId());
       dn1.setHeartbeatsDisabledForTests(true);
       cluster.setDataNodeDead(dn1.getDatanodeId());
-      assertEquals("Capacity shouldn't include DeadNode", dn2Desc.getCapacity(),
-          cluster.getNamesystem(0).getCapacityTotal());
-      assertEquals("NonDFS-used shouldn't include DeadNode",
-          dn2Desc.getNonDfsUsed(),
-          cluster.getNamesystem(0).getNonDfsUsedSpace());
+      assertEquals(dn2Desc.getCapacity(),
+          cluster.getNamesystem(0).getCapacityTotal(),
+          "Capacity shouldn't include DeadNode");
+      assertEquals(dn2Desc.getNonDfsUsed(),
+          cluster.getNamesystem(0).getNonDfsUsedSpace(),
+          "NonDFS-used shouldn't include DeadNode");
       // Wait for re-registration and heartbeat
       dn1.setHeartbeatsDisabledForTests(false);
       final DatanodeDescriptor dn1Desc = cluster.getNamesystem(0)
@@ -222,11 +222,11 @@ public class TestDeadDatanode {
           return dn1Desc.isAlive() && dn1Desc.isHeartbeatedSinceRegistration();
         }
       }, 100, 5000);
-      assertEquals("Capacity should be 0 after all DNs dead", initialCapacity,
-          cluster.getNamesystem(0).getCapacityTotal());
+      assertEquals(initialCapacity, cluster.getNamesystem(0).getCapacityTotal(),
+          "Capacity should be 0 after all DNs dead");
       long nonDfsAfterReg = cluster.getNamesystem(0).getNonDfsUsedSpace();
-      assertEquals("NonDFS should include actual DN NonDFSUsed",
-          dn1Desc.getNonDfsUsed() + dn2Desc.getNonDfsUsed(), nonDfsAfterReg);
+      assertEquals(dn1Desc.getNonDfsUsed() + dn2Desc.getNonDfsUsed(), nonDfsAfterReg,
+          "NonDFS should include actual DN NonDFSUsed");
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeadDatanode.java
@@ -178,8 +178,8 @@ public class TestDeadDatanode {
         clientNode, new HashSet<>(), 256 * 1024 * 1024L, null, (byte) 7,
         BlockType.CONTIGUOUS, null, null);
     for (DatanodeStorageInfo datanodeStorageInfo : results) {
-        assertFalse(datanodeStorageInfo.getDatanodeDescriptor().equals(clientNode),
-            "Dead node should not be chosen");
+      assertFalse(datanodeStorageInfo.getDatanodeDescriptor().equals(clientNode),
+          "Dead node should not be chosen");
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDecommissioningStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDecommissioningStatus.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -60,9 +60,10 @@ import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.hdfs.util.HostsFileWriter;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -126,13 +127,13 @@ public class TestDecommissioningStatus {
         .setHeartbeatExpireInterval(3000);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setupConfig();
     createCluster();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (hostsFileWriter != null) {
       hostsFileWriter.cleanup();
@@ -218,21 +219,21 @@ public class TestDecommissioningStatus {
           count++;
         }
       }
-      assertTrue("No decommissioning output", num != null);
-      assertEquals("Unexpected number of decomming DNs", expectedDecomm.size(),
-          num.intValue());
-      assertEquals("Unexpected number of decomming DNs", expectedDecomm.size(),
-          count);
+      assertTrue(num != null, "No decommissioning output");
+      assertEquals(expectedDecomm.size(),
+          num.intValue(), "Unexpected number of decomming DNs");
+      assertEquals(expectedDecomm.size(),
+          count, "Unexpected number of decomming DNs");
 
       // Check Java API for correct contents
       List<DatanodeInfo> decomming =
           new ArrayList<DatanodeInfo>(Arrays.asList(dfs
               .getDataNodeStats(DatanodeReportType.DECOMMISSIONING)));
-      assertEquals("Unexpected number of decomming DNs", expectedDecomm.size(),
-          decomming.size());
+      assertEquals(expectedDecomm.size(),
+          decomming.size(), "Unexpected number of decomming DNs");
       for (DatanodeID id : expectedDecomm) {
-        assertTrue("Did not find expected decomming DN " + id,
-            decomming.contains(id));
+        assertTrue(decomming.contains(id),
+            "Did not find expected decomming DN " + id);
       }
     } finally {
       System.setOut(oldOut);
@@ -265,7 +266,7 @@ public class TestDecommissioningStatus {
         .getNameNodePort());
     DFSClient client = new DFSClient(addr, conf);
     DatanodeInfo[] info = client.datanodeReport(DatanodeReportType.LIVE);
-    assertEquals("Number of Datanodes ", 2, info.length);
+    assertEquals(2, info.length, "Number of Datanodes ");
     DistributedFileSystem fileSys = cluster.getFileSystem();
     DFSAdmin admin = new DFSAdmin(cluster.getConfiguration(0));
 
@@ -391,7 +392,8 @@ public class TestDecommissioningStatus {
    * as dead before decommission has completed. That will allow DN to resume
    * the replication process after it rejoins the cluster.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testDecommissionStatusAfterDNRestart() throws Exception {
     DistributedFileSystem fileSys =
         (DistributedFileSystem)cluster.getFileSystem();
@@ -435,12 +437,12 @@ public class TestDecommissioningStatus {
     // Block until the admin's monitor updates the number of tracked nodes.
     waitForDecommissionedNodes(dm.getDatanodeAdminManager(), 1);
     // Verify that the DN remains in DECOMMISSION_INPROGRESS state.
-    assertTrue("the node should be DECOMMISSION_IN_PROGRESSS",
-        dead.get(0).isDecommissionInProgress());
+    assertTrue(dead.get(0).isDecommissionInProgress(),
+        "the node should be DECOMMISSION_IN_PROGRESSS");
     // Check DatanodeManager#getDecommissionNodes, make sure it returns
     // the node as decommissioning, even if it's dead
     List<DatanodeDescriptor> decomlist = dm.getDecommissioningNodes();
-    assertTrue("The node should be be decommissioning", decomlist.size() == 1);
+    assertTrue(decomlist.size() == 1, "The node should be be decommissioning");
     
     // Delete the under-replicated file, which should let the 
     // DECOMMISSION_IN_PROGRESS node become DECOMMISSIONED
@@ -450,8 +452,8 @@ public class TestDecommissioningStatus {
     BlockManagerTestUtil.recheckDecommissionState(dm);
     // Block until the admin's monitor updates the number of tracked nodes.
     waitForDecommissionedNodes(dm.getDatanodeAdminManager(), 0);
-    assertTrue("the node should be decommissioned",
-        dead.get(0).isDecommissioned());
+    assertTrue(dead.get(0).isDecommissioned(),
+        "the node should be decommissioned");
 
     // Add the node back
     cluster.restartDataNode(dataNodeProperties, true);
@@ -469,7 +471,8 @@ public class TestDecommissioningStatus {
    * Under this scenario the datanode should immediately be marked as
    * DECOMMISSIONED
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testDecommissionDeadDN() throws Exception {
     Logger log = LoggerFactory.getLogger(DatanodeAdminManager.class);
     GenericTestUtils.setLogLevel(log, Level.DEBUG);
@@ -498,7 +501,8 @@ public class TestDecommissioningStatus {
     dm.refreshNodes(conf);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testDecommissionLosingData() throws Exception {
     ArrayList<String> nodes = new ArrayList<String>(2);
     FSNamesystem fsn = cluster.getNamesystem();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDecommissioningStatusWithBackoffMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDecommissioningStatusWithBackoffMonitor.java
@@ -35,12 +35,13 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
 import org.apache.hadoop.hdfs.util.HostsFileWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Extends the TestDecommissioningStatus class to provide the same set of
@@ -59,6 +60,7 @@ public class TestDecommissioningStatusWithBackoffMonitor
   private HostsFileWriter hostsFileWriter;
   private Configuration conf;
 
+  @BeforeEach
   @Override
   public void setUp() throws Exception {
     conf = setupConfig();
@@ -85,7 +87,7 @@ public class TestDecommissioningStatusWithBackoffMonitor
     DFSClient client = new DFSClient(addr, conf);
     DatanodeInfo[] info =
         client.datanodeReport(HdfsConstants.DatanodeReportType.LIVE);
-    assertEquals("Number of Datanodes ", 2, info.length);
+    assertEquals(2, info.length, "Number of Datanodes ");
     DistributedFileSystem distFileSys = cluster.getFileSystem();
     DFSAdmin admin = new DFSAdmin(cluster.getConfiguration(0));
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeduplicationMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeduplicationMap.java
@@ -19,18 +19,18 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import org.apache.hadoop.hdfs.server.namenode.FSImageFormatProtobuf.SaverContext.DeduplicationMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestDeduplicationMap {
   @Test
   public void testDeduplicationMap() {
     DeduplicationMap<String> m = DeduplicationMap.newMap();
-    Assert.assertEquals(1, m.getId("1"));
-    Assert.assertEquals(2, m.getId("2"));
-    Assert.assertEquals(3, m.getId("3"));
-    Assert.assertEquals(1, m.getId("1"));
-    Assert.assertEquals(2, m.getId("2"));
-    Assert.assertEquals(3, m.getId("3"));
+    Assertions.assertEquals(1, m.getId("1"));
+    Assertions.assertEquals(2, m.getId("2"));
+    Assertions.assertEquals(3, m.getId("3"));
+    Assertions.assertEquals(1, m.getId("1"));
+    Assertions.assertEquals(2, m.getId("2"));
+    Assertions.assertEquals(3, m.getId("3"));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeduplicationMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeduplicationMap.java
@@ -19,18 +19,19 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import org.apache.hadoop.hdfs.server.namenode.FSImageFormatProtobuf.SaverContext.DeduplicationMap;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDeduplicationMap {
   @Test
   public void testDeduplicationMap() {
     DeduplicationMap<String> m = DeduplicationMap.newMap();
-    Assertions.assertEquals(1, m.getId("1"));
-    Assertions.assertEquals(2, m.getId("2"));
-    Assertions.assertEquals(3, m.getId("3"));
-    Assertions.assertEquals(1, m.getId("1"));
-    Assertions.assertEquals(2, m.getId("2"));
-    Assertions.assertEquals(3, m.getId("3"));
+    assertEquals(1, m.getId("1"));
+    assertEquals(2, m.getId("2"));
+    assertEquals(3, m.getId("3"));
+    assertEquals(1, m.getId("1"));
+    assertEquals(2, m.getId("2"));
+    assertEquals(3, m.getId("3"));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDefaultBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDefaultBlockPlacementPolicy.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -38,9 +38,9 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.net.StaticMapping;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDefaultBlockPlacementPolicy {
 
@@ -51,7 +51,7 @@ public class TestDefaultBlockPlacementPolicy {
   private FSNamesystem namesystem = null;
   private PermissionStatus perm = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     StaticMapping.resetMap();
     Configuration conf = new HdfsConfiguration();
@@ -69,7 +69,7 @@ public class TestDefaultBlockPlacementPolicy {
         FsPermission.getDefault());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -156,10 +156,10 @@ public class TestDefaultBlockPlacementPolicy {
     LocatedBlock locatedBlock = nameNodeRpc.addBlock(src, clientMachine, null,
         null, fileStatus.getFileId(), null, null);
 
-    assertEquals("Block should be allocated sufficient locations",
-        REPLICATION_FACTOR, locatedBlock.getLocations().length);
-    assertEquals("First datanode should be rack local", clientRack,
-        locatedBlock.getLocations()[0].getNetworkLocation());
+    assertEquals(REPLICATION_FACTOR, locatedBlock.getLocations().length,
+        "Block should be allocated sufficient locations");
+    assertEquals(clientRack, locatedBlock.getLocations()[0].getNetworkLocation(),
+        "First datanode should be rack local");
     nameNodeRpc.abandonBlock(locatedBlock.getBlock(), fileStatus.getFileId(),
         src, clientMachine);
   }
@@ -209,12 +209,12 @@ public class TestDefaultBlockPlacementPolicy {
       LocatedBlock locatedBlock = nameNodeRpc.addBlock(src, clientMachine,
           null, null, fileStatus.getFileId(), null, null);
 
-      assertEquals("Block should be allocated sufficient locations",
-          REPLICATION_FACTOR, locatedBlock.getLocations().length);
+      assertEquals(REPLICATION_FACTOR, locatedBlock.getLocations().length,
+          "Block should be allocated sufficient locations");
       if (clientRack != null) {
         if (hasBlockReplicaOnRack) {
-          assertEquals("First datanode should be rack local", clientRack,
-              locatedBlock.getLocations()[0].getNetworkLocation());
+          assertEquals(clientRack, locatedBlock.getLocations()[0].getNetworkLocation(),
+              "First datanode should be rack local");
         } else {
           for (DatanodeInfo dni : locatedBlock.getLocations()) {
             assertNotEquals(clientRack, dni.getNetworkLocation());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -67,6 +66,7 @@ import org.mockito.Mockito;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_LEASE_HARDLIMIT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LEASE_RECHECK_INTERVAL_MS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -115,7 +115,7 @@ public class TestDeleteRace {
         // write data and syn to make sure a block is allocated.
         out.write(new byte[32], 0, 32);
         out.hsync();
-        Assertions.fail("Should have failed.");
+        fail("Should have failed.");
       } catch (FileNotFoundException e) {
         GenericTestUtils.assertExceptionContains(filePath.getName(), e);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestDeleteRace.java
@@ -59,31 +59,28 @@ import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_LEASE_HARDLIMIT_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LEASE_RECHECK_INTERVAL_MS_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test race between delete and other operations.  For now only addBlock()
  * is tested since all others are acquiring FSNamesystem lock for the 
  * whole duration.
  */
+@Timeout(60 * 3)
 public class TestDeleteRace {
   private static final int BLOCK_SIZE = 4096;
   private static final Logger LOG = LoggerFactory.getLogger(TestDeleteRace.class);
   private static final Configuration conf = new HdfsConfiguration();
   private MiniDFSCluster cluster;
-
-  @Rule
-  public Timeout timeout = new Timeout(60000 * 3);
 
   @Test  
   public void testDeleteAddBlockRace() throws Exception {
@@ -118,7 +115,7 @@ public class TestDeleteRace {
         // write data and syn to make sure a block is allocated.
         out.write(new byte[32], 0, 32);
         out.hsync();
-        Assert.fail("Should have failed.");
+        Assertions.fail("Should have failed.");
       } catch (FileNotFoundException e) {
         GenericTestUtils.assertExceptionContains(filePath.getName(), e);
       }
@@ -361,13 +358,15 @@ public class TestDeleteRace {
     }
   }
 
-  @Test(timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testDeleteAndCommitBlockSynchonizationRaceNoSnapshot()
       throws Exception {
     testDeleteAndCommitBlockSynchronizationRace(false);
   }
 
-  @Test(timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testDeleteAndCommitBlockSynchronizationRaceHasSnapshot()
       throws Exception {
     testDeleteAndCommitBlockSynchronizationRace(true);
@@ -429,7 +428,8 @@ public class TestDeleteRace {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testOpenRenameRace() throws Exception {
     Configuration config = new Configuration();
     config.setLong(DFSConfigKeys.DFS_NAMENODE_ACCESSTIME_PRECISION_KEY, 1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
@@ -23,11 +23,11 @@ import static org.apache.hadoop.fs.permission.FsAction.*;
 import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.*;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -93,10 +93,9 @@ import org.apache.hadoop.util.Time;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 import org.xml.sax.ContentHandler;
@@ -110,14 +109,14 @@ import org.slf4j.LoggerFactory;
 /**
  * This class tests the creation and validation of a checkpoint.
  */
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestEditLog {
 
   static {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.TRACE);
   }
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{ Boolean.FALSE });
@@ -353,8 +352,8 @@ public class TestEditLog {
                 1, expectedTxns);
         File editFile1 = NNStorage.getFinalizedEditsFile(it.next(),
                 203, 404);
-        assertTrue("Expect " + editFile + " exists", editFile.exists());
-        assertTrue("Expect " + editFile1 + " exists", editFile1.exists());
+        assertTrue(editFile.exists(), "Expect " + editFile + " exists");
+        assertTrue(editFile1.exists(), "Expect " + editFile1 + " exists");
         EditLogFileInputStream editLogFileInputStream1 =
                 new EditLogFileInputStream(editFile, 1, 202, false);
         EditLogFileInputStream editLogFileInputStream2 =
@@ -454,7 +453,7 @@ public class TestEditLog {
     NNStorage storage = cluster.getNamesystem().getFSImage().getStorage();
     for (StorageDirectory sd : storage.dirIterable(dirType)) {
       File f = new File(sd.getCurrentDir(), filename);
-      assertTrue("Expect that " + f + " exists", f.exists());
+      assertTrue(f.exists(), "Expect that " + f + " exists");
     }
   }
   
@@ -536,7 +535,7 @@ public class TestEditLog {
         
         File editFile = NNStorage.getFinalizedEditsFile(it.next(), 3,
             3 + expectedTxns - 1);
-        assertTrue("Expect " + editFile + " exists", editFile.exists());
+        assertTrue(editFile.exists(), "Expect " + editFile + " exists");
         
         System.out.println("Verifying file: " + editFile);
         long numEdits = loader.loadFSEdits(
@@ -544,10 +543,11 @@ public class TestEditLog {
         int numLeases = namesystem.leaseManager.countLease();
         System.out.println("Number of outstanding leases " + numLeases);
         assertEquals(0, numLeases);
-        assertTrue("Verification for " + editFile + " failed. " +
-                   "Expected " + expectedTxns + " transactions. "+
-                   "Found " + numEdits + " transactions.",
-                   numEdits == expectedTxns);
+        assertTrue(numEdits == expectedTxns, "Verification for "
+            + editFile + " failed. " +
+            "Expected " + expectedTxns
+            + " transactions. " +
+            "Found " + numEdits + " transactions.");
   
       }
     } finally {
@@ -617,29 +617,29 @@ public class TestEditLog {
       FSImage fsimage = namesystem.getFSImage();
       final FSEditLog editLog = fsimage.getEditLog();
 
-      assertEquals("should start with only the BEGIN_LOG_SEGMENT txn synced",
-        1, editLog.getSyncTxId());
+      assertEquals(1, editLog.getSyncTxId(),
+          "should start with only the BEGIN_LOG_SEGMENT txn synced");
       
       // Log an edit from thread A
       doLogEdit(threadA, editLog, "thread-a 1");
-      assertEquals("logging edit without syncing should do not affect txid",
-        1, editLog.getSyncTxId());
+      assertEquals(1, editLog.getSyncTxId(),
+          "logging edit without syncing should do not affect txid");
 
       // Log an edit from thread B
       doLogEdit(threadB, editLog, "thread-b 1");
-      assertEquals("logging edit without syncing should do not affect txid",
-        1, editLog.getSyncTxId());
+      assertEquals(1, editLog.getSyncTxId(),
+          "logging edit without syncing should do not affect txid");
 
       // Now ask to sync edit from B, which should sync both edits.
       doCallLogSync(threadB, editLog);
-      assertEquals("logSync from second thread should bump txid up to 3",
-        3, editLog.getSyncTxId());
+      assertEquals(3, editLog.getSyncTxId(),
+          "logSync from second thread should bump txid up to 3");
 
       // Now ask to sync edit from A, which was already batched in - thus
       // it should increment the batch count metric
       doCallLogSync(threadA, editLog);
-      assertEquals("logSync from first thread shouldn't change txid",
-        3, editLog.getSyncTxId());
+      assertEquals(3, editLog.getSyncTxId(),
+          "logSync from first thread shouldn't change txid");
 
       //Should have incremented the batch count exactly once
       assertCounter("TransactionsBatchedInSync", 1L, 
@@ -685,13 +685,13 @@ public class TestEditLog {
       // async log is doing batched syncs in background.  logSync just ensures
       // the edit is durable, so the txid may increase prior to sync
       if (!useAsyncEditLog) {
-        assertEquals("logging edit without syncing should do not affect txid",
-            1, editLog.getSyncTxId());
+        assertEquals(1, editLog.getSyncTxId(),
+            "logging edit without syncing should do not affect txid");
       }
       // logSyncAll in Thread B
       doCallLogSyncAll(threadB, editLog);
-      assertEquals("logSyncAll should sync thread A's transaction",
-        2, editLog.getSyncTxId());
+      assertEquals(2, editLog.getSyncTxId(),
+          "logSyncAll should sync thread A's transaction");
 
       // Close edit log
       editLog.close();
@@ -749,9 +749,9 @@ public class TestEditLog {
       fail("should not be able to start");
     } catch (IOException e) {
       // expected
-      assertNotNull("Cause of exception should be ChecksumException", e.getCause());
-      assertEquals("Cause of exception should be ChecksumException",
-          ChecksumException.class, e.getCause().getClass());
+      assertNotNull(e.getCause(), "Cause of exception should be ChecksumException");
+      assertEquals(ChecksumException.class, e.getCause().getClass(),
+          "Cause of exception should be ChecksumException");
     }
   }
 
@@ -826,11 +826,11 @@ public class TestEditLog {
         // We should see the file as in-progress
         File editsFile = new File(currentDir,
             NNStorage.getInProgressEditsFileName(1));
-        assertTrue("Edits file " + editsFile + " should exist", editsFile.exists());        
+        assertTrue(editsFile.exists(), "Edits file " + editsFile + " should exist");
         
         File imageFile = FSImageTestUtil.findNewestImageFile(
             currentDir.getAbsolutePath());
-        assertNotNull("No image found in " + nameDir, imageFile);
+        assertNotNull(imageFile, "No image found in " + nameDir);
         assertEquals(NNStorage.getImageFileName(0), imageFile.getName());
         // Try to start a new cluster
         LOG.info("\n===========================================\n" +
@@ -858,9 +858,9 @@ public class TestEditLog {
         }
         imageFile = FSImageTestUtil.findNewestImageFile(
             currentDir.getAbsolutePath());
-        assertNotNull("No image found in " + nameDir, imageFile);
-        assertEquals(NNStorage.getImageFileName(expectedTxId),
-                     imageFile.getName());
+      assertNotNull(imageFile, "No image found in " + nameDir);
+      assertEquals(NNStorage.getImageFileName(expectedTxId),
+          imageFile.getName());
         
         // Started successfully. Shut it down and make sure it can restart.
         cluster.shutdown();    
@@ -1142,8 +1142,8 @@ public class TestEditLog {
         "[1,100]|[201,300]|[301,400]"); // nothing starting at 101
     log = getFSEditLog(storage);
     log.initJournalsForWrite();
-    assertEquals("[[1,100], [101,200], [201,300], [301,400]]" +
-            " CommittedTxId: 400", log.getEditLogManifest(1).toString());
+    assertEquals("[[1,100], [101,200], [201,300], [301,400]]" + " CommittedTxId: 400",
+        log.getEditLogManifest(1).toString());
     
     // Case where one directory has an earlier finalized log, followed
     // by a gap. The returned manifest should start after the gap.
@@ -1152,8 +1152,7 @@ public class TestEditLog {
         "[301,400]|[401,500]");
     log = getFSEditLog(storage);
     log.initJournalsForWrite();
-    assertEquals("[[301,400], [401,500]] CommittedTxId: 500",
-        log.getEditLogManifest(1).toString());
+    assertEquals("[[301,400], [401,500]] CommittedTxId: 500", log.getEditLogManifest(1).toString());
     
     // Case where different directories have different length logs
     // starting at the same txid - should pick the longer one
@@ -1200,7 +1199,7 @@ public class TestEditLog {
       String[] logSpecs = dirSpec.split("\\|");
       for (String logSpec : logSpecs) {
         Matcher m = Pattern.compile("\\[(\\d+),(\\d+)?\\]").matcher(logSpec);
-        assertTrue("bad spec: " + logSpec, m.matches());
+        assertTrue(m.matches(), "bad spec: " + logSpec);
         if (m.group(2) == null) {
           files.add(NNStorage.getInProgressEditsFileName(
               Long.parseLong(m.group(1))));
@@ -1374,7 +1373,7 @@ public class TestEditLog {
 
     editlog.close();
     storage.close();
-    assertEquals(TXNS_PER_ROLL*11, totaltxnread);    
+    assertEquals(TXNS_PER_ROLL * 11, totaltxnread);
   }
 
   /** 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLog.java
@@ -826,11 +826,11 @@ public class TestEditLog {
         // We should see the file as in-progress
         File editsFile = new File(currentDir,
             NNStorage.getInProgressEditsFileName(1));
-        assertTrue(editsFile.exists(), "Edits file " + editsFile + " should exist");
-        
+      assertTrue(editsFile.exists(), "Edits file " + editsFile + " should exist");
+
         File imageFile = FSImageTestUtil.findNewestImageFile(
             currentDir.getAbsolutePath());
-        assertNotNull(imageFile, "No image found in " + nameDir);
+      assertNotNull(imageFile, "No image found in " + nameDir);
         assertEquals(NNStorage.getImageFileName(0), imageFile.getName());
         // Try to start a new cluster
         LOG.info("\n===========================================\n" +

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogAutoroll.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogAutoroll.java
@@ -36,25 +36,25 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem.NameNodeEditLogRoller;
 import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.function.Supplier;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestEditLogAutoroll {
   static {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.DEBUG);
   }
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{ Boolean.FALSE });
@@ -76,7 +76,7 @@ public class TestEditLogAutoroll {
 
   public static final Logger LOG = LoggerFactory.getLogger(FSEditLog.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     // Stall the standby checkpointer in two ways
@@ -119,7 +119,7 @@ public class TestEditLogAutoroll {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (fs != null) {
       fs.close();
@@ -131,7 +131,8 @@ public class TestEditLogAutoroll {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testEditLogAutoroll() throws Exception {
     // Make some edits
     final long startTxId = editLog.getCurSegmentTxId();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileInputStream.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -43,7 +44,6 @@ import org.apache.hadoop.hdfs.util.Holder;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -148,13 +148,13 @@ public class TestEditLogFileInputStream {
     rwf.close();
 
     EditLogFileInputStream elis = new EditLogFileInputStream(editLog);
-    Assertions.assertEquals(NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION,
+    assertEquals(NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION,
         elis.getVersion(true));
-    Assertions.assertEquals(1, elis.scanNextOp());
+    assertEquals(1, elis.scanNextOp());
     LOG.debug("Read transaction 1 from " + editLog);
     try {
       elis.scanNextOp();
-      Assertions.fail("Expected scanNextOp to fail when op checksum was corrupt.");
+      fail("Expected scanNextOp to fail when op checksum was corrupt.");
     } catch (IOException e) {
       LOG.debug("Caught expected checksum error when reading corrupt " +
           "transaction 2", e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileInputStream.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -44,8 +43,9 @@ import org.apache.hadoop.hdfs.util.Holder;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 public class TestEditLogFileInputStream {
@@ -73,9 +73,9 @@ public class TestEditLogFileInputStream {
     // Read the edit log and verify that we got all of the data.
     EnumMap<FSEditLogOpCodes, Holder<Integer>> counts = FSImageTestUtil
         .countEditLogOpTypes(elis);
-    assertThat(counts.get(FSEditLogOpCodes.OP_ADD).held, is(1));
-    assertThat(counts.get(FSEditLogOpCodes.OP_SET_GENSTAMP_V1).held, is(1));
-    assertThat(counts.get(FSEditLogOpCodes.OP_CLOSE).held, is(1));
+    assertThat(counts.get(FSEditLogOpCodes.OP_ADD).held).isEqualTo(1);
+    assertThat(counts.get(FSEditLogOpCodes.OP_SET_GENSTAMP_V1).held).isEqualTo(1);
+    assertThat(counts.get(FSEditLogOpCodes.OP_CLOSE).held).isEqualTo(1);
 
     // Check that length header was picked up.
     assertEquals(FAKE_LOG_DATA.length, elis.length());
@@ -91,9 +91,9 @@ public class TestEditLogFileInputStream {
     // Read the edit log and verify that all of the data is present
     EnumMap<FSEditLogOpCodes, Holder<Integer>> counts = FSImageTestUtil
         .countEditLogOpTypes(elis);
-    assertThat(counts.get(FSEditLogOpCodes.OP_ADD).held, is(1));
-    assertThat(counts.get(FSEditLogOpCodes.OP_SET_GENSTAMP_V1).held, is(1));
-    assertThat(counts.get(FSEditLogOpCodes.OP_CLOSE).held, is(1));
+    assertThat(counts.get(FSEditLogOpCodes.OP_ADD).held).isEqualTo(1);
+    assertThat(counts.get(FSEditLogOpCodes.OP_SET_GENSTAMP_V1).held).isEqualTo(1);
+    assertThat(counts.get(FSEditLogOpCodes.OP_CLOSE).held).isEqualTo(1);
 
     assertEquals(FAKE_LOG_DATA.length, elis.length());
     elis.close();
@@ -103,7 +103,8 @@ public class TestEditLogFileInputStream {
    * Regression test for HDFS-8965 which verifies that
    * FSEditLogFileInputStream#scanOp verifies Op checksums.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testScanCorruptEditLog() throws Exception {
     Configuration conf = new Configuration();
     File editLog = new File(GenericTestUtils.getTempPath("testCorruptEditLog"));
@@ -147,13 +148,13 @@ public class TestEditLogFileInputStream {
     rwf.close();
 
     EditLogFileInputStream elis = new EditLogFileInputStream(editLog);
-    Assert.assertEquals(NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION,
+    Assertions.assertEquals(NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION,
         elis.getVersion(true));
-    Assert.assertEquals(1, elis.scanNextOp());
+    Assertions.assertEquals(1, elis.scanNextOp());
     LOG.debug("Read transaction 1 from " + editLog);
     try {
       elis.scanNextOp();
-      Assert.fail("Expected scanNextOp to fail when op checksum was corrupt.");
+      Assertions.fail("Expected scanNextOp to fail when op checksum was corrupt.");
     } catch (IOException e) {
       LOG.debug("Caught expected checksum error when reading corrupt " +
           "transaction 2", e);
@@ -167,7 +168,8 @@ public class TestEditLogFileInputStream {
    * with only "-1" bytes is moved aside and does not prevent the Journal
    * node from starting.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testScanEditThatFailedDuringPreAllocate() throws Exception {
     Configuration conf = new Configuration();
     File editLog = new File(GenericTestUtils.getTempPath("testCorruptEditLog"));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogFileOutputStream.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,10 +28,10 @@ import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the EditLogFileOutputStream
@@ -45,21 +45,21 @@ public class TestEditLogFileOutputStream {
 
   private Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void disableFsync() {
     // No need to fsync for the purposes of tests. This makes
     // the tests run much faster.
     EditLogFileOutputStream.setShouldSkipFsyncForTesting(true);
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void deleteEditsFile() {
     if (TEST_EDITS.exists())
       TEST_EDITS.delete();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new Configuration();
   }
@@ -137,7 +137,7 @@ public class TestEditLogFileOutputStream {
       editLogStream.close();
     } catch (IOException ioe) {
       String msg = StringUtils.stringifyException(ioe);
-      assertTrue(msg, msg.contains("Trying to use aborted output stream"));
+      assertTrue(msg.contains("Trying to use aborted output stream"), msg);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogJournalFailures.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogJournalFailures.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -45,15 +45,15 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestEditLogJournalFailures {
 
   private int editsPerformed = 0;
@@ -61,7 +61,6 @@ public class TestEditLogJournalFailures {
   private FileSystem fs;
   private boolean useAsyncEdits;
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{Boolean.FALSE});
@@ -84,7 +83,7 @@ public class TestEditLogJournalFailures {
    * Create the mini cluster for testing and sub in a custom runtime so that
    * edit log journal failures don't actually cause the JVM to exit.
    */
-  @Before
+  @BeforeEach
   public void setUpMiniCluster() throws IOException {
     setUpMiniCluster(getConf(), true);
   }
@@ -97,7 +96,7 @@ public class TestEditLogJournalFailures {
     fs = cluster.getFileSystem();
   }
   
-  @After
+  @AfterEach
   public void shutDownMiniCluster() throws IOException {
     if (fs != null) {
       fs.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 import static org.apache.hadoop.hdfs.server.namenode.FSEditLogOpCodes.OP_SET_OWNER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -42,6 +42,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import java.util.function.Supplier;
 
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -67,10 +69,8 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.event.Level;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -78,13 +78,13 @@ import org.mockito.stubbing.Answer;
  * This class tests various synchronization bugs in FSEditLog rolling
  * and namespace saving.
  */
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestEditLogRace {
   static {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.DEBUG);
   }
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{ false });
@@ -265,7 +265,7 @@ public class TestEditLogRace {
         assertEquals(previousLogTxId, nextLog);
         
         File expectedLog = NNStorage.getInProgressEditsFile(sd, previousLogTxId);
-        assertTrue("Expect " + expectedLog + " to exist", expectedLog.exists());
+        assertTrue(expectedLog.exists(), "Expect " + expectedLog + " to exist");
       }
     } finally {
       stopTransactionWorkers();
@@ -359,7 +359,7 @@ public class TestEditLogRace {
         // The checkpoint id should be 1 less than the last written ID, since
         // the log roll writes the "BEGIN" transaction to the new log.
         assertEquals(fsimage.getStorage().getMostRecentCheckpointTxId(),
-                     editLog.getLastWrittenTxId() - 1);
+            editLog.getLastWrittenTxId() - 1);
 
         namesystem.leaveSafeMode(false);
         LOG.info("Save " + i + ": complete");
@@ -485,13 +485,11 @@ public class TestEditLogRace {
       assertNull(deferredException.get());
 
       // We did 3 edits: begin, txn, and end
-      assertEquals(3, verifyEditLogs(namesystem, fsimage,
-          NNStorage.getFinalizedEditsFileName(1, 3),
-          1));
+      assertEquals(3,
+          verifyEditLogs(namesystem, fsimage, NNStorage.getFinalizedEditsFileName(1, 3), 1));
       // after the save, just the one "begin"
-      assertEquals(1, verifyEditLogs(namesystem, fsimage,
-          NNStorage.getInProgressEditsFileName(4),
-          4));
+      assertEquals(1,
+          verifyEditLogs(namesystem, fsimage, NNStorage.getInProgressEditsFileName(4), 4));
     } finally {
       LOG.info("Closing nn");
       if(namesystem != null) namesystem.close();
@@ -569,13 +567,11 @@ public class TestEditLogRace {
       assertNull(deferredException.get());
 
       // We did 3 edits: begin, txn, and end
-      assertEquals(3, verifyEditLogs(namesystem, fsimage,
-          NNStorage.getFinalizedEditsFileName(1, 3),
-          1));
+      assertEquals(3,
+          verifyEditLogs(namesystem, fsimage, NNStorage.getFinalizedEditsFileName(1, 3), 1));
       // after the save, just the one "begin"
-      assertEquals(1, verifyEditLogs(namesystem, fsimage,
-          NNStorage.getInProgressEditsFileName(4),
-          4));
+      assertEquals(1,
+          verifyEditLogs(namesystem, fsimage, NNStorage.getInProgressEditsFileName(4), 4));
     } finally {
       LOG.info("Closing nn");
       if(namesystem != null) namesystem.close();
@@ -601,7 +597,8 @@ public class TestEditLogRace {
     }
   }
 
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testDeadlock() throws Throwable {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(FSEditLogAsync.LOG, Level.DEBUG);
@@ -640,8 +637,8 @@ public class TestEditLogRace {
                 LOG.info("thread[" + ii +"] edits=" + i);
               }
             }
-            assertTrue("too many edits", done.get());
-            return null;
+                assertTrue(done.get(), "too many edits");
+                return null;
           }
         });
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditsDoubleBuffer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditsDoubleBuffer.java
@@ -17,17 +17,17 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestEditsDoubleBuffer {
   @Test
@@ -37,16 +37,14 @@ public class TestEditsDoubleBuffer {
     assertTrue(buf.isFlushed());
     byte[] data = new byte[100];
     buf.writeRaw(data, 0, data.length);
-    assertEquals("Should count new data correctly",
-        data.length, buf.countBufferedBytes());
+    assertEquals(data.length, buf.countBufferedBytes(), "Should count new data correctly");
 
-    assertTrue("Writing to current buffer should not affect flush state",
-        buf.isFlushed());
+    assertTrue(buf.isFlushed(), "Writing to current buffer should not affect flush state");
 
     // Swap the buffers
     buf.setReadyToFlush();
-    assertEquals("Swapping buffers should still count buffered bytes",
-        data.length, buf.countBufferedBytes());
+    assertEquals(data.length, buf.countBufferedBytes(),
+        "Swapping buffers should still count buffered bytes");
     assertFalse(buf.isFlushed());
  
     // Flush to a stream
@@ -58,8 +56,7 @@ public class TestEditsDoubleBuffer {
     
     // Write some more
     buf.writeRaw(data, 0, data.length);
-    assertEquals("Should count new data correctly",
-        data.length, buf.countBufferedBytes());
+    assertEquals(data.length, buf.countBufferedBytes(), "Should count new data correctly");
     buf.setReadyToFlush();
     buf.flushTo(outBuf);
     
@@ -131,11 +128,11 @@ public class TestEditsDoubleBuffer {
     }
     logs.stopCapturing();
     // Make sure ops are dumped into log in human readable format.
-    Assert.assertTrue("expected " + op.toString() + " in the log",
-        logs.getOutput().contains(op.toString()));
-    Assert.assertTrue("expected " + op2.toString() + " in the log",
-        logs.getOutput().contains(op2.toString()));
-    Assert.assertTrue("expected " + op3.toString() + " in the log",
-        logs.getOutput().contains(op3.toString()));
+    Assertions.assertTrue(logs.getOutput().contains(op.toString()),
+        "expected " + op.toString() + " in the log");
+    Assertions.assertTrue(logs.getOutput().contains(op2.toString()),
+        "expected " + op2.toString() + " in the log");
+    Assertions.assertTrue(logs.getOutput().contains(op3.toString()),
+        "expected " + op3.toString() + " in the log");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditsDoubleBuffer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditsDoubleBuffer.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestEditsDoubleBuffer {
@@ -128,11 +127,11 @@ public class TestEditsDoubleBuffer {
     }
     logs.stopCapturing();
     // Make sure ops are dumped into log in human readable format.
-    Assertions.assertTrue(logs.getOutput().contains(op.toString()),
+    assertTrue(logs.getOutput().contains(op.toString()),
         "expected " + op.toString() + " in the log");
-    Assertions.assertTrue(logs.getOutput().contains(op2.toString()),
+    assertTrue(logs.getOutput().contains(op2.toString()),
         "expected " + op2.toString() + " in the log");
-    Assertions.assertTrue(logs.getOutput().contains(op3.toString()),
+    assertTrue(logs.getOutput().contains(op3.toString()),
         "expected " + op3.toString() + " in the log");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEnabledECPolicies.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEnabledECPolicies.java
@@ -25,10 +25,9 @@ import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyState;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,20 +35,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test that ErasureCodingPolicyManager correctly parses the set of enabled
  * erasure coding policies from configuration and exposes this information.
  */
+@Timeout(600)
 public class TestEnabledECPolicies {
-
-  @Rule
-  public Timeout testTimeout = new Timeout(60000);
 
   private void expectInvalidPolicy(String value) throws IOException {
     HdfsConfiguration conf = new HdfsConfiguration();
@@ -70,8 +67,8 @@ public class TestEnabledECPolicies {
         ErasureCodingPolicyManager.getInstance();
     manager.init(conf);
     manager.enablePolicy(value);
-    assertEquals("Incorrect number of enabled policies",
-        numEnabled, manager.getEnabledPolicies().length);
+    assertEquals(numEnabled, manager.getEnabledPolicies().length,
+        "Incorrect number of enabled policies");
   }
 
   @Test
@@ -132,8 +129,8 @@ public class TestEnabledECPolicies {
     final String defaultPolicy = conf.getTrimmed(
         DFSConfigKeys.DFS_NAMENODE_EC_SYSTEM_DEFAULT_POLICY,
         DFSConfigKeys.DFS_NAMENODE_EC_SYSTEM_DEFAULT_POLICY_DEFAULT);
-    assertNotEquals("The default policy and the next default policy " +
-        "should not be the same!", testPolicy, defaultPolicy);
+    assertNotEquals(testPolicy, defaultPolicy,
+        "The default policy and the next default policy " + "should not be the same!");
 
     ErasureCodingPolicyManager manager =
         ErasureCodingPolicyManager.getInstance();
@@ -147,35 +144,32 @@ public class TestEnabledECPolicies {
 
     ErasureCodingPolicyInfo[] getPoliciesResult = manager.getPolicies();
     boolean isEnabled = isPolicyEnabled(testPolicy, getPoliciesResult);
-    assertTrue("The new default policy should be " +
-        "in enabled state!", isEnabled);
+    assertTrue(isEnabled, "The new default policy should be " + "in enabled state!");
     ErasureCodingPolicyInfo[] getPersistedPoliciesResult
         = manager.getPersistedPolicies();
     isEnabled = isPolicyEnabled(testPolicy, getPersistedPoliciesResult);
-    assertFalse("The new default policy should be " +
-        "in disabled state in the persisted list!", isEnabled);
+    assertFalse(isEnabled,
+        "The new default policy should be " + "in disabled state in the persisted list!");
 
     manager.disablePolicy(testPolicy);
     getPoliciesResult = manager.getPolicies();
     isEnabled = isPolicyEnabled(testPolicy, getPoliciesResult);
-    assertFalse("The new default policy should be " +
-        "in disabled state!", isEnabled);
+    assertFalse(isEnabled, "The new default policy should be " + "in disabled state!");
     getPersistedPoliciesResult
         = manager.getPersistedPolicies();
     isEnabled = isPolicyEnabled(testPolicy, getPersistedPoliciesResult);
-    assertFalse("The new default policy should be " +
-        "in disabled state in the persisted list!", isEnabled);
+    assertFalse(isEnabled,
+        "The new default policy should be " + "in disabled state in the persisted list!");
 
     manager.enablePolicy(testPolicy);
     getPoliciesResult = manager.getPolicies();
     isEnabled = isPolicyEnabled(testPolicy, getPoliciesResult);
-    assertTrue("The new default policy should be " +
-        "in enabled state!", isEnabled);
+    assertTrue(isEnabled, "The new default policy should be " + "in enabled state!");
     getPersistedPoliciesResult
         = manager.getPersistedPolicies();
     isEnabled = isPolicyEnabled(testPolicy, getPersistedPoliciesResult);
-    assertTrue("The new default policy should be " +
-        "in enabled state in the persisted list!", isEnabled);
+    assertTrue(isEnabled,
+        "The new default policy should be " + "in enabled state in the persisted list!");
 
     final String emptyPolicy = "";
     // Change the default policy to a empty
@@ -201,28 +195,30 @@ public class TestEnabledECPolicies {
     // Check that returned values are unique
     Set<String> found = new HashSet<>();
     for (ErasureCodingPolicy p : manager.getEnabledPolicies()) {
-      Assert.assertFalse("Duplicate policy name found: " + p.getName(),
-          found.contains(p.getName()));
-      found.add(p.getName());
+        Assertions.assertFalse(found.contains(p.getName()),
+            "Duplicate policy name found: " + p.getName());
+        found.add(p.getName());
     }
     // Check that the policies specified in conf are found
     for (ErasureCodingPolicy p: enabledPolicies) {
-      Assert.assertTrue("Did not find specified EC policy " + p.getName(),
-          found.contains(p.getName()));
+        Assertions.assertTrue(found.contains(p.getName()),
+            "Did not find specified EC policy " + p.getName());
     }
-    Assert.assertEquals(enabledPolicies.length, found.size()-1);
+    Assertions.assertEquals(enabledPolicies.length, found.size() - 1);
     // Check that getEnabledPolicyByName only returns enabled policies
     for (ErasureCodingPolicy p: SystemErasureCodingPolicies.getPolicies()) {
       if (found.contains(p.getName())) {
         // Enabled policy should be present
-        Assert.assertNotNull(
-            "getEnabledPolicyByName did not find enabled policy" + p.getName(),
-            manager.getEnabledPolicyByName(p.getName()));
+        Assertions.assertNotNull(
+
+            manager.getEnabledPolicyByName(p.getName()),
+            "getEnabledPolicyByName did not find enabled policy" + p.getName());
       } else {
         // Disabled policy should not be present
-        Assert.assertNull(
-            "getEnabledPolicyByName found disabled policy " + p.getName(),
-            manager.getEnabledPolicyByName(p.getName()));
+        Assertions.assertNull(
+
+            manager.getEnabledPolicyByName(p.getName()),
+            "getEnabledPolicyByName found disabled policy " + p.getName());
       }
     }
   }
@@ -250,7 +246,7 @@ public class TestEnabledECPolicies {
   private void assertAllPoliciesAreDisabled(
       ErasureCodingPolicyInfo[] policies) {
     for (ErasureCodingPolicyInfo p : policies) {
-      assertTrue("Policy should be disabled", p.isDisabled());
+        assertTrue(p.isDisabled(), "Policy should be disabled");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEnabledECPolicies.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEnabledECPolicies.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyState;
 import org.apache.hadoop.hdfs.protocol.SystemErasureCodingPolicies;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -39,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -195,28 +196,26 @@ public class TestEnabledECPolicies {
     // Check that returned values are unique
     Set<String> found = new HashSet<>();
     for (ErasureCodingPolicy p : manager.getEnabledPolicies()) {
-        Assertions.assertFalse(found.contains(p.getName()),
-            "Duplicate policy name found: " + p.getName());
-        found.add(p.getName());
+      assertFalse(found.contains(p.getName()),
+          "Duplicate policy name found: " + p.getName());
+      found.add(p.getName());
     }
     // Check that the policies specified in conf are found
     for (ErasureCodingPolicy p: enabledPolicies) {
-        Assertions.assertTrue(found.contains(p.getName()),
-            "Did not find specified EC policy " + p.getName());
+      assertTrue(found.contains(p.getName()),
+          "Did not find specified EC policy " + p.getName());
     }
-    Assertions.assertEquals(enabledPolicies.length, found.size() - 1);
+    assertEquals(enabledPolicies.length, found.size() - 1);
     // Check that getEnabledPolicyByName only returns enabled policies
     for (ErasureCodingPolicy p: SystemErasureCodingPolicies.getPolicies()) {
       if (found.contains(p.getName())) {
         // Enabled policy should be present
-        Assertions.assertNotNull(
-
+        assertNotNull(
             manager.getEnabledPolicyByName(p.getName()),
             "getEnabledPolicyByName did not find enabled policy" + p.getName());
       } else {
         // Disabled policy should not be present
-        Assertions.assertNull(
-
+        assertNull(
             manager.getEnabledPolicyByName(p.getName()),
             "getEnabledPolicyByName found disabled policy " + p.getName());
       }
@@ -246,7 +245,7 @@ public class TestEnabledECPolicies {
   private void assertAllPoliciesAreDisabled(
       ErasureCodingPolicyInfo[] policies) {
     for (ErasureCodingPolicyInfo p : policies) {
-        assertTrue(p.isDisabled(), "Policy should be disabled");
+      assertTrue(p.isDisabled(), "Policy should be disabled");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
@@ -151,8 +151,8 @@ public class TestFSEditLogLoader {
           .enableManagedDfsDirsRedundancy(false).format(false).build();
       fail("should not be able to start");
     } catch (IOException e) {
-        assertTrue(e.getMessage().matches(bld.toString()),
-            "error message contains opcodes message");
+      assertTrue(e.getMessage().matches(bld.toString()),
+          "error message contains opcodes message");
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -67,18 +67,18 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.FakeTimer;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 import org.apache.hadoop.thirdparty.com.google.common.io.Files;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestFSEditLogLoader {
-  @Parameters
+
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{ Boolean.FALSE });
@@ -131,7 +131,7 @@ public class TestFSEditLogLoader {
     cluster.shutdown();
 
     File editFile = FSImageTestUtil.findLatestEditsLog(sd).getFile();
-    assertTrue("Should exist: " + editFile, editFile.exists());
+    assertTrue(editFile.exists(), "Should exist: " + editFile);
 
     // Corrupt the edits file.
     long fileLen = editFile.length();
@@ -151,8 +151,8 @@ public class TestFSEditLogLoader {
           .enableManagedDfsDirsRedundancy(false).format(false).build();
       fail("should not be able to start");
     } catch (IOException e) {
-      assertTrue("error message contains opcodes message",
-          e.getMessage().matches(bld.toString()));
+        assertTrue(e.getMessage().matches(bld.toString()),
+            "error message contains opcodes message");
     }
   }
   
@@ -331,7 +331,7 @@ public class TestFSEditLogLoader {
       // disable that here.
       doNothing().when(spyLog).endCurrentLogSegment(true);
       spyLog.openForWrite(NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION);
-      assertTrue("should exist: " + inProgressFile, inProgressFile.exists());
+      assertTrue(inProgressFile.exists(), "should exist: " + inProgressFile);
       
       for (int i = 0; i < numTx; i++) {
         long trueOffset = getNonTrailerLength(inProgressFile);
@@ -396,8 +396,8 @@ public class TestFSEditLogLoader {
           Long.MAX_VALUE, true);
       long expectedEndTxId = (txId == (NUM_TXNS + 1)) ?
           NUM_TXNS : (NUM_TXNS + 1);
-      assertEquals("Failed when corrupting txn opcode at " + txOffset,
-          expectedEndTxId, validation.getEndTxId());
+      assertEquals(expectedEndTxId, validation.getEndTxId(),
+          "Failed when corrupting txn opcode at " + txOffset);
       assertTrue(!validation.hasCorruptHeader());
     }
 
@@ -414,8 +414,8 @@ public class TestFSEditLogLoader {
           Long.MAX_VALUE, true);
       long expectedEndTxId = (txId == 0) ?
           HdfsServerConstants.INVALID_TXID : (txId - 1);
-      assertEquals("Failed when corrupting txid " + txId + " txn opcode " +
-        "at " + txOffset, expectedEndTxId, validation.getEndTxId());
+      assertEquals(expectedEndTxId, validation.getEndTxId(),
+          "Failed when corrupting txid " + txId + " txn opcode " + "at " + txOffset);
       assertTrue(!validation.hasCorruptHeader());
     }
   }
@@ -451,15 +451,13 @@ public class TestFSEditLogLoader {
     //try all codes
     for(FSEditLogOpCodes c : FSEditLogOpCodes.values()) {
       final byte code = c.getOpCode();
-      assertEquals("c=" + c + ", code=" + code,
-          c, FSEditLogOpCodes.fromByte(code));
+      assertEquals(c, FSEditLogOpCodes.fromByte(code), "c=" + c + ", code=" + code);
     }
 
     //try all byte values
     for(int b = 0; b < (1 << Byte.SIZE); b++) {
       final byte code = (byte)b;
-      assertEquals("b=" + b + ", code=" + code,
-          fromByte(code), FSEditLogOpCodes.fromByte(code));
+      assertEquals(fromByte(code), FSEditLogOpCodes.fromByte(code), "b=" + b + ", code=" + code);
     }
   }
 
@@ -754,8 +752,7 @@ public class TestFSEditLogLoader {
       // check if new policy is reapplied through edit log
       ErasureCodingPolicy ecPolicy =
           ErasureCodingPolicyManager.getInstance().getByID(newPolicy.getId());
-      assertEquals(ErasureCodingPolicyState.DISABLED,
-          DFSTestUtil.getECPolicyState(ecPolicy));
+      assertEquals(ErasureCodingPolicyState.DISABLED, DFSTestUtil.getECPolicyState(ecPolicy));
 
       // 2. enable policy
       fs.enableErasureCodingPolicy(newPolicy.getName());
@@ -763,8 +760,7 @@ public class TestFSEditLogLoader {
       cluster.waitActive();
       ecPolicy =
           ErasureCodingPolicyManager.getInstance().getByID(newPolicy.getId());
-      assertEquals(ErasureCodingPolicyState.ENABLED,
-          DFSTestUtil.getECPolicyState(ecPolicy));
+      assertEquals(ErasureCodingPolicyState.ENABLED, DFSTestUtil.getECPolicyState(ecPolicy));
 
       // create a new file, use the policy
       final Path dirPath = new Path("/striped");
@@ -781,8 +777,7 @@ public class TestFSEditLogLoader {
       cluster.waitActive();
       ecPolicy =
           ErasureCodingPolicyManager.getInstance().getByID(newPolicy.getId());
-      assertEquals(ErasureCodingPolicyState.DISABLED,
-          DFSTestUtil.getECPolicyState(ecPolicy));
+      assertEquals(ErasureCodingPolicyState.DISABLED, DFSTestUtil.getECPolicyState(ecPolicy));
       // read file
       DFSTestUtil.readFileAsBytes(fs, filePath);
 
@@ -792,8 +787,7 @@ public class TestFSEditLogLoader {
       cluster.waitActive();
       ecPolicy =
           ErasureCodingPolicyManager.getInstance().getByID(newPolicy.getId());
-      assertEquals(ErasureCodingPolicyState.REMOVED,
-          DFSTestUtil.getECPolicyState(ecPolicy));
+      assertEquals(ErasureCodingPolicyState.REMOVED, DFSTestUtil.getECPolicyState(ecPolicy));
       // read file
       DFSTestUtil.readFileAsBytes(fs, filePath);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
@@ -56,8 +56,8 @@ import java.util.List;
 
 public class TestFSNamesystem {
 
-    @AfterEach
-    public void cleanUp() {
+  @AfterEach
+  public void cleanUp() {
     FileUtil.fullyDeleteContents(new File(MiniDFSCluster.getBaseDirectory()));
   }
 
@@ -207,14 +207,14 @@ public class TestFSNamesystem {
 
   @Test
   public void testGetEffectiveLayoutVersion() {
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -60, -61, -63));
-      assertEquals(-61, FSNamesystem.getEffectiveLayoutVersion(true, -61, -61, -63));
-      assertEquals(-62, FSNamesystem.getEffectiveLayoutVersion(true, -62, -61, -63));
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -63, -61, -63));
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -60, -61, -63));
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -61, -61, -63));
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -62, -61, -63));
-      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -63, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -60, -61, -63));
+    assertEquals(-61, FSNamesystem.getEffectiveLayoutVersion(true, -61, -61, -63));
+    assertEquals(-62, FSNamesystem.getEffectiveLayoutVersion(true, -62, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -63, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -60, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -61, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -62, -61, -63));
+    assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -63, -61, -63));
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystem.java
@@ -21,9 +21,8 @@ package org.apache.hadoop.hdfs.server.namenode;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_CALLER_CONTEXT_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY;
-import static org.hamcrest.CoreMatchers.either;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,16 +47,17 @@ import org.apache.hadoop.hdfs.server.namenode.top.TopAuditLogger;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.util.List;
 
 public class TestFSNamesystem {
 
-  @After
-  public void cleanUp() {
+    @AfterEach
+    public void cleanUp() {
     FileUtil.fullyDeleteContents(new File(MiniDFSCluster.getBaseDirectory()));
   }
 
@@ -109,16 +109,17 @@ public class TestFSNamesystem {
     FSNamesystem fsn = new FSNamesystem(conf, fsImage);
 
     fsn.leaveSafeMode(false);
-    assertTrue("After leaving safemode FSNamesystem.isInStartupSafeMode still "
-      + "returned true", !fsn.isInStartupSafeMode());
-    assertTrue("After leaving safemode FSNamesystem.isInSafeMode still returned"
-      + " true", !fsn.isInSafeMode());
+    assertTrue(!fsn.isInStartupSafeMode(),
+        "After leaving safemode FSNamesystem.isInStartupSafeMode still " + "returned true");
+    assertTrue(!fsn.isInSafeMode(),
+        "After leaving safemode FSNamesystem.isInSafeMode still returned" + " true");
 
     fsn.enterSafeMode(true);
-    assertTrue("After entering safemode due to low resources FSNamesystem."
-      + "isInStartupSafeMode still returned true", !fsn.isInStartupSafeMode());
-    assertTrue("After entering safemode due to low resources FSNamesystem."
-      + "isInSafeMode still returned false",  fsn.isInSafeMode());
+    assertTrue(!fsn.isInStartupSafeMode(),
+        "After entering safemode due to low resources FSNamesystem."
+            + "isInStartupSafeMode still returned true");
+    assertTrue(fsn.isInSafeMode(), "After entering safemode due to low resources FSNamesystem."
+        + "isInSafeMode still returned false");
   }
 
   @Test
@@ -145,17 +146,17 @@ public class TestFSNamesystem {
     NameNode.initMetrics(conf, NamenodeRole.NAMENODE);
 
     fsn.enterSafeMode(false);
-    assertTrue("FSNamesystem didn't enter safemode", fsn.isInSafeMode());
-    assertTrue("Replication queues were being populated during very first "
-        + "safemode", !bm.isPopulatingReplQueues());
+    assertTrue(fsn.isInSafeMode(), "FSNamesystem didn't enter safemode");
+    assertTrue(!bm.isPopulatingReplQueues(),
+        "Replication queues were being populated during very first " + "safemode");
     fsn.leaveSafeMode(false);
-    assertTrue("FSNamesystem didn't leave safemode", !fsn.isInSafeMode());
-    assertTrue("Replication queues weren't being populated even after leaving "
-      + "safemode", bm.isPopulatingReplQueues());
+    assertTrue(!fsn.isInSafeMode(), "FSNamesystem didn't leave safemode");
+    assertTrue(bm.isPopulatingReplQueues(),
+        "Replication queues weren't being populated even after leaving " + "safemode");
     fsn.enterSafeMode(false);
-    assertTrue("FSNamesystem didn't enter safemode", fsn.isInSafeMode());
-    assertTrue("Replication queues weren't being populated after entering "
-      + "safemode 2nd time", bm.isPopulatingReplQueues());
+    assertTrue(fsn.isInSafeMode(), "FSNamesystem didn't enter safemode");
+    assertTrue(bm.isPopulatingReplQueues(),
+        "Replication queues weren't being populated after entering " + "safemode 2nd time");
   }
 
   @Test
@@ -206,22 +207,14 @@ public class TestFSNamesystem {
 
   @Test
   public void testGetEffectiveLayoutVersion() {
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(true, -60, -61, -63));
-    assertEquals(-61,
-        FSNamesystem.getEffectiveLayoutVersion(true, -61, -61, -63));
-    assertEquals(-62,
-        FSNamesystem.getEffectiveLayoutVersion(true, -62, -61, -63));
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(true, -63, -61, -63));
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(false, -60, -61, -63));
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(false, -61, -61, -63));
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(false, -62, -61, -63));
-    assertEquals(-63,
-        FSNamesystem.getEffectiveLayoutVersion(false, -63, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -60, -61, -63));
+      assertEquals(-61, FSNamesystem.getEffectiveLayoutVersion(true, -61, -61, -63));
+      assertEquals(-62, FSNamesystem.getEffectiveLayoutVersion(true, -62, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(true, -63, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -60, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -61, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -62, -61, -63));
+      assertEquals(-63, FSNamesystem.getEffectiveLayoutVersion(false, -63, -61, -63));
   }
 
   @Test
@@ -240,7 +233,8 @@ public class TestFSNamesystem {
     assertEquals(2, safeReplication);
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitAuditLoggers() throws IOException {
     Configuration conf = new Configuration();
     FSImage fsImage = Mockito.mock(FSImage.class);
@@ -272,9 +266,9 @@ public class TestFSNamesystem {
     assertTrue(auditLoggers.size() == 2);
     // the audit loggers order is not defined
     for (AuditLogger auditLogger : auditLoggers) {
-      assertThat(auditLogger,
-          either(instanceOf(FSNamesystem.FSNamesystemAuditLogger.class))
-              .or(instanceOf(TopAuditLogger.class)));
+      assertThat(auditLogger)
+          .isInstanceOfAny(FSNamesystem.FSNamesystemAuditLogger.class,
+              TopAuditLogger.class);
     }
 
     // Configure default audit loggers in config
@@ -285,9 +279,9 @@ public class TestFSNamesystem {
     auditLoggers = fsn.getAuditLoggers();
     assertTrue(auditLoggers.size() == 2);
     for (AuditLogger auditLogger : auditLoggers) {
-      assertThat(auditLogger,
-          either(instanceOf(FSNamesystem.FSNamesystemAuditLogger.class))
-              .or(instanceOf(TopAuditLogger.class)));
+      assertThat(auditLogger)
+          .isInstanceOfAny(FSNamesystem.FSNamesystemAuditLogger.class,
+              TopAuditLogger.class);
     }
 
     // Configure default and customized audit loggers in config with whitespaces
@@ -299,10 +293,9 @@ public class TestFSNamesystem {
     auditLoggers = fsn.getAuditLoggers();
     assertTrue(auditLoggers.size() == 3);
     for (AuditLogger auditLogger : auditLoggers) {
-      assertThat(auditLogger,
-          either(instanceOf(FSNamesystem.FSNamesystemAuditLogger.class))
-              .or(instanceOf(TopAuditLogger.class))
-              .or(instanceOf(DummyAuditLogger.class)));
+      assertThat(auditLogger)
+          .isInstanceOfAny(FSNamesystem.FSNamesystemAuditLogger.class,
+              TopAuditLogger.class, DummyAuditLogger.class);
     }
 
     // Test Configuring TopAuditLogger.
@@ -311,7 +304,7 @@ public class TestFSNamesystem {
     fsn = new FSNamesystem(conf, fsImage);
     auditLoggers = fsn.getAuditLoggers();
     assertEquals(1, auditLoggers.size());
-    assertThat(auditLoggers.get(0), instanceOf(TopAuditLogger.class));
+    assertThat(auditLoggers.get(0)).isInstanceOf(TopAuditLogger.class);
   }
 
   static class DummyAuditLogger implements AuditLogger {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemLock.java
@@ -29,7 +29,8 @@ import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.FakeTimer;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -41,7 +42,7 @@ import java.util.regex.Pattern;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_FSLOCK_FAIR_KEY;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
@@ -138,7 +139,8 @@ public class TestFSNamesystemLock {
    * Test when FSNamesystem write lock is held for a long time,
    * logger will report it.
    */
-  @Test(timeout=45000)
+  @Test
+  @Timeout(value = 45)
   public void testFSWriteLockLongHoldingReport() throws Exception {
     final long writeLockReportingThreshold = 100L;
     final long writeLockSuppressWarningInterval = 10000L;
@@ -220,7 +222,8 @@ public class TestFSNamesystemLock {
    * Test when FSNamesystem read lock is held for a long time,
    * logger will report it.
    */
-  @Test(timeout=45000)
+  @Test
+  @Timeout(value = 45)
   public void testFSReadLockLongHoldingReport() throws Exception {
     final long readLockReportingThreshold = 100L;
     final long readLockSuppressWarningInterval = 10000L;
@@ -407,7 +410,8 @@ public class TestFSNamesystemLock {
    * Test to suppress FSNameSystem write lock report when it is held for long
    * time.
    */
-  @Test(timeout = 45000)
+  @Test
+  @Timeout(value = 45)
   public void testFSWriteLockReportSuppressed() throws Exception {
     final long writeLockReportingThreshold = 1L;
     final long writeLockSuppressWarningInterval = 10L;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemLockReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemLockReport.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.security.PrivilegedExceptionAction;
@@ -40,7 +40,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_LOCK_SUPPRESS_WARNING_INT
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_READ_LOCK_REPORTING_THRESHOLD_MS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_WRITE_LOCK_REPORTING_THRESHOLD_MS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PERMISSIONS_SUPERUSERGROUP_KEY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFSNamesystemLockReport {
 
@@ -60,7 +60,7 @@ public class TestFSNamesystemLockReport {
   private UserGroupInformation userGroupInfo;
   private GenericTestUtils.LogCapturer logs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.set(DFS_PERMISSIONS_SUPERUSERGROUP_KEY, "hadoop");
@@ -82,7 +82,7 @@ public class TestFSNamesystemLockReport {
         org.slf4j.event.Level.INFO);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws Exception {
     if (fs != null) {
       fs.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSNamesystemMBean.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.lang.management.ManagementFactory;
 import java.util.HashSet;
@@ -41,7 +41,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.metrics2.impl.ConfigBuilder;
 import org.apache.hadoop.metrics2.impl.TestMetricsConfig;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.eclipse.jetty.util.ajax.JSON;
 
 /**
@@ -160,8 +161,8 @@ public class TestFSNamesystemMBean {
       MBeanClient client = new MBeanClient();
       client.start();
       client.join(20000);
-      assertTrue("JMX calls are blocked when FSNamesystem's writerlock" +
-          "is owned by another thread", client.succeeded);
+      assertTrue(client.succeeded,
+          "JMX calls are blocked when FSNamesystem's writerlock" + "is owned by another thread");
       client.interrupt();
     } finally {
       if (fsn != null && fsn.hasWriteLock(RwLockMode.GLOBAL)) {
@@ -190,8 +191,8 @@ public class TestFSNamesystemMBean {
         MBeanClient client = new MBeanClient();
         client.start();
         client.join(20000);
-        assertTrue("JMX calls are blocked when FSEditLog" +
-            " is synchronized by another thread", client.succeeded);
+        assertTrue(client.succeeded,
+            "JMX calls are blocked when FSEditLog" + " is synchronized by another thread");
         client.interrupt();
       }
     } finally {
@@ -201,7 +202,8 @@ public class TestFSNamesystemMBean {
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testFsEditLogMetrics() throws Exception {
     final Configuration conf = new Configuration();
     MiniDFSCluster cluster = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
@@ -18,8 +18,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -44,11 +44,11 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestFavoredNodesEndToEnd {
   {
@@ -64,7 +64,7 @@ public class TestFavoredNodesEndToEnd {
   private static DistributedFileSystem dfs;
   private static ArrayList<DataNode> datanodes;
   
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(NUM_DATA_NODES)
@@ -74,14 +74,15 @@ public class TestFavoredNodesEndToEnd {
     datanodes = cluster.getDataNodes();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     if (cluster != null) { 
       cluster.shutdown();
     }
   }
 
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testFavoredNodesEndToEnd() throws Exception {
     //create 10 files with random preferred nodes
     for (int i = 0; i < NUM_FILES; i++) {
@@ -104,7 +105,8 @@ public class TestFavoredNodesEndToEnd {
     }
   }
 
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testWhenFavoredNodesNotPresent() throws Exception {
     //when we ask for favored nodes but the nodes are not there, we should
     //get some other nodes. In other words, the write to hdfs should not fail
@@ -122,7 +124,8 @@ public class TestFavoredNodesEndToEnd {
     getBlockLocations(p);
   }
 
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testWhenSomeNodesAreNotGood() throws Exception {
     // 4 favored nodes
     final InetSocketAddress addrs[] = new InetSocketAddress[4];
@@ -150,19 +153,20 @@ public class TestFavoredNodesEndToEnd {
     d.stopDecommission();
 
     BlockLocation[] locations = getBlockLocations(p);
-    Assert.assertEquals(replication, locations[0].getNames().length);
+    Assertions.assertEquals(replication, locations[0].getNames().length);
     //also make sure that the datanode[0] is not in the list of hosts
     for (int i = 0; i < replication; i++) {
       final String loc = locations[0].getNames()[i];
       int j = 0;
       for(; j < hosts.length && !loc.equals(hosts[j]); j++);
-      Assert.assertTrue("j=" + j, j > 0);
-      Assert.assertTrue("loc=" + loc + " not in host list "
-          + Arrays.asList(hosts) + ", j=" + j, j < hosts.length);
+      Assertions.assertTrue(j > 0, "j=" + j);
+      Assertions.assertTrue(j < hosts.length,
+          "loc=" + loc + " not in host list " + Arrays.asList(hosts) + ", j=" + j);
     }
   }
 
-  @Test(timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testFavoredNodesEndToEndForAppend() throws Exception {
     // create 10 files with random preferred nodes
     for (int i = 0; i < NUM_FILES; i++) {
@@ -189,7 +193,8 @@ public class TestFavoredNodesEndToEnd {
     }
   }
 
-  @Test(timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testCreateStreamBuilderFavoredNodesEndToEnd() throws Exception {
     //create 10 files with random preferred nodes
     for (int i = 0; i < NUM_FILES; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFavoredNodesEndToEnd.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -45,7 +46,6 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -153,14 +153,14 @@ public class TestFavoredNodesEndToEnd {
     d.stopDecommission();
 
     BlockLocation[] locations = getBlockLocations(p);
-    Assertions.assertEquals(replication, locations[0].getNames().length);
+    assertEquals(replication, locations[0].getNames().length);
     //also make sure that the datanode[0] is not in the list of hosts
     for (int i = 0; i < replication; i++) {
       final String loc = locations[0].getNames()[i];
       int j = 0;
       for(; j < hosts.length && !loc.equals(hosts[j]); j++);
-      Assertions.assertTrue(j > 0, "j=" + j);
-      Assertions.assertTrue(j < hosts.length,
+      assertTrue(j > 0, "j=" + j);
+      assertTrue(j < hosts.length,
           "loc=" + loc + " not in host list " + Arrays.asList(hosts) + ", j=" + j);
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileJournalManager.java
@@ -20,9 +20,10 @@ package org.apache.hadoop.hdfs.server.namenode;
 import static org.apache.hadoop.hdfs.server.namenode.TestEditLog.TXNS_PER_FAIL;
 import static org.apache.hadoop.hdfs.server.namenode.TestEditLog.TXNS_PER_ROLL;
 import static org.apache.hadoop.hdfs.server.namenode.TestEditLog.setupEdits;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -44,13 +45,12 @@ import org.apache.hadoop.hdfs.server.namenode.NNStorage.NameNodeDirType;
 import org.apache.hadoop.hdfs.server.namenode.TestEditLog.AbortSpec;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.NativeCodeLoader;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
 
 public class TestFileJournalManager {
   static final Logger LOG =
@@ -64,10 +64,7 @@ public class TestFileJournalManager {
     EditLogFileOutputStream.setShouldSkipFsyncForTesting(true);
   }
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new Configuration();
   }
@@ -155,8 +152,7 @@ public class TestFileJournalManager {
     StorageDirectory sd = storage.dirIterator(NameNodeDirType.EDITS).next();
 
     FileJournalManager jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(5*TXNS_PER_ROLL + TXNS_PER_FAIL, 
-                 getNumberOfTransactions(jm, 1, true, false));
+    assertEquals(5 * TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1, true, false));
   }
 
   /**
@@ -182,8 +178,7 @@ public class TestFileJournalManager {
     
     sd = dirs.next();
     jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(5*TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1,
-        true, false));
+    assertEquals(5 * TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1, true, false));
 
     sd = dirs.next();
     jm = new FileJournalManager(conf, sd, storage);
@@ -211,18 +206,15 @@ public class TestFileJournalManager {
     Iterator<StorageDirectory> dirs = storage.dirIterator(NameNodeDirType.EDITS);
     StorageDirectory sd = dirs.next();
     FileJournalManager jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(5*TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1,
-        true, false));
+    assertEquals(5 * TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1, true, false));
     
     sd = dirs.next();
     jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(5*TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1,
-        true, false));
+    assertEquals(5 * TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1, true, false));
 
     sd = dirs.next();
     jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(5*TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1,
-        true, false));
+    assertEquals(5 * TXNS_PER_ROLL + TXNS_PER_FAIL, getNumberOfTransactions(jm, 1, true, false));
   }
 
   /** 
@@ -237,23 +229,24 @@ public class TestFileJournalManager {
     raf.close();
   }
   
-  @Test(expected=IllegalStateException.class)
+  @Test
   public void testFinalizeErrorReportedToNNStorage() throws IOException, InterruptedException {
-    File f = new File(TestEditLog.TEST_DIR + "/filejournaltestError");
-    // abort after 10th roll
-    NNStorage storage = setupEdits(Collections.<URI>singletonList(f.toURI()),
+      assertThrows(IllegalStateException.class, () -> {
+          File f = new File(TestEditLog.TEST_DIR + "/filejournaltestError");
+          NNStorage storage = setupEdits(Collections.<URI>singletonList(f.toURI()),
                                    10, new AbortSpec(10, 0));
-    StorageDirectory sd = storage.dirIterator(NameNodeDirType.EDITS).next();
-
-    FileJournalManager jm = new FileJournalManager(conf, sd, storage);
-    String sdRootPath = sd.getRoot().getAbsolutePath();
-    FileUtil.chmod(sdRootPath, "-w", true);
-    try {
-      jm.finalizeLogSegment(0, 1);
+          StorageDirectory sd = storage.dirIterator(NameNodeDirType.EDITS).next();
+          FileJournalManager jm = new FileJournalManager(conf, sd, storage);
+          String sdRootPath = sd.getRoot().getAbsolutePath();
+          FileUtil.chmod(sdRootPath, "-w", true);
+          try {
+              jm.finalizeLogSegment(0, 1);
     } finally {
       FileUtil.chmod(sdRootPath, "+w", true);
       assertTrue(storage.getRemovedStorageDirs().contains(sd));
     }
+      });
+
   }
 
   /** 
@@ -272,15 +265,14 @@ public class TestFileJournalManager {
 
     FileJournalManager jm = new FileJournalManager(conf, sd, storage);
     long expectedTotalTxnCount = TXNS_PER_ROLL*10 + TXNS_PER_FAIL;
-    assertEquals(expectedTotalTxnCount, getNumberOfTransactions(jm, 1,
-        true, false));
+    assertEquals(expectedTotalTxnCount, getNumberOfTransactions(jm, 1, true, false));
 
     long skippedTxns = (3*TXNS_PER_ROLL); // skip first 3 files
     long startingTxId = skippedTxns + 1; 
 
     long numLoadable = getNumberOfTransactions(jm, startingTxId,
         true, false);
-    assertEquals(expectedTotalTxnCount - skippedTxns, numLoadable); 
+    assertEquals(expectedTotalTxnCount - skippedTxns, numLoadable);
   }
 
   /**
@@ -301,8 +293,7 @@ public class TestFileJournalManager {
     // 10 rolls, so 11 rolled files, 110 txids total.
     final int TOTAL_TXIDS = 10 * 11;
     for (int txid = 1; txid <= TOTAL_TXIDS; txid++) {
-      assertEquals((TOTAL_TXIDS - txid) + 1, getNumberOfTransactions(jm, txid,
-          true, false));
+        assertEquals((TOTAL_TXIDS - txid) + 1, getNumberOfTransactions(jm, txid, true, false));
     }
   }
 
@@ -340,8 +331,8 @@ public class TestFileJournalManager {
     assertEquals(0, getNumberOfTransactions(jm, startGapTxId, true, true));
 
     // rolled 10 times so there should be 11 files.
-    assertEquals(11*TXNS_PER_ROLL - endGapTxId, 
-                 getNumberOfTransactions(jm, endGapTxId + 1, true, true));
+    assertEquals(11 * TXNS_PER_ROLL - endGapTxId,
+        getNumberOfTransactions(jm, endGapTxId + 1, true, true));
   }
 
   /** 
@@ -368,8 +359,7 @@ public class TestFileJournalManager {
     corruptAfterStartSegment(files[0]);
 
     FileJournalManager jm = new FileJournalManager(conf, sd, storage);
-    assertEquals(10*TXNS_PER_ROLL+1, 
-                 getNumberOfTransactions(jm, 1, true, false));
+    assertEquals(10 * TXNS_PER_ROLL + 1, getNumberOfTransactions(jm, 1, true, false));
   }
 
   @Test
@@ -387,17 +377,19 @@ public class TestFileJournalManager {
     assertEquals("[101,200],[1001,1100]", getLogsAsString(fjm, 101));
     assertEquals("[101,200],[1001,1100]", getLogsAsString(fjm, 150));
     assertEquals("[1001,1100]", getLogsAsString(fjm, 201));
-    assertEquals("Asking for a newer log than exists should return empty list",
-        "", getLogsAsString(fjm, 9999));
+    assertEquals("", getLogsAsString(fjm, 9999),
+        "Asking for a newer log than exists should return empty list");
   }
 
   /**
    * tests that passing an invalid dir to matchEditLogs throws IOException 
    */
-  @Test(expected = IOException.class)
+  @Test
   public void testMatchEditLogInvalidDirThrowsIOException() throws IOException {
-    File badDir = new File("does not exist");
-    FileJournalManager.matchEditLogs(badDir);
+    assertThrows(IOException.class, () -> {
+      File badDir = new File("does not exist");
+      FileJournalManager.matchEditLogs(badDir);
+    });
   }
   
   private static EditLogInputStream getJournalInputStream(FileJournalManager jm,
@@ -446,7 +438,7 @@ public class TestFileJournalManager {
     EditLogInputStream elis = getJournalInputStream(jm, 5, true);
     try {
       FSEditLogOp op = elis.readOp();
-      assertEquals("read unexpected op", op.getTransactionId(), 5);
+      assertEquals(op.getTransactionId(), 5, "read unexpected op");
     } finally {
       IOUtils.cleanupWithLogger(LOG, elis);
     }
@@ -499,11 +491,13 @@ public class TestFileJournalManager {
     FileJournalManager jm = null;
     try {
       jm = new FileJournalManager(conf, sd, storage);
-      exception.expect(IOException.class);
+
+      final FileJournalManager j = jm;
+      IOException ex = assertThrows(IOException.class, () ->
+          j.doPreUpgrade());
       if (NativeCodeLoader.isNativeCodeLoaded()) {
-        exception.expectMessage("failure in native rename");
+        assertTrue(ex.getMessage().contains("failure in native rename"));
       }
-      jm.doPreUpgrade();
     } finally {
       IOUtils.cleanupWithLogger(LOG, jm);
       // Restore permissions on storage directory and make sure we can delete.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFileJournalManager.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.Assertions;
 
 public class TestFileJournalManager {
   static final Logger LOG =
@@ -231,21 +230,21 @@ public class TestFileJournalManager {
   
   @Test
   public void testFinalizeErrorReportedToNNStorage() throws IOException, InterruptedException {
-      assertThrows(IllegalStateException.class, () -> {
-          File f = new File(TestEditLog.TEST_DIR + "/filejournaltestError");
-          NNStorage storage = setupEdits(Collections.<URI>singletonList(f.toURI()),
-                                   10, new AbortSpec(10, 0));
-          StorageDirectory sd = storage.dirIterator(NameNodeDirType.EDITS).next();
-          FileJournalManager jm = new FileJournalManager(conf, sd, storage);
-          String sdRootPath = sd.getRoot().getAbsolutePath();
-          FileUtil.chmod(sdRootPath, "-w", true);
-          try {
-              jm.finalizeLogSegment(0, 1);
-    } finally {
-      FileUtil.chmod(sdRootPath, "+w", true);
-      assertTrue(storage.getRemovedStorageDirs().contains(sd));
-    }
-      });
+    assertThrows(IllegalStateException.class, () -> {
+      File f = new File(TestEditLog.TEST_DIR + "/filejournaltestError");
+      NNStorage storage = setupEdits(Collections.<URI>singletonList(f.toURI()),
+          10, new AbortSpec(10, 0));
+      StorageDirectory sd = storage.dirIterator(NameNodeDirType.EDITS).next();
+      FileJournalManager jm = new FileJournalManager(conf, sd, storage);
+      String sdRootPath = sd.getRoot().getAbsolutePath();
+      FileUtil.chmod(sdRootPath, "-w", true);
+      try {
+        jm.finalizeLogSegment(0, 1);
+      } finally {
+        FileUtil.chmod(sdRootPath, "+w", true);
+        assertTrue(storage.getRemovedStorageDirs().contains(sd));
+      }
+    });
 
   }
 
@@ -293,7 +292,8 @@ public class TestFileJournalManager {
     // 10 rolls, so 11 rolled files, 110 txids total.
     final int TOTAL_TXIDS = 10 * 11;
     for (int txid = 1; txid <= TOTAL_TXIDS; txid++) {
-        assertEquals((TOTAL_TXIDS - txid) + 1, getNumberOfTransactions(jm, txid, true, false));
+      assertEquals((TOTAL_TXIDS - txid) + 1,
+          getNumberOfTransactions(jm, txid, true, false));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestGenericJournalConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestGenericJournalConf.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.common.Storage;
 import org.apache.hadoop.hdfs.server.common.StorageInfo;
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestGenericJournalConf {
   private static final String DUMMY_URI = "dummy://test";
@@ -39,45 +39,48 @@ public class TestGenericJournalConf {
    * Test that an exception is thrown if a journal class doesn't exist
    * in the configuration 
    */
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testNotConfigured() throws Exception {
-    MiniDFSCluster cluster = null;
-    Configuration conf = new Configuration();
-
-    conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
-             "dummy://test");
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+      assertThrows(IllegalArgumentException.class, () -> {
+          MiniDFSCluster cluster = null;
+          Configuration conf = new Configuration();
+          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
+              "dummy://test");
+          try {
+              cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
       cluster.waitActive();
     } finally {
       if (cluster != null) {
         cluster.shutdown();
       }
     }
+      });
+
   }
 
   /**
    * Test that an exception is thrown if a journal class doesn't
    * exist in the classloader.
    */
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testClassDoesntExist() throws Exception {
-    MiniDFSCluster cluster = null;
-    Configuration conf = new Configuration();
-
-    conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_PLUGIN_PREFIX + ".dummy",
-             "org.apache.hadoop.nonexistent");
-    conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
-             "dummy://test");
-
-    try {
-      cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+      assertThrows(IllegalArgumentException.class, () -> {
+          MiniDFSCluster cluster = null;
+          Configuration conf = new Configuration();
+          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_PLUGIN_PREFIX + ".dummy",
+              "org.apache.hadoop.nonexistent");
+          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
+              "dummy://test");
+          try {
+              cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
       cluster.waitActive();
     } finally {
       if (cluster != null) {
         cluster.shutdown();
       }
     }
+      });
+
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestGenericJournalConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestGenericJournalConf.java
@@ -41,20 +41,20 @@ public class TestGenericJournalConf {
    */
   @Test
   public void testNotConfigured() throws Exception {
-      assertThrows(IllegalArgumentException.class, () -> {
-          MiniDFSCluster cluster = null;
-          Configuration conf = new Configuration();
-          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
-              "dummy://test");
-          try {
-              cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
-      cluster.waitActive();
-    } finally {
-      if (cluster != null) {
-        cluster.shutdown();
+    assertThrows(IllegalArgumentException.class, () -> {
+      MiniDFSCluster cluster = null;
+      Configuration conf = new Configuration();
+      conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
+          "dummy://test");
+      try {
+        cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+        cluster.waitActive();
+      } finally {
+        if (cluster != null) {
+          cluster.shutdown();
+        }
       }
-    }
-      });
+    });
 
   }
 
@@ -64,22 +64,22 @@ public class TestGenericJournalConf {
    */
   @Test
   public void testClassDoesntExist() throws Exception {
-      assertThrows(IllegalArgumentException.class, () -> {
-          MiniDFSCluster cluster = null;
-          Configuration conf = new Configuration();
-          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_PLUGIN_PREFIX + ".dummy",
-              "org.apache.hadoop.nonexistent");
-          conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
-              "dummy://test");
-          try {
-              cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
-      cluster.waitActive();
-    } finally {
-      if (cluster != null) {
-        cluster.shutdown();
+    assertThrows(IllegalArgumentException.class, () -> {
+      MiniDFSCluster cluster = null;
+      Configuration conf = new Configuration();
+      conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_PLUGIN_PREFIX + ".dummy",
+          "org.apache.hadoop.nonexistent");
+      conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
+          "dummy://test");
+      try {
+        cluster = new MiniDFSCluster.Builder(conf).numDataNodes(0).build();
+        cluster.waitActive();
+      } finally {
+        if (cluster != null) {
+          cluster.shutdown();
+        }
       }
-    }
-      });
+    });
 
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAWithInProgressTail.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAWithInProgressTail.java
@@ -27,15 +27,15 @@ import org.apache.hadoop.hdfs.qjournal.MiniJournalCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
 import org.apache.hadoop.hdfs.qjournal.client.QuorumJournalManager;
 import org.apache.hadoop.hdfs.qjournal.client.SpyQJournalUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 
 import static org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter.getFileInfo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.spy;
 
@@ -46,7 +46,7 @@ public class TestHAWithInProgressTail {
   private NameNode nn0;
   private NameNode nn1;
 
-  @Before
+  @BeforeEach
   public void startUp() throws IOException {
     Configuration conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
@@ -61,7 +61,7 @@ public class TestHAWithInProgressTail {
     nn1 = cluster.getNameNode(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestMalformedURLs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestMalformedURLs.java
@@ -22,17 +22,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestMalformedURLs {
   private MiniDFSCluster cluster;
   Configuration config;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration.addDefaultResource("hdfs-site.malformed.xml");
     config = new Configuration();
@@ -45,12 +45,12 @@ public class TestMalformedURLs {
     // correctly.
 
     assertNotEquals(config.get(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY),
-      config.getTrimmed(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY));
+        config.getTrimmed(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY));
     cluster = new MiniDFSCluster.Builder(config).build();
     cluster.waitActive();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
@@ -77,17 +77,17 @@ public class TestNameEditsConfigs {
     FSImageTransactionalStorageInspector ins = inspect(dir);
 
     if (shouldHaveImages) {
-        assertTrue(ins.foundImages.size() > 0, "Expect images in " + dir);
+      assertTrue(ins.foundImages.size() > 0, "Expect images in " + dir);
     } else {
-        assertTrue(ins.foundImages.isEmpty(), "Expect no images in " + dir);
+      assertTrue(ins.foundImages.isEmpty(), "Expect no images in " + dir);
     }
 
     List<FileJournalManager.EditLogFile> editlogs 
       = FileJournalManager.matchEditLogs(new File(dir, "current").listFiles()); 
     if (shouldHaveEdits) {
-        assertTrue(editlogs.size() > 0, "Expect edits in " + dir);
+      assertTrue(editlogs.size() > 0, "Expect edits in " + dir);
     } else {
-        assertTrue(editlogs.isEmpty(), "Expect no edits in " + dir);
+      assertTrue(editlogs.isEmpty(), "Expect no edits in " + dir);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,8 +38,8 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.namenode.NNStorage.NameNodeDirType;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
@@ -63,7 +63,7 @@ public class TestNameEditsConfigs {
   private final File base_dir = new File(
       PathUtils.getTestDir(TestNameEditsConfigs.class), "dfs");
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     if(base_dir.exists() && !FileUtil.fullyDelete(base_dir)) {
       throw new IOException("Cannot remove directory " + base_dir);
@@ -77,17 +77,17 @@ public class TestNameEditsConfigs {
     FSImageTransactionalStorageInspector ins = inspect(dir);
 
     if (shouldHaveImages) {
-      assertTrue("Expect images in " + dir, ins.foundImages.size() > 0);
+        assertTrue(ins.foundImages.size() > 0, "Expect images in " + dir);
     } else {
-      assertTrue("Expect no images in " + dir, ins.foundImages.isEmpty());      
+        assertTrue(ins.foundImages.isEmpty(), "Expect no images in " + dir);
     }
 
     List<FileJournalManager.EditLogFile> editlogs 
       = FileJournalManager.matchEditLogs(new File(dir, "current").listFiles()); 
     if (shouldHaveEdits) {
-      assertTrue("Expect edits in " + dir, editlogs.size() > 0);
+        assertTrue(editlogs.size() > 0, "Expect edits in " + dir);
     } else {
-      assertTrue("Expect no edits in " + dir, editlogs.isEmpty());
+        assertTrue(editlogs.isEmpty(), "Expect no edits in " + dir);
     }
   }
 
@@ -95,9 +95,9 @@ public class TestNameEditsConfigs {
       throws IOException {
     assertTrue(fileSys.exists(name));
     int replication = fileSys.getFileStatus(name).getReplication();
-    assertEquals("replication for " + name, repl, replication);
+    assertEquals(repl, replication, "replication for " + name);
     long size = fileSys.getContentSummary(name).getLength();
-    assertEquals("file size for " + name, size, FILE_SIZE);
+    assertEquals(size, FILE_SIZE, "file size for " + name);
   }
 
   private void cleanupFile(FileSystem fileSys, Path name)
@@ -606,14 +606,14 @@ public class TestNameEditsConfigs {
       cluster.waitActive();
       secondary = startSecondaryNameNode(conf);
       secondary.doCheckpoint();
-      assertTrue(DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY + " must be trimmed ",
-          checkpointNameDir1.exists());
-      assertTrue(DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY + " must be trimmed ",
-          checkpointNameDir2.exists());
-      assertTrue(DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_EDITS_DIR_KEY
-          + " must be trimmed ", checkpointEditsDir1.exists());
-      assertTrue(DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_EDITS_DIR_KEY
-          + " must be trimmed ", checkpointEditsDir2.exists());
+      assertTrue(checkpointNameDir1.exists(),
+          DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY + " must be trimmed ");
+      assertTrue(checkpointNameDir2.exists(),
+          DFSConfigKeys.DFS_NAMENODE_NAME_DIR_KEY + " must be trimmed ");
+      assertTrue(checkpointEditsDir1.exists(),
+          DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_EDITS_DIR_KEY + " must be trimmed ");
+      assertTrue(checkpointEditsDir2.exists(),
+          DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_EDITS_DIR_KEY + " must be trimmed ");
     } finally {
       secondary.shutdown();
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeConfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeConfiguration.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestNameNodeConfiguration {
 
@@ -33,8 +33,8 @@ public class TestNameNodeConfiguration {
   public void testNameNodeSpecificKeys() {
     Set<String> keySet = new HashSet<>();
     for (String key : NameNode.NAMENODE_SPECIFIC_KEYS) {
-      assertTrue("Duplicate key: " + key
-          + " in NameNode.NAMENODE_SPECIFIC_KEYS.", keySet.add(key));
+        assertTrue(keySet.add(key),
+            "Duplicate key: " + key + " in NameNode.NAMENODE_SPECIFIC_KEYS.");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeConfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeConfiguration.java
@@ -33,8 +33,8 @@ public class TestNameNodeConfiguration {
   public void testNameNodeSpecificKeys() {
     Set<String> keySet = new HashSet<>();
     for (String key : NameNode.NAMENODE_SPECIFIC_KEYS) {
-        assertTrue(keySet.add(key),
-            "Duplicate key: " + key + " in NameNode.NAMENODE_SPECIFIC_KEYS.");
+      assertTrue(keySet.add(key),
+          "Duplicate key: " + key + " in NameNode.NAMENODE_SPECIFIC_KEYS.");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServer.java
@@ -34,11 +34,12 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MethodSource("policy")
 @ParameterizedClass
@@ -97,14 +98,14 @@ public class TestNameNodeHttpServer {
       server = new NameNodeHttpServer(conf, null, addr);
       server.start();
 
-      Assertions.assertTrue(implies(policy.isHttpEnabled(),
+      assertTrue(implies(policy.isHttpEnabled(),
           canAccess("http", server.getHttpAddress())));
-      Assertions.assertTrue(implies(!policy.isHttpEnabled(),
+      assertTrue(implies(!policy.isHttpEnabled(),
           server.getHttpAddress() == null));
 
-      Assertions.assertTrue(implies(policy.isHttpsEnabled(),
+      assertTrue(implies(policy.isHttpsEnabled(),
           canAccess("https", server.getHttpsAddress())));
-      Assertions.assertTrue(implies(!policy.isHttpsEnabled(),          server.getHttpsAddress() == null));
+      assertTrue(implies(!policy.isHttpsEnabled(), server.getHttpsAddress() == null));
 
     } finally {
       if (server != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServer.java
@@ -33,15 +33,15 @@ import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(value = Parameterized.class)
+@MethodSource("policy")
+@ParameterizedClass
 public class TestNameNodeHttpServer {
   private static final String BASEDIR = GenericTestUtils
       .getTempPath(TestNameNodeHttpServer.class.getSimpleName());
@@ -50,7 +50,6 @@ public class TestNameNodeHttpServer {
   private static Configuration conf;
   private static URLConnectionFactory connectionFactory;
 
-  @Parameters
   public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] { { HttpConfig.Policy.HTTP_ONLY },
         { HttpConfig.Policy.HTTPS_ONLY }, { HttpConfig.Policy.HTTP_AND_HTTPS } };
@@ -64,7 +63,7 @@ public class TestNameNodeHttpServer {
     this.policy = policy;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
@@ -81,7 +80,7 @@ public class TestNameNodeHttpServer {
         KeyStoreTestUtil.getServerSSLConfigFileName());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     FileUtil.fullyDelete(new File(BASEDIR));
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
@@ -98,15 +97,14 @@ public class TestNameNodeHttpServer {
       server = new NameNodeHttpServer(conf, null, addr);
       server.start();
 
-      Assert.assertTrue(implies(policy.isHttpEnabled(),
+      Assertions.assertTrue(implies(policy.isHttpEnabled(),
           canAccess("http", server.getHttpAddress())));
-      Assert.assertTrue(implies(!policy.isHttpEnabled(),
+      Assertions.assertTrue(implies(!policy.isHttpEnabled(),
           server.getHttpAddress() == null));
 
-      Assert.assertTrue(implies(policy.isHttpsEnabled(),
+      Assertions.assertTrue(implies(policy.isHttpsEnabled(),
           canAccess("https", server.getHttpsAddress())));
-      Assert.assertTrue(implies(!policy.isHttpsEnabled(),
-          server.getHttpsAddress() == null));
+      Assertions.assertTrue(implies(!policy.isHttpsEnabled(),          server.getHttpsAddress() == null));
 
     } finally {
       if (server != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServerXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServerXFrame.java
@@ -23,10 +23,8 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -34,6 +32,8 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A class to test the XFrameoptions of Namenode HTTP Server. We are not reusing
@@ -43,13 +43,10 @@ import java.net.URI;
  */
 public class TestNameNodeHttpServerXFrame {
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   public static URL getServerURL(HttpServer2 server)
       throws MalformedURLException {
-    Assert.assertNotNull("No server", server);
-    return new URL("http://"
+      Assertions.assertNotNull(server, "No server");
+      return new URL("http://"
         + NetUtils.getHostPortString(server.getConnectorAddress(0)));
   }
 
@@ -57,9 +54,8 @@ public class TestNameNodeHttpServerXFrame {
   public void testNameNodeXFrameOptionsEnabled() throws Exception {
     HttpURLConnection conn = createServerwithXFrame(true, null);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertTrue("X-FRAME-OPTIONS is absent in the header",
-        xfoHeader != null);
-    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
+    Assertions.assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
+    Assertions.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
         .SAMEORIGIN.toString()));
   }
 
@@ -67,13 +63,14 @@ public class TestNameNodeHttpServerXFrame {
   public void testNameNodeXFrameOptionsDisabled() throws Exception {
     HttpURLConnection conn = createServerwithXFrame(false, null);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertTrue("unexpected X-FRAME-OPTION in header", xfoHeader == null);
+    Assertions.assertTrue(xfoHeader == null, "unexpected X-FRAME-OPTION in header");
   }
 
   @Test
   public void testNameNodeXFrameOptionsIllegalOption() throws Exception {
-    exception.expect(IllegalArgumentException.class);
-    createServerwithXFrame(true, "hadoop");
+    assertThrows(IllegalArgumentException.class, () -> {
+      createServerwithXFrame(true, "hadoop");
+    });
   }
 
   private HttpURLConnection createServerwithXFrame(boolean enabled, String
@@ -111,9 +108,7 @@ public class TestNameNodeHttpServerXFrame {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.connect();
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assert.assertTrue("X-FRAME-OPTIONS is absent in the header",
-        xfoHeader != null);
-    Assert.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
-        .SAMEORIGIN.toString()));
+    Assertions.assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
+    Assertions.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption        .SAMEORIGIN.toString()));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServerXFrame.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeHttpServerXFrame.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.net.NetUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -33,7 +32,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A class to test the XFrameoptions of Namenode HTTP Server. We are not reusing
@@ -45,8 +46,8 @@ public class TestNameNodeHttpServerXFrame {
 
   public static URL getServerURL(HttpServer2 server)
       throws MalformedURLException {
-      Assertions.assertNotNull(server, "No server");
-      return new URL("http://"
+    assertNotNull(server, "No server");
+    return new URL("http://"
         + NetUtils.getHostPortString(server.getConnectorAddress(0)));
   }
 
@@ -54,8 +55,8 @@ public class TestNameNodeHttpServerXFrame {
   public void testNameNodeXFrameOptionsEnabled() throws Exception {
     HttpURLConnection conn = createServerwithXFrame(true, null);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assertions.assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
-    Assertions.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
+    assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
+    assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption
         .SAMEORIGIN.toString()));
   }
 
@@ -63,7 +64,7 @@ public class TestNameNodeHttpServerXFrame {
   public void testNameNodeXFrameOptionsDisabled() throws Exception {
     HttpURLConnection conn = createServerwithXFrame(false, null);
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assertions.assertTrue(xfoHeader == null, "unexpected X-FRAME-OPTION in header");
+    assertTrue(xfoHeader == null, "unexpected X-FRAME-OPTION in header");
   }
 
   @Test
@@ -108,7 +109,7 @@ public class TestNameNodeHttpServerXFrame {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.connect();
     String xfoHeader = conn.getHeaderField("X-FRAME-OPTIONS");
-    Assertions.assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
-    Assertions.assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption        .SAMEORIGIN.toString()));
+    assertTrue(xfoHeader != null, "X-FRAME-OPTIONS is absent in the header");
+    assertTrue(xfoHeader.endsWith(HttpServer2.XFrameOption.SAMEORIGIN.toString()));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -60,12 +60,10 @@ import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.VersionInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -976,8 +974,8 @@ public class TestNameNodeMXBean {
               return true;
             }
           } catch (Exception e) {
-                  Assertions.fail("Caught unexpected exception.");
-              }
+            fail("Caught unexpected exception.");
+          }
           return false;
         }
       }, 1000, 60000);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMXBean.java
@@ -60,10 +60,11 @@ import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.VersionInfo;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.eclipse.jetty.util.ajax.JSON;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,12 +84,12 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.util.Shell.getMemlockLimit;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class for testing {@link NameNodeMXBean} implementation
@@ -103,8 +104,9 @@ public class TestNameNodeMXBean {
    */
   private static final double DELTA = 0.000001;
 
-  @Rule
-  public TemporaryFolder baseDir = new TemporaryFolder();
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @TempDir
+  java.nio.file.Path baseDir;
 
   static {
     NativeIO.POSIX.setCacheManipulator(new NoMlockCacheManipulator());
@@ -121,7 +123,7 @@ public class TestNameNodeMXBean {
     MiniDFSCluster cluster = null;
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(4).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(4).build();
       cluster.waitActive();
 
       // Set upgrade domain on the first DN.
@@ -233,31 +235,28 @@ public class TestNameNodeMXBean {
       // get attribute NodeUsage
       String nodeUsage = (String) (mbs.getAttribute(mxbeanName,
           "NodeUsage"));
-      assertEquals("Bad value for NodeUsage", fsn.getNodeUsage(), nodeUsage);
+      assertEquals(fsn.getNodeUsage(), nodeUsage, "Bad value for NodeUsage");
       // get attribute NameJournalStatus
       String nameJournalStatus = (String) (mbs.getAttribute(mxbeanName,
           "NameJournalStatus"));
-      assertEquals("Bad value for NameJournalStatus",
-          fsn.getNameJournalStatus(), nameJournalStatus);
+      assertEquals(fsn.getNameJournalStatus(), nameJournalStatus,
+          "Bad value for NameJournalStatus");
       // get attribute JournalTransactionInfo
       String journalTxnInfo = (String) mbs.getAttribute(mxbeanName,
           "JournalTransactionInfo");
-      assertEquals("Bad value for NameTxnIds", fsn.getJournalTransactionInfo(),
-          journalTxnInfo);
+      assertEquals(fsn.getJournalTransactionInfo(), journalTxnInfo, "Bad value for NameTxnIds");
       // get attribute "CompileInfo"
       String compileInfo = (String) mbs.getAttribute(mxbeanName, "CompileInfo");
-      assertEquals("Bad value for CompileInfo", fsn.getCompileInfo(),
-          compileInfo);
+      assertEquals(fsn.getCompileInfo(), compileInfo, "Bad value for CompileInfo");
       // get attribute CorruptFiles
       String corruptFiles = (String) (mbs.getAttribute(mxbeanName,
           "CorruptFiles"));
-      assertEquals("Bad value for CorruptFiles", fsn.getCorruptFiles(),
-          corruptFiles);
+      assertEquals(fsn.getCorruptFiles(), corruptFiles, "Bad value for CorruptFiles");
       // get attribute CorruptFilesCount
       int corruptFilesCount = (int) (mbs.getAttribute(mxbeanName,
           "CorruptFilesCount"));
-      assertEquals("Bad value for CorruptFilesCount",
-          fsn.getCorruptFilesCount(), corruptFilesCount);
+      assertEquals(fsn.getCorruptFilesCount(), corruptFilesCount,
+          "Bad value for CorruptFilesCount");
       // get attribute NameDirStatuses
       String nameDirStatuses = (String) (mbs.getAttribute(mxbeanName,
           "NameDirStatuses"));
@@ -277,8 +276,7 @@ public class TestNameNodeMXBean {
 
       // This will cause the first dir to fail.
       File failedNameDir = new File(nameDirUris.iterator().next());
-      assertEquals(0, FileUtil.chmod(
-          new File(failedNameDir, "current").getAbsolutePath(), "000"));
+      assertEquals(0, FileUtil.chmod(new File(failedNameDir, "current").getAbsolutePath(), "000"));
       cluster.getNameNodeRpc().rollEditLog();
 
       nameDirStatuses = (String) (mbs.getAttribute(mxbeanName,
@@ -296,11 +294,10 @@ public class TestNameNodeMXBean {
       assertEquals(1, statusMap.get("active").size());
       assertEquals(1, statusMap.get("failed").size());
       assertEquals(0L, mbs.getAttribute(mxbeanName, "CacheUsed"));
-      assertEquals(maxLockedMemory *
-          cluster.getDataNodes().size(),
-              mbs.getAttribute(mxbeanName, "CacheCapacity"));
-      assertNull("RollingUpgradeInfo should be null when there is no rolling"
-          + " upgrade", mbs.getAttribute(mxbeanName, "RollingUpgradeStatus"));
+      assertEquals(maxLockedMemory * cluster.getDataNodes().size(),
+          mbs.getAttribute(mxbeanName, "CacheCapacity"));
+      assertNull(mbs.getAttribute(mxbeanName, "RollingUpgradeStatus"),
+          "RollingUpgradeInfo should be null when there is no rolling" + " upgrade");
     } finally {
       if (cluster != null) {
         for (URI dir : cluster.getNameDirs(0)) {
@@ -323,7 +320,7 @@ public class TestNameNodeMXBean {
     hostsFileWriter.initialize(conf, "temp/TestNameNodeMXBean");
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(3).build();
       cluster.waitActive();
 
       FSNamesystem fsn = cluster.getNameNode().namesystem;
@@ -366,7 +363,8 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testDecommissioningNodes() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
@@ -376,7 +374,7 @@ public class TestNameNodeMXBean {
     hostsFileWriter.initialize(conf, "temp/TestNameNodeMXBean");
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(3).build();
       cluster.waitActive();
 
       FSNamesystem fsn = cluster.getNameNode().namesystem;
@@ -466,7 +464,8 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testInServiceNodes() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
@@ -479,7 +478,7 @@ public class TestNameNodeMXBean {
     hostsFileWriter.initialize(conf, "temp/TestInServiceNodes");
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(3).build();
       cluster.waitActive();
 
       final FSNamesystem fsn = cluster.getNameNode().namesystem;
@@ -563,7 +562,8 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testMaintenanceNodes() throws Exception {
     LOG.info("Starting testMaintenanceNodes");
     int expirationInMs = 30 * 1000;
@@ -578,7 +578,7 @@ public class TestNameNodeMXBean {
     hostsFileWriter.initialize(conf, "temp/TestNameNodeMXBean");
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(3).build();
       cluster.waitActive();
 
       FSNamesystem fsn = cluster.getNameNode().namesystem;
@@ -630,10 +630,8 @@ public class TestNameNodeMXBean {
         }
         LOG.info("Nodes entering Maintenance: " + enteringMaintenanceNodesInfo);
         recheck = false;
-        assertEquals(fsn.getEnteringMaintenanceNodes(),
-            enteringMaintenanceNodesInfo);
-        assertEquals(fsn.getNumEnteringMaintenanceDataNodes(),
-            enteringMaintenanceNodes.size());
+        assertEquals(fsn.getEnteringMaintenanceNodes(), enteringMaintenanceNodesInfo);
+        assertEquals(fsn.getNumEnteringMaintenanceDataNodes(), enteringMaintenanceNodes.size());
         assertEquals(0, fsn.getNumInMaintenanceLiveDataNodes());
         assertEquals(0, fsn.getNumInMaintenanceDeadDataNodes());
       }
@@ -651,8 +649,7 @@ public class TestNameNodeMXBean {
           (Map<String, Map<String, Object>>) JSON.parse(
               enteringMaintenanceNodesInfo);
       assertEquals(0, enteringMaintenanceNodes.size());
-      assertEquals(fsn.getEnteringMaintenanceNodes(),
-          enteringMaintenanceNodesInfo);
+      assertEquals(fsn.getEnteringMaintenanceNodes(), enteringMaintenanceNodesInfo);
       assertEquals(1, fsn.getNumInMaintenanceLiveDataNodes());
       assertEquals(0, fsn.getNumInMaintenanceDeadDataNodes());
     } finally {
@@ -663,13 +660,14 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   @SuppressWarnings("unchecked")
   public void testTopUsers() throws Exception {
     final Configuration conf = new Configuration();
     MiniDFSCluster cluster = null;
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(0).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(0).build();
       cluster.waitActive();
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanNameFsns = new ObjectName(
@@ -685,15 +683,14 @@ public class TestNameNodeMXBean {
           (String) (mbs.getAttribute(mxbeanNameFsns, "TopUserOpCounts"));
       ObjectMapper mapper = new ObjectMapper();
       Map<String, Object> map = mapper.readValue(topUsers, Map.class);
-      assertTrue("Could not find map key timestamp",
-          map.containsKey("timestamp"));
-      assertTrue("Could not find map key windows", map.containsKey("windows"));
+      assertTrue(map.containsKey("timestamp"), "Could not find map key timestamp");
+      assertTrue(map.containsKey("windows"), "Could not find map key windows");
       List<Map<String, List<Map<String, Object>>>> windows =
           (List<Map<String, List<Map<String, Object>>>>) map.get("windows");
-      assertEquals("Unexpected num windows", 3, windows.size());
+      assertEquals(3, windows.size(), "Unexpected num windows");
       for (Map<String, List<Map<String, Object>>> window : windows) {
         final List<Map<String, Object>> ops = window.get("ops");
-        assertEquals("Unexpected num ops", 4, ops.size());
+        assertEquals(4, ops.size(), "Unexpected num ops");
         for (Map<String, Object> op: ops) {
           if (op.get("opType").equals("datanodeReport")) {
             continue;
@@ -708,7 +705,7 @@ public class TestNameNodeMXBean {
           } else {
             expected = NUM_OPS;
           }
-          assertEquals("Unexpected total count", expected, count);
+          assertEquals(expected, count, "Unexpected total count");
         }
       }
     } finally {
@@ -718,14 +715,15 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testTopUsersDisabled() throws Exception {
     final Configuration conf = new Configuration();
     // Disable nntop
     conf.setBoolean(DFSConfigKeys.NNTOP_ENABLED_KEY, false);
     MiniDFSCluster cluster = null;
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(0).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(0).build();
       cluster.waitActive();
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanNameFsns = new ObjectName(
@@ -739,7 +737,7 @@ public class TestNameNodeMXBean {
       }
       String topUsers =
           (String) (mbs.getAttribute(mxbeanNameFsns, "TopUserOpCounts"));
-      assertNull("Did not expect to find TopUserOpCounts bean!", topUsers);
+      assertNull(topUsers, "Did not expect to find TopUserOpCounts bean!");
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -747,14 +745,15 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testTopUsersNoPeriods() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.NNTOP_ENABLED_KEY, true);
     conf.set(DFSConfigKeys.NNTOP_WINDOWS_MINUTES_KEY, "");
     MiniDFSCluster cluster = null;
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(0).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(0).build();
       cluster.waitActive();
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanNameFsns = new ObjectName(
@@ -768,7 +767,7 @@ public class TestNameNodeMXBean {
       }
       String topUsers =
           (String) (mbs.getAttribute(mxbeanNameFsns, "TopUserOpCounts"));
-      assertNotNull("Expected TopUserOpCounts bean!", topUsers);
+      assertNotNull(topUsers, "Expected TopUserOpCounts bean!");
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -776,12 +775,13 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testQueueLength() throws Exception {
     final Configuration conf = new Configuration();
     MiniDFSCluster cluster = null;
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(0).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(0).build();
       cluster.waitActive();
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       ObjectName mxbeanNameFs =
@@ -795,7 +795,8 @@ public class TestNameNodeMXBean {
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testNNDirectorySize() throws Exception{
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
@@ -811,7 +812,7 @@ public class TestNameNodeMXBean {
                 .addNN(
                     new MiniDFSNNTopology.NNConf("nn2").setIpcPort(ports[1])));
 
-        cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot())
+        cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile())
             .nnTopology(topology).numDataNodes(0)
             .build();
         break;
@@ -856,8 +857,7 @@ public class TestNameNodeMXBean {
     assertEquals(nameDirUris.size(), nnDirMap.size());
     for (URI dirUrl : nameDirUris) {
       File dir = new File(dirUrl);
-      assertEquals(nnDirMap.get(dir.getAbsolutePath()).longValue(),
-          FileUtils.sizeOfDirectory(dir));
+      assertEquals(nnDirMap.get(dir.getAbsolutePath()).longValue(), FileUtils.sizeOfDirectory(dir));
     }
   }
 
@@ -873,28 +873,26 @@ public class TestNameNodeMXBean {
       int dataBlocks = defaultPolicy.getNumDataUnits();
       int parityBlocks = defaultPolicy.getNumParityUnits();
       int totalSize = dataBlocks + parityBlocks;
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot())
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile())
           .numDataNodes(totalSize).build();
       fs = cluster.getFileSystem();
 
       final String defaultPolicyName = defaultPolicy.getName();
       final String rs104PolicyName = "RS-10-4-1024k";
 
-      assertEquals("Enabled EC policies metric should return with " +
-          "the default EC policy", defaultPolicyName,
-          getEnabledEcPoliciesMetric());
+      assertEquals(defaultPolicyName, getEnabledEcPoliciesMetric(),
+          "Enabled EC policies metric should return with " + "the default EC policy");
 
       fs.enableErasureCodingPolicy(rs104PolicyName);
-      assertEquals("Enabled EC policies metric should return with " +
-              "both enabled policies separated by a comma",
-          rs104PolicyName + ", " + defaultPolicyName,
-          getEnabledEcPoliciesMetric());
+      assertEquals(rs104PolicyName + ", " + defaultPolicyName, getEnabledEcPoliciesMetric(),
+          "Enabled EC policies metric should return with " +
+              "both enabled policies separated by a comma");
 
       fs.disableErasureCodingPolicy(defaultPolicyName);
       fs.disableErasureCodingPolicy(rs104PolicyName);
-      assertEquals("Enabled EC policies metric should return with " +
-          "an empty string if there is no enabled policy",
-          "", getEnabledEcPoliciesMetric());
+      assertEquals("", getEnabledEcPoliciesMetric(),
+          "Enabled EC policies metric should return with " +
+              "an empty string if there is no enabled policy");
     } finally {
       fs.close();
       cluster.shutdown();
@@ -913,7 +911,7 @@ public class TestNameNodeMXBean {
           StripedFileTestUtil.getDefaultECPolicy().getNumParityUnits();
       int cellSize = StripedFileTestUtil.getDefaultECPolicy().getCellSize();
       int totalSize = dataBlocks + parityBlocks;
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot())
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile())
           .numDataNodes(totalSize).build();
       fs = cluster.getFileSystem();
       fs.enableErasureCodingPolicy(
@@ -978,8 +976,8 @@ public class TestNameNodeMXBean {
               return true;
             }
           } catch (Exception e) {
-            Assert.fail("Caught unexpected exception.");
-          }
+                  Assertions.fail("Caught unexpected exception.");
+              }
           return false;
         }
       }, 1000, 60000);
@@ -995,13 +993,12 @@ public class TestNameNodeMXBean {
       Long ecMissingBlocks =
           (Long) mbs.getAttribute(ecBlkGrpStateMBeanName,
               "MissingECBlockGroups");
-      assertEquals("Unexpected total missing blocks!",
-          expectedMissingBlockCount, totalMissingBlocks);
-      assertEquals("Unexpected total missing blocks!",
-          totalMissingBlocks,
-          (replicaMissingBlocks + ecMissingBlocks));
-      assertEquals("Unexpected total ec missing blocks!",
-          expectedMissingBlockCount, ecMissingBlocks.longValue());
+      assertEquals(expectedMissingBlockCount, totalMissingBlocks,
+          "Unexpected total missing blocks!");
+      assertEquals(totalMissingBlocks, (replicaMissingBlocks + ecMissingBlocks),
+          "Unexpected total missing blocks!");
+      assertEquals(expectedMissingBlockCount, ecMissingBlocks.longValue(),
+          "Unexpected total ec missing blocks!");
 
       // Verification of corrupt blocks
       long totalCorruptBlocks =
@@ -1012,13 +1009,12 @@ public class TestNameNodeMXBean {
       Long ecCorruptBlocks =
           (Long) mbs.getAttribute(ecBlkGrpStateMBeanName,
               "CorruptECBlockGroups");
-      assertEquals("Unexpected total corrupt blocks!",
-          expectedCorruptBlockCount, totalCorruptBlocks);
-      assertEquals("Unexpected total corrupt blocks!",
-          totalCorruptBlocks,
-          (replicaCorruptBlocks + ecCorruptBlocks));
-      assertEquals("Unexpected total ec corrupt blocks!",
-          expectedCorruptBlockCount, ecCorruptBlocks.longValue());
+      assertEquals(expectedCorruptBlockCount, totalCorruptBlocks,
+          "Unexpected total corrupt blocks!");
+      assertEquals(totalCorruptBlocks, (replicaCorruptBlocks + ecCorruptBlocks),
+          "Unexpected total corrupt blocks!");
+      assertEquals(expectedCorruptBlockCount, ecCorruptBlocks.longValue(),
+          "Unexpected total ec corrupt blocks!");
 
       String corruptFiles = (String) (mbs.getAttribute(namenodeMXBeanName,
           "CorruptFiles"));
@@ -1056,7 +1052,7 @@ public class TestNameNodeMXBean {
       int blockSize = stripesPerBlock * cellSize;
       conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
 
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot())
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile())
           .nnTopology(MiniDFSNNTopology.simpleHAFederatedTopology(1)).
               numDataNodes(totalSize).build();
       cluster.waitActive();
@@ -1147,7 +1143,7 @@ public class TestNameNodeMXBean {
     hostsFileWriter.initialize(conf, "temp/TestNameNodeMXBean");
 
     try {
-      cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot()).numDataNodes(3).build();
+      cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile()).numDataNodes(3).build();
       cluster.waitActive();
 
       FSNamesystem fsn = cluster.getNameNode().namesystem;
@@ -1201,8 +1197,7 @@ public class TestNameNodeMXBean {
       throws Exception {
     long expectedTotalBlocks = expectedTotalReplicatedBlocks
         + expectedTotalECBlockGroups;
-    assertEquals("Unexpected total blocks!", expectedTotalBlocks,
-        actualTotalBlocks);
+    assertEquals(expectedTotalBlocks, actualTotalBlocks, "Unexpected total blocks!");
 
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
     ObjectName replStateMBeanName = new ObjectName(
@@ -1213,10 +1208,10 @@ public class TestNameNodeMXBean {
         "TotalReplicatedBlocks");
     Long totalECBlockGroups = (Long) mbs.getAttribute(ecBlkGrpStateMBeanName,
         "TotalECBlockGroups");
-    assertEquals("Unexpected total replicated blocks!",
-        expectedTotalReplicatedBlocks, totalReplicaBlocks.longValue());
-    assertEquals("Unexpected total ec block groups!",
-        expectedTotalECBlockGroups, totalECBlockGroups.longValue());
+    assertEquals(expectedTotalReplicatedBlocks, totalReplicaBlocks.longValue(),
+        "Unexpected total replicated blocks!");
+    assertEquals(expectedTotalECBlockGroups, totalECBlockGroups.longValue(),
+        "Unexpected total ec block groups!");
     verifyEcClusterSetupVerifyResult(mbs);
   }
 
@@ -1239,8 +1234,8 @@ public class TestNameNodeMXBean {
     Boolean isSupported = Boolean.parseBoolean(resultMap.get("isSupported"));
     String resultMessage = resultMap.get("resultMessage");
 
-    assertFalse("Test cluster does not support all enabled " +
-        "erasure coding policies.", isSupported);
+    assertFalse(isSupported,
+        "Test cluster does not support all enabled " + "erasure coding policies.");
     assertTrue(resultMessage.contains("3 racks are required for " +
         "the erasure coding policies: RS-6-3-1024k. " +
         "The number of racks is only 1."));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMetricsLogger.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeMetricsLogger.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import java.util.function.Supplier;
 import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -29,9 +30,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.AsyncAppender;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -39,18 +38,16 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
  * Test periodic logging of NameNode metrics.
  */
+@Timeout(300)
 public class TestNameNodeMetricsLogger {
   static final Logger LOG =
       LoggerFactory.getLogger(TestNameNodeMetricsLogger.class);
-
-  @Rule
-  public Timeout timeout = new Timeout(300000);
 
   @Test
   public void testMetricsLoggerOnByDefault() throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNamenodeCapacityReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNamenodeCapacityReport.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.namenode;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,8 +45,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.datanode.FsDatasetTestUtils;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -425,7 +424,7 @@ public class TestNamenodeCapacityReport {
     assertEquals(expectedTotalLoad, namesystem.getTotalLoad(), EPSILON);
     if (expectedInServiceNodes != 0) {
       assertEquals(expectedInServiceLoad / expectedInServiceNodes,
-        getInServiceXceiverAverage(namesystem), EPSILON);
+          getInServiceXceiverAverage(namesystem), EPSILON);
     } else {
       assertEquals(0.0, getInServiceXceiverAverage(namesystem), EPSILON);
     }


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part12.

### How was this patch tested?
Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

