### PR TITLE
HADOOP-19653. [JDK25] Bump ByteBuddy 1.17.6 and ASM 9.8 to support Java 25 bytecode

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -146,7 +146,7 @@
     <netty4.version>4.1.118.Final</netty4.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <lz4-java.version>1.7.1</lz4-java.version>
-    <byte-buddy.version>1.15.11</byte-buddy.version>
+    <byte-buddy.version>1.17.6</byte-buddy.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
@@ -2219,6 +2219,22 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
+          <dependencies>
+            <!--
+              TODO: Remove ASM version management once upstream change released
+              https://github.com/apache/maven-shade-plugin/pull/744
+              -->
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>9.8</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-commons</artifactId>
+              <version>9.8</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19653. [JDK25] Bump ByteBuddy 1.17.6 and ASM 9.8 to support Java 25 bytecode.

Java 25 is the next LTS release, GA release is scheduled for 2025/09/16.
https://openjdk.org/projects/jdk/25/

Before making Hadoop fully support Java 25, I'd like to ensure that Hadoop compiles on Java 25 and that Hadoop clients are compatible with Java 25. This will unblock downstream projects like Spark to support Java 25.

```
Caused by: java.lang.IllegalArgumentException: Java 25 (69) is not supported by the current version of Byte Buddy which officially supports Java 24 (68) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:120)
	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:95)
	at net.bytebuddy.utility.AsmClassReader$Factory$Default.make(AsmClassReader.java:82)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:4031)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2246)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4085)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3769)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.transform(InlineBytecodeGenerator.java:401)
	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:257)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:594)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:221)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:280)
	... 19 more

[ERROR] org.apache.hadoop.http.TestHttpServer.testHasAdministratorAccess -- Time elapsed: 0.051 s <<< ERROR!
org.mockito.exceptions.base.MockitoException:

Mockito cannot mock this class: class org.apache.hadoop.security.authorize.AccessControlList.

If you're not sure why you're getting this error, please open an issue on GitHub.


Java               : 25
JVM vendor name    : Oracle Corporation
JVM vendor version : 25-ea+30-3419
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 25-ea+30-3419
JVM info           : mixed mode, sharing
OS name            : Linux
OS version         : 6.12.10-76061203-generic
```

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.6.0:shade (default) on project hadoop-client-minicluster: Error creating shaded jar: Problem shading JAR /home/chengpan/.m2/repository/net/bytebuddy/byte-buddy/1.17.6/byte-buddy-1.17.6.jar entry META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$1.class: java.lang.IllegalArgumentException: Unsupported class file major version 68 -> [Help 1]
```

### How was this patch tested?

```
export JAVA_HOME=/path/of/java-25
mvn clean install -DskipTests
mvn -pl :hadoop-common test
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

