### PR TITLE
HADOOP-19212. Hadoop UGI compatible with Java 25

### DIFF
--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
@@ -19,6 +19,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.security.authentication.server.HttpConstants;
 import org.apache.hadoop.security.authentication.util.AuthToken;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.hadoop.util.SubjectUtil;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
@@ -35,8 +36,6 @@ import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
@@ -300,8 +299,7 @@ public class KerberosAuthenticator implements Authenticator {
   private void doSpnegoSequence(final AuthenticatedURL.Token token)
       throws IOException, AuthenticationException {
     try {
-      AccessControlContext context = AccessController.getContext();
-      Subject subject = Subject.getSubject(context);
+      Subject subject = SubjectUtil.current();
       if (subject == null
           || (!KerberosUtil.hasKerberosKeyTab(subject)
               && !KerberosUtil.hasKerberosTicket(subject))) {

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/client/KerberosAuthenticator.java
@@ -19,7 +19,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.security.authentication.server.HttpConstants;
 import org.apache.hadoop.security.authentication.util.AuthToken;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
-import org.apache.hadoop.util.SubjectUtil;
+import org.apache.hadoop.security.authentication.util.SubjectUtil;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.security.authentication.util;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -223,17 +222,14 @@ public final class SubjectUtil {
       try {
         return callAs(subject, privilegedExceptionActionToCallable(action));
       } catch (CompletionException ce) {
-        try {
-          Exception cause = (Exception) ce.getCause();
-          if (cause instanceof RuntimeException) {
-            throw (RuntimeException) cause;
-          } else {
-            throw new PrivilegedActionException(cause);
-          }
-        } catch (ClassCastException castException) {
-          // This should never happen, as PrivilegedExceptionAction should not wrap
-          // non-checked exceptions
-          throw new PrivilegedActionException(new UndeclaredThrowableException(ce.getCause()));
+        Throwable cause = ce.getCause();
+        if (cause instanceof RuntimeException) {
+          throw (RuntimeException) cause;
+        } else if (cause instanceof Exception) {
+          throw new PrivilegedActionException((Exception) cause);
+        } else {
+          // This should never happen, CompletionException should only wraps an exception
+          throw sneakyThrow(cause);
         }
       }
     } else {

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -139,9 +139,7 @@ public final class SubjectUtil {
   }
 
   /**
-   * Maps to Subject.callAs() if available, otherwise maps to Subject.doAs().
-   * It also wraps the Callable so that the Subject is propagated to the new thread
-   * in all Java versions.
+   * Map to Subject.callAs() if available, otherwise maps to Subject.doAs().
    *
    * @param subject the subject this action runs as
    * @param action  the action to run
@@ -161,19 +159,21 @@ public final class SubjectUtil {
       }
     } else {
       try {
-        return (T) DO_AS.invoke(subject, callableToPrivilegedAction(action));
+        return doAs(subject, callableToPrivilegedAction(action));
       } catch (Exception e) {
         throw new CompletionException(e);
-      } catch (Throwable t) {
-        throw sneakyThrow(t);
       }
     }
   }
 
   /**
-   * Maps action to a Callable, and delegates to callAs(). On older JVMs,
-   * the action may be double wrapped (into Callable, and then back into
-   * PrivilegedAction).
+   * Map action to a Callable on Java 18 onwards, and delegates to callAs().
+   * Call Subject.doAs directly on older JVM.
+   * <p>
+   * Note: Exception propagation behavior is different since Java 12, it always
+   * throw the original exception thrown by action; for lower Java versions,
+   * throw a PrivilegedActionException that wraps the original exception when
+   * action throw a checked exception.
    *
    * @param subject the subject this action runs as
    * @param action action  the action to run
@@ -205,16 +205,16 @@ public final class SubjectUtil {
   }
 
   /**
-   * Maps action to a Callable, and delegates to callAs(). On older JVMs, the
-   * action may be double wrapped (into Callable, and then back into PrivilegedAction).
+   * Maps action to a Callable on Java 18 onwards, and delegates to callAs().
+   * Call Subject.doAs directly on older JVM.
    *
    * @param subject the subject this action runs as
    * @param action action  the action to run
    * @return the result of the action
    * @param <T> the type of the result
-   * @throws PrivilegedActionException if {@code action.run()} throws an exception.
-   *      The cause of the {@code PrivilegedActionException} is set to the exception
-   *      thrown by {@code action.run()}.
+   * @throws PrivilegedActionException if {@code action.run()} throws an checked exception.
+   *      The cause of the {@code PrivilegedActionException} is set to the exception thrown
+   *      by {@code action.run()}.
    */
   @SuppressWarnings("unchecked")
   public static <T> T doAs(
@@ -267,11 +267,6 @@ public final class SubjectUtil {
         throw sneakyThrow(e);
       }
     };
-  }
-
-  private static <T> PrivilegedExceptionAction<T> callableToPrivilegedExceptionAction(
-      Callable<T> callable) {
-    return callable::call;
   }
 
   private static <T> Callable<T> privilegedExceptionActionToCallable(

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -33,7 +33,7 @@ import javax.security.auth.Subject;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 /**
- * An utility class that adapt the Security Manager and APIs related to it for
+ * An utility class that adapts the Security Manager and APIs related to it for
  * JDK 8 and above.
  * <p>
  * In JDK 17, the Security Manager and APIs related to it have been deprecated
@@ -43,6 +43,9 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
  * <p>
  * In JDK 24, the Security Manager has been permanently disabled. See
  * <a href="https://openjdk.org/jeps/486">JEP 486</a> for more information.
+ * <p>
+ * This is derived from Apache Calcite Avatica, which is derived from the Jetty
+ * implementation.
  */
 @Private
 public final class SubjectUtil {

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.util;
+package org.apache.hadoop.security.authentication.util;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -32,44 +32,65 @@ import javax.security.auth.Subject;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 
+/**
+ * An utility class that adapt the Security Manager and APIs related to it for
+ * JDK 8 and above.
+ * <p>
+ * In JDK 17, the Security Manager and APIs related to it have been deprecated
+ * and are subject to removal in a future release. There is no replacement for
+ * the Security Manager. See <a href="https://openjdk.org/jeps/411">JEP 411</a>
+ * for discussion and alternatives.
+ * <p>
+ * In JDK 24, the Security Manager has been permanently disabled. See
+ * <a href="https://openjdk.org/jeps/486">JEP 486</a> for more information.
+ */
 @Private
-public class SubjectUtil {
-  private static MethodHandle CALL_AS;
-  private static MethodHandle CURRENT;
+public final class SubjectUtil {
+  private static final MethodHandle CALL_AS = lookupCallAs();
+  static final boolean HAS_CALL_AS = CALL_AS != null;
+  private static final MethodHandle DO_AS = HAS_CALL_AS ? null : lookupDoAs();
+  private static final MethodHandle DO_AS_THROW_EXCEPTION =
+      HAS_CALL_AS ? null : lookupDoAsThrowException();
+  private static final MethodHandle CURRENT = lookupCurrent();
 
-  static {
+  private static MethodHandle lookupCallAs() {
     MethodHandles.Lookup lookup = MethodHandles.lookup();
     try {
       try {
-        // Subject.doAs() is deprecated for removal and replaced by Subject.callAs().
-        // Lookup first the new API, since for Java versions where both exist, the
-        // new API delegates to the old API (e.g. Java 18, 19 and 20).
-        // Otherwise (e.g. Java 17), lookup the old API.
-        CALL_AS = lookup.findStatic(Subject.class, "callAs",
+        // Subject.callAs() is available since Java 18.
+        return lookup.findStatic(Subject.class, "callAs",
             MethodType.methodType(Object.class, Subject.class, Callable.class));
       } catch (NoSuchMethodException x) {
-        try {
-          // Lookup the old API.
-          MethodType oldSignature = MethodType.methodType(
-              Object.class, Subject.class, PrivilegedExceptionAction.class);
-          MethodHandle doAs = lookup.findStatic(Subject.class, "doAs", oldSignature);
-          // Convert the Callable used in the new API to the PrivilegedAction used
-          // in the old API.
-          MethodType convertSignature = MethodType.methodType(
-              PrivilegedExceptionAction.class, Callable.class);
-          MethodHandle converter = lookup.findStatic(
-              SubjectUtil.class, "callableToPrivilegedExceptionAction", convertSignature);
-          CALL_AS = MethodHandles.filterArguments(doAs, 1, converter);
-        } catch (NoSuchMethodException e) {
-          throw new AssertionError(e);
-        }
+        return null;
       }
     } catch (IllegalAccessException e) {
-      throw new AssertionError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 
-  static {
+  private static MethodHandle lookupDoAs() {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      MethodType signature = MethodType.methodType(
+          Object.class, Subject.class, PrivilegedAction.class);
+      return lookup.findStatic(Subject.class, "doAs", signature);
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static MethodHandle lookupDoAsThrowException() {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      MethodType signature = MethodType.methodType(
+          Object.class, Subject.class, PrivilegedExceptionAction.class);
+      return lookup.findStatic(Subject.class, "doAs", signature);
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static MethodHandle lookupCurrent() {
     MethodHandles.Lookup lookup = MethodHandles.lookup();
     try {
       // Subject.getSubject(AccessControlContext) is deprecated for removal and
@@ -77,14 +98,14 @@ public class SubjectUtil {
       // Lookup first the new API, since for Java versions where both exists, the
       // new API delegates to the old API (e.g. Java 18, 19 and 20).
       // Otherwise (e.g. Java 17), lookup the old API.
-      CURRENT = lookup.findStatic(
+      return lookup.findStatic(
           Subject.class, "current", MethodType.methodType(Subject.class));
     } catch (NoSuchMethodException e) {
       MethodHandle getContext = lookupGetContext();
       MethodHandle getSubject = lookupGetSubject();
-      CURRENT = MethodHandles.filterReturnValue(getContext, getSubject);
+      return MethodHandles.filterReturnValue(getContext, getSubject);
     } catch (IllegalAccessException e) {
-      throw new AssertionError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -96,7 +117,7 @@ public class SubjectUtil {
       return lookup.findStatic(Subject.class,
           "getSubject", MethodType.methodType(Subject.class, contextKlass));
     } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
-      throw new AssertionError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -113,7 +134,7 @@ public class SubjectUtil {
       return lookup.findStatic(
           controllerKlass, "getContext", MethodType.methodType(contextKlass));
     } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
-      throw new AssertionError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -132,18 +153,26 @@ public class SubjectUtil {
    */
   @SuppressWarnings("unchecked")
   public static <T> T callAs(Subject subject, Callable<T> action) throws CompletionException {
-    try {
-      return (T) CALL_AS.invoke(subject, action);
-    } catch (PrivilegedActionException e) {
-      throw new CompletionException(e.getCause());
-    } catch (Throwable t) {
-      throw sneakyThrow(t);
+    if (HAS_CALL_AS) {
+      try {
+        return (T) CALL_AS.invoke(subject, action);
+      } catch (Throwable t) {
+        throw sneakyThrow(t);
+      }
+    } else {
+      try {
+        return (T) DO_AS.invoke(subject, callableToPrivilegedAction(action));
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      } catch (Throwable t) {
+        throw sneakyThrow(t);
+      }
     }
   }
 
   /**
-   * Maps action to a Callable, and delegates to callAs(). On older JVMs, the
-   * action may be double wrapped (into Callable, and then back into
+   * Maps action to a Callable, and delegates to callAs(). On older JVMs,
+   * the action may be double wrapped (into Callable, and then back into
    * PrivilegedAction).
    *
    * @param subject the subject this action runs as
@@ -151,16 +180,26 @@ public class SubjectUtil {
    * @return the result of the action
    * @param <T> the type of the result
    */
+  @SuppressWarnings("unchecked")
   public static <T> T doAs(Subject subject, PrivilegedAction<T> action) {
-    try {
-      return callAs(subject, privilegedActionToCallable(action));
-    } catch (CompletionException ce) {
-      Throwable cause = ce.getCause();
-      if (cause != null) {
-        throw sneakyThrow(cause);
-      } else {
-        // This should never happen, as CompletionException should always wrap an exception
-        throw ce;
+    if (HAS_CALL_AS) {
+      try {
+        return callAs(subject, privilegedActionToCallable(action));
+      } catch (CompletionException ce) {
+        Throwable cause = ce.getCause();
+        if (cause != null) {
+          throw sneakyThrow(cause);
+        } else {
+          // This should never happen, CompletionException thrown by Subject.callAs
+          // should always wrap an exception
+          throw ce;
+        }
+      }
+    } else {
+      try {
+        return (T) DO_AS.invoke(subject, action);
+      } catch (Throwable t) {
+        throw sneakyThrow(t);
       }
     }
   }
@@ -177,18 +216,31 @@ public class SubjectUtil {
    *      The cause of the {@code PrivilegedActionException} is set to the exception
    *      thrown by {@code action.run()}.
    */
+  @SuppressWarnings("unchecked")
   public static <T> T doAs(
       Subject subject, PrivilegedExceptionAction<T> action) throws PrivilegedActionException {
-    try {
-      return callAs(subject, privilegedExceptionActionToCallable(action));
-    } catch (CompletionException ce) {
+    if (HAS_CALL_AS) {
       try {
-        Exception cause = (Exception) ce.getCause();
-        throw new PrivilegedActionException(cause);
-      } catch (ClassCastException castException) {
-        // This should never happen, as PrivilegedExceptionAction should not wrap
-        // non-checked exceptions
-        throw new PrivilegedActionException(new UndeclaredThrowableException(ce.getCause()));
+        return callAs(subject, privilegedExceptionActionToCallable(action));
+      } catch (CompletionException ce) {
+        try {
+          Exception cause = (Exception) ce.getCause();
+          if (cause instanceof RuntimeException) {
+            throw (RuntimeException) cause;
+          } else {
+            throw new PrivilegedActionException(cause);
+          }
+        } catch (ClassCastException castException) {
+          // This should never happen, as PrivilegedExceptionAction should not wrap
+          // non-checked exceptions
+          throw new PrivilegedActionException(new UndeclaredThrowableException(ce.getCause()));
+        }
+      }
+    } else {
+      try {
+        return (T) DO_AS_THROW_EXCEPTION.invoke(subject, action);
+      } catch (Throwable t) {
+        throw sneakyThrow(t);
       }
     }
   }
@@ -206,7 +258,17 @@ public class SubjectUtil {
     }
   }
 
-  @SuppressWarnings("unused")
+  private static <T> PrivilegedAction<T> callableToPrivilegedAction(
+      Callable<T> callable) {
+    return () -> {
+      try {
+        return callable.call();
+      } catch (Exception e) {
+        throw sneakyThrow(e);
+      }
+    };
+  }
+
   private static <T> PrivilegedExceptionAction<T> callableToPrivilegedExceptionAction(
       Callable<T> callable) {
     return callable::call;
@@ -222,8 +284,21 @@ public class SubjectUtil {
     return action::run;
   }
 
+  /**
+   * The sneaky throw concept allows the caller to throw any checked exception without
+   * defining it explicitly in the method signature.
+   * <p>
+   * See <a href="https://www.baeldung.com/java-sneaky-throws">"Sneaky Throws" in Java</a>
+   * for more details.
+   *
+   * @param e the exception that will be thrown.
+   * @return unreachable, the method always throws an exception before returning
+   * @param <E> the thrown exception type, trick the compiler into inferring it as
+   *      a {@code RuntimeException} type.
+   * @throws E the original exception passes by caller
+   */
   @SuppressWarnings("unchecked")
-  private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
+  static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
     throw (E) e;
   }
 

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -24,6 +24,7 @@ import java.lang.invoke.MethodType;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 
@@ -144,12 +145,14 @@ public final class SubjectUtil {
    * @param action  the action to run
    * @return the result of the action
    * @param <T> the type of the result
+   * @throws NullPointerException if action is null
    * @throws CompletionException if {@code action.call()} throws an exception.
    *      The cause of the {@code CompletionException} is set to the exception
    *      thrown by {@code action.call()}.
    */
   @SuppressWarnings("unchecked")
   public static <T> T callAs(Subject subject, Callable<T> action) throws CompletionException {
+    Objects.requireNonNull(action);
     if (HAS_CALL_AS) {
       try {
         return (T) CALL_AS.invoke(subject, action);
@@ -178,9 +181,11 @@ public final class SubjectUtil {
    * @param action the action to run
    * @return the result of the action
    * @param <T> the type of the result
+   * @throws NullPointerException if action is null
    */
   @SuppressWarnings("unchecked")
   public static <T> T doAs(Subject subject, PrivilegedAction<T> action) {
+    Objects.requireNonNull(action);
     if (HAS_CALL_AS) {
       try {
         return callAs(subject, privilegedActionToCallable(action));
@@ -211,6 +216,7 @@ public final class SubjectUtil {
    * @param action the action to run
    * @return the result of the action
    * @param <T> the type of the result
+   * @throws NullPointerException if action is null
    * @throws PrivilegedActionException if {@code action.run()} throws an checked exception.
    *      The cause of the {@code PrivilegedActionException} is set to the exception thrown
    *      by {@code action.run()}.
@@ -218,6 +224,7 @@ public final class SubjectUtil {
   @SuppressWarnings("unchecked")
   public static <T> T doAs(
       Subject subject, PrivilegedExceptionAction<T> action) throws PrivilegedActionException {
+    Objects.requireNonNull(action);
     if (HAS_CALL_AS) {
       try {
         return callAs(subject, privilegedExceptionActionToCallable(action));

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/SubjectUtil.java
@@ -176,7 +176,7 @@ public final class SubjectUtil {
    * action throw a checked exception.
    *
    * @param subject the subject this action runs as
-   * @param action action  the action to run
+   * @param action the action to run
    * @return the result of the action
    * @param <T> the type of the result
    */
@@ -209,7 +209,7 @@ public final class SubjectUtil {
    * Call Subject.doAs directly on older JVM.
    *
    * @param subject the subject this action runs as
-   * @param action action  the action to run
+   * @param action the action to run
    * @return the result of the action
    * @param <T> the type of the result
    * @throws PrivilegedActionException if {@code action.run()} throws an checked exception.

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -155,7 +155,7 @@ public class SubjectUtil {
     try {
       return callAs(subject, privilegedActionToCallable(action));
     } catch (CompletionException ce) {
-      Exception cause = (Exception) (ce.getCause());
+      Throwable cause = ce.getCause();
       if (cause != null) {
         throw sneakyThrow(cause);
       } else {

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -194,8 +194,7 @@ public class SubjectUtil {
   }
 
   /**
-   * Maps to Subject.current() if available, otherwise maps to
-   * Subject.getSubject()
+   * Maps to Subject.current() if available, otherwise maps to Subject.getSubject().
    *
    * @return the current subject
    */
@@ -226,5 +225,8 @@ public class SubjectUtil {
   @SuppressWarnings("unchecked")
   private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
     throw (E) e;
+  }
+
+  private SubjectUtil() {
   }
 }

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
+
+import javax.security.auth.Subject;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+
+@Private
+public class SubjectUtil {
+  private static MethodHandle CALL_AS;
+  private static MethodHandle CURRENT;
+
+  static {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      try {
+        // Subject.doAs() is deprecated for removal and replaced by Subject.callAs().
+        // Lookup first the new API, since for Java versions where both exist, the
+        // new API delegates to the old API (e.g. Java 18, 19 and 20).
+        // Otherwise (e.g. Java 17), lookup the old API.
+        CALL_AS = lookup.findStatic(Subject.class, "callAs",
+            MethodType.methodType(Object.class, Subject.class, Callable.class));
+      } catch (NoSuchMethodException x) {
+        try {
+          // Lookup the old API.
+          MethodType oldSignature = MethodType.methodType(
+              Object.class, Subject.class, PrivilegedExceptionAction.class);
+          MethodHandle doAs = lookup.findStatic(Subject.class, "doAs", oldSignature);
+          // Convert the Callable used in the new API to the PrivilegedAction used
+          // in the old API.
+          MethodType convertSignature = MethodType.methodType(
+              PrivilegedExceptionAction.class, Callable.class);
+          MethodHandle converter = lookup.findStatic(
+              SubjectUtil.class, "callableToPrivilegedExceptionAction", convertSignature);
+          CALL_AS = MethodHandles.filterArguments(doAs, 1, converter);
+        } catch (NoSuchMethodException e) {
+          throw new AssertionError(e);
+        }
+      }
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      // Subject.getSubject(AccessControlContext) is deprecated for removal and
+      // replaced by Subject.current().
+      // Lookup first the new API, since for Java versions where both exists, the
+      // new API delegates to the old API (e.g. Java 18, 19 and 20).
+      // Otherwise (e.g. Java 17), lookup the old API.
+      CURRENT = lookup.findStatic(
+          Subject.class, "current", MethodType.methodType(Subject.class));
+    } catch (NoSuchMethodException e) {
+      MethodHandle getContext = lookupGetContext();
+      MethodHandle getSubject = lookupGetSubject();
+      CURRENT = MethodHandles.filterReturnValue(getContext, getSubject);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static MethodHandle lookupGetSubject() {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      Class<?> contextKlass = ClassLoader.getSystemClassLoader()
+          .loadClass("java.security.AccessControlContext");
+      return lookup.findStatic(Subject.class,
+          "getSubject", MethodType.methodType(Subject.class, contextKlass));
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static MethodHandle lookupGetContext() {
+    try {
+      // Use reflection to work with Java versions that have and don't have
+      // AccessController.
+      Class<?> controllerKlass = ClassLoader.getSystemClassLoader()
+          .loadClass("java.security.AccessController");
+      Class<?> contextKlass = ClassLoader.getSystemClassLoader()
+          .loadClass("java.security.AccessControlContext");
+
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+      return lookup.findStatic(
+          controllerKlass, "getContext", MethodType.methodType(contextKlass));
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Maps to Subject.callAs() if available, otherwise maps to Subject.doAs().
+   * It also wraps the Callable so that the Subject is propagated to the new thread
+   * in all Java versions.
+   *
+   * @param subject the subject this action runs as
+   * @param action  the action to run
+   * @return the result of the action
+   * @param <T> the type of the result
+   * @throws CompletionException
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T callAs(Subject subject, Callable<T> action) throws CompletionException {
+    try {
+      return (T) CALL_AS.invoke(subject, action);
+    } catch (PrivilegedActionException e) {
+      throw new CompletionException(e.getCause());
+    } catch (Throwable t) {
+      throw sneakyThrow(t);
+    }
+  }
+
+  /**
+   * Maps action to a Callable, and delegates to callAs(). On older JVMs, the
+   * action may be double wrapped (into Callable, and then back into
+   * PrivilegedAction).
+   *
+   * @param subject the subject this action runs as
+   * @param action action  the action to run
+   * @return the result of the action
+   */
+  public static <T> T doAs(Subject subject, PrivilegedAction<T> action) {
+    return callAs(subject, privilegedActionToCallable(action));
+  }
+
+  /**
+   * Maps action to a Callable, and delegates to callAs(). On older JVMs, the
+   * action may be double wrapped (into Callable, and then back into
+   * PrivilegedAction).
+   *
+   * @param subject the subject this action runs as
+   * @param action action  the action to run
+   * @return the result of the action
+   */
+  public static <T> T doAs(
+      Subject subject, PrivilegedExceptionAction<T> action) throws PrivilegedActionException {
+    try {
+      return callAs(subject, privilegedExceptionActionToCallable(action));
+    } catch (CompletionException ce) {
+      try {
+        Exception cause = (Exception) (ce.getCause());
+        throw new PrivilegedActionException(cause);
+      } catch (ClassCastException castException) {
+        // This should never happen, as PrivilegedExceptionAction should not wrap
+        // non-checked exceptions
+        throw new PrivilegedActionException(new UndeclaredThrowableException(ce.getCause()));
+      }
+    }
+  }
+
+  /**
+   * Maps to Subject.currect() is available, otherwise maps to
+   * Subject.getSubject()
+   *
+   * @return the current subject
+   */
+  public static Subject current() {
+    try {
+      return (Subject) CURRENT.invoke();
+    } catch (Throwable t) {
+      throw sneakyThrow(t);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static <T> PrivilegedExceptionAction<T> callableToPrivilegedExceptionAction(
+      Callable<T> callable) {
+    return callable::call;
+  }
+
+  private static <T> Callable<T> privilegedExceptionActionToCallable(
+      PrivilegedExceptionAction<T> action) {
+    return action::run;
+  }
+
+  private static <T> Callable<T> privilegedActionToCallable(
+      PrivilegedAction<T> action) {
+    return action::run;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
+    throw (E) e;
+  }
+}

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -126,7 +126,9 @@ public class SubjectUtil {
    * @param action  the action to run
    * @return the result of the action
    * @param <T> the type of the result
-   * @throws CompletionException
+   * @throws CompletionException if {@code action.call()} throws an exception.
+   *      The cause of the {@code CompletionException} is set to the exception
+   *      thrown by {@code action.call()}.
    */
   @SuppressWarnings("unchecked")
   public static <T> T callAs(Subject subject, Callable<T> action) throws CompletionException {
@@ -147,6 +149,7 @@ public class SubjectUtil {
    * @param subject the subject this action runs as
    * @param action action  the action to run
    * @return the result of the action
+   * @param <T> the type of the result
    */
   public static <T> T doAs(Subject subject, PrivilegedAction<T> action) {
     try {
@@ -164,12 +167,15 @@ public class SubjectUtil {
 
   /**
    * Maps action to a Callable, and delegates to callAs(). On older JVMs, the
-   * action may be double wrapped (into Callable, and then back into
-   * PrivilegedAction).
+   * action may be double wrapped (into Callable, and then back into PrivilegedAction).
    *
    * @param subject the subject this action runs as
    * @param action action  the action to run
    * @return the result of the action
+   * @param <T> the type of the result
+   * @throws PrivilegedActionException if {@code action.run()} throws an exception.
+   *      The cause of the {@code PrivilegedActionException} is set to the exception
+   *      thrown by {@code action.run()}.
    */
   public static <T> T doAs(
       Subject subject, PrivilegedExceptionAction<T> action) throws PrivilegedActionException {
@@ -177,7 +183,7 @@ public class SubjectUtil {
       return callAs(subject, privilegedExceptionActionToCallable(action));
     } catch (CompletionException ce) {
       try {
-        Exception cause = (Exception) (ce.getCause());
+        Exception cause = (Exception) ce.getCause();
         throw new PrivilegedActionException(cause);
       } catch (ClassCastException castException) {
         // This should never happen, as PrivilegedExceptionAction should not wrap

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -149,7 +149,17 @@ public class SubjectUtil {
    * @return the result of the action
    */
   public static <T> T doAs(Subject subject, PrivilegedAction<T> action) {
-    return callAs(subject, privilegedActionToCallable(action));
+    try {
+      return callAs(subject, privilegedActionToCallable(action));
+    } catch (CompletionException ce) {
+      Exception cause = (Exception) (ce.getCause());
+      if (cause != null) {
+        throw sneakyThrow(cause);
+      } else {
+        // This should never happen, as CompletionException should always wrap an exception
+        throw ce;
+      }
+    }
   }
 
   /**

--- a/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/util/SubjectUtil.java
@@ -188,7 +188,7 @@ public class SubjectUtil {
   }
 
   /**
-   * Maps to Subject.currect() is available, otherwise maps to
+   * Maps to Subject.current() if available, otherwise maps to
    * Subject.getSubject()
    *
    * @return the current subject

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.authentication.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
+
+public class TestSubjectUtil {
+
+  // "1.8"->8, "9"->9, "10"->10
+  private static final int JAVA_SPEC_VER = Math.max(8, Integer.parseInt(
+      System.getProperty("java.specification.version").split("\\.")[0]));
+
+  @Test
+  void testHasCallAs() {
+    assertEquals(JAVA_SPEC_VER > 17, SubjectUtil.HAS_CALL_AS);
+  }
+
+  @Test
+  void testDoAsPrivilegedActionExceptionPropagation() {
+    // always throw the original exception thrown by action
+    Throwable e = assertThrows(IllegalArgumentException.class, () ->
+      SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
+        @Override
+        public Object run() {
+          RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
+          throw new IllegalArgumentException("Dummy IllegalArgumentException", innerE);
+        }
+      })
+    );
+    assertInstanceOf(IllegalArgumentException.class, e);
+    assertEquals("Dummy IllegalArgumentException", e.getMessage());
+    assertInstanceOf(RuntimeException.class, e.getCause());
+    assertEquals("Inner Dummy RuntimeException", e.getCause().getMessage());
+    assertNull(e.getCause().getCause());
+
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
+          @Override
+          public Object run() {
+            throw new CompletionException("Dummy CompletionException", null);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertEquals("Dummy CompletionException", e.getMessage());
+    assertNull(e.getCause());
+
+    e = assertThrows(LinkageError.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
+          @Override
+          public Object run() {
+            throw new LinkageError("Dummy LinkageError");
+          }
+        })
+    );
+    assertInstanceOf(LinkageError.class, e);
+    assertEquals("Dummy LinkageError", e.getMessage());
+    assertNull(e.getCause());
+  }
+
+  @Test
+  void testDoAsPrivilegedExceptionActionExceptionPropagation() {
+    // throw PrivilegedActionException that wrap the original exception when action throw
+    // a checked exception
+    Throwable e = assertThrows(PrivilegedActionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+          @Override
+          public Object run() throws Exception {
+            RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
+            throw new IOException("Dummy IOException", innerE);
+          }
+        })
+    );
+    assertInstanceOf(PrivilegedActionException.class, e);
+    assertNull(e.getMessage());
+    assertInstanceOf(IOException.class, e.getCause());
+    assertEquals("Dummy IOException", e.getCause().getMessage());
+    assertInstanceOf(RuntimeException.class, e.getCause().getCause());
+    assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
+    assertNull(e.getCause().getCause().getCause());
+
+    // the original exception when action throw a runtime exception
+    e = assertThrows(RuntimeException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+          @Override
+          public Object run() throws Exception {
+            throw new RuntimeException("Dummy RuntimeException");
+          }
+        })
+    );
+    assertInstanceOf(RuntimeException.class, e);
+    assertEquals("Dummy RuntimeException", e.getMessage());
+    assertNull(e.getCause());
+
+    // CompletionException is subclass of RuntimeException, same as above case
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+          @Override
+          public Object run() throws Exception {
+            throw new CompletionException(null);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertNull(e.getMessage());
+    assertNull(e.getCause());
+
+    // wrap a PrivilegedActionException when action throws a PrivilegedActionException, because
+    // PrivilegedActionException is a checked exception
+    e = assertThrows(PrivilegedActionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+          @Override
+          public Object run() throws Exception {
+            throw new PrivilegedActionException(null);
+          }
+        })
+    );
+    assertInstanceOf(PrivilegedActionException.class, e);
+    assertNull(e.getMessage());
+    assertInstanceOf(PrivilegedActionException.class, e.getCause());
+    assertNull(e.getCause().getMessage());
+    assertNull(e.getCause().getCause());
+
+    // throw original error when action throw an error that is not the subclass of Exception
+    e = assertThrows(LinkageError.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+          @Override
+          public Object run() throws Exception {
+            throw new LinkageError("Dummy LinkageError");
+          }
+        })
+    );
+    assertInstanceOf(LinkageError.class, e);
+    assertEquals("Dummy LinkageError", e.getMessage());
+    assertNull(e.getCause());
+  }
+
+  @Test
+  void testCallAsExceptionPropagation() {
+    // throw PrivilegedActionException that wrap the original exception when action throws
+    // an error that is the subclass of Exception. try checked exception
+    Throwable e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+          @Override
+          public Object call() throws Exception {
+            RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
+            throw new IOException("Dummy IOException", innerE);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertEquals("java.io.IOException: Dummy IOException", e.getMessage());
+    assertInstanceOf(IOException.class, e.getCause());
+    assertEquals("Dummy IOException", e.getCause().getMessage());
+    assertInstanceOf(RuntimeException.class, e.getCause().getCause());
+    assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
+    assertNull(e.getCause().getCause().getCause());
+
+    // same as above, try runtime exception
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+          @Override
+          public Object call() throws Exception {
+            throw new RuntimeException("Dummy RuntimeException");
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertEquals("java.lang.RuntimeException: Dummy RuntimeException", e.getMessage());
+    assertInstanceOf(RuntimeException.class, e.getCause());
+    assertEquals("Dummy RuntimeException", e.getCause().getMessage());
+    assertNull(e.getCause().getCause());
+
+    // wrap a CompletionException even the action throws a PrivilegedActionException
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+          @Override
+          public Object call() throws Exception {
+            throw new PrivilegedActionException(null);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertEquals("java.security.PrivilegedActionException", e.getMessage());
+    assertInstanceOf(PrivilegedActionException.class, e.getCause());
+    assertNull(e.getCause().getMessage());
+    assertNull(e.getCause().getCause());
+
+    // throw original error when action throw an error that is not the subclass of Exception
+    e = assertThrows(LinkageError.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+          @Override
+          public Object call() throws Exception {
+            throw new LinkageError("Dummy LinkageError");
+          }
+        })
+    );
+    assertInstanceOf(LinkageError.class, e);
+    assertEquals("Dummy LinkageError", e.getMessage());
+    assertNull(e.getCause());
+  }
+
+  @Test
+  void testSneakyThrow() {
+    IOException e = assertThrows(IOException.class, this::throwCheckedException);
+    assertEquals("Dummy IOException", e.getMessage());
+  }
+
+  // A method that throw a checked exception, but has no exception declaration in signature
+  private void throwCheckedException() {
+    throw SubjectUtil.sneakyThrow(new IOException("Dummy IOException"));
+  }
+}

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
@@ -130,6 +130,11 @@ public class TestSubjectUtil {
     assertInstanceOf(LinkageError.class, e);
     assertEquals("Dummy LinkageError", e.getMessage());
     assertNull(e.getCause());
+
+    // throw NPE when action is NULL
+    assertThrows(NullPointerException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), (PrivilegedAction<Object>) null)
+    );
   }
 
   @Test
@@ -206,6 +211,11 @@ public class TestSubjectUtil {
     assertInstanceOf(LinkageError.class, e);
     assertEquals("Dummy LinkageError", e.getMessage());
     assertNull(e.getCause());
+
+    // throw NPE when action is NULL
+    assertThrows(NullPointerException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), (PrivilegedExceptionAction<Object>) null)
+    );
   }
 
   @Test
@@ -307,6 +317,11 @@ public class TestSubjectUtil {
     assertInstanceOf(LinkageError.class, e);
     assertEquals("Dummy LinkageError", e.getMessage());
     assertNull(e.getCause());
+
+    // throw NPE when action is NULL
+    assertThrows(NullPointerException.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), null)
+    );
   }
 
   @Test

--- a/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
+++ b/hadoop-common-project/hadoop-auth/src/test/java/org/apache/hadoop/security/authentication/util/TestSubjectUtil.java
@@ -42,24 +42,72 @@ public class TestSubjectUtil {
 
   @Test
   void testDoAsPrivilegedActionExceptionPropagation() {
-    // always throw the original exception thrown by action
-    Throwable e = assertThrows(IllegalArgumentException.class, () ->
-      SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
-        @Override
-        public Object run() {
-          RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
-          throw new IllegalArgumentException("Dummy IllegalArgumentException", innerE);
-        }
-      })
+    // in Java 12 onwards, always throw the original exception thrown by action;
+    // in lower Java versions, throw a PrivilegedActionException that wraps the
+    // original exception when action throws a checked exception
+    Throwable e = assertThrows(Exception.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<Object>() {
+          @Override
+          public Object run() {
+            RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
+            throw SubjectUtil.sneakyThrow(new IOException("Dummy IOException", innerE));
+          }
+        })
     );
-    assertInstanceOf(IllegalArgumentException.class, e);
-    assertEquals("Dummy IllegalArgumentException", e.getMessage());
-    assertInstanceOf(RuntimeException.class, e.getCause());
-    assertEquals("Inner Dummy RuntimeException", e.getCause().getMessage());
-    assertNull(e.getCause().getCause());
+    if (JAVA_SPEC_VER > 11) {
+      assertInstanceOf(IOException.class, e);
+      assertEquals("Dummy IOException", e.getMessage());
+      assertInstanceOf(RuntimeException.class, e.getCause());
+      assertEquals("Inner Dummy RuntimeException", e.getCause().getMessage());
+      assertNull(e.getCause().getCause());
+    } else {
+      assertInstanceOf(PrivilegedActionException.class, e);
+      assertNull(e.getMessage());
+      assertInstanceOf(IOException.class, e.getCause());
+      assertEquals("Dummy IOException", e.getCause().getMessage());
+      assertInstanceOf(RuntimeException.class, e.getCause().getCause());
+      assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
+      assertNull(e.getCause().getCause().getCause());
+    }
 
+    // same as above case because PrivilegedActionException is a checked exception
+    e = assertThrows(PrivilegedActionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<Object>() {
+          @Override
+          public Object run() {
+            throw SubjectUtil.sneakyThrow(new PrivilegedActionException(null));
+          }
+        })
+    );
+    if (JAVA_SPEC_VER > 11) {
+      assertInstanceOf(PrivilegedActionException.class, e);
+      assertNull(e.getMessage());
+      assertNull(e.getCause());
+    } else {
+      assertInstanceOf(PrivilegedActionException.class, e);
+      assertNull(e.getMessage());
+      assertInstanceOf(PrivilegedActionException.class, e.getCause());
+      assertNull(e.getCause().getMessage());
+      assertNull(e.getCause().getCause());
+    }
+
+    // throw a PrivilegedActionException that wraps the original exception when action throws
+    // a runtime exception
+    e = assertThrows(RuntimeException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<Object>() {
+          @Override
+          public Object run() {
+            throw new RuntimeException("Dummy RuntimeException");
+          }
+        })
+    );
+    assertInstanceOf(RuntimeException.class, e);
+    assertEquals("Dummy RuntimeException", e.getMessage());
+    assertNull(e.getCause());
+
+    // same as above case because CompletionException is a runtime exception
     e = assertThrows(CompletionException.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<Object>() {
           @Override
           public Object run() {
             throw new CompletionException("Dummy CompletionException", null);
@@ -70,8 +118,9 @@ public class TestSubjectUtil {
     assertEquals("Dummy CompletionException", e.getMessage());
     assertNull(e.getCause());
 
+    // throw the original error when action throws an error
     e = assertThrows(LinkageError.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<>() {
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedAction<Object>() {
           @Override
           public Object run() {
             throw new LinkageError("Dummy LinkageError");
@@ -85,10 +134,10 @@ public class TestSubjectUtil {
 
   @Test
   void testDoAsPrivilegedExceptionActionExceptionPropagation() {
-    // throw PrivilegedActionException that wrap the original exception when action throw
+    // throw PrivilegedActionException that wraps the original exception when action throws
     // a checked exception
     Throwable e = assertThrows(PrivilegedActionException.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<Object>() {
           @Override
           public Object run() throws Exception {
             RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
@@ -104,36 +153,9 @@ public class TestSubjectUtil {
     assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
     assertNull(e.getCause().getCause().getCause());
 
-    // the original exception when action throw a runtime exception
-    e = assertThrows(RuntimeException.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
-          @Override
-          public Object run() throws Exception {
-            throw new RuntimeException("Dummy RuntimeException");
-          }
-        })
-    );
-    assertInstanceOf(RuntimeException.class, e);
-    assertEquals("Dummy RuntimeException", e.getMessage());
-    assertNull(e.getCause());
-
-    // CompletionException is subclass of RuntimeException, same as above case
-    e = assertThrows(CompletionException.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
-          @Override
-          public Object run() throws Exception {
-            throw new CompletionException(null);
-          }
-        })
-    );
-    assertInstanceOf(CompletionException.class, e);
-    assertNull(e.getMessage());
-    assertNull(e.getCause());
-
-    // wrap a PrivilegedActionException when action throws a PrivilegedActionException, because
-    // PrivilegedActionException is a checked exception
+    // same as above because PrivilegedActionException is a checked exception
     e = assertThrows(PrivilegedActionException.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<Object>() {
           @Override
           public Object run() throws Exception {
             throw new PrivilegedActionException(null);
@@ -146,9 +168,35 @@ public class TestSubjectUtil {
     assertNull(e.getCause().getMessage());
     assertNull(e.getCause().getCause());
 
-    // throw original error when action throw an error that is not the subclass of Exception
+    // throw the original exception when action throw a runtime exception
+    e = assertThrows(RuntimeException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<Object>() {
+          @Override
+          public Object run() throws Exception {
+            throw new RuntimeException("Dummy RuntimeException");
+          }
+        })
+    );
+    assertInstanceOf(RuntimeException.class, e);
+    assertEquals("Dummy RuntimeException", e.getMessage());
+    assertNull(e.getCause());
+
+    // same as above case because CompletionException is a runtime exception
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<Object>() {
+          @Override
+          public Object run() throws Exception {
+            throw new CompletionException(null);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    assertNull(e.getMessage());
+    assertNull(e.getCause());
+
+    // throw the original error when action throw an error
     e = assertThrows(LinkageError.class, () ->
-        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<>() {
+        SubjectUtil.doAs(SubjectUtil.current(), new PrivilegedExceptionAction<Object>() {
           @Override
           public Object run() throws Exception {
             throw new LinkageError("Dummy LinkageError");
@@ -162,10 +210,10 @@ public class TestSubjectUtil {
 
   @Test
   void testCallAsExceptionPropagation() {
-    // throw PrivilegedActionException that wrap the original exception when action throws
-    // an error that is the subclass of Exception. try checked exception
+    // always throw a CompletionException that wraps the original exception, when action throw
+    // a checked or runtime exception
     Throwable e = assertThrows(CompletionException.class, () ->
-        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<Object>() {
           @Override
           public Object call() throws Exception {
             RuntimeException innerE = new RuntimeException("Inner Dummy RuntimeException");
@@ -174,16 +222,54 @@ public class TestSubjectUtil {
         })
     );
     assertInstanceOf(CompletionException.class, e);
-    assertEquals("java.io.IOException: Dummy IOException", e.getMessage());
-    assertInstanceOf(IOException.class, e.getCause());
-    assertEquals("Dummy IOException", e.getCause().getMessage());
-    assertInstanceOf(RuntimeException.class, e.getCause().getCause());
-    assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
-    assertNull(e.getCause().getCause().getCause());
+    if (JAVA_SPEC_VER > 11) {
+      assertEquals("java.io.IOException: Dummy IOException", e.getMessage());
+      assertInstanceOf(IOException.class, e.getCause());
+      assertEquals("Dummy IOException", e.getCause().getMessage());
+      assertInstanceOf(RuntimeException.class, e.getCause().getCause());
+      assertEquals("Inner Dummy RuntimeException", e.getCause().getCause().getMessage());
+      assertNull(e.getCause().getCause().getCause());
+    } else {
+      assertEquals(
+          "java.security.PrivilegedActionException: java.io.IOException: Dummy IOException",
+          e.getMessage());
+      assertInstanceOf(PrivilegedActionException.class, e.getCause());
+      assertNull(e.getCause().getMessage());
+      assertInstanceOf(IOException.class, e.getCause().getCause());
+      assertEquals("Dummy IOException", e.getCause().getCause().getMessage());
+      assertInstanceOf(RuntimeException.class, e.getCause().getCause().getCause());
+      assertEquals("Inner Dummy RuntimeException",
+          e.getCause().getCause().getCause().getMessage());
+      assertNull(e.getCause().getCause().getCause().getCause());
+    }
 
-    // same as above, try runtime exception
     e = assertThrows(CompletionException.class, () ->
-        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<Object>() {
+          @Override
+          public Object call() throws Exception {
+            throw new PrivilegedActionException(null);
+          }
+        })
+    );
+    assertInstanceOf(CompletionException.class, e);
+    if (JAVA_SPEC_VER > 11) {
+      assertEquals("java.security.PrivilegedActionException", e.getMessage());
+      assertInstanceOf(PrivilegedActionException.class, e.getCause());
+      assertNull(e.getCause().getMessage());
+      assertNull(e.getCause().getCause());
+    } else {
+      assertEquals(
+          "java.security.PrivilegedActionException: java.security.PrivilegedActionException",
+          e.getMessage());
+      assertInstanceOf(PrivilegedActionException.class, e.getCause());
+      assertNull(e.getCause().getMessage());
+      assertInstanceOf(PrivilegedActionException.class, e.getCause().getCause());
+      assertNull(e.getCause().getCause().getMessage());
+      assertNull(e.getCause().getCause().getCause());
+    }
+
+    e = assertThrows(CompletionException.class, () ->
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<Object>() {
           @Override
           public Object call() throws Exception {
             throw new RuntimeException("Dummy RuntimeException");
@@ -196,24 +282,22 @@ public class TestSubjectUtil {
     assertEquals("Dummy RuntimeException", e.getCause().getMessage());
     assertNull(e.getCause().getCause());
 
-    // wrap a CompletionException even the action throws a PrivilegedActionException
     e = assertThrows(CompletionException.class, () ->
-        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<Object>() {
           @Override
           public Object call() throws Exception {
-            throw new PrivilegedActionException(null);
+            throw new CompletionException(null);
           }
         })
     );
     assertInstanceOf(CompletionException.class, e);
-    assertEquals("java.security.PrivilegedActionException", e.getMessage());
-    assertInstanceOf(PrivilegedActionException.class, e.getCause());
+    assertEquals("java.util.concurrent.CompletionException", e.getMessage());
+    assertInstanceOf(CompletionException.class, e.getCause());
     assertNull(e.getCause().getMessage());
-    assertNull(e.getCause().getCause());
 
-    // throw original error when action throw an error that is not the subclass of Exception
+    // throw original error when action throw an error
     e = assertThrows(LinkageError.class, () ->
-        SubjectUtil.callAs(SubjectUtil.current(), new Callable<>() {
+        SubjectUtil.callAs(SubjectUtil.current(), new Callable<Object>() {
           @Override
           public Object call() throws Exception {
             throw new LinkageError("Dummy LinkageError");

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -83,11 +83,11 @@ import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.security.SaslRpcServer.AuthMethod;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.apache.hadoop.security.authentication.util.SubjectUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.SubjectUtil;
 import org.apache.hadoop.util.Time;
 
 import org.slf4j.Logger;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -89,6 +87,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.SubjectUtil;
 import org.apache.hadoop.util.Time;
 
 import org.slf4j.Logger;
@@ -585,8 +584,7 @@ public class UserGroupInformation {
   @InterfaceStability.Evolving
   public static UserGroupInformation getCurrentUser() throws IOException {
     ensureInitialized();
-    AccessControlContext context = AccessController.getContext();
-    Subject subject = Subject.getSubject(context);
+    Subject subject = SubjectUtil.current();
     if (subject == null || subject.getPrincipals(User.class).isEmpty()) {
       return getLoginUser();
     } else {
@@ -1936,9 +1934,9 @@ public class UserGroupInformation {
   @InterfaceStability.Evolving
   public <T> T doAs(PrivilegedAction<T> action) {
     tracePrivilegedAction(action);
-    return Subject.doAs(subject, action);
+    return SubjectUtil.doAs(subject, action);
   }
-  
+
   /**
    * Run the given action as the user, potentially throwing an exception.
    * @param <T> the return type of the run method
@@ -1956,7 +1954,7 @@ public class UserGroupInformation {
                     ) throws IOException, InterruptedException {
     try {
       tracePrivilegedAction(action);
-      return Subject.doAs(subject, action);
+      return SubjectUtil.doAs(subject, action);
     } catch (PrivilegedActionException pae) {
       Throwable cause = pae.getCause();
       LOG.debug("PrivilegedActionException as: {}", this, cause);


### PR DESCRIPTION
Co-authored-by: Istvan Toth <stoty@apache.org>

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

https://docs.oracle.com/en/java/javase/24/security/migrating-deprecated-removal-subject-getsubject-and-subject-doas-methods-subject-current-and-subje.html

> In JDK 24, the Security Manager has been permanently disabled. See [JEP 486](https://openjdk.org/jeps/486) for more information.

This PR is extracted from @stoty's PR https://github.com/apache/hadoop/pull/7434, with some tweaks, which is an alternative to https://github.com/apache/hadoop/pull/7081

The main goal is to make minimal changes to make the Hadoop client compatible with Java 25, which unlocks downstream projects that rely on the Hadoop client, e.g. Spark, to support Java 25.

### How was this patch tested?

#### Spark Integration

Integrated with Spark 4.1.0-SNAPSHOT (master branch) with Java 25.

##### Steps

Install JDK 25-ea and set up `JAVA_HOME` env
```
export JAVA_HOME=/path/openjdk-25
```

Pull this PR, then compile and install Hadoop jars to maven local repo.
```
git clone -o apache https://github.com/apache/hadoop.git
cd hadoop
git fetch apache pull/7434/head:HADOOP-19212
git checkout HADOOP-19212
mvn clean install -DskipTests
```

Pull Spark master code, and 
```
git clone -o apache https://github.com/apache/spark.git
cd spark
```

Modify `pom.xml` to use the compiled Hadoop Jars
```patch
- <hadoop.version>3.4.1</hadoop.version>
+ <hadoop.version>3.5.0-SNAPSHOT</hadoop.version>
```

Run UT with the compiled Hadoop Jars
```
build/sbt -Phive,hive-thriftserver,yarn "yarn/test"
```

```
build/sbt -Phive,hive-thriftserver,yarn "hive/test"
```


##### Before
```
java.lang.UnsupportedOperationException: getSubject is not supported
    at java.base/javax.security.auth.Subject.getSubject(Subject.java:277)
    at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:588)
    at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3888)
    at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3878)
    at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3666)
    at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
    at org.apache.hadoop.fs.FileSystem.getLocal(FileSystem.java:510)
    at org.apache.spark.deploy.yarn.Client$.org$apache$spark$deploy$yarn$Client$$getQualifiedLocalPath(Client.scala:1751)
    at org.apache.spark.deploy.yarn.Client$.addFileToClasspath(Client.scala:1660)
    at org.apache.spark.deploy.yarn.Client$.$anonfun$populateClasspath$3(Client.scala:1549)
    at org.apache.spark.deploy.yarn.Client$.$anonfun$populateClasspath$3$adapted(Client.scala:1548)
    ...
```

##### After

With this patch, Spark passes all UTs of the YARN module with Java 25, a few Hive SQL tests fail with irrelevant issues. 

#### Run Spark Job on Kerberized YARN/HDFS cluster

@cxzl25 also helps test this patch using a Spark job on a Kerberized cluster with Java 25, basic SQL, including reading and writing Hive tables, which works as expected.

#### Hadoop Existing UT

I set up a GitHub Actions workflow in [my forked repo](https://github.com/pan3793/hadoop/commit/d3e7c3d5187a917105261c8c0414a3f1ff7eb9e6) to run Hadoop UT with Java 17 and 25.

Note: I have to exclude some UTs because they are flaky or failed consistently even without this PR.

The test jobs show a positive report of this change.
https://github.com/pan3793/hadoop/actions/runs/17120184276

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
