### PR TITLE
HADOOP-19343: Include hadoop-gcp in distro.

### DIFF
--- a/hadoop-tools/hadoop-gcp/pom.xml
+++ b/hadoop-tools/hadoop-gcp/pom.xml
@@ -351,7 +351,6 @@
                   </shadedPattern>
                 </relocation>
               </relocations>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-tools/hadoop-tools-dist/pom.xml
+++ b/hadoop-tools/hadoop-tools-dist/pom.xml
@@ -139,6 +139,12 @@
       <scope>compile</scope>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-gcp</artifactId>
+      <scope>compile</scope>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Description of PR

Include hadoop-gcp in hadoop-tools-dist, so that it makes it into the final release tarball.

### How was this patch tested?

```
mvn -Pdist -Dtar -DskipTests clean package

tar tf hadoop-dist/target/hadoop-3.5.0-SNAPSHOT.tar.gz hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/hadoop-gcp-3.5.0-SNAPSHOT.jar
hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/hadoop-gcp-3.5.0-SNAPSHOT.jar
```

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
