### PR TITLE
YARN-11824: Prevent test dependencies from leaking into the distro.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/pom.xml
@@ -171,6 +171,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
@@ -172,6 +172,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/pom.xml
@@ -279,6 +279,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/pom.xml
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-jetty</artifactId>
-      <scope>compile</scope>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <artifactId>jakarta.servlet-api</artifactId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/pom.xml
@@ -153,12 +153,6 @@
       <artifactId>hadoop-yarn-server-common</artifactId>
     </dependency>
 
-    <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->
-    <dependency>
-      <groupId>org.glassfish.jersey.test-framework</groupId>
-      <artifactId>jersey-test-framework-core</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
### Description of PR

First, make sure test libraries like jersey-test-framework-provider-jetty are limited to scope test.

Then, update other modules that didn't know they were getting their test dependencies through YARN to depend on test libraries explicitly.

### How was this patch tested?

I used `mvn dependency:tree` to check that the test dependencies were gone after these changes. Before the changes, we had this in the final distro after `mvn clean package -Pdist -Dtar -DskipTests -DskipShade`:

```
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/mapreduce/lib/mockito-junit-jupiter-4.11.0.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/yarn/lib/junit-jupiter-5.11.0.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-4.13.2.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-jupiter-engine-5.13.3.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-platform-commons-1.13.3.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-platform-engine-1.13.3.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-jupiter-params-5.13.3.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/junit-jupiter-api-5.13.3.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/yarn/lib/hamcrest-3.0.jar
/tmp/distro/hadoop-3.5.0-SNAPSHOT/share/hadoop/tools/lib/hamcrest-core-1.3.jar
```

After these changes, everything is gone except for the stuff in `hadoop/tools/lib`. This is apparently intentional dependencies of `hadoop-tools/hadoop-compat-bench`, but it won't creep into the classpath for dependent projects like Parquet.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

