### PR TITLE
HADOOP-19651. Upgrade libopenssl to 3.5.2-1 needed for rsync

### DIFF
--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -74,11 +74,11 @@ RUN powershell Invoke-WebRequest -Uri https://github.com/facebook/zstd/releases/
 RUN powershell Expand-Archive -Path $Env:TEMP\zstd-v1.5.4-win64.zip -DestinationPath "C:\ZStd"
 RUN setx PATH "%PATH%;C:\ZStd"
 
-# Install libopenssl 3.1.4 needed for rsync 3.2.7.
-RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.1.4-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.1.4-1-x86_64.pkg.tar.zst
-RUN powershell zstd -d $Env:TEMP\libopenssl-3.1.4-1-x86_64.pkg.tar.zst -o $Env:TEMP\libopenssl-3.1.4-1-x86_64.pkg.tar
+# Install libopenssl 3.5.2-1 needed for rsync 3.2.7.
+RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.5.2-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.5.2-1-x86_64.pkg.tar.zst
+RUN powershell zstd -d $Env:TEMP\libopenssl-3.5.2-1-x86_64.pkg.tar.zst -o $Env:TEMP\libopenssl-3.5.2-1-x86_64.pkg.tar
 RUN powershell mkdir "C:\LibOpenSSL"
-RUN powershell tar -xvf $Env:TEMP\libopenssl-3.1.4-1-x86_64.pkg.tar -C "C:\LibOpenSSL"
+RUN powershell tar -xvf $Env:TEMP\libopenssl-3.5.2-1-x86_64.pkg.tar -C "C:\LibOpenSSL"
 
 # Install libxxhash 0.8.3 needed for rsync 3.2.7.
 RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libxxhash-0.8.3-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libxxhash-0.8.3-1-x86_64.pkg.tar.zst


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

The currently used `libopenssl-3.1.4-1` is no longer available on the msys repo - https://repo.msys2.org/msys/x86_64/libopenssl-3.1.4-1-x86_64.pkg.tar.zst

The Jenkins CI thus fails to download the same and thus it fails to build the docker image for Windows.

```
00:25:33 SUCCESS: Specified value was saved.
00:25:46 Removing intermediate container 5ce7355571a1
00:25:46 ---> a13a4bc69545
00:25:46 Step 21/78 : RUN powershell Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl-3.1.4-1-x86_64.pkg.tar.zst -OutFile $Env:TEMP\libopenssl-3.1.4-1-x86_64.pkg.tar.zst
00:25:46 ---> Running in d2dafad446f9
00:25:54 [91mInvoke-WebRequest : The remote server returned an error: (404) Not Found.
00:25:54 [0m[91mAt line:1 char:1
00:25:54 [0m[91m+ Invoke-WebRequest -Uri https://repo.msys2.org/msys/x86_64/libopenssl- ...
00:25:54 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
00:25:54 [0m[91m + CategoryInfo : InvalidOperation: (System.Net.HttpWebRequest:Htt
```

Thus, we need to upgrade to the latest available version to address this.

### How was this patch tested?

Jenkins CI - In progress.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

