### PR TITLE
HADOOP-19650. [ABFS] Fixing NPE when close() called on uninitialized filesystem

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -148,7 +148,7 @@ public class AzureBlobFileSystem extends FileSystem
   private URI uri;
   private Path workingDir;
   private AzureBlobFileSystemStore abfsStore;
-  private boolean isClosed;
+  private boolean isClosed = true;
   private final String fileSystemId = UUID.randomUUID().toString();
 
   private boolean delegationTokenEnabled = false;
@@ -312,6 +312,7 @@ public class AzureBlobFileSystem extends FileSystem
     }
 
     rateLimiting = RateLimitingFactory.create(abfsConfiguration.getRateLimit());
+    isClosed = false;
     LOG.debug("Initializing AzureBlobFileSystem for {} complete", uri);
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsDriverException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.FileSystemOperationUnhandledException;
@@ -131,6 +132,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.B
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DATA_BLOCKS_BUFFER_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_CREATE_ON_ROOT;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_INVALID_ABFS_STATE;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.UNAUTHORIZED_SAS;
 import static org.apache.hadoop.fs.impl.PathCapabilitiesSupport.validatePathCapabilityArgs;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.logIOStatisticsAtLevel;
@@ -330,8 +332,8 @@ public class AzureBlobFileSystem extends FileSystem
     final StringBuilder sb = new StringBuilder(
         "AzureBlobFileSystem{");
     sb.append("uri=").append(fullPathUri);
-    sb.append(", user='").append(abfsStore.getUser()).append('\'');
-    sb.append(", primaryUserGroup='").append(abfsStore.getPrimaryGroup()).append('\'');
+    sb.append(", user='").append(getAbfsStore().getUser()).append('\'');
+    sb.append(", primaryUserGroup='").append(getAbfsStore().getPrimaryGroup()).append('\'');
     sb.append("[" + CAPABILITY_SAFE_READAHEAD + "]");
     sb.append('}');
     return sb.toString();
@@ -355,7 +357,7 @@ public class AzureBlobFileSystem extends FileSystem
     // bufferSize is unused.
     LOG.debug(
         "AzureBlobFileSystem.open path: {} bufferSize as configured in 'fs.azure.read.request.size': {}",
-        path, abfsStore.getAbfsConfiguration().getReadBufferSize());
+        path, getAbfsStore().getAbfsConfiguration().getReadBufferSize());
     return open(path, Optional.empty());
   }
 
@@ -518,7 +520,7 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.APPEND, tracingHeaderFormat,
           listener);
-      OutputStream outputStream = abfsStore
+      OutputStream outputStream = getAbfsStore()
           .openFileForWrite(qualifiedPath, statistics, false, tracingContext);
       return new FSDataOutputStream(outputStream, statistics);
     } catch (AzureBlobFileSystemException ex) {
@@ -783,7 +785,7 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.MKDIR, false, tracingHeaderFormat,
           listener);
-      abfsStore.createDirectory(qualifiedPath,
+      getAbfsStore().createDirectory(qualifiedPath,
           permission == null ? FsPermission.getDirDefault() : permission,
           FsPermission.getUMask(getConf()), tracingContext);
       statIncrement(DIRECTORIES_CREATED);
@@ -799,7 +801,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (isClosed()) {
       return;
     }
-    if (abfsStore.getClient().isMetricCollectionEnabled()) {
+    if (getAbfsStore().getClient().isMetricCollectionEnabled()) {
       TracingContext tracingMetricContext = new TracingContext(
               clientCorrelationId,
               fileSystemId, FSOperationType.GET_ATTR, true,
@@ -820,7 +822,7 @@ public class AzureBlobFileSystem extends FileSystem
               IOSTATISTICS_LOGGING_LEVEL_DEFAULT);
       logIOStatisticsAtLevel(LOG, iostatisticsLoggingLevel, getIOStatistics());
     }
-    IOUtils.cleanupWithLogger(LOG, abfsStore, delegationTokenManager,
+    IOUtils.cleanupWithLogger(LOG, getAbfsStore(), delegationTokenManager,
         getAbfsClient());
     this.isClosed = true;
     if (LOG.isDebugEnabled()) {
@@ -867,7 +869,7 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.BREAK_LEASE, tracingHeaderFormat,
           listener);
-      abfsStore.breakLease(qualifiedPath, tracingContext);
+      getAbfsStore().breakLease(qualifiedPath, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(f, ex);
     }
@@ -885,6 +887,8 @@ public class AzureBlobFileSystem extends FileSystem
    */
   @Override
   public Path makeQualified(Path path) {
+    // Every API works on qualified paths. If store is null better to fail early.
+    Preconditions.checkState(getAbfsStore() != null);
     // To support format: abfs://{dfs.nameservices}/file/path,
     // path need to be first converted to URI, then get the raw path string,
     // during which {dfs.nameservices} will be omitted.
@@ -918,7 +922,7 @@ public class AzureBlobFileSystem extends FileSystem
   public Path getHomeDirectory() {
     return makeQualified(new Path(
         FileSystemConfigurations.USER_HOME_DIRECTORY_PREFIX
-            + "/" + abfsStore.getUser()));
+            + "/" + getAbfsStore().getUser()));
   }
 
   /**
@@ -940,7 +944,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (file.getLen() < start) {
       return new BlockLocation[0];
     }
-    final String blobLocationHost = abfsStore.getAbfsConfiguration().getAzureBlockLocationHost();
+    final String blobLocationHost = getAbfsStore().getAbfsConfiguration().getAzureBlockLocationHost();
 
     final String[] name = {blobLocationHost};
     final String[] host = {blobLocationHost};
@@ -974,7 +978,7 @@ public class AzureBlobFileSystem extends FileSystem
    * @return the short name of the user who instantiated the FS
    */
   public String getOwnerUser() {
-    return abfsStore.getUser();
+    return getAbfsStore().getUser();
   }
 
   /**
@@ -982,7 +986,7 @@ public class AzureBlobFileSystem extends FileSystem
    * @return primary group name
    */
   public String getOwnerUserPrimaryGroup() {
-    return abfsStore.getPrimaryGroup();
+    return getAbfsStore().getPrimaryGroup();
   }
 
   private boolean deleteRoot() throws IOException {
@@ -1054,7 +1058,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.setOwner(qualifiedPath,
+      getAbfsStore().setOwner(qualifiedPath,
           owner,
           group,
           tracingContext);
@@ -1091,15 +1095,15 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.SET_ATTR, true, tracingHeaderFormat,
           listener);
-      Hashtable<String, String> properties = abfsStore
+      Hashtable<String, String> properties = getAbfsStore()
           .getPathStatus(qualifiedPath, tracingContext);
       String xAttrName = ensureValidAttributeName(name);
       boolean xAttrExists = properties.containsKey(xAttrName);
       XAttrSetFlag.validate(name, xAttrExists, flag);
 
-      String xAttrValue = abfsStore.decodeAttribute(value);
+      String xAttrValue = getAbfsStore().decodeAttribute(value);
       properties.put(xAttrName, xAttrValue);
-      abfsStore.setPathProperties(qualifiedPath, properties, tracingContext);
+      getAbfsStore().setPathProperties(qualifiedPath, properties, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1131,12 +1135,12 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.GET_ATTR, true, tracingHeaderFormat,
           listener);
-      Hashtable<String, String> properties = abfsStore
+      Hashtable<String, String> properties = getAbfsStore()
           .getPathStatus(qualifiedPath, tracingContext);
       String xAttrName = ensureValidAttributeName(name);
       if (properties.containsKey(xAttrName)) {
         String xAttrValue = properties.get(xAttrName);
-        value = abfsStore.encodeAttribute(xAttrValue);
+        value = getAbfsStore().encodeAttribute(xAttrValue);
       }
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
@@ -1174,7 +1178,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.setPermission(qualifiedPath, permission, tracingContext);
+      getAbfsStore().setPermission(qualifiedPath, permission, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1211,7 +1215,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.modifyAclEntries(qualifiedPath, aclSpec, tracingContext);
+      getAbfsStore().modifyAclEntries(qualifiedPath, aclSpec, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1246,7 +1250,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.removeAclEntries(qualifiedPath, aclSpec, tracingContext);
+      getAbfsStore().removeAclEntries(qualifiedPath, aclSpec, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1274,7 +1278,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.removeDefaultAcl(qualifiedPath, tracingContext);
+      getAbfsStore().removeDefaultAcl(qualifiedPath, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1304,7 +1308,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.removeAcl(qualifiedPath, tracingContext);
+      getAbfsStore().removeAcl(qualifiedPath, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1341,7 +1345,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      abfsStore.setAcl(qualifiedPath, aclSpec, tracingContext);
+      getAbfsStore().setAcl(qualifiedPath, aclSpec, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
     }
@@ -1369,7 +1373,7 @@ public class AzureBlobFileSystem extends FileSystem
     Path qualifiedPath = makeQualified(path);
 
     try {
-      return abfsStore.getAclStatus(qualifiedPath, tracingContext);
+      return getAbfsStore().getAclStatus(qualifiedPath, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(path, ex);
       return null;
@@ -1396,7 +1400,7 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.ACCESS, tracingHeaderFormat,
           listener);
-      this.abfsStore.access(qualifiedPath, mode, tracingContext);
+      this.getAbfsStore().access(qualifiedPath, mode, tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkCheckAccessException(path, ex);
     }
@@ -1418,11 +1422,11 @@ public class AzureBlobFileSystem extends FileSystem
   public RemoteIterator<FileStatus> listStatusIterator(Path path)
       throws IOException {
     LOG.debug("AzureBlobFileSystem.listStatusIterator path : {}", path);
-    if (abfsStore.getAbfsConfiguration().enableAbfsListIterator()) {
+    if (getAbfsStore().getAbfsConfiguration().enableAbfsListIterator()) {
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.LISTSTATUS, true, tracingHeaderFormat, listener);
       AbfsListStatusRemoteIterator abfsLsItr =
-          new AbfsListStatusRemoteIterator(path, abfsStore,
+          new AbfsListStatusRemoteIterator(path, getAbfsStore(),
               tracingContext);
       return RemoteIterators.typeCastingRemoteIterator(abfsLsItr);
     } else {
@@ -1504,7 +1508,7 @@ public class AzureBlobFileSystem extends FileSystem
     try {
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.TEST_OP, tracingHeaderFormat, listener);
-      abfsStore.getFilesystemProperties(tracingContext);
+      getAbfsStore().getFilesystemProperties(tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       try {
         checkException(null, ex);
@@ -1523,7 +1527,7 @@ public class AzureBlobFileSystem extends FileSystem
     LOG.debug(
         "AzureBlobFileSystem.createFileSystem uri: {}", uri);
     try {
-      abfsStore.createFilesystem(tracingContext);
+      getAbfsStore().createFilesystem(tracingContext);
     } catch (AzureBlobFileSystemException ex) {
       checkException(null, ex);
     }
@@ -1738,12 +1742,15 @@ public class AzureBlobFileSystem extends FileSystem
 
   @VisibleForTesting
   public AzureBlobFileSystemStore getAbfsStore() {
+    if (abfsStore == null) {
+      throw new IllegalStateException(ERR_INVALID_ABFS_STATE);
+    }
     return abfsStore;
   }
 
   @VisibleForTesting
   AbfsClient getAbfsClient() {
-    return abfsStore.getClient();
+    return getAbfsStore().getClient();
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -149,6 +149,10 @@ public class AzureBlobFileSystem extends FileSystem
   private URI uri;
   private Path workingDir;
   private AzureBlobFileSystemStore abfsStore;
+
+  /**
+   * Flag to indicate whether the file system is closed or not initiated.
+   */
   private boolean isClosed = true;
   private final String fileSystemId = UUID.randomUUID().toString();
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -796,7 +796,7 @@ public class AzureBlobFileSystem extends FileSystem
 
   @Override
   public synchronized void close() throws IOException {
-    if (isClosed) {
+    if (isClosed()) {
       return;
     }
     if (abfsStore.getClient().isMetricCollectionEnabled()) {
@@ -1746,6 +1746,10 @@ public class AzureBlobFileSystem extends FileSystem
     return abfsStore.getClient();
   }
 
+  @VisibleForTesting
+  boolean isClosed() {
+    return isClosed;
+  }
   /**
    * Get any Delegation Token manager created by the filesystem.
    * @return the DT manager or null.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -72,7 +72,6 @@ import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes;
-import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsDriverException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.FileSystemOperationUnhandledException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsErrors.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsErrors.java
@@ -77,5 +77,6 @@ public final class AbfsErrors {
   public static final String ERR_BLOB_LIST_PARSING = "Parsing of XML List Response Failed in BlobClient.";
   public static final String ERR_DFS_LIST_PARSING = "Parsing of Json List Response Failed in DfsClient.";
   public static final String INCORRECT_INGRESS_TYPE = "Ingress Type Cannot be DFS for Blob endpoint configured filesystem.";
+  public static final String ERR_INVALID_ABFS_STATE = "Invalid state for AzureBlobFilesystem. Either Filesystem was closed or not initialized.";
   private AbfsErrors() {}
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.net.URI;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -34,6 +33,7 @@ import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
 import static org.apache.hadoop.fs.CommonPathCapabilities.FS_ACLS;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test AzureBlobFileSystem initialization.
@@ -81,18 +81,18 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
 
     final Path p = new Path("}");
     // etags always present
-    Assertions.assertThat(fs.hasPathCapability(p, ETAGS_AVAILABLE))
+    assertThat(fs.hasPathCapability(p, ETAGS_AVAILABLE))
         .describedAs("path capability %s in %s", ETAGS_AVAILABLE, fs)
         .isTrue();
     // readahead always correct
-    Assertions.assertThat(fs.hasPathCapability(p, CAPABILITY_SAFE_READAHEAD))
+    assertThat(fs.hasPathCapability(p, CAPABILITY_SAFE_READAHEAD))
         .describedAs("path capability %s in %s", CAPABILITY_SAFE_READAHEAD, fs)
         .isTrue();
 
     // etags-over-rename and ACLs are either both true or both false.
     final boolean etagsAcrossRename = fs.hasPathCapability(p, ETAGS_PRESERVED_IN_RENAME);
     final boolean acls = fs.hasPathCapability(p, FS_ACLS);
-    Assertions.assertThat(etagsAcrossRename)
+    assertThat(etagsAcrossRename)
         .describedAs("capabilities %s=%s and %s=%s in %s",
             ETAGS_PRESERVED_IN_RENAME, etagsAcrossRename,
             FS_ACLS, acls, fs)
@@ -105,6 +105,12 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
    */
   @Test
   public void testABFSCloseWithoutInit() throws Exception {
-    new AzureBlobFileSystem().close();
+    AzureBlobFileSystem fs = new AzureBlobFileSystem();
+    assertThat(fs.isClosed()).isTrue();
+    fs.close();
+    fs.initialize(this.getFileSystem().getUri(), getRawConfiguration());
+    assertThat(fs.isClosed()).isFalse();
+    fs.close();
+    assertThat(fs.isClosed()).isTrue();
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,13 +29,19 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
 import static org.apache.hadoop.fs.CommonPathCapabilities.FS_ACLS;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_INVALID_ABFS_STATE;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -112,5 +121,92 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
     assertThat(fs.isClosed()).isFalse();
     fs.close();
     assertThat(fs.isClosed()).isTrue();
+  }
+
+  /**
+   * Test that the AzureBlobFileSystem throws an exception
+   * when trying to perform an operation without initialization.
+   * @throws Exception if an error occurs
+   */
+  @Test
+  public void testABFSUninitializedFileSystem() throws Exception {
+    AzureBlobFileSystem fs = new AzureBlobFileSystem();
+    assertThat(fs.isClosed()).isTrue();
+    Path testPath = new Path("testPath");
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        fs::toString);
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.open(testPath, ONE_MB));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.create(testPath, FsPermission.getDefault(), false, ONE_MB,
+            fs.getDefaultReplication(testPath), ONE_MB, null));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.createNonRecursive(testPath, FsPermission.getDefault(), false, ONE_MB,
+            fs.getDefaultReplication(testPath), ONE_MB, null));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.append(testPath, ONE_MB, null));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.rename(testPath, testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.delete(testPath, true));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.listStatus(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.mkdirs(testPath, FsPermission.getDefault()));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.getFileStatus(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.breakLease(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.makeQualified(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.setOwner(testPath, "", ""));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.setXAttr(testPath, "xattr", new byte[0],
+            EnumSet.of(XAttrSetFlag.CREATE)));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.getXAttr(testPath, "xattr"));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.setPermission(testPath, FsPermission.getDefault()));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.modifyAclEntries(testPath, new ArrayList<>()));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.removeAclEntries(testPath, new ArrayList<>()));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.removeDefaultAcl(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.removeAcl(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.setAcl(testPath, new ArrayList<>()));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.getAclStatus(testPath));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.access(testPath, FsAction.ALL));
+
+    intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
+        () -> fs.exists(testPath));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.azurebfs;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
 import static org.apache.hadoop.fs.CommonPathCapabilities.FS_ACLS;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_INVALID_ABFS_STATE;
@@ -172,7 +173,7 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
         () -> fs.makeQualified(testPath));
 
     intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
-        () -> fs.setOwner(testPath, "", ""));
+        () -> fs.setOwner(testPath, EMPTY_STRING, EMPTY_STRING));
 
     intercept(IllegalStateException.class, ERR_INVALID_ABFS_STATE,
         () -> fs.setXAttr(testPath, "xattr", new byte[0],

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -98,4 +98,13 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
             FS_ACLS, acls, fs)
         .isEqualTo(acls);
   }
+
+  /**
+   * Test that the AzureBlobFileSystem close without init works
+   * @throws Exception if an error occurs
+   */
+  @Test
+  public void testABFSCloseWithoutInit() throws Exception {
+    new AzureBlobFileSystem().close();
+  }
 }


### PR DESCRIPTION
### Description of PR
AzureBlobFileSystem.close() throws NPE when called before initialize().
Before initialize, store is null.

Fix is to avoid calling any stor method before initialize is complete.

### How was this patch tested?
New test added and existing tests were run.