### PR TITLE
HADOOP-19343: Manage hadoop-gcp Guava version directly in its pom.xml.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -108,7 +108,7 @@
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.6.1</dnsjava.version>
 
-    <guava.version>33.1.0-jre</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 
     <bouncycastle.version>1.78.1</bouncycastle.version>

--- a/hadoop-tools/hadoop-gcp/pom.xml
+++ b/hadoop-tools/hadoop-gcp/pom.xml
@@ -428,6 +428,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.1.0-jre</version>
+      </dependency>
+      <dependency>
         <!--
         We're using a specific Protobuf version to ensure compatibility with the
         Google Cloud Storage (GCS) client. The GCS client often relies on
@@ -456,6 +461,11 @@
         <exclusion>
           <groupId>javax.enterprise</groupId>
           <artifactId>cdi-api</artifactId>
+        </exclusion>
+        <!-- Exclude guava 27.0-jre -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
         <!-- Exclude protobuf-java 2.5.0 -->
         <exclusion>


### PR DESCRIPTION
### Description of PR

Instead of upgrading the Guava version for the whole project, manage the version specifically needed just in hadoop-gcp due to its GCS SDK dependencies.

### How was this patch tested?

Full build with all GCS integration tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

