### PR TITLE
HDFS-17680. Fix redirect for https Datanode server

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -164,7 +164,7 @@ public class DatanodeHttpServer implements Closeable {
                 }
                 p.addLast(
                     new ChunkedWriteHandler(),
-                    new URLDispatcher(jettyAddr, conf, confForCreate));
+                    new URLDispatcher(jettyAddr, conf, confForCreate, false));
               }
             });
 
@@ -222,7 +222,7 @@ public class DatanodeHttpServer implements Closeable {
               }
               p.addLast(
                   new ChunkedWriteHandler(),
-                  new URLDispatcher(jettyAddr, conf, confForCreate));
+                  new URLDispatcher(jettyAddr, conf, confForCreate, true));
             }
           });
     } else {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/SimpleHttpProxyHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/SimpleHttpProxyHandler.java
@@ -33,8 +33,12 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+
 import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
@@ -48,17 +52,26 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
  * inside the context, assuming that the remote peer is reasonable fast and
  * the response is small. The upper layer should be filtering out malicious
  * inputs.
+ *
+ * Constructs an internal netty server to proxy the HttpRequest to 'host',
+ * and forward the response back via the inbound channel.
  */
 class SimpleHttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
   private String uri;
   private Channel proxiedChannel;
   private final InetSocketAddress host;
+  private final boolean isSecure;
   static final Logger LOG = DatanodeHttpServer.LOG;
 
-  SimpleHttpProxyHandler(InetSocketAddress host) {
+  SimpleHttpProxyHandler(InetSocketAddress host, boolean isSecure) {
     this.host = host;
+    this.isSecure = isSecure;
   }
 
+  /**
+   * Accepts the inbound response from the proxied server and forwards it
+   * to the 'client' channel.
+   */
   private static class Forwarder extends ChannelInboundHandlerAdapter {
     private final String uri;
     private final Channel client;
@@ -95,6 +108,36 @@ class SimpleHttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
     }
   }
 
+  /**
+   * SSL redirect rewriter to adapt HTTP redirects to HTTPS. In the context
+   * SimpleHttpProxyHandler is used, 'host' is always an HTTP server; if it
+   * performs a redirect, it will redirect to an HTTP URL (HDFS-17680), which
+   * will fail if the external server is configured to use HTTPS.
+   *
+   * This handler rewrites the Location header of an HttpResponse to use HTTPS
+   * instead of HTTP, so that the client can follow the redirect.
+   */
+  private static final class SslRedirectRewriter extends ChannelInboundHandlerAdapter {
+    private SslRedirectRewriter() { }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, Object message) {
+      if (!(message instanceof HttpResponse)) {
+        ctx.fireChannelRead(message);
+        return;
+      }
+
+      HttpResponse response = (HttpResponse) message;
+      String location = response.headers().get(HttpHeaderNames.LOCATION);
+      if (location != null && location.startsWith("http://")) {
+        LOG.debug("Rewriting Location header from http to https: {}", location);
+        location = location.replaceFirst("http://", "https://");
+        response.headers().set(HttpHeaderNames.LOCATION, location);
+      }
+      ctx.fireChannelRead(response);
+    }
+  }
+
   @Override
   public void channelRead0
     (final ChannelHandlerContext ctx, final HttpRequest req) {
@@ -107,7 +150,17 @@ class SimpleHttpProxyHandler extends SimpleChannelInboundHandler<HttpRequest> {
         @Override
         protected void initChannel(SocketChannel ch) throws Exception {
           ChannelPipeline p = ch.pipeline();
-          p.addLast(new HttpRequestEncoder(), new Forwarder(uri, client));
+          p.addLast(new HttpRequestEncoder());
+          if (isSecure) {
+            LOG.debug("Proxying secure request {} to {}", uri, host);
+            // Decode the proxy response and - if it's a redirect - rewrite the
+            // Location header to use https instead of http.
+            p.addLast(new HttpResponseDecoder(), new SslRedirectRewriter());
+            // The client (proxy) channel now needs to re-encode the response
+            // from Forwarder before sending it.
+            client.pipeline().addFirst(new HttpResponseEncoder());
+          }
+          p.addLast(new Forwarder(uri, client));
         }
       });
     ChannelFuture f = proxiedServer.connect(host);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/URLDispatcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/URLDispatcher.java
@@ -32,12 +32,14 @@ class URLDispatcher extends SimpleChannelInboundHandler<HttpRequest> {
   private final InetSocketAddress proxyHost;
   private final Configuration conf;
   private final Configuration confForCreate;
+  private final boolean isSecure;
 
   URLDispatcher(InetSocketAddress proxyHost, Configuration conf,
-                Configuration confForCreate) {
+                Configuration confForCreate, boolean isSecure) {
     this.proxyHost = proxyHost;
     this.conf = conf;
     this.confForCreate = confForCreate;
+    this.isSecure = isSecure;
   }
 
   @Override
@@ -50,7 +52,7 @@ class URLDispatcher extends SimpleChannelInboundHandler<HttpRequest> {
       p.replace(this, WebHdfsHandler.class.getSimpleName(), h);
       h.channelRead0(ctx, req);
     } else {
-      SimpleHttpProxyHandler h = new SimpleHttpProxyHandler(proxyHost);
+      SimpleHttpProxyHandler h = new SimpleHttpProxyHandler(proxyHost, isSecure);
       p.replace(this, SimpleHttpProxyHandler.class.getSimpleName(), h);
       h.channelRead0(ctx, req);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpServer.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs.server.datanode.web;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
+import org.apache.hadoop.http.HttpConfig;
+import org.apache.hadoop.http.HttpConfig.Policy;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class TestDatanodeHttpServer {
+  private static final String BASEDIR = GenericTestUtils
+      .getTempPath(TestDatanodeHttpServer.class.getSimpleName());
+  private static String keystoresDir;
+  private static String sslConfDir;
+  private static Configuration conf;
+  private static URLConnectionFactory connectionFactory;
+
+  @Parameters
+  public static Collection<Object[]> policy() {
+    Object[][] params = new Object[][] {{HttpConfig.Policy.HTTP_ONLY},
+        {HttpConfig.Policy.HTTPS_ONLY}, {HttpConfig.Policy.HTTP_AND_HTTPS}};
+    return Arrays.asList(params);
+  }
+
+  private final HttpConfig.Policy policy;
+
+  public TestDatanodeHttpServer(Policy policy) {
+    super();
+    this.policy = policy;
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    File base = new File(BASEDIR);
+    FileUtil.fullyDelete(base);
+    base.mkdirs();
+    conf = new Configuration();
+    keystoresDir = new File(BASEDIR).getAbsolutePath();
+    sslConfDir = KeyStoreTestUtil.getClasspathDir(TestDatanodeHttpServer.class);
+    KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
+    connectionFactory = URLConnectionFactory
+        .newDefaultURLConnectionFactory(conf);
+    conf.set(DFSConfigKeys.DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY,
+        KeyStoreTestUtil.getClientSSLConfigFileName());
+    conf.set(DFSConfigKeys.DFS_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
+        KeyStoreTestUtil.getServerSSLConfigFileName());
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    FileUtil.fullyDelete(new File(BASEDIR));
+    KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
+  }
+
+  @Test
+  public void testHttpPolicy() throws Exception {
+    conf.set(DFSConfigKeys.DFS_HTTP_POLICY_KEY, policy.name());
+    conf.set(DFSConfigKeys.DFS_DATANODE_HTTP_ADDRESS_KEY, "localhost:0");
+    conf.set(DFSConfigKeys.DFS_DATANODE_HTTPS_ADDRESS_KEY, "localhost:0");
+
+    DatanodeHttpServer server = null;
+    try {
+      server = new DatanodeHttpServer(conf, null, null);
+      server.start();
+
+      Assert.assertTrue(implies(policy.isHttpEnabled(),
+          canAccess("http", server.getHttpAddress())));
+      Assert.assertTrue(implies(!policy.isHttpEnabled(),
+          server.getHttpAddress() == null));
+
+      Assert.assertTrue(implies(policy.isHttpsEnabled(),
+          canAccess("https", server.getHttpsAddress())));
+      Assert.assertTrue(implies(!policy.isHttpsEnabled(),
+          server.getHttpsAddress() == null));
+
+    } finally {
+      if (server != null) {
+        server.close();
+      }
+    }
+  }
+
+  private static boolean canAccess(String scheme, InetSocketAddress addr) {
+    if (addr == null) {
+      return false;
+    }
+    try {
+      URL url = new URL(scheme + "://" + NetUtils.getHostPortString(addr));
+      URLConnection conn = connectionFactory.openConnection(url);
+      conn.connect();
+      Assert.assertTrue(conn instanceof java.net.HttpURLConnection);
+      java.net.HttpURLConnection httpConn = (java.net.HttpURLConnection) conn;
+      if (httpConn.getResponseCode() != 200) {
+        return false;
+      }
+
+      StringBuilder builder = new StringBuilder();
+      InputStreamReader responseReader = new InputStreamReader((conn.getInputStream()));
+      try (BufferedReader reader = new BufferedReader(responseReader)) {
+        String output;
+        while ((output = reader.readLine()) != null) {
+          builder.append(output);
+        }
+      }
+      return builder.toString().contains("Hadoop Administration");
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean implies(boolean a, boolean b) {
+    return !a || b;
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

When the DatanodeHttpServer is configured with TLS and recieves a request at '/', WebServlet redirects to '/index.html'. However the infoServer does not know the scheme and creates a redirect to an 'http' address. If only TLS is configured, this causes the redirect to fail, and breaks links from the NameNode UI.

Adds handlers to the HTTPS Netty server to rewrite the Location header if present to use 'https' so that the redirect works correctly.

Alternatives considered
- Add an HTTPS endpoint to infoServer. This fails because then it tries to decrypt the request and fails; I see no way to skip this.
- Move redirect handling into the Netty server. This would duplicate WebServlet logic and be more fragile as it could miss other redirects.

### How was this patch tested?

Manual testing of the DataNode UI at '/' and '/index.html'.

Unit test for DatanodeHttpServer added. Before this fix, the HTTPS response would be 302 because URLConnection does not follow redirects that change scheme.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

