### PR TITLE
YARN-11856. DOWNLOADING resources unlock and cleanup is interrupted w…

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1295,10 +1295,10 @@ public class ResourceLocalizationService extends CompositeService
           // Notify resource of failed localization
           ContainerId cId = context.getContainerId();
           try {
-              dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
-                      cId, null, exception.getMessage()));
+            dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
+                cId, null, exception.getMessage()));
           } catch (Exception | FSError e) {
-              LOG.info("Failed to send container resource failed event for " + cId, e);
+            LOG.info("Failed to send container resource failed event for " + cId, e);
           }
         }
         List<Path> paths = new ArrayList<Path>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1298,7 +1298,7 @@ public class ResourceLocalizationService extends CompositeService
             dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
                 cId, null, exception.getMessage()));
           } catch (Exception | FSError e) {
-            LOG.info("Failed to send container resource failed event for " + cId, e);
+            LOG.info("Failed to send container resource failed event for " + cId.toString(), e);
           }
         }
         List<Path> paths = new ArrayList<Path>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1297,7 +1297,7 @@ public class ResourceLocalizationService extends CompositeService
           try {
             dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
                 cId, null, exception.getMessage()));
-          } catch (Exception | FSError e) {
+          } catch (Exception e) {
             LOG.info("Failed to send container resource failed event for " + cId.toString(), e);
           }
         }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/localizer/ResourceLocalizationService.java
@@ -1294,8 +1294,12 @@ public class ResourceLocalizationService extends CompositeService
           // On error, report failure to Container and signal ABORT
           // Notify resource of failed localization
           ContainerId cId = context.getContainerId();
-          dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
-              cId, null, exception.getMessage()));
+          try {
+              dispatcher.getEventHandler().handle(new ContainerResourceFailedEvent(
+                      cId, null, exception.getMessage()));
+          } catch (Exception | FSError e) {
+              LOG.info("Failed to send container resource failed event for " + cId, e);
+          }
         }
         List<Path> paths = new ArrayList<Path>();
         for (LocalizerResourceRequestEvent event : scheduled.values()) {


### PR DESCRIPTION
…hen killing a container that is localizing

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

Currently, LocalizerRunner tries to send a ContainerResourceFailedEvent to dispatcher before unlocking and cleaning up downloading resource when failed by interruption. This handle invoking will throw uncaught exception, which causes other containers depend on the same private resource stuck at localizing.

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

