### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part14.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAddOverReplicatedStripedBlocks.java
@@ -201,6 +201,7 @@ public class TestAddOverReplicatedStripedBlocks {
     // let a internal block be corrupt
     BlockManager bm = cluster.getNamesystem().getBlockManager();
     List<DatanodeInfo> infos = Arrays.asList(bg.getLocations());
+    cluster.stopDataNode(infos.get(0).getXferAddr());
     List<String> storages = Arrays.asList(bg.getStorageIDs());
     cluster.getNamesystem().writeLock(RwLockMode.BM);
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSecureNameNodeWithExternalKdc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSecureNameNodeWithExternalKdc.java
@@ -35,7 +35,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import static org.apache.hadoop.security.SecurityUtilTestHelper.isExternalKdcRunning;
-import org.junit.Assume;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +60,7 @@ public class TestSecureNameNodeWithExternalKdc {
   @BeforeEach
   public void testExternalKdcRunning() {
     // Tests are skipped if external KDC is not running.
-    Assume.assumeTrue(isExternalKdcRunning());
+    assumeTrue(isExternalKdcRunning());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test {@link FSNLockBenchmarkThroughput}.
@@ -93,8 +93,8 @@ public class TestFSNLockBenchmarkThroughput {
           String.valueOf(readWriteRatio), String.valueOf(testingCount),
           String.valueOf(numClients)};
 
-      Assert.assertEquals(0, ToolRunner.run(conf,
-          new FSNLockBenchmarkThroughput(fileSystem), args));
+      Assertions.assertEquals(0,
+          ToolRunner.run(conf, new FSNLockBenchmarkThroughput(fileSystem), args));
     } finally {
       if (qjmhaCluster != null) {
         qjmhaCluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFSNLockBenchmarkThroughput.java
@@ -25,8 +25,9 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * To test {@link FSNLockBenchmarkThroughput}.
@@ -93,7 +94,7 @@ public class TestFSNLockBenchmarkThroughput {
           String.valueOf(readWriteRatio), String.valueOf(testingCount),
           String.valueOf(numClients)};
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           ToolRunner.run(conf, new FSNLockBenchmarkThroughput(fileSystem), args));
     } finally {
       if (qjmhaCluster != null) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFineGrainedFSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFineGrainedFSNamesystemLock.java
@@ -20,7 +20,8 @@ package org.apache.hadoop.hdfs.server.namenode.fgl;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,8 @@ public class TestFineGrainedFSNamesystemLock {
   /**
    * Test read/write lock of Global, FS and BM model through multi-threading.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testMultipleThreadsUsingLocks()
       throws InterruptedException, ExecutionException {
     FineGrainedFSNamesystemLock fsn = new FineGrainedFSNamesystemLock(new Configuration(), null);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAConfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAConfiguration.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.SecondaryNameNode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -107,8 +107,8 @@ public class TestHAConfiguration {
     NameNode.initializeGenericKeys(conf, "ns1", "nn1");
 
     checkpointer = new StandbyCheckpointer(conf, fsn);
-    assertEquals("Got an unexpected number of possible active NNs", 2, checkpointer
-        .getActiveNNAddresses().size());
+    assertEquals(2, checkpointer.getActiveNNAddresses().size(),
+        "Got an unexpected number of possible active NNs");
     assertEquals(new URL("http", "1.2.3.2", DFSConfigKeys.DFS_NAMENODE_HTTP_PORT_DEFAULT, ""),
         checkpointer.getActiveNNAddresses().get(0));
     assertAddressMatches("1.2.3.2", checkpointer.getActiveNNAddresses().get(0));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNNMetricFilesInGetListingOps.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNNMetricFilesInGetListingOps.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for FilesInGetListingOps metric in Namenode
@@ -52,7 +52,7 @@ public class TestNNMetricFilesInGetListingOps {
   private DistributedFileSystem fs;
   private final Random rand = new Random();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     cluster = new MiniDFSCluster.Builder(CONF).build();
     cluster.waitActive();
@@ -60,7 +60,7 @@ public class TestNNMetricFilesInGetListingOps {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestNameNodeMetrics.java
@@ -37,8 +37,8 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounterGt;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.File;
@@ -94,9 +94,10 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test for metrics published by the Namenode
@@ -162,7 +163,7 @@ public class TestNameNodeMetrics {
     return new Path(TEST_ROOT_DIR_PATH, fileName);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     hostsFileWriter = new HostsFileWriter();
     hostsFileWriter.initialize(CONF, "temp/decommission");
@@ -178,7 +179,7 @@ public class TestNameNodeMetrics {
     fs.setErasureCodingPolicy(ecDir, EC_POLICY.getName());
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     MetricsSource source = DefaultMetricsSystem.instance().getSource("UgiMetrics");
     if (source != null) {
@@ -213,7 +214,8 @@ public class TestNameNodeMetrics {
    * Test that capacity metrics are exported and pass
    * basic sanity tests.
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCapacityMetrics() throws Exception {
     MetricsRecordBuilder rb = getMetrics(NS_METRICS);
     long capacityTotal = MetricsAsserts.getLongGauge("CapacityTotal", rb);
@@ -443,35 +445,34 @@ public class TestNameNodeMetrics {
    */
   private void verifyAggregatedMetricsTally() throws Exception {
     BlockManagerTestUtil.updateState(bm);
-    assertEquals("Under replicated metrics not matching!",
-        namesystem.getLowRedundancyBlocks(),
-        namesystem.getUnderReplicatedBlocks());
-    assertEquals("Low redundancy metrics not matching!",
-        namesystem.getLowRedundancyBlocks(),
+    assertEquals(namesystem.getLowRedundancyBlocks(),
+        namesystem.getUnderReplicatedBlocks(),
+        "Under replicated metrics not matching!");
+    assertEquals(namesystem.getLowRedundancyBlocks(),
         namesystem.getLowRedundancyReplicatedBlocks() +
-            namesystem.getLowRedundancyECBlockGroups());
-    assertEquals("Corrupt blocks metrics not matching!",
-        namesystem.getCorruptReplicaBlocks(),
+            namesystem.getLowRedundancyECBlockGroups(),
+        "Low redundancy metrics not matching!");
+    assertEquals(namesystem.getCorruptReplicaBlocks(),
         namesystem.getCorruptReplicatedBlocks() +
-            namesystem.getCorruptECBlockGroups());
-    assertEquals("Missing blocks metrics not matching!",
-        namesystem.getMissingBlocksCount(),
+            namesystem.getCorruptECBlockGroups(),
+        "Corrupt blocks metrics not matching!");
+    assertEquals(namesystem.getMissingBlocksCount(),
         namesystem.getMissingReplicatedBlocks() +
-            namesystem.getMissingECBlockGroups());
-    assertEquals("Missing blocks with replication factor one not matching!",
-        namesystem.getMissingReplOneBlocksCount(),
-        namesystem.getMissingReplicationOneBlocks());
-    assertEquals("Blocks with badly distributed are not matching!",
-        namesystem.getBadlyDistributedBlocksCount(),
-        namesystem.getBadlyDistributedBlocks());
-    assertEquals("Bytes in future blocks metrics not matching!",
-        namesystem.getBytesInFuture(),
+            namesystem.getMissingECBlockGroups(),
+        "Missing blocks metrics not matching!");
+    assertEquals(namesystem.getMissingReplOneBlocksCount(),
+        namesystem.getMissingReplicationOneBlocks(),
+        "Missing blocks with replication factor one not matching!");
+    assertEquals(namesystem.getBadlyDistributedBlocksCount(),
+        namesystem.getBadlyDistributedBlocks(), "Blocks with badly distributed are not matching!");
+    assertEquals(namesystem.getBytesInFuture(),
         namesystem.getBytesInFutureReplicatedBlocks() +
-            namesystem.getBytesInFutureECBlockGroups());
-    assertEquals("Pending deletion blocks metrics not matching!",
-        namesystem.getPendingDeletionBlocks(),
+            namesystem.getBytesInFutureECBlockGroups(),
+        "Bytes in future blocks metrics not matching!");
+    assertEquals(namesystem.getPendingDeletionBlocks(),
         namesystem.getPendingDeletionReplicatedBlocks() +
-            namesystem.getPendingDeletionECBlocks());
+            namesystem.getPendingDeletionECBlocks(),
+        "Pending deletion blocks metrics not matching!");
   }
 
   /** Corrupt a block and ensure metrics reflects it */
@@ -567,7 +568,8 @@ public class TestNameNodeMetrics {
     verifyAggregatedMetricsTally();
   }
 
-  @Test (timeout = 90000L)
+  @Test
+  @Timeout(90)
   public void testStripedFileCorruptBlocks() throws Exception {
     final long fileLen = BLOCK_SIZE * 4;
     final Path ecFile = new Path(ecDir, "ecFile.log");
@@ -810,7 +812,8 @@ public class TestNameNodeMetrics {
    * Testing TransactionsSinceLastCheckpoint. Need a new cluster as
    * the other tests in here don't use HA. See HDFS-7501.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testTransactionSinceLastCheckpointMetrics() throws Exception {
     Random random = new Random();
     int retryCount = 0;
@@ -845,10 +848,10 @@ public class TestNameNodeMetrics {
         HATestUtil.waitForStandbyToCatchUp(nn0, nn1);
         // Test to ensure tracking works before the first-ever
         // checkpoint.
-        assertEquals("SBN failed to track 2 transactions pre-checkpoint.",
-            4L, // 2 txns added further when catch-up is called.
+        assertEquals(4L, // 2 txns added further when catch-up is called.
             cluster2.getNameNode(1).getNamesystem()
-              .getTransactionsSinceLastCheckpoint());
+                .getTransactionsSinceLastCheckpoint(),
+            "SBN failed to track 2 transactions pre-checkpoint.");
         // Complete up to the boundary required for
         // an auto-checkpoint. Using 94 to expect fsimage
         // rounded at 100, as 4 + 94 + 2 (catch-up call) = 100.
@@ -861,19 +864,19 @@ public class TestNameNodeMetrics {
         // Test to ensure number tracks the right state of
         // uncheckpointed edits, and does not go negative
         // (as fixed in HDFS-7501).
-        assertEquals("Should be zero right after the checkpoint.",
-            0L,
+        assertEquals(0L,
             cluster2.getNameNode(1).getNamesystem()
-              .getTransactionsSinceLastCheckpoint());
+                .getTransactionsSinceLastCheckpoint(),
+            "Should be zero right after the checkpoint.");
         fs2.mkdirs(new Path("/tmp-t3"));
         fs2.mkdirs(new Path("/tmp-t4"));
         HATestUtil.waitForStandbyToCatchUp(nn0, nn1);
         // Test to ensure we track the right numbers after
         // the checkpoint resets it to zero again.
-        assertEquals("SBN failed to track 2 added txns after the ckpt.",
-            4L,
+        assertEquals(4L,
             cluster2.getNameNode(1).getNamesystem()
-              .getTransactionsSinceLastCheckpoint());
+                .getTransactionsSinceLastCheckpoint(),
+            "SBN failed to track 2 added txns after the ckpt.");
         cluster2.shutdown();
         break;
       } catch (Exception e) {
@@ -966,7 +969,8 @@ public class TestNameNodeMetrics {
    * Test metrics indicating the number of active clients and the files under
    * construction
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testNumActiveClientsAndFilesUnderConstructionMetrics()
       throws Exception {
     final Path file1 = getTestPath("testFileAdd1");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestTopMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/metrics/TestTopMetrics.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdfs.server.namenode.top.metrics.TopMetrics;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.lib.Interns;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.server.namenode.top.metrics.TopMetrics.TOPMETRICS_METRICS_SOURCE_NAME;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotTestHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotTestHelper.java
@@ -50,7 +50,7 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.WriterAppender;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +59,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper for writing snapshot related tests
@@ -210,7 +210,7 @@ public class SnapshotTestHelper {
       final String label = "mkdirs " + dir;
       LOG.info(label);
       hdfs.mkdirs(dir);
-      Assert.assertTrue(label, hdfs.exists(dir));
+      Assertions.assertTrue(hdfs.exists(dir), label);
       return dir;
     }
 
@@ -222,7 +222,7 @@ public class SnapshotTestHelper {
       final String label = "createFile " + file;
       LOG.info(label);
       DFSTestUtil.createFile(hdfs, file, 0, (short)1, 0L);
-      Assert.assertTrue(label, hdfs.exists(file));
+      Assertions.assertTrue(hdfs.exists(file), label);
       return file;
     }
 
@@ -233,7 +233,7 @@ public class SnapshotTestHelper {
       final String label = "rename " + src + " -> " + dst;
       final boolean renamed = hdfs.rename(src, dst);
       LOG.info("{}: success? {}", label, renamed);
-      Assert.assertTrue(label, renamed);
+      Assertions.assertTrue(renamed, label);
       return snapshot;
     }
 
@@ -355,9 +355,9 @@ public class SnapshotTestHelper {
     // Compare the snapshot with the current dir
     FileStatus[] currentFiles = hdfs.listStatus(snapshottedDir);
     FileStatus[] snapshotFiles = hdfs.listStatus(snapshotRoot);
-    assertEquals("snapshottedDir=" + snapshottedDir
-        + ", snapshotRoot=" + snapshotRoot,
-        currentFiles.length, snapshotFiles.length);
+    assertEquals(currentFiles.length, snapshotFiles.length,
+        "snapshottedDir=" + snapshottedDir
+            + ", snapshotRoot=" + snapshotRoot);
   }
   
   /**
@@ -449,8 +449,8 @@ public class SnapshotTestHelper {
         }
         assertEquals(line1.trim(), line2.trim());
       }
-      Assert.assertNull(reader1.readLine());
-      Assert.assertNull(reader2.readLine());
+      Assertions.assertNull(reader1.readLine());
+      Assertions.assertNull(reader2.readLine());
     } finally {
       reader1.close();
       reader2.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotTestHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/SnapshotTestHelper.java
@@ -50,7 +50,6 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.WriterAppender;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -210,7 +210,7 @@ public class SnapshotTestHelper {
       final String label = "mkdirs " + dir;
       LOG.info(label);
       hdfs.mkdirs(dir);
-      Assertions.assertTrue(hdfs.exists(dir), label);
+      assertTrue(hdfs.exists(dir), label);
       return dir;
     }
 
@@ -222,7 +222,7 @@ public class SnapshotTestHelper {
       final String label = "createFile " + file;
       LOG.info(label);
       DFSTestUtil.createFile(hdfs, file, 0, (short)1, 0L);
-      Assertions.assertTrue(hdfs.exists(file), label);
+      assertTrue(hdfs.exists(file), label);
       return file;
     }
 
@@ -233,7 +233,7 @@ public class SnapshotTestHelper {
       final String label = "rename " + src + " -> " + dst;
       final boolean renamed = hdfs.rename(src, dst);
       LOG.info("{}: success? {}", label, renamed);
-      Assertions.assertTrue(renamed, label);
+      assertTrue(renamed, label);
       return snapshot;
     }
 
@@ -449,8 +449,8 @@ public class SnapshotTestHelper {
         }
         assertEquals(line1.trim(), line2.trim());
       }
-      Assertions.assertNull(reader1.readLine());
-      Assertions.assertNull(reader2.readLine());
+      assertNull(reader1.readLine());
+      assertNull(reader2.readLine());
     } finally {
       reader1.close();
       reader2.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
@@ -154,15 +154,13 @@ public class TestAclWithSnapshot {
     AclStatus s = hdfs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "diana", READ_EXECUTE),
-            aclEntry(ACCESS, GROUP, NONE)},
-        returned);
+        aclEntry(ACCESS, GROUP, NONE)}, returned);
     assertPermission((short)010550, path);
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
     assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-            aclEntry(ACCESS, GROUP, NONE)},
-        returned);
+        aclEntry(ACCESS, GROUP, NONE)}, returned);
     assertPermission((short)010750, snapshotPath);
 
     assertDirPermissionDenied(fsAsBruce, BRUCE, path);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
@@ -21,7 +21,12 @@ import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.*;
 import static org.apache.hadoop.fs.permission.AclEntryScope.*;
 import static org.apache.hadoop.fs.permission.AclEntryType.*;
 import static org.apache.hadoop.fs.permission.FsAction.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.List;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestAclWithSnapshot.java
@@ -21,7 +21,7 @@ import static org.apache.hadoop.hdfs.server.namenode.AclTestHelpers.*;
 import static org.apache.hadoop.fs.permission.AclEntryScope.*;
 import static org.apache.hadoop.fs.permission.AclEntryType.*;
 import static org.apache.hadoop.fs.permission.FsAction.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,12 +50,10 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests interaction of ACLs with snapshots.
@@ -74,17 +72,14 @@ public class TestAclWithSnapshot {
   private static Path path, snapshotPath;
   private static String snapshotName;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_KEY, true);
     initCluster(true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws Exception {
     IOUtils.cleanupWithLogger(null, hdfs, fsAsBruce, fsAsDiana);
     if (cluster != null) {
@@ -92,7 +87,7 @@ public class TestAclWithSnapshot {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ++pathCount;
     path = new Path("/p" + pathCount);
@@ -119,16 +114,16 @@ public class TestAclWithSnapshot {
     // Both original and snapshot still have same ACL.
     AclStatus s = hdfs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, path);
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, snapshotPath);
 
     assertDirPermissionGranted(fsAsBruce, BRUCE, snapshotPath);
@@ -153,16 +148,16 @@ public class TestAclWithSnapshot {
       Path snapshotPath) throws Exception {
     AclStatus s = hdfs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "diana", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "diana", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010550, path);
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, snapshotPath);
 
     assertDirPermissionDenied(fsAsBruce, BRUCE, path);
@@ -302,16 +297,16 @@ public class TestAclWithSnapshot {
     // Both original and snapshot still have same ACL.
     AclStatus s = hdfs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, path);
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, snapshotPath);
 
     assertDirPermissionGranted(fsAsBruce, BRUCE, snapshotPath);
@@ -336,9 +331,9 @@ public class TestAclWithSnapshot {
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_EXECUTE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010750, snapshotPath);
 
     assertDirPermissionDenied(fsAsBruce, BRUCE, path);
@@ -511,22 +506,18 @@ public class TestAclWithSnapshot {
 
     AclStatus s = hdfs.getAclStatus(path);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(DEFAULT, USER, ALL),
-      aclEntry(DEFAULT, USER, "bruce", READ_EXECUTE),
-      aclEntry(DEFAULT, GROUP, NONE),
-      aclEntry(DEFAULT, MASK, READ_EXECUTE),
-      aclEntry(DEFAULT, OTHER, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, "bruce", READ_EXECUTE), aclEntry(DEFAULT, GROUP, NONE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+        returned);
     assertPermission((short)010700, path);
 
     s = hdfs.getAclStatus(snapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(DEFAULT, USER, ALL),
-      aclEntry(DEFAULT, USER, "bruce", READ_EXECUTE),
-      aclEntry(DEFAULT, GROUP, NONE),
-      aclEntry(DEFAULT, MASK, READ_EXECUTE),
-      aclEntry(DEFAULT, OTHER, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(DEFAULT, USER, ALL),
+            aclEntry(DEFAULT, USER, "bruce", READ_EXECUTE), aclEntry(DEFAULT, GROUP, NONE),
+            aclEntry(DEFAULT, MASK, READ_EXECUTE), aclEntry(DEFAULT, OTHER, NONE)},
+        returned);
     assertPermission((short)010700, snapshotPath);
 
     assertDirPermissionDenied(fsAsBruce, BRUCE, snapshotPath);
@@ -538,8 +529,9 @@ public class TestAclWithSnapshot {
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
     List<AclEntry> aclSpec = Lists.newArrayList(
       aclEntry(DEFAULT, USER, "bruce", READ_EXECUTE));
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.modifyAclEntries(snapshotPath, aclSpec);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.modifyAclEntries(snapshotPath, aclSpec);
+    });
   }
 
   @Test
@@ -548,24 +540,27 @@ public class TestAclWithSnapshot {
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
     List<AclEntry> aclSpec = Lists.newArrayList(
       aclEntry(DEFAULT, USER, "bruce"));
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.removeAclEntries(snapshotPath, aclSpec);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.removeAclEntries(snapshotPath, aclSpec);
+    });
   }
 
   @Test
   public void testRemoveDefaultAclSnapshotPath() throws Exception {
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short)0700));
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.removeDefaultAcl(snapshotPath);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.removeDefaultAcl(snapshotPath);
+    });
   }
 
   @Test
   public void testRemoveAclSnapshotPath() throws Exception {
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short)0700));
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.removeAcl(snapshotPath);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.removeAcl(snapshotPath);
+    });
   }
 
   @Test
@@ -574,8 +569,9 @@ public class TestAclWithSnapshot {
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
     List<AclEntry> aclSpec = Lists.newArrayList(
       aclEntry(DEFAULT, USER, "bruce"));
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.setAcl(snapshotPath, aclSpec);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.setAcl(snapshotPath, aclSpec);
+    });
   }
 
   @Test
@@ -596,16 +592,16 @@ public class TestAclWithSnapshot {
 
     AclStatus s = hdfs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_WRITE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_WRITE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010660, filePath);
 
     s = hdfs.getAclStatus(fileSnapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_WRITE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_WRITE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010660, filePath);
 
     aclSpec = Lists.newArrayList(
@@ -631,16 +627,16 @@ public class TestAclWithSnapshot {
 
     AclStatus s = hdfs.getAclStatus(filePath);
     AclEntry[] returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_WRITE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_WRITE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010660, filePath);
 
     s = hdfs.getAclStatus(fileSnapshotPath);
     returned = s.getEntries().toArray(new AclEntry[0]);
-    assertArrayEquals(new AclEntry[] {
-      aclEntry(ACCESS, USER, "bruce", READ_WRITE),
-      aclEntry(ACCESS, GROUP, NONE) }, returned);
+    assertArrayEquals(new AclEntry[]{aclEntry(ACCESS, USER, "bruce", READ_WRITE),
+            aclEntry(ACCESS, GROUP, NONE)},
+        returned);
     assertPermission((short)010660, filePath);
 
     aclSpec = Lists.newArrayList(
@@ -666,8 +662,8 @@ public class TestAclWithSnapshot {
         aclEntry(ACCESS, GROUP, "testdeduplicategroup", ALL));
     hdfs.mkdirs(path);
     hdfs.modifyAclEntries(path, aclSpec);
-    assertEquals("One more ACL feature should be unique", startSize + 1,
-        AclStorage.getUniqueAclFeatures().getUniqueElementsSize());
+    assertEquals(startSize + 1, AclStorage.getUniqueAclFeatures().getUniqueElementsSize(),
+        "One more ACL feature should be unique");
     Path subdir = new Path(path, "sub-dir");
     hdfs.mkdirs(subdir);
     Path file = new Path(path, "file");
@@ -677,15 +673,15 @@ public class TestAclWithSnapshot {
       // create the snapshot with root directory having ACLs should refer to
       // same ACLFeature without incrementing the reference count
       aclFeature = FSAclBaseTest.getAclFeature(path, cluster);
-      assertEquals("Reference count should be one before snapshot", 1,
-          aclFeature.getRefCount());
+      assertEquals(1, aclFeature.getRefCount(),
+          "Reference count should be one before snapshot");
       Path snapshotPath = SnapshotTestHelper.createSnapshot(hdfs, path,
           snapshotName);
       AclFeature snapshotAclFeature = FSAclBaseTest.getAclFeature(snapshotPath,
           cluster);
       assertSame(aclFeature, snapshotAclFeature);
-      assertEquals("Reference count should be increased", 2,
-          snapshotAclFeature.getRefCount());
+      assertEquals(2, snapshotAclFeature.getRefCount(),
+          "Reference count should be increased");
     }
     {
       // deleting the snapshot with root directory having ACLs should not alter
@@ -695,15 +691,16 @@ public class TestAclWithSnapshot {
     {
       hdfs.modifyAclEntries(subdir, aclSpec);
       aclFeature = FSAclBaseTest.getAclFeature(subdir, cluster);
-      assertEquals("Reference count should be 1", 1, aclFeature.getRefCount());
+      assertEquals(1, aclFeature.getRefCount(),
+          "Reference count should be 1");
       Path snapshotPath = SnapshotTestHelper.createSnapshot(hdfs, path,
           snapshotName);
       Path subdirInSnapshot = new Path(snapshotPath, "sub-dir");
       AclFeature snapshotAcl = FSAclBaseTest.getAclFeature(subdirInSnapshot,
           cluster);
       assertSame(aclFeature, snapshotAcl);
-      assertEquals("Reference count should remain same", 1,
-          aclFeature.getRefCount());
+      assertEquals(1, aclFeature.getRefCount(),
+          "Reference count should remain same");
 
       // Delete the snapshot with sub-directory containing the ACLs should not
       // alter the reference count for AclFeature
@@ -712,15 +709,16 @@ public class TestAclWithSnapshot {
     {
       hdfs.modifyAclEntries(file, aclSpec);
       aclFeature = FSAclBaseTest.getAclFeature(file, cluster);
-      assertEquals("Reference count should be 1", 1, aclFeature.getRefCount());
+      assertEquals(1, aclFeature.getRefCount(),
+          "Reference count should be 1");
       Path snapshotPath = SnapshotTestHelper.createSnapshot(hdfs, path,
           snapshotName);
       Path fileInSnapshot = new Path(snapshotPath, file.getName());
       AclFeature snapshotAcl = FSAclBaseTest.getAclFeature(fileInSnapshot,
           cluster);
       assertSame(aclFeature, snapshotAcl);
-      assertEquals("Reference count should remain same", 1,
-          aclFeature.getRefCount());
+      assertEquals(1, aclFeature.getRefCount(),
+          "Reference count should remain same");
 
       // Delete the snapshot with contained file having ACLs should not
       // alter the reference count for AclFeature
@@ -735,8 +733,8 @@ public class TestAclWithSnapshot {
       AclFeature snapshotAcl = FSAclBaseTest.getAclFeature(snapshotPath,
           cluster);
       aclFeature = FSAclBaseTest.getAclFeature(path, cluster);
-      assertEquals("Before modification same ACL should be referenced twice", 2,
-          aclFeature.getRefCount());
+      assertEquals(2, aclFeature.getRefCount(),
+          "Before modification same ACL should be referenced twice");
       List<AclEntry> newAcl = Lists.newArrayList(aclEntry(ACCESS, USER,
           "testNewUser", ALL));
       hdfs.modifyAclEntries(path, newAcl);
@@ -745,10 +743,10 @@ public class TestAclWithSnapshot {
           snapshotPath, cluster);
       assertSame(snapshotAcl, snapshotAclPostModification);
       assertNotSame(aclFeature, snapshotAclPostModification);
-      assertEquals("Old ACL feature reference count should be same", 1,
-          snapshotAcl.getRefCount());
-      assertEquals("New ACL feature reference should be used", 1,
-          aclFeature.getRefCount());
+      assertEquals(1, snapshotAcl.getRefCount(),
+          "Old ACL feature reference count should be same");
+      assertEquals(1, aclFeature.getRefCount(),
+          "New ACL feature reference should be used");
       deleteSnapshotWithAclAndVerify(aclFeature, path, startSize);
     }
     {
@@ -765,9 +763,10 @@ public class TestAclWithSnapshot {
       hdfs.modifyAclEntries(subdir, newAcl);
       aclFeature = FSAclBaseTest.getAclFeature(subdir, cluster);
       assertNotSame(aclFeature, snapshotAclFeature);
-      assertEquals("Reference count should remain same", 1,
-          snapshotAclFeature.getRefCount());
-      assertEquals("New AclFeature should be used", 1, aclFeature.getRefCount());
+      assertEquals(1, snapshotAclFeature.getRefCount(),
+          "Reference count should remain same");
+      assertEquals(1, aclFeature.getRefCount(),
+          "New AclFeature should be used");
 
       deleteSnapshotWithAclAndVerify(aclFeature, subdir, startSize);
     }
@@ -785,8 +784,8 @@ public class TestAclWithSnapshot {
       hdfs.modifyAclEntries(file, newAcl);
       aclFeature = FSAclBaseTest.getAclFeature(file, cluster);
       assertNotSame(aclFeature, snapshotAclFeature);
-      assertEquals("Reference count should remain same", 1,
-          snapshotAclFeature.getRefCount());
+      assertEquals(1, snapshotAclFeature.getRefCount(),
+          "Reference count should remain same");
       deleteSnapshotWithAclAndVerify(aclFeature, file, startSize);
     }
     {
@@ -814,14 +813,14 @@ public class TestAclWithSnapshot {
       assertSame(dirAcl, snapshotDirAclFeature);
       hdfs.delete(subdir, true);
       assertEquals(
-          "Original ACLs references should be maintained for snapshot", 1,
-          snapshotFileAclFeature.getRefCount());
+          1, snapshotFileAclFeature.getRefCount(),
+          "Original ACLs references should be maintained for snapshot");
       assertEquals(
-          "Original ACLs references should be maintained for snapshot", 1,
-          snapshotDirAclFeature.getRefCount());
+          1, snapshotDirAclFeature.getRefCount(),
+          "Original ACLs references should be maintained for snapshot");
       hdfs.deleteSnapshot(path, snapshotName);
-      assertEquals("ACLs should be deleted from snapshot", startSize, AclStorage
-          .getUniqueAclFeatures().getUniqueElementsSize());
+      assertEquals(startSize, AclStorage.getUniqueAclFeatures().getUniqueElementsSize(),
+          "ACLs should be deleted from snapshot");
     }
   }
 
@@ -831,14 +830,13 @@ public class TestAclWithSnapshot {
     AclFeature afterDeleteAclFeature = FSAclBaseTest.getAclFeature(
         pathToCheckAcl, cluster);
     assertSame(aclFeature, afterDeleteAclFeature);
-    assertEquals("Reference count should remain same"
-        + " even after deletion of snapshot", 1,
-        afterDeleteAclFeature.getRefCount());
+    assertEquals(1, afterDeleteAclFeature.getRefCount(),
+        "Reference count should remain same" + " even after deletion of snapshot");
 
     hdfs.removeAcl(pathToCheckAcl);
-    assertEquals("Reference count should be 0", 0, aclFeature.getRefCount());
-    assertEquals("Unique ACL features should remain same", totalAclFeatures,
-        AclStorage.getUniqueAclFeatures().getUniqueElementsSize());
+    assertEquals(0, aclFeature.getRefCount(), "Reference count should be 0");
+    assertEquals(totalAclFeatures, AclStorage.getUniqueAclFeatures().getUniqueElementsSize(),
+        "Unique ACL features should remain same");
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestCheckpointsWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestCheckpointsWithSnapshots.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -34,6 +32,8 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.namenode.SecondaryNameNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestCheckpointsWithSnapshots {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestCheckpointsWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestCheckpointsWithSnapshots.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,8 +32,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsAdmin;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.namenode.SecondaryNameNode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCheckpointsWithSnapshots {
   
@@ -43,7 +43,7 @@ public class TestCheckpointsWithSnapshots {
     conf.set(DFSConfigKeys.DFS_NAMENODE_SECONDARY_HTTP_ADDRESS_KEY, "0.0.0.0:0");
   }
   
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtil.fullyDeleteContents(new File(MiniDFSCluster.getBaseDirectory()));
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDiffListBySkipList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDiffListBySkipList.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeat
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeature.DirectoryDiff;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DiffListBySkipList.SkipListNode;
 import org.apache.hadoop.hdfs.util.ReadOnlyList;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +57,7 @@ public class TestDiffListBySkipList {
   private static FSDirectory fsdir;
   private static DistributedFileSystem hdfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     cluster =
         new MiniDFSCluster.Builder(CONF).numDataNodes(0).format(true).build();
@@ -67,7 +67,7 @@ public class TestDiffListBySkipList {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -81,9 +81,9 @@ public class TestDiffListBySkipList {
   }
 
   static void assertList(List<INode> expected, List<INode> computed) {
-    Assert.assertEquals(expected.size(), computed.size());
+    Assertions.assertEquals(expected.size(), computed.size());
     for (int index = 0; index < expected.size(); index++) {
-      Assert.assertEquals(expected.get(index), computed.get(index));
+      Assertions.assertEquals(expected.get(index), computed.get(index));
     }
   }
 
@@ -107,7 +107,7 @@ public class TestDiffListBySkipList {
       DiffList<DirectoryDiff> array, DiffListBySkipList skip,
       INodeDirectory dir, List<INode> childrenList) {
     final int n = array.size();
-    Assert.assertEquals(n, skip.size());
+    Assertions.assertEquals(n, skip.size());
     for (int i = 0; i < n - 1; i++) {
       for (int j = i + 1; j < n - 1; j++) {
         final List<INode> expected = getCombined(array, i, j, dir)
@@ -254,8 +254,8 @@ public class TestDiffListBySkipList {
     final DiffListBySkipList skipList = newDiffListBySkipList();
     final DiffList<DirectoryDiff> arrayList = new DiffListByArrayList<>(0);
     final INodeDirectory dir = addDiff(n, skipList, arrayList, root);
-    Assert.assertEquals(n, arrayList.size());
-    Assert.assertEquals(n, skipList.size());
+    Assertions.assertEquals(n, arrayList.size());
+    Assertions.assertEquals(n, skipList.size());
 
     for (int i = 0; i < n; i++) {
       DiffListBySkipList.LOG.debug("i={}: {}", i, skipList);
@@ -326,7 +326,7 @@ public class TestDiffListBySkipList {
 
   static void assertDirectoryDiff(DirectoryDiff expected,
       DirectoryDiff computed) {
-    Assert.assertEquals(expected.getSnapshotId(), computed.getSnapshotId());
+    Assertions.assertEquals(expected.getSnapshotId(), computed.getSnapshotId());
   }
 
   static void assertSkipList(DiffListBySkipList skipList) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDiffListBySkipList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDiffListBySkipList.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeat
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DiffListBySkipList.SkipListNode;
 import org.apache.hadoop.hdfs.util.ReadOnlyList;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +38,8 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class tests the DirectoryDiffList API's.
@@ -81,9 +82,9 @@ public class TestDiffListBySkipList {
   }
 
   static void assertList(List<INode> expected, List<INode> computed) {
-    Assertions.assertEquals(expected.size(), computed.size());
+    assertEquals(expected.size(), computed.size());
     for (int index = 0; index < expected.size(); index++) {
-      Assertions.assertEquals(expected.get(index), computed.get(index));
+      assertEquals(expected.get(index), computed.get(index));
     }
   }
 
@@ -107,7 +108,7 @@ public class TestDiffListBySkipList {
       DiffList<DirectoryDiff> array, DiffListBySkipList skip,
       INodeDirectory dir, List<INode> childrenList) {
     final int n = array.size();
-    Assertions.assertEquals(n, skip.size());
+    assertEquals(n, skip.size());
     for (int i = 0; i < n - 1; i++) {
       for (int j = i + 1; j < n - 1; j++) {
         final List<INode> expected = getCombined(array, i, j, dir)
@@ -254,8 +255,8 @@ public class TestDiffListBySkipList {
     final DiffListBySkipList skipList = newDiffListBySkipList();
     final DiffList<DirectoryDiff> arrayList = new DiffListByArrayList<>(0);
     final INodeDirectory dir = addDiff(n, skipList, arrayList, root);
-    Assertions.assertEquals(n, arrayList.size());
-    Assertions.assertEquals(n, skipList.size());
+    assertEquals(n, arrayList.size());
+    assertEquals(n, skipList.size());
 
     for (int i = 0; i < n; i++) {
       DiffListBySkipList.LOG.debug("i={}: {}", i, skipList);
@@ -326,7 +327,7 @@ public class TestDiffListBySkipList {
 
   static void assertDirectoryDiff(DirectoryDiff expected,
       DirectoryDiff computed) {
-    Assertions.assertEquals(expected.getSnapshotId(), computed.getSnapshotId());
+    assertEquals(expected.getSnapshotId(), computed.getSnapshotId());
   }
 
   static void assertSkipList(DiffListBySkipList skipList) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDisallowModifyROSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDisallowModifyROSnapshot.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
@@ -33,7 +34,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * This class tests snapshot functionality. One or multiple snapshots are
@@ -85,7 +85,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testSetReplication() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.setReplication(objInSnapshot, (short) 1);
     });
   }
@@ -93,7 +93,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testSetPermission() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.setPermission(objInSnapshot, new FsPermission("777"));
     });
   }
@@ -101,7 +101,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testSetOwner() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.setOwner(objInSnapshot, "username", "groupname");
     });
   }
@@ -128,7 +128,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testDelete() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.delete(objInSnapshot, true);
     });
   }
@@ -136,7 +136,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testQuota() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.setQuota(objInSnapshot, 100, 100);
     });
   }
@@ -144,7 +144,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testSetTime() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.setTimes(objInSnapshot, 100, 100);
     });
   }
@@ -152,7 +152,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testCreate() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       @SuppressWarnings("deprecation")
       DFSClient dfsclient = new DFSClient(conf);
       dfsclient.create(objInSnapshot.toString(), true);
@@ -162,7 +162,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testAppend() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.append(objInSnapshot, 65535, null);
     });
   }
@@ -170,7 +170,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testMkdir() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       fs.mkdirs(objInSnapshot, new FsPermission("777"));
     });
   }
@@ -178,7 +178,7 @@ public class TestDisallowModifyROSnapshot {
   @Test
   @Timeout(value = 60)
   public void testCreateSymlink() throws Exception {
-    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+    assertThrows(SnapshotAccessControlException.class, () -> {
       @SuppressWarnings("deprecation")
       DFSClient dfsclient = new DFSClient(conf);
       dfsclient.createSymlink(sub2.toString(), "/TestSnapshot/sub1/.snapshot",

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDisallowModifyROSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestDisallowModifyROSnapshot.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Options;
@@ -29,9 +29,11 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.SnapshotAccessControlException;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * This class tests snapshot functionality. One or multiple snapshots are
@@ -55,7 +57,7 @@ public class TestDisallowModifyROSnapshot {
   protected static ArrayList<Path> snapshotList = new ArrayList<Path>();
   static Path objInSnapshot = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
@@ -73,29 +75,39 @@ public class TestDisallowModifyROSnapshot {
         "dir1");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testSetReplication() throws Exception {
-    fs.setReplication(objInSnapshot, (short) 1);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.setReplication(objInSnapshot, (short) 1);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testSetPermission() throws Exception {
-    fs.setPermission(objInSnapshot, new FsPermission("777"));
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.setPermission(objInSnapshot, new FsPermission("777"));
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testSetOwner() throws Exception {
-    fs.setOwner(objInSnapshot, "username", "groupname");
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.setOwner(objInSnapshot, "username", "groupname");
+    });
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRename() throws Exception {
     try {
       fs.rename(objInSnapshot, new Path("/invalid/path"));
@@ -113,43 +125,64 @@ public class TestDisallowModifyROSnapshot {
     } catch (SnapshotAccessControlException e) { /* Ignored */ }
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testDelete() throws Exception {
-    fs.delete(objInSnapshot, true);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.delete(objInSnapshot, true);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testQuota() throws Exception {
-    fs.setQuota(objInSnapshot, 100, 100);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.setQuota(objInSnapshot, 100, 100);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testSetTime() throws Exception {
-    fs.setTimes(objInSnapshot, 100, 100);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.setTimes(objInSnapshot, 100, 100);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testCreate() throws Exception {
-    @SuppressWarnings("deprecation")
-    DFSClient dfsclient = new DFSClient(conf);
-    dfsclient.create(objInSnapshot.toString(), true);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      @SuppressWarnings("deprecation")
+      DFSClient dfsclient = new DFSClient(conf);
+      dfsclient.create(objInSnapshot.toString(), true);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testAppend() throws Exception {
-    fs.append(objInSnapshot, 65535, null);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.append(objInSnapshot, 65535, null);
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testMkdir() throws Exception {
-    fs.mkdirs(objInSnapshot, new FsPermission("777"));
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      fs.mkdirs(objInSnapshot, new FsPermission("777"));
+    });
   }
 
-  @Test(timeout=60000, expected = SnapshotAccessControlException.class)
+  @Test
+  @Timeout(value = 60)
   public void testCreateSymlink() throws Exception {
-    @SuppressWarnings("deprecation")
-    DFSClient dfsclient = new DFSClient(conf);
-    dfsclient.createSymlink(sub2.toString(), "/TestSnapshot/sub1/.snapshot",
-        false);
+    Assertions.assertThrows(SnapshotAccessControlException.class, () -> {
+      @SuppressWarnings("deprecation")
+      DFSClient dfsclient = new DFSClient(conf);
+      dfsclient.createSymlink(sub2.toString(), "/TestSnapshot/sub1/.snapshot",
+          false);
+    });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFSImageWithOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFSImageWithOrderedSnapshotDeletion.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.visitor.NamespacePrintVisitor;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -37,6 +36,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -191,7 +191,7 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     output.println(b);
 
     final String s = NamespacePrintVisitor.print2Sting(fsn);
-    Assertions.assertEquals(b, s);
+    assertEquals(b, s);
     return b;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFSImageWithOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFSImageWithOrderedSnapshotDeletion.java
@@ -25,10 +25,11 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.visitor.NamespacePrintVisitor;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.io.File;
@@ -36,7 +37,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test FSImage correctness with ordered snapshot deletion.
@@ -60,7 +61,7 @@ public class TestFSImageWithOrderedSnapshotDeletion {
   FSNamesystem fsn;
   DistributedFileSystem hdfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, true);
@@ -71,7 +72,7 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -101,7 +102,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     printTree("deleted snapshot " + snapshotName);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDoubleRename() throws Exception {
     final Path parent = new Path("/parent");
     hdfs.mkdirs(parent);
@@ -189,11 +191,12 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     output.println(b);
 
     final String s = NamespacePrintVisitor.print2Sting(fsn);
-    Assert.assertEquals(b, s);
+    Assertions.assertEquals(b, s);
     return b;
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFSImageWithDoubleRename() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -234,7 +237,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
   }
 
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFSImageWithRename1() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -279,7 +283,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFSImageWithRename2() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -320,7 +325,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFSImageWithRename3() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -365,7 +371,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFSImageWithRename4() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -454,7 +461,8 @@ public class TestFSImageWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDoubleRenamesWithSnapshotDelete() throws Exception {
     final Path sub1 = new Path(dir, "sub1");
     hdfs.mkdirs(sub1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileContextSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileContextSnapshot.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileContext;
@@ -31,9 +31,10 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestFileContextSnapshot {
 
@@ -49,7 +50,7 @@ public class TestFileContextSnapshot {
   private final Path filePath = new Path(snapshotRoot, "file1");
   private Path snapRootPath;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -63,7 +64,7 @@ public class TestFileContextSnapshot {
     dfs.mkdirs(snapRootPath);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -71,7 +72,8 @@ public class TestFileContextSnapshot {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreateAndDeleteSnapshot() throws Exception {
     DFSTestUtil.createFile(dfs, filePath, BLOCKSIZE, REPLICATION, SEED);
     // disallow snapshot on dir
@@ -86,40 +88,41 @@ public class TestFileContextSnapshot {
     // allow snapshot on dir
     dfs.allowSnapshot(snapRootPath);
     Path ssPath = fileContext.createSnapshot(snapRootPath, "s1");
-    assertTrue("Failed to create snapshot", dfs.exists(ssPath));
+    assertTrue(dfs.exists(ssPath), "Failed to create snapshot");
     fileContext.deleteSnapshot(snapRootPath, "s1");
-    assertFalse("Failed to delete snapshot", dfs.exists(ssPath));
+    assertFalse(dfs.exists(ssPath), "Failed to delete snapshot");
   }
 
   /**
    * Test FileStatus of snapshot file before/after rename
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameSnapshot() throws Exception {
     DFSTestUtil.createFile(dfs, filePath, BLOCKSIZE, REPLICATION, SEED);
     dfs.allowSnapshot(snapRootPath);
     // Create snapshot for sub1
     Path snapPath1 = fileContext.createSnapshot(snapRootPath, "s1");
     Path ssPath = new Path(snapPath1, filePath.getName());
-    assertTrue("Failed to create snapshot", dfs.exists(ssPath));
+    assertTrue(dfs.exists(ssPath), "Failed to create snapshot");
     FileStatus statusBeforeRename = dfs.getFileStatus(ssPath);
 
     // Rename the snapshot
     fileContext.renameSnapshot(snapRootPath, "s1", "s2");
     // <sub1>/.snapshot/s1/file1 should no longer exist
-    assertFalse("Old snapshot still exists after rename!", dfs.exists(ssPath));
+    assertFalse(dfs.exists(ssPath), "Old snapshot still exists after rename!");
     Path snapshotRoot = SnapshotTestHelper.getSnapshotRoot(snapRootPath, "s2");
     ssPath = new Path(snapshotRoot, filePath.getName());
 
     // Instead, <sub1>/.snapshot/s2/file1 should exist
-    assertTrue("Snapshot doesn't exists!", dfs.exists(ssPath));
+    assertTrue(dfs.exists(ssPath), "Snapshot doesn't exists!");
     FileStatus statusAfterRename = dfs.getFileStatus(ssPath);
 
     // FileStatus of the snapshot should not change except the path
-    assertFalse("Filestatus of the snapshot matches",
-        statusBeforeRename.equals(statusAfterRename));
+    assertFalse(statusBeforeRename.equals(statusAfterRename),
+        "Filestatus of the snapshot matches");
     statusBeforeRename.setPath(statusAfterRename.getPath());
-    assertEquals("FileStatus of the snapshot mismatches!",
-        statusBeforeRename.toString(), statusAfterRename.toString());
+    assertEquals(statusBeforeRename.toString(), statusAfterRename.toString(),
+        "FileStatus of the snapshot mismatches!");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileWithSnapshotFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileWithSnapshotFeature.java
@@ -33,13 +33,13 @@ import org.apache.hadoop.hdfs.server.namenode.QuotaCounts;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.fs.StorageType.DISK;
 import static org.apache.hadoop.fs.StorageType.SSD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyByte;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -79,8 +79,8 @@ public class TestFileWithSnapshotFeature {
         bsps, collectedBlocks, removedINodes, null);
     sf.updateQuotaAndCollectBlocks(ctx, file, diff);
     QuotaCounts counts = ctx.quotaDelta().getCountsCopy();
-    Assertions.assertEquals(0, counts.getStorageSpace());
-    Assertions.assertTrue(counts.getTypeSpaces().allLessOrEqual(0));
+    assertEquals(0, counts.getStorageSpace());
+    assertTrue(counts.getTypeSpaces().allLessOrEqual(0));
 
     // INode only exists in the snapshot
     INodeFile snapshotINode = mock(INodeFile.class);
@@ -95,10 +95,10 @@ public class TestFileWithSnapshotFeature {
     blocks[0].setReplication(REPL_3);
     sf.updateQuotaAndCollectBlocks(ctx, file, diff);
     counts = ctx.quotaDelta().getCountsCopy();
-    Assertions.assertEquals((REPL_3 - REPL_1) * BLOCK_SIZE,
+    assertEquals((REPL_3 - REPL_1) * BLOCK_SIZE,
         counts.getStorageSpace());
-    Assertions.assertEquals(BLOCK_SIZE, counts.getTypeSpaces().get(DISK));
-    Assertions.assertEquals(-BLOCK_SIZE, counts.getTypeSpaces().get(SSD));
+    assertEquals(BLOCK_SIZE, counts.getTypeSpaces().get(DISK));
+    assertEquals(-BLOCK_SIZE, counts.getTypeSpaces().get(SSD));
   }
 
   private INodeFile createMockFile(short replication) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileWithSnapshotFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFileWithSnapshotFeature.java
@@ -33,13 +33,13 @@ import org.apache.hadoop.hdfs.server.namenode.QuotaCounts;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.fs.StorageType.DISK;
 import static org.apache.hadoop.fs.StorageType.SSD;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.anyByte;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -79,8 +79,8 @@ public class TestFileWithSnapshotFeature {
         bsps, collectedBlocks, removedINodes, null);
     sf.updateQuotaAndCollectBlocks(ctx, file, diff);
     QuotaCounts counts = ctx.quotaDelta().getCountsCopy();
-    Assert.assertEquals(0, counts.getStorageSpace());
-    Assert.assertTrue(counts.getTypeSpaces().allLessOrEqual(0));
+    Assertions.assertEquals(0, counts.getStorageSpace());
+    Assertions.assertTrue(counts.getTypeSpaces().allLessOrEqual(0));
 
     // INode only exists in the snapshot
     INodeFile snapshotINode = mock(INodeFile.class);
@@ -95,10 +95,10 @@ public class TestFileWithSnapshotFeature {
     blocks[0].setReplication(REPL_3);
     sf.updateQuotaAndCollectBlocks(ctx, file, diff);
     counts = ctx.quotaDelta().getCountsCopy();
-    Assert.assertEquals((REPL_3 - REPL_1) * BLOCK_SIZE,
-                        counts.getStorageSpace());
-    Assert.assertEquals(BLOCK_SIZE, counts.getTypeSpaces().get(DISK));
-    Assert.assertEquals(-BLOCK_SIZE, counts.getTypeSpaces().get(SSD));
+    Assertions.assertEquals((REPL_3 - REPL_1) * BLOCK_SIZE,
+        counts.getStorageSpace());
+    Assertions.assertEquals(BLOCK_SIZE, counts.getTypeSpaces().get(DISK));
+    Assertions.assertEquals(-BLOCK_SIZE, counts.getTypeSpaces().get(SSD));
   }
 
   private INodeFile createMockFile(short replication) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFsShellMoveToTrashWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFsShellMoveToTrashWithSnapshots.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -38,6 +37,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing snapshots with FsShell move-to-trash feature.
@@ -246,7 +247,7 @@ public class TestFsShellMoveToTrashWithSnapshots {
     for (MyFile f : files) {
       final String original = f.trash.toUri().getPath();
       if (!original.startsWith(trashPathPrefix)) {
-        Assertions.assertTrue(original.startsWith(commonPrefix));
+        assertTrue(original.startsWith(commonPrefix));
 
         final int i = original.indexOf('/', commonPrefix.length());
         final String suffix = original.substring(i + 1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFsShellMoveToTrashWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestFsShellMoveToTrashWithSnapshots.java
@@ -20,10 +20,11 @@ package org.apache.hadoop.hdfs.server.namenode.snapshot;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,14 +56,14 @@ public class TestFsShellMoveToTrashWithSnapshots {
 
   private static SnapshotTestHelper.MyCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final Configuration conf = new Configuration();
     conf.setInt(CommonConfigurationKeys.FS_TRASH_INTERVAL_KEY, 100);
     cluster = new SnapshotTestHelper.MyCluster(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -245,7 +246,7 @@ public class TestFsShellMoveToTrashWithSnapshots {
     for (MyFile f : files) {
       final String original = f.trash.toUri().getPath();
       if (!original.startsWith(trashPathPrefix)) {
-        Assert.assertTrue(original.startsWith(commonPrefix));
+        Assertions.assertTrue(original.startsWith(commonPrefix));
 
         final int i = original.indexOf('/', commonPrefix.length());
         final String suffix = original.substring(i + 1);
@@ -254,12 +255,14 @@ public class TestFsShellMoveToTrashWithSnapshots {
     }
   }
 
-  @Test(timeout = 300_000)
+  @Test
+  @Timeout(value = 300)
   public void test100tasks20files() throws Exception {
     runMultipleTasks(100, 20);
   }
 
-  @Test(timeout = 300_000)
+  @Test
+  @Timeout(value = 300)
   public void test10tasks200files() throws Exception {
     runMultipleTasks(10, 200);
   }
@@ -289,7 +292,8 @@ public class TestFsShellMoveToTrashWithSnapshots {
     assertExists(buckets, f -> removeSubstring(f.getPath()));
   }
 
-  @Test(timeout = 100_000)
+  @Test
+  @Timeout(value = 100)
   public void test4files() throws Exception {
     final Path dbDir = cluster.mkdirs(WAREHOUSE_DIR + "db");
     final Path tmpDir = cluster.mkdirs(WAREHOUSE_DIR + "tmp");
@@ -298,7 +302,8 @@ public class TestFsShellMoveToTrashWithSnapshots {
     assertExists(buckets, f -> removeSubstring(f.getPath()));
   }
 
-  @Test(timeout = 300_000)
+  @Test
+  @Timeout(value = 300)
   public void test200files() throws Exception {
     final Path dbDir = cluster.mkdirs(WAREHOUSE_DIR + "db");
     final Path tmpDir = cluster.mkdirs(WAREHOUSE_DIR + "tmp");
@@ -307,7 +312,8 @@ public class TestFsShellMoveToTrashWithSnapshots {
     assertExists(buckets, f -> removeSubstring(f.getPath()));
   }
 
-  @Test(timeout = 300_000)
+  @Test
+  @Timeout(value = 300)
   public void test50files10times() throws Exception {
     final Path tmpDir = cluster.mkdirs(WAREHOUSE_DIR + "tmp");
     final List<MyFile> buckets = new ArrayList<>();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestGetContentSummaryWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestGetContentSummaryWithSnapshot.java
@@ -26,12 +26,10 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -51,10 +49,7 @@ public class TestGetContentSummaryWithSnapshot {
   protected FSDirectory fsdir;
   protected DistributedFileSystem dfs;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -66,7 +61,7 @@ public class TestGetContentSummaryWithSnapshot {
     dfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -103,68 +98,68 @@ public class TestGetContentSummaryWithSnapshot {
 
     ContentSummary summary = cluster.getNameNodeRpc().getContentSummary(
         bar.toString());
-    Assert.assertEquals(1, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(20, summary.getLength());
+    Assertions.assertEquals(1, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(20, summary.getLength());
 
     final Path barS1 = SnapshotTestHelper.getSnapshotPath(foo, "s1", "bar");
     summary = cluster.getNameNodeRpc().getContentSummary(barS1.toString());
-    Assert.assertEquals(1, summary.getDirectoryCount());
-    Assert.assertEquals(0, summary.getFileCount());
-    Assert.assertEquals(0, summary.getLength());
+    Assertions.assertEquals(1, summary.getDirectoryCount());
+    Assertions.assertEquals(0, summary.getFileCount());
+    Assertions.assertEquals(0, summary.getLength());
 
     // also check /foo and /foo/.snapshot/s1
     summary = cluster.getNameNodeRpc().getContentSummary(foo.toString());
-    Assert.assertEquals(2, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(20, summary.getLength());
+    Assertions.assertEquals(2, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(20, summary.getLength());
 
     final Path fooS1 = SnapshotTestHelper.getSnapshotRoot(foo, "s1");
     summary = cluster.getNameNodeRpc().getContentSummary(fooS1.toString());
-    Assert.assertEquals(2, summary.getDirectoryCount());
-    Assert.assertEquals(0, summary.getFileCount());
-    Assert.assertEquals(0, summary.getLength());
+    Assertions.assertEquals(2, summary.getDirectoryCount());
+    Assertions.assertEquals(0, summary.getFileCount());
+    Assertions.assertEquals(0, summary.getLength());
 
     // create a new snapshot s2 and update the file
     dfs.createSnapshot(foo, "s2");
     DFSTestUtil.appendFile(dfs, baz, 10);
     summary = cluster.getNameNodeRpc().getContentSummary(
         bar.toString());
-    Assert.assertEquals(1, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(30, summary.getLength());
+    Assertions.assertEquals(1, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(30, summary.getLength());
 
     final Path fooS2 = SnapshotTestHelper.getSnapshotRoot(foo, "s2");
     summary = cluster.getNameNodeRpc().getContentSummary(fooS2.toString());
-    Assert.assertEquals(2, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(20, summary.getLength());
+    Assertions.assertEquals(2, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(20, summary.getLength());
 
     cluster.getNameNodeRpc().delete(baz.toString(), false);
 
     summary = cluster.getNameNodeRpc().getContentSummary(
         foo.toString());
-    Assert.assertEquals(0, summary.getSnapshotDirectoryCount());
-    Assert.assertEquals(1, summary.getSnapshotFileCount());
-    Assert.assertEquals(20, summary.getSnapshotLength());
-    Assert.assertEquals(2, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(30, summary.getLength());
+    Assertions.assertEquals(0, summary.getSnapshotDirectoryCount());
+    Assertions.assertEquals(1, summary.getSnapshotFileCount());
+    Assertions.assertEquals(20, summary.getSnapshotLength());
+    Assertions.assertEquals(2, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(30, summary.getLength());
 
     final Path bazS1 = SnapshotTestHelper.getSnapshotPath(foo, "s1", "bar/baz");
     try {
       cluster.getNameNodeRpc().getContentSummary(bazS1.toString());
-      Assert.fail("should get FileNotFoundException");
+      Assertions.fail("should get FileNotFoundException");
     } catch (FileNotFoundException ignored) {}
     cluster.getNameNodeRpc().rename(qux.toString(), "/temp/qux");
     summary = cluster.getNameNodeRpc().getContentSummary(
         foo.toString());
-    Assert.assertEquals(0, summary.getSnapshotDirectoryCount());
-    Assert.assertEquals(2, summary.getSnapshotFileCount());
-    Assert.assertEquals(30, summary.getSnapshotLength());
-    Assert.assertEquals(2, summary.getDirectoryCount());
-    Assert.assertEquals(2, summary.getFileCount());
-    Assert.assertEquals(30, summary.getLength());
+    Assertions.assertEquals(0, summary.getSnapshotDirectoryCount());
+    Assertions.assertEquals(2, summary.getSnapshotFileCount());
+    Assertions.assertEquals(30, summary.getSnapshotLength());
+    Assertions.assertEquals(2, summary.getDirectoryCount());
+    Assertions.assertEquals(2, summary.getFileCount());
+    Assertions.assertEquals(30, summary.getLength());
 
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestGetContentSummaryWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestGetContentSummaryWithSnapshot.java
@@ -27,12 +27,14 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Verify content summary is computed correctly when
@@ -98,68 +100,68 @@ public class TestGetContentSummaryWithSnapshot {
 
     ContentSummary summary = cluster.getNameNodeRpc().getContentSummary(
         bar.toString());
-    Assertions.assertEquals(1, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(20, summary.getLength());
+    assertEquals(1, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(20, summary.getLength());
 
     final Path barS1 = SnapshotTestHelper.getSnapshotPath(foo, "s1", "bar");
     summary = cluster.getNameNodeRpc().getContentSummary(barS1.toString());
-    Assertions.assertEquals(1, summary.getDirectoryCount());
-    Assertions.assertEquals(0, summary.getFileCount());
-    Assertions.assertEquals(0, summary.getLength());
+    assertEquals(1, summary.getDirectoryCount());
+    assertEquals(0, summary.getFileCount());
+    assertEquals(0, summary.getLength());
 
     // also check /foo and /foo/.snapshot/s1
     summary = cluster.getNameNodeRpc().getContentSummary(foo.toString());
-    Assertions.assertEquals(2, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(20, summary.getLength());
+    assertEquals(2, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(20, summary.getLength());
 
     final Path fooS1 = SnapshotTestHelper.getSnapshotRoot(foo, "s1");
     summary = cluster.getNameNodeRpc().getContentSummary(fooS1.toString());
-    Assertions.assertEquals(2, summary.getDirectoryCount());
-    Assertions.assertEquals(0, summary.getFileCount());
-    Assertions.assertEquals(0, summary.getLength());
+    assertEquals(2, summary.getDirectoryCount());
+    assertEquals(0, summary.getFileCount());
+    assertEquals(0, summary.getLength());
 
     // create a new snapshot s2 and update the file
     dfs.createSnapshot(foo, "s2");
     DFSTestUtil.appendFile(dfs, baz, 10);
     summary = cluster.getNameNodeRpc().getContentSummary(
         bar.toString());
-    Assertions.assertEquals(1, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(30, summary.getLength());
+    assertEquals(1, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(30, summary.getLength());
 
     final Path fooS2 = SnapshotTestHelper.getSnapshotRoot(foo, "s2");
     summary = cluster.getNameNodeRpc().getContentSummary(fooS2.toString());
-    Assertions.assertEquals(2, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(20, summary.getLength());
+    assertEquals(2, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(20, summary.getLength());
 
     cluster.getNameNodeRpc().delete(baz.toString(), false);
 
     summary = cluster.getNameNodeRpc().getContentSummary(
         foo.toString());
-    Assertions.assertEquals(0, summary.getSnapshotDirectoryCount());
-    Assertions.assertEquals(1, summary.getSnapshotFileCount());
-    Assertions.assertEquals(20, summary.getSnapshotLength());
-    Assertions.assertEquals(2, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(30, summary.getLength());
+    assertEquals(0, summary.getSnapshotDirectoryCount());
+    assertEquals(1, summary.getSnapshotFileCount());
+    assertEquals(20, summary.getSnapshotLength());
+    assertEquals(2, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(30, summary.getLength());
 
     final Path bazS1 = SnapshotTestHelper.getSnapshotPath(foo, "s1", "bar/baz");
     try {
       cluster.getNameNodeRpc().getContentSummary(bazS1.toString());
-      Assertions.fail("should get FileNotFoundException");
+      fail("should get FileNotFoundException");
     } catch (FileNotFoundException ignored) {}
     cluster.getNameNodeRpc().rename(qux.toString(), "/temp/qux");
     summary = cluster.getNameNodeRpc().getContentSummary(
         foo.toString());
-    Assertions.assertEquals(0, summary.getSnapshotDirectoryCount());
-    Assertions.assertEquals(2, summary.getSnapshotFileCount());
-    Assertions.assertEquals(30, summary.getSnapshotLength());
-    Assertions.assertEquals(2, summary.getDirectoryCount());
-    Assertions.assertEquals(2, summary.getFileCount());
-    Assertions.assertEquals(30, summary.getLength());
+    assertEquals(0, summary.getSnapshotDirectoryCount());
+    assertEquals(2, summary.getSnapshotFileCount());
+    assertEquals(30, summary.getSnapshotLength());
+    assertEquals(2, summary.getDirectoryCount());
+    assertEquals(2, summary.getFileCount());
+    assertEquals(30, summary.getLength());
 
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestINodeFileUnderConstructionWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestINodeFileUnderConstructionWithSnapshot.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -50,9 +50,10 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeat
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test snapshot functionalities while file appending.
@@ -75,7 +76,7 @@ public class TestINodeFileUnderConstructionWithSnapshot {
   DistributedFileSystem hdfs;
   FSDirectory fsdir;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -88,7 +89,7 @@ public class TestINodeFileUnderConstructionWithSnapshot {
     hdfs.mkdirs(dir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -99,7 +100,8 @@ public class TestINodeFileUnderConstructionWithSnapshot {
   /**
    * Test snapshot after file appending
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotAfterAppending() throws Exception {
     Path file = new Path(dir, "file");
     // 1. create snapshot --> create file --> append
@@ -125,7 +127,7 @@ public class TestINodeFileUnderConstructionWithSnapshot {
     
     // check corresponding inodes
     fileNode = (INodeFile) fsdir.getINode(file.toString());
-    assertEquals(REPLICATION - 1,  fileNode.getFileReplication());
+    assertEquals(REPLICATION - 1, fileNode.getFileReplication());
     assertEquals(BLOCKSIZE * 4, fileNode.computeFileSize());
   }
   
@@ -143,7 +145,8 @@ public class TestINodeFileUnderConstructionWithSnapshot {
    * Test snapshot during file appending, before the corresponding
    * {@link FSDataOutputStream} instance closes.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotWhileAppending() throws Exception {
     Path file = new Path(dir, "file");
     DFSTestUtil.createFile(hdfs, file, BLOCKSIZE, REPLICATION, seed);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestListSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestListSnapshot.java
@@ -26,16 +26,17 @@ import org.apache.hadoop.hdfs.protocol.SnapshotStatus;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.
     DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests listSnapshot.
@@ -51,7 +52,7 @@ public class TestListSnapshot {
   FSNamesystem fsn;
   DistributedFileSystem hdfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, true);
@@ -63,7 +64,7 @@ public class TestListSnapshot {
     hdfs.mkdirs(dir1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -74,7 +75,8 @@ public class TestListSnapshot {
   /**
    * Test listing all the snapshottable directories.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testListSnapshot() throws Exception {
     fsn.getSnapshotManager().setAllowNestedSnapshots(true);
 
@@ -106,10 +108,8 @@ public class TestListSnapshot {
     hdfs.createSnapshot(dir1, "s0");
     snapshotStatuses = hdfs.getSnapshotListing(dir1);
     assertEquals(1, snapshotStatuses.length);
-    assertEquals("s0", snapshotStatuses[0].getDirStatus().
-        getLocalName());
-    assertEquals(SnapshotTestHelper.getSnapshotRoot(dir1, "s0"),
-        snapshotStatuses[0].getFullPath());
+    assertEquals("s0", snapshotStatuses[0].getDirStatus().getLocalName());
+    assertEquals(SnapshotTestHelper.getSnapshotRoot(dir1, "s0"), snapshotStatuses[0].getFullPath());
     // snapshot id is zero
     assertEquals(0, snapshotStatuses[0].getSnapshotID());
     // Create a snapshot for dir1

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestNestedSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestNestedSnapshots.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_MAX_LIMIT;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Random;
@@ -39,10 +39,11 @@ import org.apache.hadoop.hdfs.server.namenode.EditLogFileOutputStream;
 import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.INodeDirectory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /** Testing nested snapshots. */
 public class TestNestedSnapshots {
@@ -67,7 +68,7 @@ public class TestNestedSnapshots {
   private static MiniDFSCluster cluster;
   private static DistributedFileSystem hdfs;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf.setInt(DFS_NAMENODE_SNAPSHOT_MAX_LIMIT, SNAPSHOTLIMIT);
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
@@ -76,7 +77,7 @@ public class TestNestedSnapshots {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -90,7 +91,8 @@ public class TestNestedSnapshots {
    * snapshots and the files created after the snapshots should not appear in
    * any of the snapshots.  
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testNestedSnapshots() throws Exception {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(true);
 
@@ -141,14 +143,14 @@ public class TestNestedSnapshots {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(false);
     try {
       hdfs.allowSnapshot(rootPath);
-      Assert.fail();
+      Assertions.fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "subdirectory");
     }
     try {
       hdfs.allowSnapshot(foo);
-      Assert.fail();
+      Assertions.fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "subdirectory");
@@ -159,14 +161,14 @@ public class TestNestedSnapshots {
     hdfs.mkdirs(sub2Bar);
     try {
       hdfs.allowSnapshot(sub1Bar);
-      Assert.fail();
+      Assertions.fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "ancestor");
     }
     try {
       hdfs.allowSnapshot(sub2Bar);
-      Assert.fail();
+      Assertions.fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "ancestor");
@@ -174,9 +176,9 @@ public class TestNestedSnapshots {
   }
   
   static void assertNestedSnapshotException(SnapshotException se, String substring) {
-    Assert.assertTrue(se.getMessage().startsWith(
+    Assertions.assertTrue(se.getMessage().startsWith(
         "Nested snapshottable directories not allowed"));
-    Assert.assertTrue(se.getMessage().contains(substring));
+    Assertions.assertTrue(se.getMessage().contains(substring));
   }
 
   private static void print(String message) throws UnresolvedLinkException {
@@ -190,10 +192,10 @@ public class TestNestedSnapshots {
         new Path(s1, "bar/" + file.getName()),
         new Path(s2, file.getName())
     };
-    Assert.assertEquals(expected.length, paths.length);
+    Assertions.assertEquals(expected.length, paths.length);
     for(int i = 0; i < paths.length; i++) {
       final boolean computed = hdfs.exists(paths[i]);
-      Assert.assertEquals("Failed on " + paths[i], expected[i], computed);
+      Assertions.assertEquals(expected[i], computed, "Failed on " + paths[i]);
     }
   }
 
@@ -201,7 +203,8 @@ public class TestNestedSnapshots {
    * Test the snapshot limit of a single snapshottable directory.
    * @throws Exception
    */
-  @Test (timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testSnapshotLimit() throws Exception {
     final int step = 1000;
     final String dirStr = "/testSnapshotLimit/dir";
@@ -224,7 +227,7 @@ public class TestNestedSnapshots {
 
     try {
       hdfs.createSnapshot(dir, "s" + s);
-      Assert.fail("Expected to fail to create snapshot, but didn't.");
+      Assertions.fail("Expected to fail to create snapshot, but didn't.");
     } catch(IOException ioe) {
       SnapshotTestHelper.LOG.info("The exception is expected.", ioe);
     }
@@ -235,12 +238,13 @@ public class TestNestedSnapshots {
       for(; s < SNAPSHOTLIMIT; s += RANDOM.nextInt(step)) {
         final Path p = SnapshotTestHelper.getSnapshotPath(dir, "s" + s, file);
         //the file #f exists in snapshot #s iff s > f.
-        Assert.assertEquals(s > f, hdfs.exists(p));
+        Assertions.assertEquals(s > f, hdfs.exists(p));
       }
     }
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testSnapshotName() throws Exception {
     final String dirStr = "/testSnapshotWithQuota/dir";
     final Path dir = new Path(dirStr);
@@ -260,20 +264,21 @@ public class TestNestedSnapshots {
       final Path snapshotPath = hdfs.createSnapshot(dir);
 
       //check snapshot path and the default snapshot name
-      final String snapshotName = snapshotPath.getName(); 
-      Assert.assertTrue("snapshotName=" + snapshotName, Pattern.matches(
+      final String snapshotName = snapshotPath.getName();
+      Assertions.assertTrue(Pattern.matches(
           "s\\d\\d\\d\\d\\d\\d\\d\\d-\\d\\d\\d\\d\\d\\d\\.\\d\\d\\d",
-          snapshotName));
+          snapshotName), "snapshotName=" + snapshotName);
       final Path parent = snapshotPath.getParent();
-      Assert.assertEquals(HdfsConstants.DOT_SNAPSHOT_DIR, parent.getName());
-      Assert.assertEquals(dir, parent.getParent());
+      Assertions.assertEquals(HdfsConstants.DOT_SNAPSHOT_DIR, parent.getName());
+      Assertions.assertEquals(dir, parent.getParent());
     }
   }
 
   /**
    * Test {@link Snapshot#ID_COMPARATOR}.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testIdCmp() {
     final PermissionStatus perm = PermissionStatus.createImmutable(
         "user", "group", FsPermission.createImmutable((short)0));
@@ -287,18 +292,18 @@ public class TestNestedSnapshots {
       new Snapshot(2, "s2", snapshottable),
     };
 
-    Assert.assertEquals(0, Snapshot.ID_COMPARATOR.compare(null, null));
-    for(Snapshot s : snapshots) {
-      Assert.assertTrue(Snapshot.ID_COMPARATOR.compare(null, s) > 0);
-      Assert.assertTrue(Snapshot.ID_COMPARATOR.compare(s, null) < 0);
-      
-      for(Snapshot t : snapshots) {
+    Assertions.assertEquals(0, Snapshot.ID_COMPARATOR.compare(null, null));
+    for (Snapshot s : snapshots) {
+      Assertions.assertTrue(Snapshot.ID_COMPARATOR.compare(null, s) > 0);
+      Assertions.assertTrue(Snapshot.ID_COMPARATOR.compare(s, null) < 0);
+
+      for (Snapshot t : snapshots) {
         final int expected = s.getRoot().getLocalName().compareTo(
             t.getRoot().getLocalName());
         final int computed = Snapshot.ID_COMPARATOR.compare(s, t);
-        Assert.assertEquals(expected > 0, computed > 0);
-        Assert.assertEquals(expected == 0, computed == 0);
-        Assert.assertEquals(expected < 0, computed < 0);
+        Assertions.assertEquals(expected > 0, computed > 0);
+        Assertions.assertEquals(expected == 0, computed == 0);
+        Assertions.assertEquals(expected < 0, computed < 0);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestNestedSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestNestedSnapshots.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_MAX_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Random;
@@ -40,7 +42,6 @@ import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.INodeDirectory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -143,14 +144,14 @@ public class TestNestedSnapshots {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(false);
     try {
       hdfs.allowSnapshot(rootPath);
-      Assertions.fail();
+      fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "subdirectory");
     }
     try {
       hdfs.allowSnapshot(foo);
-      Assertions.fail();
+      fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "subdirectory");
@@ -161,14 +162,14 @@ public class TestNestedSnapshots {
     hdfs.mkdirs(sub2Bar);
     try {
       hdfs.allowSnapshot(sub1Bar);
-      Assertions.fail();
+      fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "ancestor");
     }
     try {
       hdfs.allowSnapshot(sub2Bar);
-      Assertions.fail();
+      fail();
     } catch (SnapshotException se) {
       assertNestedSnapshotException(
           se, "ancestor");
@@ -176,9 +177,9 @@ public class TestNestedSnapshots {
   }
   
   static void assertNestedSnapshotException(SnapshotException se, String substring) {
-    Assertions.assertTrue(se.getMessage().startsWith(
+    assertTrue(se.getMessage().startsWith(
         "Nested snapshottable directories not allowed"));
-    Assertions.assertTrue(se.getMessage().contains(substring));
+    assertTrue(se.getMessage().contains(substring));
   }
 
   private static void print(String message) throws UnresolvedLinkException {
@@ -192,10 +193,10 @@ public class TestNestedSnapshots {
         new Path(s1, "bar/" + file.getName()),
         new Path(s2, file.getName())
     };
-    Assertions.assertEquals(expected.length, paths.length);
+    assertEquals(expected.length, paths.length);
     for(int i = 0; i < paths.length; i++) {
       final boolean computed = hdfs.exists(paths[i]);
-      Assertions.assertEquals(expected[i], computed, "Failed on " + paths[i]);
+      assertEquals(expected[i], computed, "Failed on " + paths[i]);
     }
   }
 
@@ -227,7 +228,7 @@ public class TestNestedSnapshots {
 
     try {
       hdfs.createSnapshot(dir, "s" + s);
-      Assertions.fail("Expected to fail to create snapshot, but didn't.");
+      fail("Expected to fail to create snapshot, but didn't.");
     } catch(IOException ioe) {
       SnapshotTestHelper.LOG.info("The exception is expected.", ioe);
     }
@@ -238,7 +239,7 @@ public class TestNestedSnapshots {
       for(; s < SNAPSHOTLIMIT; s += RANDOM.nextInt(step)) {
         final Path p = SnapshotTestHelper.getSnapshotPath(dir, "s" + s, file);
         //the file #f exists in snapshot #s iff s > f.
-        Assertions.assertEquals(s > f, hdfs.exists(p));
+        assertEquals(s > f, hdfs.exists(p));
       }
     }
   }
@@ -265,12 +266,12 @@ public class TestNestedSnapshots {
 
       //check snapshot path and the default snapshot name
       final String snapshotName = snapshotPath.getName();
-      Assertions.assertTrue(Pattern.matches(
+      assertTrue(Pattern.matches(
           "s\\d\\d\\d\\d\\d\\d\\d\\d-\\d\\d\\d\\d\\d\\d\\.\\d\\d\\d",
           snapshotName), "snapshotName=" + snapshotName);
       final Path parent = snapshotPath.getParent();
-      Assertions.assertEquals(HdfsConstants.DOT_SNAPSHOT_DIR, parent.getName());
-      Assertions.assertEquals(dir, parent.getParent());
+      assertEquals(HdfsConstants.DOT_SNAPSHOT_DIR, parent.getName());
+      assertEquals(dir, parent.getParent());
     }
   }
 
@@ -292,18 +293,18 @@ public class TestNestedSnapshots {
       new Snapshot(2, "s2", snapshottable),
     };
 
-    Assertions.assertEquals(0, Snapshot.ID_COMPARATOR.compare(null, null));
+    assertEquals(0, Snapshot.ID_COMPARATOR.compare(null, null));
     for (Snapshot s : snapshots) {
-      Assertions.assertTrue(Snapshot.ID_COMPARATOR.compare(null, s) > 0);
-      Assertions.assertTrue(Snapshot.ID_COMPARATOR.compare(s, null) < 0);
+      assertTrue(Snapshot.ID_COMPARATOR.compare(null, s) > 0);
+      assertTrue(Snapshot.ID_COMPARATOR.compare(s, null) < 0);
 
       for (Snapshot t : snapshots) {
         final int expected = s.getRoot().getLocalName().compareTo(
             t.getRoot().getLocalName());
         final int computed = Snapshot.ID_COMPARATOR.compare(s, t);
-        Assertions.assertEquals(expected > 0, computed > 0);
-        Assertions.assertEquals(expected == 0, computed == 0);
-        Assertions.assertEquals(expected < 0, computed < 0);
+        assertEquals(expected > 0, computed > 0);
+        assertEquals(expected == 0, computed == 0);
+        assertEquals(expected < 0, computed < 0);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
@@ -45,10 +45,14 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestOpenFilesWithSnapshot {
   private static final Logger LOG =
@@ -252,6 +256,7 @@ public class TestOpenFilesWithSnapshot {
    *   \- level_2_D        (Snapshottable Dir)
    *     +- hbase.log      (open file, under snap root)
    */
+  @SuppressWarnings("checkstyle:methodlength")
   @Test
   @Timeout(value = 120)
   public void testPointInTimeSnapshotCopiesForOpenFiles() throws Exception {
@@ -315,13 +320,13 @@ public class TestOpenFilesWithSnapshot {
     final long hbaseFileLengthAfterS1 = fs.getFileStatus(hbaseFile).getLen();
 
     // Verify if Snap S1 file lengths are same as the the live ones
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS1,
+    assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assertions.assertEquals(appAFileInitialLength,
+    assertEquals(appAFileInitialLength,
         fs.getFileStatus(appAFile).getLen());
-    Assertions.assertEquals(appBFileInitialLength,
+    assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
@@ -348,17 +353,17 @@ public class TestOpenFilesWithSnapshot {
     // Verify live files lengths are same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
     final long hbaseFileLengthAfterS2 = fs.getFileStatus(hbaseFile).getLen();
-    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
-    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
+    assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
 
     // Verify if Snap S2 file lengths are same as the live ones
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS2,
+    assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
-    Assertions.assertEquals(appAFileInitialLength,
+    assertEquals(appAFileInitialLength,
         fs.getFileStatus(appAFile).getLen());
-    Assertions.assertEquals(appBFileInitialLength,
+    assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     // Write more data to appA file only
@@ -368,9 +373,9 @@ public class TestOpenFilesWithSnapshot {
     appAFileWrittenDataLength += writeToStream(appAOutputStream, buf);
 
     // Verify other open files are not affected in their snapshots
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assertions.assertEquals(appAFileWrittenDataLength,
+    assertEquals(appAFileWrittenDataLength,
         fs.getFileStatus(appAFile).getLen());
 
     // Write more data to flume file only
@@ -390,35 +395,35 @@ public class TestOpenFilesWithSnapshot {
     // Verify live files lengths are same as all data written till now
     final long flumeFileLengthAfterS3 = fs.getFileStatus(flumeFile).getLen();
     final long hbaseFileLengthAfterS3 = fs.getFileStatus(hbaseFile).getLen();
-    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS3);
-    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
+    assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS3);
+    assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
 
     // Verify if Snap S3 file lengths are same as the live ones
-    Assertions.assertEquals(flumeFileLengthAfterS3,
+    assertEquals(flumeFileLengthAfterS3,
         fs.getFileStatus(flumeS3Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS3,
+    assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
-    Assertions.assertEquals(appAFileWrittenDataLength,
+    assertEquals(appAFileWrittenDataLength,
         fs.getFileStatus(appAFile).getLen());
-    Assertions.assertEquals(appBFileInitialLength,
+    assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS3,
+    assertEquals(flumeFileLengthAfterS3,
         fs.getFileStatus(flumeS3Path).getLen());
 
     // Verify old hbase snapshots have point-in-time / frozen file lengths
     // even after the live files have moved forward.
-    Assertions.assertEquals(hbaseFileLengthAfterS1,
+    assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS2,
+    assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS3,
+    assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
 
     flumeOutputStream.close();
@@ -453,7 +458,7 @@ public class TestOpenFilesWithSnapshot {
     final long flumeFileLengthAfterS1 = fs.getFileStatus(flumeFile).getLen();
 
     // Verify if Snap S1 file length is same as the the live one
-    Assertions.assertEquals(flumeFileLengthAfterS1, fs.getFileStatus(flumeS1Path).getLen());
+    assertEquals(flumeFileLengthAfterS1, fs.getFileStatus(flumeS1Path).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
     int newWriteLength = (int) (BLOCKSIZE * 1.5);
@@ -471,19 +476,19 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify live files length is same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
-    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the live one
-    Assertions.assertEquals(flumeFileLengthAfterS2, fs.getFileStatus(flumeS2Path).getLen());
+    assertEquals(flumeFileLengthAfterS2, fs.getFileStatus(flumeS2Path).getLen());
 
     // Write more data to flume file
     flumeFileWrittenDataLength += writeToStream(flumeOutputStream, buf);
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
 
     // Restart the NameNode
@@ -491,14 +496,14 @@ public class TestOpenFilesWithSnapshot {
     cluster.waitActive();
 
     // Verify live file length hasn't changed after NN restart
-    Assertions.assertEquals(flumeFileWrittenDataLength,
+    assertEquals(flumeFileWrittenDataLength,
         fs.getFileStatus(flumeFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // after NN restart and live file moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
 
     flumeOutputStream.close();
@@ -536,9 +541,9 @@ public class TestOpenFilesWithSnapshot {
     final long hbaseFileLengthAfterS1 = fs.getFileStatus(hbaseFile).getLen();
 
     // Verify if Snap S1 file length is same as the the current versions
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS1,
+    assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
@@ -560,14 +565,14 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify current files length are same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
-    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
     final long hbaseFileLengthAfterS2 = fs.getFileStatus(hbaseFile).getLen();
-    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
+    assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the current versions
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS2,
+    assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
 
     // Write more data to open files
@@ -576,22 +581,22 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify old snapshots have point-in-time/frozen file
     // lengths even after the current versions have moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS1,
+    assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assertions.assertEquals(hbaseFileLengthAfterS2,
+    assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
 
     // Delete flume current file. Snapshots should
     // still have references to flume file.
     boolean flumeFileDeleted = fs.delete(flumeFile, true);
-    Assertions.assertTrue(flumeFileDeleted);
-    Assertions.assertFalse(fs.exists(flumeFile));
-    Assertions.assertTrue(fs.exists(flumeS1Path));
-    Assertions.assertTrue(fs.exists(flumeS2Path));
+    assertTrue(flumeFileDeleted);
+    assertFalse(fs.exists(flumeFile));
+    assertTrue(fs.exists(flumeS1Path));
+    assertTrue(fs.exists(flumeS2Path));
 
     SnapshotTestHelper.createSnapshot(fs, snapRootDir, "tmp_snap");
     fs.deleteSnapshot(snapRootDir, "tmp_snap");
@@ -599,14 +604,14 @@ public class TestOpenFilesWithSnapshot {
     // Delete snap_2. snap_1 still has reference to
     // the flume file.
     fs.deleteSnapshot(snapRootDir, snap2Name);
-    Assertions.assertFalse(fs.exists(flumeS2Path));
-    Assertions.assertTrue(fs.exists(flumeS1Path));
+    assertFalse(fs.exists(flumeS2Path));
+    assertTrue(fs.exists(flumeS1Path));
 
     // Delete snap_1. Now all traces of flume file
     // is gone.
     fs.deleteSnapshot(snapRootDir, snap1Name);
-    Assertions.assertFalse(fs.exists(flumeS2Path));
-    Assertions.assertFalse(fs.exists(flumeS1Path));
+    assertFalse(fs.exists(flumeS2Path));
+    assertFalse(fs.exists(flumeS1Path));
 
     // Create Snapshot S3
     final Path snap3Dir = SnapshotTestHelper.createSnapshot(
@@ -615,7 +620,7 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify live files length is same as all data written till now
     final long hbaseFileLengthAfterS3 = fs.getFileStatus(hbaseFile).getLen();
-    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
+    assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
 
     // Write more data to open files
     hbaseFileWrittenDataLength += writeToStream(hbaseOutputStream, buf);
@@ -623,9 +628,9 @@ public class TestOpenFilesWithSnapshot {
     // Verify old snapshots have point-in-time/frozen file
     // lengths even after the flume open file is deleted and
     // the hbase live file has moved forward.
-    Assertions.assertEquals(hbaseFileLengthAfterS3,
+    assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
-    Assertions.assertEquals(hbaseFileWrittenDataLength,
+    assertEquals(hbaseFileWrittenDataLength,
         fs.getFileStatus(hbaseFile).getLen());
 
     hbaseOutputStream.close();
@@ -669,12 +674,12 @@ public class TestOpenFilesWithSnapshot {
     // its output stream is still open.
     fs.delete(hbaseFile, true);
     fs.deleteSnapshot(snapRootDir, snap1Name);
-    Assertions.assertFalse(fs.exists(hbaseFile));
+    assertFalse(fs.exists(hbaseFile));
 
     // Verify file existence after the NameNode restart
     cluster.restartNameNode();
     cluster.waitActive();
-    Assertions.assertFalse(fs.exists(hbaseFile));
+    assertFalse(fs.exists(hbaseFile));
   }
 
   /**
@@ -774,7 +779,7 @@ public class TestOpenFilesWithSnapshot {
     SnapshotTestHelper.createSnapshot(fs, snapRootDir, "test");
 
     t.join();
-    Assertions.assertFalse(writerError.get(), "Client encountered writing error!");
+    assertFalse(writerError.get(), "Client encountered writing error!");
 
     restartNameNode();
     cluster.waitActive();
@@ -813,7 +818,7 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumS1 = fs.getFileChecksum(hbaseS1Path);
 
     // Verify if Snap S1 checksum is same as the current version one
-    Assertions.assertEquals(hbaseWALFileCksum0, fs.getFileChecksum(hbaseS1Path),
+    assertEquals(hbaseWALFileCksum0, fs.getFileChecksum(hbaseS1Path),
         "Live and snap1 file checksum doesn't match!");
 
     int newWriteLength = (int) (BLOCKSIZE * 1.5);
@@ -829,10 +834,10 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumS2 = fs.getFileChecksum(hbaseS2Path);
 
     // Verify if the s1 checksum is still the same
-    Assertions.assertEquals(hbaseFileCksumS1, fs.getFileChecksum(hbaseS1Path),
+    assertEquals(hbaseFileCksumS1, fs.getFileChecksum(hbaseS1Path),
         "Snap file checksum has changed!");
     // Verify if the s2 checksum is different from the s1 checksum
-    Assertions.assertNotEquals(hbaseFileCksumS1, hbaseFileCksumS2,
+    assertNotEquals(hbaseFileCksumS1, hbaseFileCksumS2,
         "Snap1 and snap2 file checksum should differ!");
 
     newWriteLength = (int) (BLOCKSIZE * 2.5);
@@ -850,17 +855,17 @@ public class TestOpenFilesWithSnapshot {
     hbaseOutputStream.close();
     final FileChecksum hbaseFileCksumBeforeTruncate =
         fs.getFileChecksum(hbaseFile);
-    Assertions.assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
+    assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
         "Snap3 and before truncate file checksum should match!");
 
     // Truncate the current file and record the after truncate checksum
     long currentFileLen = fs.getFileStatus(hbaseFile).getLen();
     boolean fileTruncated = fs.truncate(hbaseFile, currentFileLen / 2);
-    Assertions.assertTrue(fileTruncated, "File truncation failed!");
+    assertTrue(fileTruncated, "File truncation failed!");
     final FileChecksum hbaseFileCksumAfterTruncate =
         fs.getFileChecksum(hbaseFile);
 
-    Assertions.assertNotEquals(hbaseFileCksumS3, hbaseFileCksumAfterTruncate,
+    assertNotEquals(hbaseFileCksumS3, hbaseFileCksumAfterTruncate,
         "Snap3 and after truncate checksum shouldn't match!");
 
     // Append more data to the current file
@@ -881,12 +886,12 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumAfterAppend =
         fs.getFileChecksum(hbaseFile);
 
-    Assertions.assertEquals(hbaseFileCksumAfterAppend, hbaseFileCksumS4,
+    assertEquals(hbaseFileCksumAfterAppend, hbaseFileCksumS4,
         "Snap4 and after append file checksum should match!");
 
     // Recompute checksum for S3 path and verify it has not changed
     hbaseFileCksumS3 = fs.getFileChecksum(hbaseS3Path);
-    Assertions.assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
+    assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
         "Snap3 and before truncate file checksum should match!");
   }
 
@@ -900,7 +905,7 @@ public class TestOpenFilesWithSnapshot {
   private void verifyFileSize(long fileSize, Path... filePaths) throws
       IOException {
     for (Path filePath : filePaths) {
-      Assertions.assertEquals(fileSize, fs.getFileStatus(filePath).getLen());
+      assertEquals(fileSize, fs.getFileStatus(filePath).getLen());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOpenFilesWithSnapshot.java
@@ -44,10 +44,11 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestOpenFilesWithSnapshot {
   private static final Logger LOG =
@@ -62,7 +63,7 @@ public class TestOpenFilesWithSnapshot {
   private static final long BUFFERLEN = BLOCKSIZE / 2;
   private static final long FILELEN = BLOCKSIZE * 2;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf.setBoolean(
         DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_CAPTURE_OPENFILES, true);
@@ -72,7 +73,7 @@ public class TestOpenFilesWithSnapshot {
     fs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     if (fs != null) {
       fs.close();
@@ -251,7 +252,8 @@ public class TestOpenFilesWithSnapshot {
    *   \- level_2_D        (Snapshottable Dir)
    *     +- hbase.log      (open file, under snap root)
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testPointInTimeSnapshotCopiesForOpenFiles() throws Exception {
     // Construct the directory tree
     final Path level0A = new Path("/level_0_A");
@@ -313,13 +315,13 @@ public class TestOpenFilesWithSnapshot {
     final long hbaseFileLengthAfterS1 = fs.getFileStatus(hbaseFile).getLen();
 
     // Verify if Snap S1 file lengths are same as the the live ones
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS1,
+    Assertions.assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assert.assertEquals(appAFileInitialLength,
+    Assertions.assertEquals(appAFileInitialLength,
         fs.getFileStatus(appAFile).getLen());
-    Assert.assertEquals(appBFileInitialLength,
+    Assertions.assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
@@ -346,17 +348,17 @@ public class TestOpenFilesWithSnapshot {
     // Verify live files lengths are same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
     final long hbaseFileLengthAfterS2 = fs.getFileStatus(hbaseFile).getLen();
-    Assert.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
-    Assert.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
+    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
 
     // Verify if Snap S2 file lengths are same as the live ones
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS2,
+    Assertions.assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
-    Assert.assertEquals(appAFileInitialLength,
+    Assertions.assertEquals(appAFileInitialLength,
         fs.getFileStatus(appAFile).getLen());
-    Assert.assertEquals(appBFileInitialLength,
+    Assertions.assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     // Write more data to appA file only
@@ -366,9 +368,9 @@ public class TestOpenFilesWithSnapshot {
     appAFileWrittenDataLength += writeToStream(appAOutputStream, buf);
 
     // Verify other open files are not affected in their snapshots
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assert.assertEquals(appAFileWrittenDataLength,
+    Assertions.assertEquals(appAFileWrittenDataLength,
         fs.getFileStatus(appAFile).getLen());
 
     // Write more data to flume file only
@@ -388,35 +390,35 @@ public class TestOpenFilesWithSnapshot {
     // Verify live files lengths are same as all data written till now
     final long flumeFileLengthAfterS3 = fs.getFileStatus(flumeFile).getLen();
     final long hbaseFileLengthAfterS3 = fs.getFileStatus(hbaseFile).getLen();
-    Assert.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS3);
-    Assert.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
+    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS3);
+    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
 
     // Verify if Snap S3 file lengths are same as the live ones
-    Assert.assertEquals(flumeFileLengthAfterS3,
+    Assertions.assertEquals(flumeFileLengthAfterS3,
         fs.getFileStatus(flumeS3Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS3,
+    Assertions.assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
-    Assert.assertEquals(appAFileWrittenDataLength,
+    Assertions.assertEquals(appAFileWrittenDataLength,
         fs.getFileStatus(appAFile).getLen());
-    Assert.assertEquals(appBFileInitialLength,
+    Assertions.assertEquals(appBFileInitialLength,
         fs.getFileStatus(appBFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS3,
+    Assertions.assertEquals(flumeFileLengthAfterS3,
         fs.getFileStatus(flumeS3Path).getLen());
 
     // Verify old hbase snapshots have point-in-time / frozen file lengths
     // even after the live files have moved forward.
-    Assert.assertEquals(hbaseFileLengthAfterS1,
+    Assertions.assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS2,
+    Assertions.assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS3,
+    Assertions.assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
 
     flumeOutputStream.close();
@@ -429,7 +431,8 @@ public class TestOpenFilesWithSnapshot {
    * Test snapshot capturing open files and verify the same
    * across NameNode restarts.
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testSnapshotsForOpenFilesWithNNRestart() throws Exception {
     // Construct the directory tree
     final Path level0A = new Path("/level_0_A");
@@ -450,8 +453,7 @@ public class TestOpenFilesWithSnapshot {
     final long flumeFileLengthAfterS1 = fs.getFileStatus(flumeFile).getLen();
 
     // Verify if Snap S1 file length is same as the the live one
-    Assert.assertEquals(flumeFileLengthAfterS1,
-        fs.getFileStatus(flumeS1Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS1, fs.getFileStatus(flumeS1Path).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
     int newWriteLength = (int) (BLOCKSIZE * 1.5);
@@ -469,20 +471,19 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify live files length is same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
-    Assert.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the live one
-    Assert.assertEquals(flumeFileLengthAfterS2,
-        fs.getFileStatus(flumeS2Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS2, fs.getFileStatus(flumeS2Path).getLen());
 
     // Write more data to flume file
     flumeFileWrittenDataLength += writeToStream(flumeOutputStream, buf);
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
 
     // Restart the NameNode
@@ -490,14 +491,14 @@ public class TestOpenFilesWithSnapshot {
     cluster.waitActive();
 
     // Verify live file length hasn't changed after NN restart
-    Assert.assertEquals(flumeFileWrittenDataLength,
+    Assertions.assertEquals(flumeFileWrittenDataLength,
         fs.getFileStatus(flumeFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // after NN restart and live file moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
 
     flumeOutputStream.close();
@@ -507,7 +508,8 @@ public class TestOpenFilesWithSnapshot {
    * Test snapshot capturing open files when an open file with active lease
    * is deleted by the client.
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testSnapshotsForOpenFilesAndDeletion() throws Exception {
     // Construct the directory tree
     final Path snapRootDir = new Path("/level_0_A");
@@ -534,9 +536,9 @@ public class TestOpenFilesWithSnapshot {
     final long hbaseFileLengthAfterS1 = fs.getFileStatus(hbaseFile).getLen();
 
     // Verify if Snap S1 file length is same as the the current versions
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS1,
+    Assertions.assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
 
     long flumeFileWrittenDataLength = flumeFileLengthAfterS1;
@@ -558,14 +560,14 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify current files length are same as all data written till now
     final long flumeFileLengthAfterS2 = fs.getFileStatus(flumeFile).getLen();
-    Assert.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
     final long hbaseFileLengthAfterS2 = fs.getFileStatus(hbaseFile).getLen();
-    Assert.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
+    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the current versions
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS2,
+    Assertions.assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
 
     // Write more data to open files
@@ -574,22 +576,22 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify old snapshots have point-in-time/frozen file
     // lengths even after the current versions have moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         fs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         fs.getFileStatus(flumeS2Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS1,
+    Assertions.assertEquals(hbaseFileLengthAfterS1,
         fs.getFileStatus(hbaseS1Path).getLen());
-    Assert.assertEquals(hbaseFileLengthAfterS2,
+    Assertions.assertEquals(hbaseFileLengthAfterS2,
         fs.getFileStatus(hbaseS2Path).getLen());
 
     // Delete flume current file. Snapshots should
     // still have references to flume file.
     boolean flumeFileDeleted = fs.delete(flumeFile, true);
-    Assert.assertTrue(flumeFileDeleted);
-    Assert.assertFalse(fs.exists(flumeFile));
-    Assert.assertTrue(fs.exists(flumeS1Path));
-    Assert.assertTrue(fs.exists(flumeS2Path));
+    Assertions.assertTrue(flumeFileDeleted);
+    Assertions.assertFalse(fs.exists(flumeFile));
+    Assertions.assertTrue(fs.exists(flumeS1Path));
+    Assertions.assertTrue(fs.exists(flumeS2Path));
 
     SnapshotTestHelper.createSnapshot(fs, snapRootDir, "tmp_snap");
     fs.deleteSnapshot(snapRootDir, "tmp_snap");
@@ -597,14 +599,14 @@ public class TestOpenFilesWithSnapshot {
     // Delete snap_2. snap_1 still has reference to
     // the flume file.
     fs.deleteSnapshot(snapRootDir, snap2Name);
-    Assert.assertFalse(fs.exists(flumeS2Path));
-    Assert.assertTrue(fs.exists(flumeS1Path));
+    Assertions.assertFalse(fs.exists(flumeS2Path));
+    Assertions.assertTrue(fs.exists(flumeS1Path));
 
     // Delete snap_1. Now all traces of flume file
     // is gone.
     fs.deleteSnapshot(snapRootDir, snap1Name);
-    Assert.assertFalse(fs.exists(flumeS2Path));
-    Assert.assertFalse(fs.exists(flumeS1Path));
+    Assertions.assertFalse(fs.exists(flumeS2Path));
+    Assertions.assertFalse(fs.exists(flumeS1Path));
 
     // Create Snapshot S3
     final Path snap3Dir = SnapshotTestHelper.createSnapshot(
@@ -613,7 +615,7 @@ public class TestOpenFilesWithSnapshot {
 
     // Verify live files length is same as all data written till now
     final long hbaseFileLengthAfterS3 = fs.getFileStatus(hbaseFile).getLen();
-    Assert.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
+    Assertions.assertEquals(hbaseFileWrittenDataLength, hbaseFileLengthAfterS3);
 
     // Write more data to open files
     hbaseFileWrittenDataLength += writeToStream(hbaseOutputStream, buf);
@@ -621,9 +623,9 @@ public class TestOpenFilesWithSnapshot {
     // Verify old snapshots have point-in-time/frozen file
     // lengths even after the flume open file is deleted and
     // the hbase live file has moved forward.
-    Assert.assertEquals(hbaseFileLengthAfterS3,
+    Assertions.assertEquals(hbaseFileLengthAfterS3,
         fs.getFileStatus(hbaseS3Path).getLen());
-    Assert.assertEquals(hbaseFileWrittenDataLength,
+    Assertions.assertEquals(hbaseFileWrittenDataLength,
         fs.getFileStatus(hbaseFile).getLen());
 
     hbaseOutputStream.close();
@@ -635,7 +637,8 @@ public class TestOpenFilesWithSnapshot {
    *
    * @throws Exception
    */
-  @Test (timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testOpenFileDeletionAndNNRestart() throws Exception {
     // Construct the directory tree
     final Path snapRootDir = new Path("/level_0_A/test");
@@ -666,19 +669,20 @@ public class TestOpenFilesWithSnapshot {
     // its output stream is still open.
     fs.delete(hbaseFile, true);
     fs.deleteSnapshot(snapRootDir, snap1Name);
-    Assert.assertFalse(fs.exists(hbaseFile));
+    Assertions.assertFalse(fs.exists(hbaseFile));
 
     // Verify file existence after the NameNode restart
     cluster.restartNameNode();
     cluster.waitActive();
-    Assert.assertFalse(fs.exists(hbaseFile));
+    Assertions.assertFalse(fs.exists(hbaseFile));
   }
 
   /**
    * Test client writing to open files are not interrupted when snapshots
    * that captured open files get deleted.
    */
-  @Test (timeout = 240000)
+  @Test
+  @Timeout(value = 240)
   public void testOpenFileWritingAcrossSnapDeletion() throws Exception {
     final Path snapRootDir = new Path("/level_0_A");
     final String flumeFileName = "flume.log";
@@ -770,7 +774,7 @@ public class TestOpenFilesWithSnapshot {
     SnapshotTestHelper.createSnapshot(fs, snapRootDir, "test");
 
     t.join();
-    Assert.assertFalse("Client encountered writing error!", writerError.get());
+    Assertions.assertFalse(writerError.get(), "Client encountered writing error!");
 
     restartNameNode();
     cluster.waitActive();
@@ -780,7 +784,8 @@ public class TestOpenFilesWithSnapshot {
    * Verify snapshots with open files captured are safe even when the
    * 'current' version of the file is truncated and appended later.
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testOpenFilesSnapChecksumWithTrunkAndAppend() throws Exception {
     // Construct the directory tree
     final Path dir = new Path("/A/B/C");
@@ -808,8 +813,8 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumS1 = fs.getFileChecksum(hbaseS1Path);
 
     // Verify if Snap S1 checksum is same as the current version one
-    Assert.assertEquals("Live and snap1 file checksum doesn't match!",
-        hbaseWALFileCksum0, fs.getFileChecksum(hbaseS1Path));
+    Assertions.assertEquals(hbaseWALFileCksum0, fs.getFileChecksum(hbaseS1Path),
+        "Live and snap1 file checksum doesn't match!");
 
     int newWriteLength = (int) (BLOCKSIZE * 1.5);
     byte[] buf = new byte[newWriteLength];
@@ -824,11 +829,11 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumS2 = fs.getFileChecksum(hbaseS2Path);
 
     // Verify if the s1 checksum is still the same
-    Assert.assertEquals("Snap file checksum has changed!",
-        hbaseFileCksumS1, fs.getFileChecksum(hbaseS1Path));
+    Assertions.assertEquals(hbaseFileCksumS1, fs.getFileChecksum(hbaseS1Path),
+        "Snap file checksum has changed!");
     // Verify if the s2 checksum is different from the s1 checksum
-    Assert.assertNotEquals("Snap1 and snap2 file checksum should differ!",
-        hbaseFileCksumS1, hbaseFileCksumS2);
+    Assertions.assertNotEquals(hbaseFileCksumS1, hbaseFileCksumS2,
+        "Snap1 and snap2 file checksum should differ!");
 
     newWriteLength = (int) (BLOCKSIZE * 2.5);
     buf = new byte[newWriteLength];
@@ -845,18 +850,18 @@ public class TestOpenFilesWithSnapshot {
     hbaseOutputStream.close();
     final FileChecksum hbaseFileCksumBeforeTruncate =
         fs.getFileChecksum(hbaseFile);
-    Assert.assertEquals("Snap3 and before truncate file checksum should match!",
-        hbaseFileCksumBeforeTruncate, hbaseFileCksumS3);
+    Assertions.assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
+        "Snap3 and before truncate file checksum should match!");
 
     // Truncate the current file and record the after truncate checksum
     long currentFileLen = fs.getFileStatus(hbaseFile).getLen();
     boolean fileTruncated = fs.truncate(hbaseFile, currentFileLen / 2);
-    Assert.assertTrue("File truncation failed!", fileTruncated);
+    Assertions.assertTrue(fileTruncated, "File truncation failed!");
     final FileChecksum hbaseFileCksumAfterTruncate =
         fs.getFileChecksum(hbaseFile);
 
-    Assert.assertNotEquals("Snap3 and after truncate checksum shouldn't match!",
-        hbaseFileCksumS3, hbaseFileCksumAfterTruncate);
+    Assertions.assertNotEquals(hbaseFileCksumS3, hbaseFileCksumAfterTruncate,
+        "Snap3 and after truncate checksum shouldn't match!");
 
     // Append more data to the current file
     hbaseOutputStream = fs.append(hbaseFile);
@@ -876,13 +881,13 @@ public class TestOpenFilesWithSnapshot {
     final FileChecksum hbaseFileCksumAfterAppend =
         fs.getFileChecksum(hbaseFile);
 
-    Assert.assertEquals("Snap4 and after append file checksum should match!",
-        hbaseFileCksumAfterAppend, hbaseFileCksumS4);
+    Assertions.assertEquals(hbaseFileCksumAfterAppend, hbaseFileCksumS4,
+        "Snap4 and after append file checksum should match!");
 
     // Recompute checksum for S3 path and verify it has not changed
     hbaseFileCksumS3 = fs.getFileChecksum(hbaseS3Path);
-    Assert.assertEquals("Snap3 and before truncate file checksum should match!",
-        hbaseFileCksumBeforeTruncate, hbaseFileCksumS3);
+    Assertions.assertEquals(hbaseFileCksumBeforeTruncate, hbaseFileCksumS3,
+        "Snap3 and before truncate file checksum should match!");
   }
 
   private Path createSnapshot(Path snapRootDir, String snapName,
@@ -895,7 +900,7 @@ public class TestOpenFilesWithSnapshot {
   private void verifyFileSize(long fileSize, Path... filePaths) throws
       IOException {
     for (Path filePath : filePaths) {
-      Assert.assertEquals(fileSize, fs.getFileStatus(filePath).getLen());
+      Assertions.assertEquals(fileSize, fs.getFileStatus(filePath).getLen());
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdfs.XAttrHelper;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.XAttrFeature;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -41,6 +40,10 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.XATTR_SNAPSHOT_DELETED;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -108,27 +111,27 @@ public class TestOrderedSnapshotDeletion {
     final Path snapPathNew =
         SnapshotTestHelper.getSnapshotRoot(snapshottableDir, snapName);
     // Check if the path exists
-    Assertions.assertNotNull(cluster.getFileSystem().getFileStatus(snapPathNew));
+    assertNotNull(cluster.getFileSystem().getFileStatus(snapPathNew));
 
     // Check xAttr for snapshotRoot
     final INode inode = cluster.getNamesystem().getFSDirectory()
         .getINode(snapPathNew.toString());
     final XAttrFeature f = inode.getXAttrFeature();
     final XAttr xAttr = f.getXAttr(XATTR_SNAPSHOT_DELETED);
-    Assertions.assertNotNull(xAttr);
-    Assertions.assertEquals(XATTR_SNAPSHOT_DELETED.substring("system.".length()), xAttr.getName());
-    Assertions.assertEquals(XAttr.NameSpace.SYSTEM, xAttr.getNameSpace());
-    Assertions.assertNull(xAttr.getValue());
+    assertNotNull(xAttr);
+    assertEquals(XATTR_SNAPSHOT_DELETED.substring("system.".length()), xAttr.getName());
+    assertEquals(XAttr.NameSpace.SYSTEM, xAttr.getNameSpace());
+    assertNull(xAttr.getValue());
 
     // Check inode
-    Assertions.assertTrue(inode instanceof Snapshot.Root);
-    Assertions.assertTrue(((Snapshot.Root) inode).isMarkedAsDeleted());
+    assertTrue(inode instanceof Snapshot.Root);
+    assertTrue(((Snapshot.Root) inode).isMarkedAsDeleted());
   }
 
   static void assertNotMarkedAsDeleted(Path snapshotRoot,
       MiniDFSCluster cluster) throws IOException {
     // Check if the path exists
-    Assertions.assertNotNull(cluster.getFileSystem().getFileStatus(snapshotRoot));
+    assertNotNull(cluster.getFileSystem().getFileStatus(snapshotRoot));
 
     // Check xAttr for snapshotRoot
     final INode inode = cluster.getNamesystem().getFSDirectory()
@@ -136,12 +139,12 @@ public class TestOrderedSnapshotDeletion {
     final XAttrFeature f = inode.getXAttrFeature();
     if (f != null) {
       final XAttr xAttr = f.getXAttr(XATTR_SNAPSHOT_DELETED);
-      Assertions.assertNull(xAttr);
+      assertNull(xAttr);
     }
 
     // Check inode
-    Assertions.assertTrue(inode instanceof Snapshot.Root);
-    Assertions.assertFalse(((Snapshot.Root) inode).isMarkedAsDeleted());
+    assertTrue(inode instanceof Snapshot.Root);
+    assertFalse(((Snapshot.Root) inode).isMarkedAsDeleted());
   }
 
   void assertXAttrSet(String snapshot,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletion.java
@@ -28,10 +28,11 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.XAttrHelper;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.XAttrFeature;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -40,7 +41,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.XATTR_SNAPSHOT_DELETED;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test ordered snapshot deletion.
@@ -53,7 +54,7 @@ public class TestOrderedSnapshotDeletion {
 
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, true);
@@ -62,7 +63,7 @@ public class TestOrderedSnapshotDeletion {
     cluster.waitActive();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -70,7 +71,8 @@ public class TestOrderedSnapshotDeletion {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testOrderedSnapshotDeletion() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
@@ -106,28 +108,27 @@ public class TestOrderedSnapshotDeletion {
     final Path snapPathNew =
         SnapshotTestHelper.getSnapshotRoot(snapshottableDir, snapName);
     // Check if the path exists
-    Assert.assertNotNull(cluster.getFileSystem().getFileStatus(snapPathNew));
+    Assertions.assertNotNull(cluster.getFileSystem().getFileStatus(snapPathNew));
 
     // Check xAttr for snapshotRoot
     final INode inode = cluster.getNamesystem().getFSDirectory()
         .getINode(snapPathNew.toString());
     final XAttrFeature f = inode.getXAttrFeature();
     final XAttr xAttr = f.getXAttr(XATTR_SNAPSHOT_DELETED);
-    Assert.assertNotNull(xAttr);
-    Assert.assertEquals(XATTR_SNAPSHOT_DELETED.substring("system.".length()),
-        xAttr.getName());
-    Assert.assertEquals(XAttr.NameSpace.SYSTEM, xAttr.getNameSpace());
-    Assert.assertNull(xAttr.getValue());
+    Assertions.assertNotNull(xAttr);
+    Assertions.assertEquals(XATTR_SNAPSHOT_DELETED.substring("system.".length()), xAttr.getName());
+    Assertions.assertEquals(XAttr.NameSpace.SYSTEM, xAttr.getNameSpace());
+    Assertions.assertNull(xAttr.getValue());
 
     // Check inode
-    Assert.assertTrue(inode instanceof Snapshot.Root);
-    Assert.assertTrue(((Snapshot.Root) inode).isMarkedAsDeleted());
+    Assertions.assertTrue(inode instanceof Snapshot.Root);
+    Assertions.assertTrue(((Snapshot.Root) inode).isMarkedAsDeleted());
   }
 
   static void assertNotMarkedAsDeleted(Path snapshotRoot,
       MiniDFSCluster cluster) throws IOException {
     // Check if the path exists
-    Assert.assertNotNull(cluster.getFileSystem().getFileStatus(snapshotRoot));
+    Assertions.assertNotNull(cluster.getFileSystem().getFileStatus(snapshotRoot));
 
     // Check xAttr for snapshotRoot
     final INode inode = cluster.getNamesystem().getFSDirectory()
@@ -135,12 +136,12 @@ public class TestOrderedSnapshotDeletion {
     final XAttrFeature f = inode.getXAttrFeature();
     if (f != null) {
       final XAttr xAttr = f.getXAttr(XATTR_SNAPSHOT_DELETED);
-      Assert.assertNull(xAttr);
+      Assertions.assertNull(xAttr);
     }
 
     // Check inode
-    Assert.assertTrue(inode instanceof Snapshot.Root);
-    Assert.assertFalse(((Snapshot.Root)inode).isMarkedAsDeleted());
+    Assertions.assertTrue(inode instanceof Snapshot.Root);
+    Assertions.assertFalse(((Snapshot.Root) inode).isMarkedAsDeleted());
   }
 
   void assertXAttrSet(String snapshot,
@@ -166,7 +167,8 @@ public class TestOrderedSnapshotDeletion {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotXattrPersistence() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
@@ -185,7 +187,8 @@ public class TestOrderedSnapshotDeletion {
     assertXAttrSet("s1", hdfs, null);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotXattrWithSaveNameSpace() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
@@ -206,7 +209,8 @@ public class TestOrderedSnapshotDeletion {
     assertXAttrSet("s1", hdfs, null);
   }
 
-  @Test(timeout = 6000000)
+  @Test
+  @Timeout(value = 6000)
   public void testOrderedDeletionWithRestart() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
@@ -226,7 +230,8 @@ public class TestOrderedSnapshotDeletion {
     cluster.restartNameNodes();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotXattrWithDisablingXattr() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);
@@ -255,7 +260,8 @@ public class TestOrderedSnapshotDeletion {
     assertXAttrSet("s1", hdfs, null);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotXAttrWithPreExistingXattrs() throws Exception {
     DistributedFileSystem hdfs = cluster.getFileSystem();
     hdfs.mkdirs(snapshottableDir);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdfs.server.namenode.FSEditLogOpCodes;
 import org.apache.hadoop.hdfs.util.Holder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -52,6 +51,7 @@ import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DF
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertNotMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.getDeletedSnapshotName;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -96,17 +96,17 @@ public class TestOrderedSnapshotDeletionGc {
     final Path sub0 = new Path(snapshottableDir, "sub0");
     hdfs.mkdirs(sub0);
     final Path s0path = hdfs.createSnapshot(snapshottableDir, "s0");
-    Assertions.assertTrue(exist(s0path, hdfs));
+    assertTrue(exist(s0path, hdfs));
 
     final Path sub1 = new Path(snapshottableDir, "sub1");
     hdfs.mkdirs(sub1);
     final Path s1path = hdfs.createSnapshot(snapshottableDir, "s1");
-    Assertions.assertTrue(exist(s1path, hdfs));
+    assertTrue(exist(s1path, hdfs));
 
     final Path sub2 = new Path(snapshottableDir, "sub2");
     hdfs.mkdirs(sub2);
     final Path s2path = hdfs.createSnapshot(snapshottableDir, "s2");
-    Assertions.assertTrue(exist(s2path, hdfs));
+    assertTrue(exist(s2path, hdfs));
 
     assertNotMarkedAsDeleted(s0path, cluster);
     assertNotMarkedAsDeleted(s1path, cluster);
@@ -118,9 +118,9 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
     final Path s2pathNew = new Path(s2path.getParent(),
         getDeletedSnapshotName(hdfs, snapshottableDir, s2path.getName()));
-    Assertions.assertFalse(exist(s2path, hdfs));
-    Assertions.assertTrue(exist(s2pathNew, hdfs));
-    Assertions.assertFalse(s2path.equals(s2pathNew));
+    assertFalse(exist(s2path, hdfs));
+    assertTrue(exist(s2pathNew, hdfs));
+    assertFalse(s2path.equals(s2pathNew));
 
     hdfs.deleteSnapshot(snapshottableDir, "s1");
     assertNotMarkedAsDeleted(s0path, cluster);
@@ -128,9 +128,9 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
     final Path s1pathNew = new Path(s1path.getParent(),
         getDeletedSnapshotName(hdfs, snapshottableDir, s1path.getName()));
-    Assertions.assertFalse(exist(s1path, hdfs));
-    Assertions.assertTrue(exist(s1pathNew, hdfs));
-    Assertions.assertFalse(s1path.equals(s1pathNew));
+    assertFalse(exist(s1path, hdfs));
+    assertTrue(exist(s1pathNew, hdfs));
+    assertFalse(s1path.equals(s1pathNew));
     // should not be gc'ed
     Thread.sleep(10*GC_PERIOD);
     assertNotMarkedAsDeleted(s0path, cluster);
@@ -138,7 +138,7 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
 
     hdfs.deleteSnapshot(snapshottableDir, "s0");
-    Assertions.assertFalse(exist(s0path, hdfs));
+    assertFalse(exist(s0path, hdfs));
 
     waitForGc(Arrays.asList(s1pathNew, s2pathNew), hdfs);
     // total no of edit log records created for delete snapshot will be equal
@@ -171,7 +171,7 @@ public class TestOrderedSnapshotDeletionGc {
         .build();
     cluster.waitActive();
     // ensure after the edits get replayed , all the snapshots are deleted
-    Assertions.assertEquals(0,
+    assertEquals(0,
         cluster.getNamesystem().getSnapshotManager().getNumSnapshots());
   }
 
@@ -238,7 +238,7 @@ public class TestOrderedSnapshotDeletionGc {
       hdfs.mkdirs(sub);
       final Path p = hdfs.createSnapshot(snapshottableDir, "s" + i);
       snapshotPaths.add(p);
-      Assertions.assertTrue(exist(p, hdfs));
+      assertTrue(exist(p, hdfs));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
@@ -29,10 +29,11 @@ import org.apache.hadoop.hdfs.server.namenode.NNStorage;
 import org.apache.hadoop.hdfs.server.namenode.FSEditLogOpCodes;
 import org.apache.hadoop.hdfs.util.Holder;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.io.File;
@@ -51,8 +52,8 @@ import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DF
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertNotMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.getDeletedSnapshotName;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test {@link SnapshotDeletionGc}.
@@ -62,7 +63,7 @@ public class TestOrderedSnapshotDeletionGc {
   private static final int NUM_DATANODES = 0;
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, true);
@@ -75,7 +76,7 @@ public class TestOrderedSnapshotDeletionGc {
     GenericTestUtils.setLogLevel(SnapshotDeletionGc.LOG, Level.TRACE);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -83,7 +84,8 @@ public class TestOrderedSnapshotDeletionGc {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSingleDir() throws Exception {
     final DistributedFileSystem hdfs = cluster.getFileSystem();
 
@@ -94,17 +96,17 @@ public class TestOrderedSnapshotDeletionGc {
     final Path sub0 = new Path(snapshottableDir, "sub0");
     hdfs.mkdirs(sub0);
     final Path s0path = hdfs.createSnapshot(snapshottableDir, "s0");
-    Assert.assertTrue(exist(s0path, hdfs));
+    Assertions.assertTrue(exist(s0path, hdfs));
 
     final Path sub1 = new Path(snapshottableDir, "sub1");
     hdfs.mkdirs(sub1);
     final Path s1path = hdfs.createSnapshot(snapshottableDir, "s1");
-    Assert.assertTrue(exist(s1path, hdfs));
+    Assertions.assertTrue(exist(s1path, hdfs));
 
     final Path sub2 = new Path(snapshottableDir, "sub2");
     hdfs.mkdirs(sub2);
     final Path s2path = hdfs.createSnapshot(snapshottableDir, "s2");
-    Assert.assertTrue(exist(s2path, hdfs));
+    Assertions.assertTrue(exist(s2path, hdfs));
 
     assertNotMarkedAsDeleted(s0path, cluster);
     assertNotMarkedAsDeleted(s1path, cluster);
@@ -116,9 +118,9 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
     final Path s2pathNew = new Path(s2path.getParent(),
         getDeletedSnapshotName(hdfs, snapshottableDir, s2path.getName()));
-    Assert.assertFalse(exist(s2path, hdfs));
-    Assert.assertTrue(exist(s2pathNew, hdfs));
-    Assert.assertFalse(s2path.equals(s2pathNew));
+    Assertions.assertFalse(exist(s2path, hdfs));
+    Assertions.assertTrue(exist(s2pathNew, hdfs));
+    Assertions.assertFalse(s2path.equals(s2pathNew));
 
     hdfs.deleteSnapshot(snapshottableDir, "s1");
     assertNotMarkedAsDeleted(s0path, cluster);
@@ -126,9 +128,9 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
     final Path s1pathNew = new Path(s1path.getParent(),
         getDeletedSnapshotName(hdfs, snapshottableDir, s1path.getName()));
-    Assert.assertFalse(exist(s1path, hdfs));
-    Assert.assertTrue(exist(s1pathNew, hdfs));
-    Assert.assertFalse(s1path.equals(s1pathNew));
+    Assertions.assertFalse(exist(s1path, hdfs));
+    Assertions.assertTrue(exist(s1pathNew, hdfs));
+    Assertions.assertFalse(s1path.equals(s1pathNew));
     // should not be gc'ed
     Thread.sleep(10*GC_PERIOD);
     assertNotMarkedAsDeleted(s0path, cluster);
@@ -136,7 +138,7 @@ public class TestOrderedSnapshotDeletionGc {
     assertMarkedAsDeleted(s2path, snapshottableDir, cluster);
 
     hdfs.deleteSnapshot(snapshottableDir, "s0");
-    Assert.assertFalse(exist(s0path, hdfs));
+    Assertions.assertFalse(exist(s0path, hdfs));
 
     waitForGc(Arrays.asList(s1pathNew, s2pathNew), hdfs);
     // total no of edit log records created for delete snapshot will be equal
@@ -155,12 +157,12 @@ public class TestOrderedSnapshotDeletionGc {
     cluster.shutdown();
 
     File editFile = FSImageTestUtil.findLatestEditsLog(sd).getFile();
-    assertTrue("Should exist: " + editFile, editFile.exists());
+    assertTrue(editFile.exists(), "Should exist: " + editFile);
     EnumMap<FSEditLogOpCodes, Holder<Integer>> counts;
     counts = FSImageTestUtil.countEditLogOpTypes(editFile);
     if (editLogOpCount > 0) {
-      assertEquals(editLogOpCount, (int) counts.get(FSEditLogOpCodes.
-          OP_DELETE_SNAPSHOT).held);
+      assertEquals(editLogOpCount,
+          (int) counts.get(FSEditLogOpCodes.OP_DELETE_SNAPSHOT).held);
     }
     // make sure the gc thread doesn't start for a long time after the restart
     conf.setInt(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED_GC_PERIOD_MS,
@@ -169,7 +171,7 @@ public class TestOrderedSnapshotDeletionGc {
         .build();
     cluster.waitActive();
     // ensure after the edits get replayed , all the snapshots are deleted
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         cluster.getNamesystem().getSnapshotManager().getNumSnapshots());
   }
 
@@ -195,7 +197,8 @@ public class TestOrderedSnapshotDeletionGc {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testMultipleDirs() throws Exception {
     final int numSnapshottables = 10;
     final DistributedFileSystem hdfs = cluster.getFileSystem();
@@ -235,7 +238,7 @@ public class TestOrderedSnapshotDeletionGc {
       hdfs.mkdirs(sub);
       final Path p = hdfs.createSnapshot(snapshottableDir, "s" + i);
       snapshotPaths.add(p);
-      Assert.assertTrue(exist(p, hdfs));
+      Assertions.assertTrue(exist(p, hdfs));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRandomOpsWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRandomOpsWithSnapshots.java
@@ -31,9 +31,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.SnapshotException;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +48,10 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing random FileSystem operations with random Snapshot operations.
@@ -178,7 +179,7 @@ public class TestRandomOpsWithSnapshots {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     CONFIG.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
     cluster = new MiniDFSCluster.Builder(CONFIG).numDataNodes(REPL).
@@ -190,7 +191,7 @@ public class TestRandomOpsWithSnapshots {
     hdfs.mkdirs(WITNESSDIR);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -201,7 +202,8 @@ public class TestRandomOpsWithSnapshots {
   /*
    * Random file system operations with snapshot operations in between.
    */
-  @Test(timeout = 900000)
+  @Test
+  @Timeout(value = 900)
   public void testRandomOperationsWithSnapshots()
           throws IOException, InterruptedException, TimeoutException {
     // Set
@@ -283,7 +285,7 @@ public class TestRandomOpsWithSnapshots {
           break;
 
         default:
-          assertNull("Invalid FileSystem operation", fsOperation);
+          assertNull(fsOperation, "Invalid FileSystem operation");
           break;
         }
       }
@@ -308,7 +310,7 @@ public class TestRandomOpsWithSnapshots {
           break;
 
         default:
-          assertNull("Invalid Snapshot operation", snapshotOperation);
+          assertNull(snapshotOperation, "Invalid Snapshot operation");
           break;
         }
       }
@@ -331,7 +333,7 @@ public class TestRandomOpsWithSnapshots {
               TESTDIRSTRING, WITNESSDIRSTRING));
         }
         hdfs.mkdirs(newDir);
-        assertTrue("Directory exists", hdfs.exists(newDir));
+        assertTrue(hdfs.exists(newDir), "Directory exists");
         LOG.info("Directory created: " + newDir);
         numberDirectoryCreated++;
       }
@@ -353,7 +355,7 @@ public class TestRandomOpsWithSnapshots {
                 TESTDIRSTRING, WITNESSDIRSTRING));
           }
           hdfs.delete(deleteDir, true);
-          assertFalse("Directory does not exist", hdfs.exists(deleteDir));
+          assertFalse(hdfs.exists(deleteDir), "Directory does not exist");
           if (!isWitnessDir) {
             snapshottableDirectories.remove(deleteDir);
           }
@@ -380,9 +382,10 @@ public class TestRandomOpsWithSnapshots {
                 TESTDIRSTRING, WITNESSDIRSTRING));
           }
           hdfs.rename(oldDir, newDir, Options.Rename.OVERWRITE);
-          assertTrue("Target directory exists", hdfs.exists(newDir));
-          assertFalse("Source directory does not exist",
-              hdfs.exists(oldDir));
+          assertTrue(hdfs.exists(newDir),
+              "Target directory exists");
+          assertFalse(hdfs.exists(oldDir),
+              "Source directory does not exist");
 
           if (dir == OperationDirectories.TestDir) {
             snapshottableDirectories.remove(oldDir);
@@ -482,7 +485,7 @@ public class TestRandomOpsWithSnapshots {
               TESTDIRSTRING, WITNESSDIRSTRING));
         }
         hdfs.createNewFile(newFile);
-        assertTrue("File exists", hdfs.exists(newFile));
+        assertTrue(hdfs.exists(newFile), "File exists");
         LOG.info("createTestFile, file created: " + newFile);
         numberFileCreated++;
       }
@@ -505,8 +508,8 @@ public class TestRandomOpsWithSnapshots {
                   TESTDIRSTRING, WITNESSDIRSTRING));
             }
             hdfs.delete(deleteFile, false);
-            assertFalse("File does not exists",
-                hdfs.exists(deleteFile));
+            assertFalse(hdfs.exists(deleteFile),
+                "File does not exists");
             LOG.info("deleteTestFile, file deleted: " + deleteFile);
             numberFileDeleted++;
           }
@@ -536,8 +539,8 @@ public class TestRandomOpsWithSnapshots {
             }
 
             hdfs.rename(oldFile, newFile, Options.Rename.OVERWRITE);
-            assertTrue("Target file exists", hdfs.exists(newFile));
-            assertFalse("Source file does not exist", hdfs.exists(oldFile));
+            assertTrue(hdfs.exists(newFile), "Target file exists");
+            assertFalse(hdfs.exists(oldFile), "Source file does not exist");
             LOG.info("Renamed file: " + oldFile + " to file: " + newFile);
             numberFileRenamed++;
           }
@@ -597,9 +600,9 @@ public class TestRandomOpsWithSnapshots {
       }
     }, 10, 100000);
 
-    assertTrue("NameNode is up", cluster.getNameNode().isActiveState());
-    assertTrue("DataNode is up and running", cluster.isDataNodeUp());
-    assertTrue("Cluster is up and running", cluster.isClusterUp());
+    assertTrue(cluster.getNameNode().isActiveState(), "NameNode is up");
+    assertTrue(cluster.isDataNodeUp(), "DataNode is up and running");
+    assertTrue(cluster.isClusterUp(), "Cluster is up and running");
     LOG.info("checkClusterHealth, cluster is healthy.");
 
     printOperationStats();
@@ -639,14 +642,15 @@ public class TestRandomOpsWithSnapshots {
       }
       filename += "file" + i;
       createFile(filename, fileLength, true);
-      assertTrue("Test file created", hdfs.exists(new Path(filename)));
+      assertTrue(hdfs.exists(new Path(filename)),
+          "Test file created");
       LOG.info("createFiles, file: " + filename + "was created");
 
       String witnessFile =
           filename.replaceAll(TESTDIRSTRING, WITNESSDIRSTRING);
       createFile(witnessFile, fileLength, false);
-      assertTrue("Witness file exists",
-          hdfs.exists(new Path(witnessFile)));
+      assertTrue(hdfs.exists(new Path(witnessFile)),
+          "Witness file exists");
       LOG.info("createFiles, file: " + witnessFile + "was created");
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithOrderedSnapshotDeletion.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -32,6 +31,9 @@ import java.io.IOException;
 
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED;
 import static org.apache.hadoop.hdfs.server.namenode.FSNamesystem.DFS_NAMENODE_SNAPSHOT_TRASHROOT_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 /**
  * Test Rename with ordered snapshot deletion.
  */
@@ -102,10 +104,9 @@ public class TestRenameWithOrderedSnapshotDeletion {
   private void validateRename(Path src, Path dest) {
     try {
       hdfs.rename(src, dest);
-      Assertions.fail("Expected exception not thrown.");
+      fail("Expected exception not thrown.");
     } catch (IOException ioe) {
-      Assertions
-          .assertTrue(ioe.getMessage().contains("are not under the" +          " same snapshot root."));
+      assertTrue(ioe.getMessage().contains("are not under the" + " same snapshot root."));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithOrderedSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithOrderedSnapshotDeletion.java
@@ -22,11 +22,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.DFSTestUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
@@ -41,7 +41,7 @@ public class TestRenameWithOrderedSnapshotDeletion {
   private DistributedFileSystem hdfs;
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final Configuration conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_SNAPSHOT_DELETION_ORDERED, true);
@@ -52,7 +52,7 @@ public class TestRenameWithOrderedSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -60,7 +60,8 @@ public class TestRenameWithOrderedSnapshotDeletion {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRename() throws Exception {
     final Path dir1 = new Path("/dir1");
     final Path dir2 = new Path("/dir2");
@@ -101,10 +102,10 @@ public class TestRenameWithOrderedSnapshotDeletion {
   private void validateRename(Path src, Path dest) {
     try {
       hdfs.rename(src, dest);
-      Assert.fail("Expected exception not thrown.");
+      Assertions.fail("Expected exception not thrown.");
     } catch (IOException ioe) {
-      Assert.assertTrue(ioe.getMessage().contains("are not under the" +
-          " same snapshot root."));
+      Assertions
+          .assertTrue(ioe.getMessage().contains("are not under the" +          " same snapshot root."));
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdfs.util.ReadOnlyList;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -57,8 +56,10 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -151,20 +152,20 @@ public class TestRenameWithSnapshots {
     
     final INode fooRef = fsdir.getINode(
         SnapshotTestHelper.getSnapshotPath(abc, "s0", "foo").toString());
-    Assertions.assertTrue(fooRef.isReference());
-    Assertions.assertTrue(fooRef.asReference() instanceof INodeReference.WithName);
+    assertTrue(fooRef.isReference());
+    assertTrue(fooRef.asReference() instanceof INodeReference.WithName);
 
     final INodeReference.WithCount withCount
         = (INodeReference.WithCount)fooRef.asReference().getReferredINode();
-    Assertions.assertEquals(2, withCount.getReferenceCount());
+    assertEquals(2, withCount.getReferenceCount());
 
     final INode barRef = fsdir.getINode(bar.toString());
-    Assertions.assertTrue(barRef.isReference());
+    assertTrue(barRef.isReference());
 
-    Assertions.assertSame(withCount, barRef.asReference().getReferredINode());
+    assertSame(withCount, barRef.asReference().getReferredINode());
     
     hdfs.delete(bar, false);
-    Assertions.assertEquals(1, withCount.getReferenceCount());
+    assertEquals(1, withCount.getReferenceCount());
     restartClusterAndCheckImage(true);
   }
   
@@ -354,10 +355,10 @@ public class TestRenameWithSnapshots {
             .asReference();
     INodeReference.WithCount withCount = (WithCount) ref
             .getReferredINode();
-    Assertions.assertEquals(withCount.getReferenceCount(), 1);
+    assertEquals(withCount.getReferenceCount(), 1);
     // Ensure name list is empty for the reference sub3file3Inode
-    Assertions.assertNull(withCount.getLastWithName());
-    Assertions.assertTrue(sub3file3Inode.isInCurrentState());
+    assertNull(withCount.getLastWithName());
+    assertTrue(sub3file3Inode.isInCurrentState());
   }
 
   /**
@@ -2231,7 +2232,7 @@ public class TestRenameWithSnapshots {
     hdfs.deleteSnapshot(test, "s0");
     // check the internal
     assertFalse(hdfs.exists(foo_s0),
-    "after deleting s0, " + foo_s0 + " should not exist");
+        "after deleting s0, " + foo_s0 + " should not exist");
     INodeDirectory dir2Node = fsdir.getINode4Write(dir2.toString())
         .asDirectory();
     assertTrue(!dir2Node.isWithSnapshot(),
@@ -2329,7 +2330,7 @@ public class TestRenameWithSnapshots {
         (INodeReference.WithName) fsdir.getINode(foo_s2.toString());
     assertSame(dList.get(0), fooNode_s2);
     assertSame(fooNode.asReference().getReferredINode(),
-fooNode_s2.getReferredINode());
+        fooNode_s2.getReferredINode());
     
     restartClusterAndCheckImage(true);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -41,10 +41,11 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeat
 import org.apache.hadoop.hdfs.util.ReadOnlyList;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -54,11 +55,11 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -99,7 +100,7 @@ public class TestRenameWithSnapshots {
     assertEquals(deletedSize, diff.getDeletedUnmodifiable().size());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPL).format(true)
@@ -112,7 +113,7 @@ public class TestRenameWithSnapshots {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -120,7 +121,8 @@ public class TestRenameWithSnapshots {
     }
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testRenameFromSDir2NonSDir() throws Exception {
     final String dirStr = "/testRenameWithSnapshot";
     final String abcStr = dirStr + "/abc";
@@ -149,20 +151,20 @@ public class TestRenameWithSnapshots {
     
     final INode fooRef = fsdir.getINode(
         SnapshotTestHelper.getSnapshotPath(abc, "s0", "foo").toString());
-    Assert.assertTrue(fooRef.isReference());
-    Assert.assertTrue(fooRef.asReference() instanceof INodeReference.WithName);
+    Assertions.assertTrue(fooRef.isReference());
+    Assertions.assertTrue(fooRef.asReference() instanceof INodeReference.WithName);
 
     final INodeReference.WithCount withCount
         = (INodeReference.WithCount)fooRef.asReference().getReferredINode();
-    Assert.assertEquals(2, withCount.getReferenceCount());
+    Assertions.assertEquals(2, withCount.getReferenceCount());
 
     final INode barRef = fsdir.getINode(bar.toString());
-    Assert.assertTrue(barRef.isReference());
+    Assertions.assertTrue(barRef.isReference());
 
-    Assert.assertSame(withCount, barRef.asReference().getReferredINode());
+    Assertions.assertSame(withCount, barRef.asReference().getReferredINode());
     
     hdfs.delete(bar, false);
-    Assert.assertEquals(1, withCount.getReferenceCount());
+    Assertions.assertEquals(1, withCount.getReferenceCount());
     restartClusterAndCheckImage(true);
   }
   
@@ -182,7 +184,8 @@ public class TestRenameWithSnapshots {
    * Rename a file under a snapshottable directory, file does not exist
    * in a snapshot.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameFileNotInSnapshot() throws Exception {
     hdfs.mkdirs(sub1);
     hdfs.allowSnapshot(sub1);
@@ -223,7 +226,8 @@ public class TestRenameWithSnapshots {
     restartClusterAndCheckImage(true);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameTwiceInSnapshot() throws Exception {
     hdfs.mkdirs(sub1);
     hdfs.allowSnapshot(sub1);
@@ -262,7 +266,8 @@ public class TestRenameWithSnapshots {
         file3.getName()));
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameFileInSubDirOfDirWithSnapshot() throws Exception {
     final Path sub2 = new Path(sub1, "sub2");
     final Path sub2file1 = new Path(sub2, "sub2file1");
@@ -288,7 +293,8 @@ public class TestRenameWithSnapshots {
         + "/" + sub2file1.getName(), sub2.getName() + "/" + sub2file2.getName()));
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameDirectoryInSnapshot() throws Exception {
     final Path sub2 = new Path(sub1, "sub2");
     final Path sub3 = new Path(sub1, "sub3");
@@ -314,7 +320,8 @@ public class TestRenameWithSnapshots {
         sub3.getName()));
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameDirectoryAndFileInSnapshot() throws Exception {
     final Path sub2 = new Path(sub1, "sub2");
     final Path sub3 = new Path(sub1, "sub3");
@@ -347,10 +354,10 @@ public class TestRenameWithSnapshots {
             .asReference();
     INodeReference.WithCount withCount = (WithCount) ref
             .getReferredINode();
-    Assert.assertEquals(withCount.getReferenceCount(), 1);
+    Assertions.assertEquals(withCount.getReferenceCount(), 1);
     // Ensure name list is empty for the reference sub3file3Inode
-    Assert.assertNull(withCount.getLastWithName());
-    Assert.assertTrue(sub3file3Inode.isInCurrentState());
+    Assertions.assertNull(withCount.getLastWithName());
+    Assertions.assertTrue(sub3file3Inode.isInCurrentState());
   }
 
   /**
@@ -364,7 +371,8 @@ public class TestRenameWithSnapshots {
    * </pre>
    * When changes happening on foo, the diff should be recorded in snapshot s2. 
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameDirAcrossSnapshottableDirs() throws Exception {
     final Path sdir1 = new Path("/dir1");
     final Path sdir2 = new Path("/dir2");
@@ -412,7 +420,8 @@ public class TestRenameWithSnapshots {
   /**
    * Rename a single file across snapshottable dirs.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameFileAcrossSnapshottableDirs() throws Exception {
     final Path sdir1 = new Path("/dir1");
     final Path sdir2 = new Path("/dir2");
@@ -801,8 +810,7 @@ public class TestRenameWithSnapshots {
     assertEquals(1, foo.getDiffs().asList().size());
     INodeDirectory sdir1Node = fsdir.getINode(sdir1.toString()).asDirectory();
     Snapshot s1 = sdir1Node.getSnapshot(DFSUtil.string2Bytes("s1"));
-    assertEquals(s1.getId(), foo.getDirectoryWithSnapshotFeature()
-        .getLastSnapshotId());
+    assertEquals(s1.getId(), foo.getDirectoryWithSnapshotFeature().getLastSnapshotId());
     INodeFile bar1 = fsdir.getINode4Write(bar1_dir1.toString()).asFile();
     assertEquals(1, bar1.getDiffs().asList().size());
     assertEquals(s1.getId(), bar1.getDiffs().getLastSnapshotId());
@@ -1102,7 +1110,8 @@ public class TestRenameWithSnapshots {
   /**
    * Test rename from a non-snapshottable dir to a snapshottable dir
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameFromNonSDir2SDir() throws Exception {
     final Path sdir1 = new Path("/dir1");
     final Path sdir2 = new Path("/dir2");
@@ -1126,7 +1135,8 @@ public class TestRenameWithSnapshots {
    * directories without snapshots. In such case we need to update the 
    * snapshottable dir list in SnapshotManager.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameAndUpdateSnapshottableDirs() throws Exception {
     final Path sdir1 = new Path("/dir1");
     final Path sdir2 = new Path("/dir2");
@@ -2210,8 +2220,8 @@ public class TestRenameWithSnapshots {
     
     final Path foo_s0 = SnapshotTestHelper.getSnapshotPath(test, "s0",
         "dir2/foo");
-    assertTrue("the snapshot path " + foo_s0 + " should exist",
-        hdfs.exists(foo_s0));
+    assertTrue(hdfs.exists(foo_s0),
+        "the snapshot path " + foo_s0 + " should exist");
     
     // delete snapshot s0. The deletion will first go down through dir1, and 
     // find foo in the created list of dir1. Then it will use null as the prior
@@ -2220,12 +2230,12 @@ public class TestRenameWithSnapshots {
     // foo subtree.
     hdfs.deleteSnapshot(test, "s0");
     // check the internal
-    assertFalse("after deleting s0, " + foo_s0 + " should not exist",
-        hdfs.exists(foo_s0));
+    assertFalse(hdfs.exists(foo_s0),
+    "after deleting s0, " + foo_s0 + " should not exist");
     INodeDirectory dir2Node = fsdir.getINode4Write(dir2.toString())
         .asDirectory();
-    assertTrue("the diff list of " + dir2
-        + " should be empty after deleting s0", !dir2Node.isWithSnapshot());
+    assertTrue(!dir2Node.isWithSnapshot(),
+        "the diff list of " + dir2 + " should be empty after deleting s0");
     
     assertTrue(hdfs.exists(newfoo));
     INode fooRefNode = fsdir.getINode4Write(newfoo.toString());
@@ -2301,8 +2311,7 @@ public class TestRenameWithSnapshots {
     Snapshot s0 = testNode.getSnapshot(DFSUtil.string2Bytes("s0"));
     assertEquals(s0.getId(), diff.getSnapshotId());
     // and file should be stored in the deleted list of this snapshot diff
-    assertEquals("file", diff.getChildrenDiff().getDeletedUnmodifiable()
-        .get(0).getLocalName());
+    assertEquals("file", diff.getChildrenDiff().getDeletedUnmodifiable().get(0).getLocalName());
     
     // check dir2: a WithName instance for foo should be in the deleted list
     // of the snapshot diff for s2
@@ -2320,7 +2329,7 @@ public class TestRenameWithSnapshots {
         (INodeReference.WithName) fsdir.getINode(foo_s2.toString());
     assertSame(dList.get(0), fooNode_s2);
     assertSame(fooNode.asReference().getReferredINode(),
-        fooNode_s2.getReferredINode());
+fooNode_s2.getReferredINode());
     
     restartClusterAndCheckImage(true);
   }
@@ -2456,7 +2465,8 @@ public class TestRenameWithSnapshots {
     assertTrue(existsInDiffReport(entries, DiffType.RENAME, "foo/file3", "newDir/file1"));
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDoubleRenamesWithSnapshotDelete() throws Exception {
     hdfs.mkdirs(sub1);
     hdfs.allowSnapshot(sub1);
@@ -2522,7 +2532,8 @@ public class TestRenameWithSnapshots {
   /**
    * Test getContentsummary and getQuotausage for an INodeReference.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testQuotaForRenameFileInSnapshot() throws Exception {
     final Path snapshotDir = new Path("/testRenameWithSnapshot");
     hdfs.mkdirs(snapshotDir, new FsPermission((short) 0777));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -60,7 +60,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSetQuotaWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSetQuotaWithSnapshot.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -38,11 +38,10 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.INodeDirectory;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectoryWithSnapshotFeature.DirectoryDiff;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSetQuotaWithSnapshot {
   protected static final long seed = 0;
@@ -54,11 +53,8 @@ public class TestSetQuotaWithSnapshot {
   protected FSNamesystem fsn;
   protected FSDirectory fsdir;
   protected DistributedFileSystem hdfs;
-  
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -71,7 +67,7 @@ public class TestSetQuotaWithSnapshot {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -79,7 +75,8 @@ public class TestSetQuotaWithSnapshot {
     }
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSetQuota() throws Exception {
     final Path dir = new Path("/TestSnapshot");
     hdfs.mkdirs(dir);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapRootDescendantDiff.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapRootDescendantDiff.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,9 +28,9 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test snapshot diff report for the snapshot root descendant directory.
@@ -48,7 +48,7 @@ public class TestSnapRootDescendantDiff {
   protected DistributedFileSystem hdfs;
   private final Map<Path, Integer> snapshotNumberMap = new HashMap<>();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setBoolean(
@@ -66,7 +66,7 @@ public class TestSnapRootDescendantDiff {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,11 +61,10 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests snapshot functionality. One or multiple snapshots are
@@ -100,9 +99,6 @@ public class TestSnapshot {
   
   private static final String testDir =
       GenericTestUtils.getTestDir().getAbsolutePath();
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
   
   /**
    * The list recording all previous snapshots. Each element in the array
@@ -114,7 +110,7 @@ public class TestSnapshot {
    */
   private TestDirectoryTree dirTree;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -128,7 +124,7 @@ public class TestSnapshot {
     dirTree = new TestDirectoryTree(DIRECTORY_TREE_LEVEL, hdfs);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -256,7 +252,7 @@ public class TestSnapshot {
     File originalFsimage = FSImageTestUtil.findLatestImageFile(
         FSImageTestUtil.getFSImage(
         cluster.getNameNode()).getStorage().getStorageDir(0));
-    assertNotNull("Didn't generate or can't find fsimage", originalFsimage);
+    assertNotNull(originalFsimage, "Didn't generate or can't find fsimage");
     PrintStream o = new PrintStream(NullOutputStream.INSTANCE);
     PBImageXmlWriter v = new PBImageXmlWriter(new Configuration(), o);
     v.visit(new RandomAccessFile(originalFsimage, "r"));
@@ -304,7 +300,8 @@ public class TestSnapshot {
    * A simple test that updates a sub-directory of a snapshottable directory
    * with snapshots
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateDirectory() throws Exception {
     Path dir = new Path("/dir");
     Path sub = new Path(dir, "sub");
@@ -358,7 +355,8 @@ public class TestSnapshot {
   /**
    * Creating snapshots for a directory that is not snapshottable must fail.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshottableDirectory() throws Exception {
     Path dir = new Path("/TestSnapshot/sub");
     Path file0 = new Path(dir, "file0");
@@ -457,7 +455,8 @@ public class TestSnapshot {
     assertEquals(0, rootNode.getDirectorySnapshottableFeature().getSnapshotQuota());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotMtime() throws Exception {
     Path dir = new Path("/dir");
     Path sub = new Path(dir, "sub");
@@ -473,7 +472,8 @@ public class TestSnapshot {
         newSnapshotStatus.getModificationTime());
   }
 
-  @Test(timeout = 60000)
+@Test
+@Timeout(value = 60)
   public void testRenameSnapshotMtime() throws Exception {
     Path dir = new Path("/dir");
     Path sub = new Path(dir, "sub");
@@ -493,7 +493,8 @@ public class TestSnapshot {
   /**
    * Test snapshot directory mtime after snapshot deletion.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeletionSnapshotMtime() throws Exception {
     Path dir = new Path("/dir");
     Path sub = new Path(dir, "sub");
@@ -517,7 +518,8 @@ public class TestSnapshot {
    * HDFS-15446 - ensure that snapshot operations on /.reserved/raw
    * paths work and the NN can load the resulting edits.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotOpsOnReservedPath() throws Exception {
     Path dir = new Path("/dir");
     Path nestedDir = new Path("/nested/dir");
@@ -548,7 +550,8 @@ public class TestSnapshot {
    * paths work and the NN can load the resulting edits. This test if for
    * snapshots at the root level.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testSnapshotOpsOnRootReservedPath() throws Exception {
     Path dir = new Path("/");
     Path sub = new Path(dir, "sub");
@@ -749,7 +752,7 @@ public class TestSnapshot {
             
             SnapshotTestHelper.dumpTree(s, cluster);
           }
-          assertEquals(s, currentStatus.toString(), originalStatus.toString());
+          assertEquals(currentStatus.toString(), originalStatus.toString(), s);
         }
       }
     }
@@ -860,7 +863,7 @@ public class TestSnapshot {
               + "\n\nsnapshotFile: " + fsdir.getINode(snapshotFile.toString()).toDetailString();
           SnapshotTestHelper.dumpTree(s, cluster);
         }
-        assertEquals(s, originalSnapshotFileLen, currentSnapshotFileLen);
+        assertEquals(originalSnapshotFileLen, currentSnapshotFileLen, s);
         // Read the snapshot file out of the boundary
         if (currentSnapshotFileLen != -1L
             && !(this instanceof FileAppendNotClose)) {
@@ -875,7 +878,7 @@ public class TestSnapshot {
                 + "\n\nsnapshotFile: " + fsdir.getINode(snapshotFile.toString()).toDetailString();
             SnapshotTestHelper.dumpTree(s, cluster);
           }
-          assertEquals(s, -1, readLen);
+          assertEquals(-1, readLen, s);
           input.close();
         }
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshot.java
@@ -472,8 +472,8 @@ public class TestSnapshot {
         newSnapshotStatus.getModificationTime());
   }
 
-@Test
-@Timeout(value = 60)
+  @Test
+  @Timeout(value = 60)
   public void testRenameSnapshotMtime() throws Exception {
     Path dir = new Path("/dir");
     Path sub = new Path(dir, "sub");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -43,10 +43,11 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test cases for snapshot-related information in blocksMap.
@@ -66,7 +67,7 @@ public class TestSnapshotBlocksMap {
   BlockManager blockmanager;
   protected DistributedFileSystem hdfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -80,7 +81,7 @@ public class TestSnapshotBlocksMap {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -100,15 +101,16 @@ public class TestSnapshotBlocksMap {
 
   static void assertBlockCollection(final BlockManager blkManager,
       final INodeFile file, final BlockInfo b) {
-    Assert.assertSame(b, blkManager.getStoredBlock(b));
-    Assert.assertEquals(file.getId(), b.getBlockCollectionId());
+    Assertions.assertSame(b, blkManager.getStoredBlock(b));
+    Assertions.assertEquals(file.getId(), b.getBlockCollectionId());
   }
 
   /**
    * Test deleting a file with snapshots. Need to check the blocksMap to make
    * sure the corresponding record is updated correctly.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeletionWithSnapshots() throws Exception {
     Path file0 = new Path(sub1, "file0");
     Path file1 = new Path(sub1, "file1");
@@ -150,7 +152,7 @@ public class TestSnapshotBlocksMap {
     {
       INodeFile f1 = assertBlockCollection(file1.toString(), 2, fsdir,
           blockmanager);
-      Assert.assertSame(INodeFile.class, f1.getClass());
+      Assertions.assertSame(INodeFile.class, f1.getClass());
       hdfs.setReplication(file1, (short)2);
       f1 = assertBlockCollection(file1.toString(), 2, fsdir, blockmanager);
       assertTrue(f1.isWithSnapshot());
@@ -201,7 +203,8 @@ public class TestSnapshotBlocksMap {
    * Try to read the files inside snapshot but deleted in original place after
    * restarting post checkpoint. refer HDFS-5427
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testReadSnapshotFileWithCheckpoint() throws Exception {
     Path foo = new Path("/foo");
     hdfs.mkdirs(foo);
@@ -227,7 +230,8 @@ public class TestSnapshotBlocksMap {
    * Try to read the files inside snapshot but renamed to different file and
    * deleted after restarting post checkpoint. refer HDFS-5427
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testReadRenamedSnapshotFileWithCheckpoint() throws Exception {
     final Path foo = new Path("/foo");
     final Path foo2 = new Path("/foo2");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotBlocksMap.java
@@ -22,7 +22,9 @@ import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -44,7 +46,6 @@ import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -101,8 +102,8 @@ public class TestSnapshotBlocksMap {
 
   static void assertBlockCollection(final BlockManager blkManager,
       final INodeFile file, final BlockInfo b) {
-    Assertions.assertSame(b, blkManager.getStoredBlock(b));
-    Assertions.assertEquals(file.getId(), b.getBlockCollectionId());
+    assertSame(b, blkManager.getStoredBlock(b));
+    assertEquals(file.getId(), b.getBlockCollectionId());
   }
 
   /**
@@ -152,7 +153,7 @@ public class TestSnapshotBlocksMap {
     {
       INodeFile f1 = assertBlockCollection(file1.toString(), 2, fsdir,
           blockmanager);
-      Assertions.assertSame(INodeFile.class, f1.getClass());
+      assertSame(INodeFile.class, f1.getClass());
       hdfs.setReplication(file1, (short)2);
       f1 = assertBlockCollection(file1.toString(), 2, fsdir, blockmanager);
       assertTrue(f1.isWithSnapshot());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -60,12 +60,11 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,11 +89,8 @@ public class TestSnapshotDeletion {
   protected FSDirectory fsdir;
   protected BlockManager blockmanager;
   protected DistributedFileSystem hdfs;
-  
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
@@ -107,7 +103,7 @@ public class TestSnapshotDeletion {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -118,7 +114,8 @@ public class TestSnapshotDeletion {
   /**
    * Deleting snapshottable directory with snapshots must fail.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteDirectoryWithSnapshot() throws Exception {
     Path file0 = new Path(sub, "file0");
     Path file1 = new Path(sub, "file1");
@@ -130,12 +127,13 @@ public class TestSnapshotDeletion {
     hdfs.createSnapshot(sub, "s1");
 
     // Deleting a snapshottable dir with snapshots should fail
-    exception.expect(RemoteException.class);
     String error = "The directory " + sub.toString()
         + " cannot be deleted since " + sub.toString()
         + " is snapshottable and already has snapshots";
-    exception.expectMessage(error);
-    hdfs.delete(sub, true);
+    RemoteException ex = assertThrows(RemoteException.class, () -> {
+      hdfs.delete(sub, true);
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
 
   /**
@@ -143,7 +141,8 @@ public class TestSnapshotDeletion {
    * without snapshots. The snapshottable dir list in snapshot manager should be
    * updated.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testApplyEditLogForDeletion() throws Exception {
     final Path foo = new Path("/foo");
     final Path bar1 = new Path(foo, "bar1");
@@ -176,7 +175,8 @@ public class TestSnapshotDeletion {
   /**
    * Deleting directory with snapshottable descendant with snapshots must fail.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteDirectoryWithSnapshot2() throws Exception {
     Path file0 = new Path(sub, "file0");
     Path file1 = new Path(sub, "file1");
@@ -193,11 +193,12 @@ public class TestSnapshotDeletion {
     hdfs.createSnapshot(subsub, "s1");
 
     // Deleting dir while its descedant subsub1 having snapshots should fail
-    exception.expect(RemoteException.class);
     String error = subsub.toString()
         + " is snapshottable and already has snapshots";
-    exception.expectMessage(error);
-    hdfs.delete(dir, true);
+    RemoteException ex = assertThrows(RemoteException.class, () -> {
+      hdfs.delete(dir, true);
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
   
   private static INodeDirectory getDir(final FSDirectory fsdir, final Path dir)
@@ -211,15 +212,15 @@ public class TestSnapshotDeletion {
     INodeDirectory dirNode = getDir(fsdir, dirPath);
     assertTrue(dirNode.isQuotaSet());
     QuotaCounts q = dirNode.getDirectoryWithQuotaFeature().getSpaceConsumed();
-    assertEquals(dirNode.dumpTreeRecursively().toString(), expectedNs,
-        q.getNameSpace());
-    assertEquals(dirNode.dumpTreeRecursively().toString(), expectedDs,
-        q.getStorageSpace());
+    assertEquals(expectedNs, q.getNameSpace(),
+        dirNode.dumpTreeRecursively().toString());
+    assertEquals(expectedDs, q.getStorageSpace(),
+        dirNode.dumpTreeRecursively().toString());
     QuotaCounts counts = dirNode.computeQuotaUsage(fsdir.getBlockStoragePolicySuite(), false);
-    assertEquals(dirNode.dumpTreeRecursively().toString(), expectedNs,
-        counts.getNameSpace());
-    assertEquals(dirNode.dumpTreeRecursively().toString(), expectedDs,
-        counts.getStorageSpace());
+    assertEquals(expectedNs, counts.getNameSpace(),
+        dirNode.dumpTreeRecursively().toString());
+    assertEquals(expectedDs, counts.getStorageSpace(),
+        dirNode.dumpTreeRecursively().toString());
   }
   
   /**
@@ -234,7 +235,8 @@ public class TestSnapshotDeletion {
    * 4. Delete current INodeDirectoryWithSnapshot.
    * </pre>
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteCurrentFileDirectory() throws Exception {
     // create a folder which will be deleted before taking snapshots
     Path deleteDir = new Path(subsub, "deleteDir");
@@ -363,8 +365,7 @@ public class TestSnapshotDeletion {
     assertTrue(snapshotNode4Sub.isWithSnapshot());
     // the snapshot copy of sub has only one child subsub.
     // newFile should have been destroyed
-    assertEquals(1, snapshotNode4Sub.getChildrenList(Snapshot.CURRENT_STATE_ID)
-        .size());
+    assertEquals(1, snapshotNode4Sub.getChildrenList(Snapshot.CURRENT_STATE_ID).size());
     // but should have two children, subsub and noChangeDir, when s1 was taken  
     assertEquals(2, snapshotNode4Sub.getChildrenList(snapshot1.getId()).size());
     
@@ -402,7 +403,8 @@ public class TestSnapshotDeletion {
    * snapshots are taken on the same directory, and we do not need to combine
    * snapshot diffs.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteEarliestSnapshot1() throws Exception {
     // create files under sub
     Path file0 = new Path(sub, "file0");
@@ -460,8 +462,7 @@ public class TestSnapshotDeletion {
     FileStatus statusAfterDeletion = hdfs.getFileStatus(ss);
     System.out.println("Before deletion: " + statusBeforeDeletion.toString()
         + "\n" + "After deletion: " + statusAfterDeletion.toString());
-    assertEquals(statusBeforeDeletion.toString(),
-        statusAfterDeletion.toString());
+    assertEquals(statusBeforeDeletion.toString(), statusAfterDeletion.toString());
   }
   
   /**
@@ -475,7 +476,8 @@ public class TestSnapshotDeletion {
    * Also, the recursive cleanTree process should cover both INodeFile and 
    * INodeDirectory.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteEarliestSnapshot2() throws Exception {
     Path noChangeDir = new Path(sub, "noChangeDir");
     Path noChangeFile = new Path(noChangeDir, "noChangeFile");
@@ -573,7 +575,8 @@ public class TestSnapshotDeletion {
    * Delete a snapshot that is taken before a directory deletion,
    * directory diff list should be combined correctly.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeleteSnapshot1() throws Exception {
     final Path root = new Path("/");
 
@@ -610,7 +613,8 @@ public class TestSnapshotDeletion {
    * Delete a snapshot that is taken before a directory deletion (recursively),
    * directory diff list should be combined correctly.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeleteSnapshot2() throws Exception {
     final Path root = new Path("/");
 
@@ -647,7 +651,8 @@ public class TestSnapshotDeletion {
    * Test deleting snapshots in a more complicated scenario: need to combine
    * snapshot diffs, but no need to handle diffs distributed in a dir tree
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCombineSnapshotDiff1() throws Exception {
     testCombineSnapshotDiffImpl(sub, "", 1);
   }
@@ -656,7 +661,8 @@ public class TestSnapshotDeletion {
    * Test deleting snapshots in more complicated scenarios (snapshot diffs are
    * distributed in the directory sub-tree)
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCombineSnapshotDiff2() throws Exception {
     testCombineSnapshotDiffImpl(sub, "subsub1/subsubsub1/", 3);
   }
@@ -665,7 +671,8 @@ public class TestSnapshotDeletion {
    * When combine two snapshots, make sure files/directories created after the 
    * prior snapshot get destroyed.
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCombineSnapshotDiff3() throws Exception {
     // create initial dir and subdir
     Path dir = new Path("/dir");
@@ -863,7 +870,8 @@ public class TestSnapshotDeletion {
   }
   
   /** Test deleting snapshots with modification on the metadata of directory */ 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testDeleteSnapshotWithDirModification() throws Exception {
     Path file = new Path(sub, "file");
     DFSTestUtil.createFile(hdfs, file, BLOCKSIZE, REPLICATION, seed);
@@ -943,7 +951,8 @@ public class TestSnapshotDeletion {
    * A test covering the case where the snapshot diff to be deleted is renamed 
    * to its previous snapshot. 
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testRenameSnapshotDiff() throws Exception {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(true);
 
@@ -1082,7 +1091,8 @@ public class TestSnapshotDeletion {
    * OP_DELETE_SNAPSHOT edits op was not decrementing the safemode threshold on
    * restart in HA mode. HDFS-5504
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testHANNRestartAfterSnapshotDeletion() throws Exception {
     hdfs.close();
     cluster.shutdown();
@@ -1235,13 +1245,13 @@ public class TestSnapshotDeletion {
 
     // make sure bar has been removed from its parent
     INode p = fsdir.getInode(parentId);
-    Assert.assertNotNull(p);
+    Assertions.assertNotNull(p);
     INodeDirectory pd = p.asDirectory();
-    Assert.assertNotNull(pd);
-    Assert.assertNull(pd.getChild("bar".getBytes(), Snapshot.CURRENT_STATE_ID));
+    Assertions.assertNotNull(pd);
+    Assertions.assertNull(pd.getChild("bar".getBytes(), Snapshot.CURRENT_STATE_ID));
 
     // make sure bar has been cleaned from inodeMap
-    Assert.assertNull(fsdir.getInode(fileId));
+    Assertions.assertNull(fsdir.getInode(fileId));
   }
 
   @Test
@@ -1267,17 +1277,18 @@ public class TestSnapshotDeletion {
 
     hdfs.createSnapshot(st, "s0");
 
-    // Verify the SnapshotException is thrown as expected for HDFS-4529
-    exception.expect(RemoteException.class);
+    // Verify the SnapshotException is thrown as expected for HDFS-4529;
     String error = "Concat: the source file /st/0.txt is in snapshot";
-    exception.expectMessage(error);
-    hdfs.concat(dest, files);
+    RemoteException ex = assertThrows(RemoteException.class, () -> {
+      hdfs.concat(dest, files);
 
-    hdfs.setSafeMode(SafeModeAction.ENTER);
-    hdfs.saveNamespace();
-    hdfs.setSafeMode(SafeModeAction.LEAVE);
+      hdfs.setSafeMode(SafeModeAction.ENTER);
+      hdfs.saveNamespace();
+      hdfs.setSafeMode(SafeModeAction.LEAVE);
 
-    cluster.restartNameNodes();
+      cluster.restartNameNodes();
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
 
   @Test
@@ -1345,11 +1356,11 @@ public class TestSnapshotDeletion {
 
       SnapshotDiffReport sdr = hdfs.getSnapshotDiffReport(st, "s" + i, "ss");
       LOG.info("Snapshot Diff s{} to ss : {}", i, sdr);
-      Assert.assertEquals(sdr.getDiffList().size(), 1);
-      Assert.assertTrue(sdr.getDiffList().get(0).getType() ==
+      Assertions.assertEquals(sdr.getDiffList().size(), 1);
+      Assertions.assertTrue(sdr.getDiffList().get(0).getType() ==
           SnapshotDiffReport.DiffType.MODIFY);
-      Assert.assertTrue(new Path(st, DFSUtilClient.bytes2String(
-          sdr.getDiffList().get(0).getSourcePath())).equals(dest));
+      Assertions.assertTrue(new Path(st,
+          DFSUtilClient.bytes2String(sdr.getDiffList().get(0).getSourcePath())).equals(dest));
     }
 
     hdfs.deleteSnapshot(st, "s1");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
@@ -18,7 +18,13 @@
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -61,7 +67,6 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -235,6 +240,7 @@ public class TestSnapshotDeletion {
    * 4. Delete current INodeDirectoryWithSnapshot.
    * </pre>
    */
+  @SuppressWarnings("checkstyle:methodlength")
   @Test
   @Timeout(value = 300)
   public void testDeleteCurrentFileDirectory() throws Exception {
@@ -1245,13 +1251,13 @@ public class TestSnapshotDeletion {
 
     // make sure bar has been removed from its parent
     INode p = fsdir.getInode(parentId);
-    Assertions.assertNotNull(p);
+    assertNotNull(p);
     INodeDirectory pd = p.asDirectory();
-    Assertions.assertNotNull(pd);
-    Assertions.assertNull(pd.getChild("bar".getBytes(), Snapshot.CURRENT_STATE_ID));
+    assertNotNull(pd);
+    assertNull(pd.getChild("bar".getBytes(), Snapshot.CURRENT_STATE_ID));
 
     // make sure bar has been cleaned from inodeMap
-    Assertions.assertNull(fsdir.getInode(fileId));
+    assertNull(fsdir.getInode(fileId));
   }
 
   @Test
@@ -1356,10 +1362,10 @@ public class TestSnapshotDeletion {
 
       SnapshotDiffReport sdr = hdfs.getSnapshotDiffReport(st, "s" + i, "ss");
       LOG.info("Snapshot Diff s{} to ss : {}", i, sdr);
-      Assertions.assertEquals(sdr.getDiffList().size(), 1);
-      Assertions.assertTrue(sdr.getDiffList().get(0).getType() ==
+      assertEquals(sdr.getDiffList().size(), 1);
+      assertTrue(sdr.getDiffList().get(0).getType() ==
           SnapshotDiffReport.DiffType.MODIFY);
-      Assertions.assertTrue(new Path(st,
+      assertTrue(new Path(st,
           DFSUtilClient.bytes2String(sdr.getDiffList().get(0).getSourcePath())).equals(dest));
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -59,10 +59,11 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ChunkedArrayList;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +92,7 @@ public class TestSnapshotDiffReport {
   private DistributedFileSystem hdfs;
   private final HashMap<Path, Integer> snapshotNumberMap = new HashMap<Path, Integer>();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setBoolean(
@@ -110,7 +111,7 @@ public class TestSnapshotDiffReport {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -207,7 +208,8 @@ public class TestSnapshotDiffReport {
   /**
    * Test the computation and representation of diff between snapshots.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDiffReport() throws Exception {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(true);
 
@@ -322,7 +324,8 @@ public class TestSnapshotDiffReport {
             DFSUtil.string2Bytes("subsub1/subsubsub1/link13")));
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapRootDescendantDiffReport() throws Exception {
     Path subSub = new Path(sub1, "subsub1");
     Path subSubSub = new Path(subSub, "subsubsub1");
@@ -780,7 +783,8 @@ public class TestSnapshotDiffReport {
    * sure the diff report computation correctly retrieve the diff from the
    * deleted sub-directory.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDiffReport2() throws Exception {
     Path subsub1 = new Path(sub1, "subsub1");
     Path subsubsub1 = new Path(subsub1, "subsubsub1");
@@ -824,7 +828,7 @@ public class TestSnapshotDiffReport {
     final SnapshotDiffReport report =
         hdfs.getSnapshotDiffReport(testdir, "s0", "");
     // The diff should be null. Snapshot dir inode should keep the quota.
-    Assert.assertEquals(0, report.getDiffList().size());
+    Assertions.assertEquals(0, report.getDiffList().size());
     // Cleanup
     hdfs.deleteSnapshot(testdir, "s0");
     hdfs.disallowSnapshot(testdir);
@@ -1054,7 +1058,8 @@ public class TestSnapshotDiffReport {
    * Test Snapshot diff report for snapshots with open files captures in them.
    * Also verify if the diff report remains the same across NameNode restarts.
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testDiffReportWithOpenFiles() throws Exception {
     // Construct the directory tree
     final Path level0A = new Path("/level_0_A");
@@ -1075,8 +1080,7 @@ public class TestSnapshotDiffReport {
     final long flumeFileLengthAfterS1 = hdfs.getFileStatus(flumeFile).getLen();
 
     // Verify if Snap S1 file length is same as the the live one
-    Assert.assertEquals(flumeFileLengthAfterS1,
-        hdfs.getFileStatus(flumeS1Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
         new DiffReportEntry(DiffType.MODIFY, DFSUtil.string2Bytes("")));
@@ -1097,11 +1101,10 @@ public class TestSnapshotDiffReport {
 
     // Verify live files length is same as all data written till now
     final long flumeFileLengthAfterS2 = hdfs.getFileStatus(flumeFile).getLen();
-    Assert.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the live one
-    Assert.assertEquals(flumeFileLengthAfterS2,
-        hdfs.getFileStatus(flumeS2Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
         new DiffReportEntry(DiffType.MODIFY, DFSUtil.string2Bytes("")),
@@ -1120,22 +1123,19 @@ public class TestSnapshotDiffReport {
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
-        hdfs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
-        hdfs.getFileStatus(flumeS2Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
+    Assertions.assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
 
     flumeOutputStream.close();
 
     // Verify if Snap S2 file length is same as the live one
-    Assert.assertEquals(flumeFileWrittenDataLength,
-        hdfs.getFileStatus(flumeFile).getLen());
+    Assertions.assertEquals(flumeFileWrittenDataLength, hdfs.getFileStatus(flumeFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assert.assertEquals(flumeFileLengthAfterS1,
+    Assertions.assertEquals(flumeFileLengthAfterS1,
         hdfs.getFileStatus(flumeS1Path).getLen());
-    Assert.assertEquals(flumeFileLengthAfterS2,
+    Assertions.assertEquals(flumeFileLengthAfterS2,
         hdfs.getFileStatus(flumeS2Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
@@ -1554,10 +1554,10 @@ public class TestSnapshotDiffReport {
     try {
       iterator.next();
     } catch (Exception e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("No more entry in SnapshotDiffReport for /"));
     }
-    Assert.assertNotEquals(0, reportList.size());
+    Assertions.assertNotEquals(0, reportList.size());
     // generate the snapshotDiffReport and Verify
     snapshotDiffReport = new SnapshotDiffReportGenerator("/", "s0", "s1",
         report.getIsFromEarlier(), modifiedList, createdList, deletedList);
@@ -1598,7 +1598,7 @@ public class TestSnapshotDiffReport {
     try {
       hdfs.snapshotDiffReportListingRemoteIterator(root, "s0", "");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Remote Iterator is"
+      Assertions.assertTrue(e.getMessage().contains("Remote Iterator is"
           + "supported for snapshotDiffReport between two snapshots"));
     }
   }
@@ -1613,15 +1613,15 @@ public class TestSnapshotDiffReport {
 
     final SnapshottableDirectoryStatus[] snapshottables
         = hdfs.getSnapshottableDirListing();
-    Assert.assertEquals(1, snapshottables.length);
-    Assert.assertEquals(3, snapshottables[0].getSnapshotNumber());
+    Assertions.assertEquals(1, snapshottables.length);
+    Assertions.assertEquals(3, snapshottables[0].getSnapshotNumber());
 
     final SnapshotStatus[] statuses = hdfs.getSnapshotListing(root);
-    Assert.assertEquals(3, statuses.length);
+    Assertions.assertEquals(3, statuses.length);
     for (int i = 0; i < statuses.length; i++) {
       final SnapshotStatus s = statuses[i];
       LOG.info("Snapshot #{}: {}", s.getSnapshotID(), s.getFullPath());
-      Assert.assertEquals(i, s.getSnapshotID());
+      Assertions.assertEquals(i, s.getSnapshotID());
     }
 
     for (int i = 0; i <= 2; i++) {
@@ -1635,11 +1635,11 @@ public class TestSnapshotDiffReport {
       String from, String to) throws Exception {
     final String barDiff = diff(bar, from, to);
     final String fooDiff = diff(foo, from, to);
-    Assert.assertEquals(barDiff, fooDiff.replace("/bar", ""));
+    Assertions.assertEquals(barDiff, fooDiff.replace("/bar", ""));
 
     final String rootDiff = diff(root, from, to);
-    Assert.assertEquals(fooDiff, rootDiff.replace("/foo", ""));
-    Assert.assertEquals(barDiff, rootDiff.replace("/foo/bar", ""));
+    Assertions.assertEquals(fooDiff, rootDiff.replace("/foo", ""));
+    Assertions.assertEquals(barDiff, rootDiff.replace("/foo/bar", ""));
   }
 
   private String diff(Path path, String from, String to) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDiffReport.java
@@ -60,7 +60,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ChunkedArrayList;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -828,7 +827,7 @@ public class TestSnapshotDiffReport {
     final SnapshotDiffReport report =
         hdfs.getSnapshotDiffReport(testdir, "s0", "");
     // The diff should be null. Snapshot dir inode should keep the quota.
-    Assertions.assertEquals(0, report.getDiffList().size());
+    assertEquals(0, report.getDiffList().size());
     // Cleanup
     hdfs.deleteSnapshot(testdir, "s0");
     hdfs.disallowSnapshot(testdir);
@@ -1080,7 +1079,7 @@ public class TestSnapshotDiffReport {
     final long flumeFileLengthAfterS1 = hdfs.getFileStatus(flumeFile).getLen();
 
     // Verify if Snap S1 file length is same as the the live one
-    Assertions.assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
+    assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
         new DiffReportEntry(DiffType.MODIFY, DFSUtil.string2Bytes("")));
@@ -1101,10 +1100,10 @@ public class TestSnapshotDiffReport {
 
     // Verify live files length is same as all data written till now
     final long flumeFileLengthAfterS2 = hdfs.getFileStatus(flumeFile).getLen();
-    Assertions.assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
+    assertEquals(flumeFileWrittenDataLength, flumeFileLengthAfterS2);
 
     // Verify if Snap S2 file length is same as the live one
-    Assertions.assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
+    assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
         new DiffReportEntry(DiffType.MODIFY, DFSUtil.string2Bytes("")),
@@ -1123,19 +1122,19 @@ public class TestSnapshotDiffReport {
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
+    assertEquals(flumeFileLengthAfterS1, hdfs.getFileStatus(flumeS1Path).getLen());
+    assertEquals(flumeFileLengthAfterS2, hdfs.getFileStatus(flumeS2Path).getLen());
 
     flumeOutputStream.close();
 
     // Verify if Snap S2 file length is same as the live one
-    Assertions.assertEquals(flumeFileWrittenDataLength, hdfs.getFileStatus(flumeFile).getLen());
+    assertEquals(flumeFileWrittenDataLength, hdfs.getFileStatus(flumeFile).getLen());
 
     // Verify old flume snapshots have point-in-time / frozen file lengths
     // even after the live file have moved forward.
-    Assertions.assertEquals(flumeFileLengthAfterS1,
+    assertEquals(flumeFileLengthAfterS1,
         hdfs.getFileStatus(flumeS1Path).getLen());
-    Assertions.assertEquals(flumeFileLengthAfterS2,
+    assertEquals(flumeFileLengthAfterS2,
         hdfs.getFileStatus(flumeS2Path).getLen());
 
     verifyDiffReport(level0A, flumeSnap1Name, "",
@@ -1554,10 +1553,10 @@ public class TestSnapshotDiffReport {
     try {
       iterator.next();
     } catch (Exception e) {
-      Assertions.assertTrue(
+      assertTrue(
           e.getMessage().contains("No more entry in SnapshotDiffReport for /"));
     }
-    Assertions.assertNotEquals(0, reportList.size());
+    assertNotEquals(0, reportList.size());
     // generate the snapshotDiffReport and Verify
     snapshotDiffReport = new SnapshotDiffReportGenerator("/", "s0", "s1",
         report.getIsFromEarlier(), modifiedList, createdList, deletedList);
@@ -1598,7 +1597,7 @@ public class TestSnapshotDiffReport {
     try {
       hdfs.snapshotDiffReportListingRemoteIterator(root, "s0", "");
     } catch (Exception e) {
-      Assertions.assertTrue(e.getMessage().contains("Remote Iterator is"
+      assertTrue(e.getMessage().contains("Remote Iterator is"
           + "supported for snapshotDiffReport between two snapshots"));
     }
   }
@@ -1613,15 +1612,15 @@ public class TestSnapshotDiffReport {
 
     final SnapshottableDirectoryStatus[] snapshottables
         = hdfs.getSnapshottableDirListing();
-    Assertions.assertEquals(1, snapshottables.length);
-    Assertions.assertEquals(3, snapshottables[0].getSnapshotNumber());
+    assertEquals(1, snapshottables.length);
+    assertEquals(3, snapshottables[0].getSnapshotNumber());
 
     final SnapshotStatus[] statuses = hdfs.getSnapshotListing(root);
-    Assertions.assertEquals(3, statuses.length);
+    assertEquals(3, statuses.length);
     for (int i = 0; i < statuses.length; i++) {
       final SnapshotStatus s = statuses[i];
       LOG.info("Snapshot #{}: {}", s.getSnapshotID(), s.getFullPath());
-      Assertions.assertEquals(i, s.getSnapshotID());
+      assertEquals(i, s.getSnapshotID());
     }
 
     for (int i = 0; i <= 2; i++) {
@@ -1635,11 +1634,11 @@ public class TestSnapshotDiffReport {
       String from, String to) throws Exception {
     final String barDiff = diff(bar, from, to);
     final String fooDiff = diff(foo, from, to);
-    Assertions.assertEquals(barDiff, fooDiff.replace("/bar", ""));
+    assertEquals(barDiff, fooDiff.replace("/bar", ""));
 
     final String rootDiff = diff(root, from, to);
-    Assertions.assertEquals(fooDiff, rootDiff.replace("/foo", ""));
-    Assertions.assertEquals(barDiff, rootDiff.replace("/foo/bar", ""));
+    assertEquals(fooDiff, rootDiff.replace("/foo", ""));
+    assertEquals(barDiff, rootDiff.replace("/foo/bar", ""));
   }
 
   private String diff(Path path, String from, String to) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotFileLength.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotFileLength.java
@@ -26,15 +26,14 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hdfs.AppendTestUtil;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -60,7 +59,7 @@ public class TestSnapshotFileLength {
   private final String file1Name = "file1";
   private final String snapshot1 = "snapshot1";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf.setLong(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, BLOCKSIZE);
     conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, BLOCKSIZE);
@@ -70,7 +69,7 @@ public class TestSnapshotFileLength {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -84,7 +83,8 @@ public class TestSnapshotFileLength {
    * when accessing it via a snapshot path.
    *
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testSnapshotfileLength() throws Exception {
     hdfs.mkdirs(sub);
 
@@ -108,8 +108,9 @@ public class TestSnapshotFileLength {
         = SnapshotTestHelper.getSnapshotPath(sub, snapshot1, file1Name);
 
     final FileChecksum snapChksum1 = hdfs.getFileChecksum(file1snap1);
-    assertThat("file and snapshot file checksums are not equal",
-        hdfs.getFileChecksum(file1), is(snapChksum1));
+    assertThat(hdfs.getFileChecksum(file1))
+        .as("file and snapshot file checksums are not equal")
+        .isEqualTo(snapChksum1);
 
     // Append to the file.
     FSDataOutputStream out = hdfs.append(file1);
@@ -124,48 +125,54 @@ public class TestSnapshotFileLength {
           "Fail to get checksum, since file " + file1
               + " is under construction."));
     }
-    assertThat("snapshot checksum (post-open for append) has changed",
-        hdfs.getFileChecksum(file1snap1), is(snapChksum1));
+    assertThat(hdfs.getFileChecksum(file1snap1))
+        .as("snapshot checksum (post-open for append) has changed")
+        .isEqualTo(snapChksum1);
     try {
       AppendTestUtil.write(out, 0, toAppend);
       out.hflush();
       // Test reading from snapshot of file that is open for append
       byte[] dataFromSnapshot = DFSTestUtil.readFileBuffer(hdfs, file1snap1);
-      assertThat("Wrong data size in snapshot.",
-          dataFromSnapshot.length, is(origLen));
+      assertThat(dataFromSnapshot.length)
+          .as("Wrong data size in snapshot.")
+              .isEqualTo(origLen);
       // Verify that checksum didn't change
-      assertThat("snapshot checksum (post-append) has changed",
-          hdfs.getFileChecksum(file1snap1), is(snapChksum1));
+      assertThat(hdfs.getFileChecksum(file1snap1))
+          .as("snapshot checksum (post-append) has changed")
+          .isEqualTo(snapChksum1);
     } finally {
       out.close();
     }
-    assertThat("file and snapshot file checksums (post-close) are equal",
-        hdfs.getFileChecksum(file1), not(snapChksum1));
-    assertThat("snapshot file checksum (post-close) has changed",
-        hdfs.getFileChecksum(file1snap1), is(snapChksum1));
+    assertThat(hdfs.getFileChecksum(file1))
+        .as("file and snapshot file checksums (post-close) are equal")
+            .isNotEqualTo(snapChksum1);
+    assertThat(hdfs.getFileChecksum(file1snap1))
+        .as("snapshot file checksum (post-close) has changed")
+        .isEqualTo(snapChksum1);
 
     // Make sure we can read the entire file via its non-snapshot path.
     fileStatus = hdfs.getFileStatus(file1);
-    assertThat(fileStatus.getLen(), is((long) origLen + toAppend));
+    assertThat(fileStatus.getLen()).isEqualTo((long) origLen + toAppend);
     fis = hdfs.open(file1);
     bytesRead = fis.read(0, buffer, 0, buffer.length);
-    assertThat(bytesRead, is(origLen + toAppend));
+    assertThat(bytesRead).isEqualTo(origLen + toAppend);
     fis.close();
 
     // Try to open the file via its snapshot path.
     fis = hdfs.open(file1snap1);
     fileStatus = hdfs.getFileStatus(file1snap1);
-    assertThat(fileStatus.getLen(), is((long) origLen));
+    assertThat(fileStatus.getLen()).isEqualTo((long) origLen);
 
     // Make sure we can only read up to the snapshot length.
     bytesRead = fis.read(0, buffer, 0, buffer.length);
-    assertThat(bytesRead, is(origLen));
+    assertThat(bytesRead).isEqualTo(origLen);
     fis.close();
 
     byte[] dataFromSnapshot = DFSTestUtil.readFileBuffer(hdfs,
         file1snap1);
-    assertThat("Wrong data size in snapshot.",
-        dataFromSnapshot.length, is(origLen));
+    assertThat(dataFromSnapshot.length)
+        .as("Wrong data size in snapshot.")
+        .isEqualTo(origLen);
   }
 
   /**
@@ -174,7 +181,8 @@ public class TestSnapshotFileLength {
    *  cannot read a file beyond snapshot file length
    * @throws Exception
    */
-  @Test (timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testSnapshotFileLengthWithCatCommand() throws Exception {
 
     FSDataInputStream fis = null;
@@ -194,10 +202,10 @@ public class TestSnapshotFileLength {
 
     // Make sure we can read the entire file via its non-snapshot path.
     fileStatus = hdfs.getFileStatus(file1);
-    assertEquals("Unexpected file length", BLOCKSIZE * 2, fileStatus.getLen());
+    assertEquals(BLOCKSIZE * 2, fileStatus.getLen(), "Unexpected file length");
     fis = hdfs.open(file1);
     bytesRead = fis.read(buffer, 0, buffer.length);
-    assertEquals("Unexpected # bytes read", BLOCKSIZE * 2, bytesRead);
+    assertEquals(BLOCKSIZE * 2, bytesRead, "Unexpected # bytes read");
     fis.close();
 
     Path file1snap1 =
@@ -207,7 +215,7 @@ public class TestSnapshotFileLength {
     assertEquals(fileStatus.getLen(), BLOCKSIZE);
     // Make sure we can only read up to the snapshot length.
     bytesRead = fis.read(buffer, 0, buffer.length);
-    assertEquals("Unexpected # bytes read", BLOCKSIZE, bytesRead);
+    assertEquals(BLOCKSIZE, bytesRead, "Unexpected # bytes read");
     fis.close();
 
     PrintStream outBackup = System.out;
@@ -220,7 +228,7 @@ public class TestSnapshotFileLength {
     try {
       ToolRunner.run(conf, shell, new String[] { "-cat",
       "/TestSnapshotFileLength/sub1/.snapshot/snapshot1/file1" });
-      assertEquals("Unexpected # bytes from -cat", BLOCKSIZE, bao.size());
+      assertEquals(BLOCKSIZE, bao.size(), "Unexpected # bytes from -cat");
     } finally {
       System.setOut(outBackup);
       System.setErr(errBackup);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotListing.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotListing.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -29,9 +29,10 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSnapshotListing {
 
@@ -46,7 +47,7 @@ public class TestSnapshotListing {
   FSNamesystem fsn;
   DistributedFileSystem hdfs;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
@@ -57,7 +58,7 @@ public class TestSnapshotListing {
     hdfs.mkdirs(dir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -68,7 +69,8 @@ public class TestSnapshotListing {
   /**
    * Test listing snapshots under a snapshottable directory
    */
-  @Test (timeout=15000)
+  @Test
+  @Timeout(value = 15)
   public void testListSnapshots() throws Exception {
     final Path snapshotsPath = new Path(dir, ".snapshot");
     FileStatus[] stats = null;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -37,7 +40,6 @@ import org.apache.hadoop.hdfs.server.namenode.LeaseManager;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -101,9 +103,9 @@ public class TestSnapshotManager {
     try {
       sm.createSnapshot(leaseManager, iip, "dummy", "shouldFailSnapshot",
           Time.now());
-      Assertions.fail("Expected SnapshotException not thrown");
+      fail("Expected SnapshotException not thrown");
     } catch (SnapshotException se) {
-      Assertions.assertTrue(
+      assertTrue(
           StringUtils.toLowerCase(se.getMessage()).contains(errMsg));
     }
 
@@ -121,10 +123,10 @@ public class TestSnapshotManager {
       // in case the snapshot ID limit is hit, further creation of snapshots
       // even post deletions of snapshots won't succeed
       if (maxSnapID < maxSnapshotLimit) {
-          Assertions.fail("CreateSnapshot should succeed");
+        fail("CreateSnapshot should succeed");
       }
     } catch (SnapshotException se) {
-      Assertions.assertTrue(
+      assertTrue(
           StringUtils.toLowerCase(se.getMessage()).contains(errMsg));
     }
   }
@@ -137,7 +139,7 @@ public class TestSnapshotManager {
     FSDirectory fsdir = mock(FSDirectory.class);
     SnapshotManager snapshotManager = new SnapshotManager(new Configuration(),
         fsdir);
-    Assertions.assertTrue(snapshotManager.
+    assertTrue(snapshotManager.
         getMaxSnapshotID() < Snapshot.CURRENT_STATE_ID);
   }
 
@@ -174,10 +176,10 @@ public class TestSnapshotManager {
           getSnapshotManager();
 
       // make sure edits of all previous 5 create snapshots are replayed
-      Assertions.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+      assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
 
       // make sure namenode has the new snapshot limit configured as 2
-      Assertions.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+      assertEquals(2, snapshotManager.getMaxSnapshotLimit());
 
       // Any new snapshot creation should still fail
       LambdaTestUtils.intercept(SnapshotException.class,
@@ -189,10 +191,10 @@ public class TestSnapshotManager {
       snapshotManager = cluster.getNamesystem().
           getSnapshotManager();
       // make sure edits of all previous 5 create snapshots are replayed
-      Assertions.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+      assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
 
       // make sure namenode has the new snapshot limit configured as 2
-      Assertions.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+      assertEquals(2, snapshotManager.getMaxSnapshotLimit());
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotManager.java
@@ -37,8 +37,9 @@ import org.apache.hadoop.hdfs.server.namenode.LeaseManager;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
@@ -52,7 +53,8 @@ public class TestSnapshotManager {
   /**
    * Test that the global limit on snapshot Ids is honored.
    */
-  @Test (timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testSnapshotIDLimits() throws Exception {
     testMaxSnapshotLimit(testMaxSnapshotIDLimit, "rollover",
         new Configuration(), testMaxSnapshotIDLimit);
@@ -61,7 +63,8 @@ public class TestSnapshotManager {
   /**
    * Tests that the global limit on snapshots is honored.
    */
-  @Test (timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testMaxSnapshotLimit() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_SNAPSHOT_FILESYSTEM_LIMIT,
@@ -98,9 +101,9 @@ public class TestSnapshotManager {
     try {
       sm.createSnapshot(leaseManager, iip, "dummy", "shouldFailSnapshot",
           Time.now());
-      Assert.fail("Expected SnapshotException not thrown");
+      Assertions.fail("Expected SnapshotException not thrown");
     } catch (SnapshotException se) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           StringUtils.toLowerCase(se.getMessage()).contains(errMsg));
     }
 
@@ -118,10 +121,10 @@ public class TestSnapshotManager {
       // in case the snapshot ID limit is hit, further creation of snapshots
       // even post deletions of snapshots won't succeed
       if (maxSnapID < maxSnapshotLimit) {
-        Assert.fail("CreateSnapshot should succeed");
+          Assertions.fail("CreateSnapshot should succeed");
       }
     } catch (SnapshotException se) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           StringUtils.toLowerCase(se.getMessage()).contains(errMsg));
     }
   }
@@ -134,7 +137,7 @@ public class TestSnapshotManager {
     FSDirectory fsdir = mock(FSDirectory.class);
     SnapshotManager snapshotManager = new SnapshotManager(new Configuration(),
         fsdir);
-    Assert.assertTrue(snapshotManager.
+    Assertions.assertTrue(snapshotManager.
         getMaxSnapshotID() < Snapshot.CURRENT_STATE_ID);
   }
 
@@ -171,10 +174,10 @@ public class TestSnapshotManager {
           getSnapshotManager();
 
       // make sure edits of all previous 5 create snapshots are replayed
-      Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+      Assertions.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
 
       // make sure namenode has the new snapshot limit configured as 2
-      Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+      Assertions.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
 
       // Any new snapshot creation should still fail
       LambdaTestUtils.intercept(SnapshotException.class,
@@ -186,10 +189,10 @@ public class TestSnapshotManager {
       snapshotManager = cluster.getNamesystem().
           getSnapshotManager();
       // make sure edits of all previous 5 create snapshots are replayed
-      Assert.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
+      Assertions.assertEquals(numSnapshots, snapshotManager.getNumSnapshots());
 
       // make sure namenode has the new snapshot limit configured as 2
-      Assert.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
+      Assertions.assertEquals(2, snapshotManager.getMaxSnapshotLimit());
     } finally {
       if (cluster != null) {
         cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotMetrics.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode.snapshot;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -28,9 +28,9 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the snapshot-related metrics
@@ -52,7 +52,7 @@ public class TestSnapshotMetrics {
   private MiniDFSCluster cluster;
   private DistributedFileSystem hdfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf)
@@ -65,7 +65,7 @@ public class TestSnapshotMetrics {
     DFSTestUtil.createFile(hdfs, file2, 1024, REPLICATION, seed);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotNameWithInvalidCharacters.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotNameWithInvalidCharacters.java
@@ -24,9 +24,10 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.ipc.RemoteException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSnapshotNameWithInvalidCharacters {
   private static final long SEED = 0;
@@ -42,7 +43,7 @@ public class TestSnapshotNameWithInvalidCharacters {
   private final String snapshot1 = "a:b:c";
   private final String snapshot2 = "a/b/c";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
                                               .build();
@@ -50,7 +51,7 @@ public class TestSnapshotNameWithInvalidCharacters {
     hdfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -58,7 +59,8 @@ public class TestSnapshotNameWithInvalidCharacters {
     }
   }
 
-  @Test (timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void TestSnapshotWithInvalidName() throws Exception {
 
     Path file1 = new Path(dir1,file1Name);
@@ -71,7 +73,8 @@ public class TestSnapshotNameWithInvalidCharacters {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void TestSnapshotWithInvalidName1() throws Exception{
     Path file1 = new Path(dir1, file1Name);
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, SEED);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotRename.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotRename.java
@@ -17,10 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -43,11 +44,10 @@ import org.apache.hadoop.hdfs.util.ReadOnlyList;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test for renaming snapshot
@@ -68,7 +68,7 @@ public class TestSnapshotRename {
   DistributedFileSystem hdfs;
   FSDirectory fsdir;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
@@ -79,16 +79,13 @@ public class TestSnapshotRename {
     fsdir = fsn.getFSDirectory();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
       cluster = null;
     }
   }
-  
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
   
   /**
    * Check the correctness of snapshot list within snapshottable dir
@@ -115,7 +112,8 @@ public class TestSnapshotRename {
    * Rename snapshot(s), and check the correctness of the snapshot list within
    * {@link INodeDirectorySnapshottable}
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotList() throws Exception {
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
     // Create three snapshots for sub1
@@ -144,7 +142,8 @@ public class TestSnapshotRename {
   /**
    * Test FileStatus of snapshot file before/after rename
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSnapshotRename() throws Exception {
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
     // Create snapshot for sub1
@@ -173,50 +172,56 @@ public class TestSnapshotRename {
   /**
    * Test rename a non-existing snapshot
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameNonExistingSnapshot() throws Exception {
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
     // Create snapshot for sub1
     SnapshotTestHelper.createSnapshot(hdfs, sub1, "s1");
-    
-    exception.expect(SnapshotException.class);
+
     String error = "The snapshot wrongName does not exist for directory "
         + sub1.toString();
-    exception.expectMessage(error);
-    hdfs.renameSnapshot(sub1, "wrongName", "s2");
+    SnapshotException ex = assertThrows(SnapshotException.class, () -> {
+      hdfs.renameSnapshot(sub1, "wrongName", "s2");
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
 
   /**
    * Test rename a non-existing snapshot to itself.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameNonExistingSnapshotToItself() throws Exception {
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
     // Create snapshot for sub1
     SnapshotTestHelper.createSnapshot(hdfs, sub1, "s1");
 
-    exception.expect(SnapshotException.class);
     String error = "The snapshot wrongName does not exist for directory "
         + sub1.toString();
-    exception.expectMessage(error);
-    hdfs.renameSnapshot(sub1, "wrongName", "wrongName");
+    SnapshotException ex = assertThrows(SnapshotException.class, () -> {
+      hdfs.renameSnapshot(sub1, "wrongName", "wrongName");
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
   
   /**
    * Test rename a snapshot to another existing snapshot 
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameToExistingSnapshot() throws Exception {
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
     // Create snapshots for sub1
     SnapshotTestHelper.createSnapshot(hdfs, sub1, "s1");
     SnapshotTestHelper.createSnapshot(hdfs, sub1, "s2");
-    
-    exception.expect(SnapshotException.class);
+
     String error = "The snapshot s2 already exists for directory "
         + sub1.toString();
-    exception.expectMessage(error);
-    hdfs.renameSnapshot(sub1, "s1", "s2");
+    SnapshotException ex = assertThrows(SnapshotException.class, () -> {
+      hdfs.renameSnapshot(sub1, "s1", "s2");
+    });
+    assertTrue(ex.getMessage().contains(error));
   }
   
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotReplication.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,9 +35,10 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.INode;
 import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.INodesInPath;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests the replication handling/calculation of snapshots to make
@@ -61,7 +62,7 @@ public class TestSnapshotReplication {
   DistributedFileSystem hdfs;
   FSDirectory fsdir;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(NUMDATANODE)
@@ -72,7 +73,7 @@ public class TestSnapshotReplication {
     fsdir = fsn.getFSDirectory();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -106,7 +107,8 @@ public class TestSnapshotReplication {
   /**
    * Test replication number calculation for a normal file without snapshots.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReplicationWithoutSnapshot() throws Exception {
     // Create file1, set its replication to REPLICATION
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);
@@ -164,7 +166,8 @@ public class TestSnapshotReplication {
   /**
    * Test replication number calculation for a file with snapshots.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReplicationWithSnapshot() throws Exception {
     short fileRep = 1;
     // Create file1, set its replication to 1
@@ -205,7 +208,8 @@ public class TestSnapshotReplication {
    * Test replication for a file with snapshots, also including the scenario
    * where the original file is deleted
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testReplicationAfterDeletion() throws Exception {
     // Create file1, set its replication to 3
     DFSTestUtil.createFile(hdfs, file1, BLOCKSIZE, REPLICATION, seed);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotStatsMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotStatsMXBean.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Array;
@@ -31,7 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSnapshotStatsMXBean {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshottableDirListing.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshottableDirListing.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PERMISSIONS_SUPERUSERGROUP_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_PERMISSIONS_SUPERUSERGROUP_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Options.Rename;
@@ -32,9 +32,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.SnapshottableDirectoryStatus;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSnapshottableDirListing {
 
@@ -51,7 +52,7 @@ public class TestSnapshottableDirListing {
   FSNamesystem fsn;
   DistributedFileSystem hdfs;
   
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(REPLICATION)
@@ -63,7 +64,7 @@ public class TestSnapshottableDirListing {
     hdfs.mkdirs(dir2);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -74,7 +75,8 @@ public class TestSnapshottableDirListing {
   /**
    * Test listing all the snapshottable directories
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testListSnapshottableDir() throws Exception {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(true);
 
@@ -172,7 +174,8 @@ public class TestSnapshottableDirListing {
    * Test the listing with different user names to make sure only directories
    * that are owned by the user are listed.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testListWithDifferentUser() throws Exception {
     cluster.getNamesystem().getSnapshotManager().setAllowNestedSnapshots(true);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestUpdatePipelineWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestUpdatePipelineWithSnapshots.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.io.IOUtils;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUpdatePipelineWithSnapshots {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestXAttrWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestXAttrWithSnapshot.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -148,11 +147,11 @@ public class TestXAttrWithSnapshot {
     SnapshotDiffReport report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assertions.assertEquals(0, report.getDiffList().size());
+    assertEquals(0, report.getDiffList().size());
     report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assertions.assertEquals(0, report.getDiffList().size());
+    assertEquals(0, report.getDiffList().size());
     hdfs.setSafeMode(SafeModeAction.ENTER);
     hdfs.saveNamespace();
     hdfs.setSafeMode(SafeModeAction.LEAVE);
@@ -160,7 +159,7 @@ public class TestXAttrWithSnapshot {
     report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assertions.assertEquals(0, report.getDiffList().size());
+    assertEquals(0, report.getDiffList().size());
   }
 
   /**
@@ -210,14 +209,14 @@ public class TestXAttrWithSnapshot {
 
     // Both original and snapshot have same XAttrs.
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     // Original XAttrs have changed, but snapshot still has old XAttrs.
     hdfs.setXAttr(path, name1, newValue1);
@@ -232,14 +231,14 @@ public class TestXAttrWithSnapshot {
   private static void doSnapshotRootChangeAssertions(Path path,
       Path snapshotPath) throws Exception {
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(newValue1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
   }
 
   /**
@@ -257,14 +256,14 @@ public class TestXAttrWithSnapshot {
 
     // Both original and snapshot have same XAttrs.
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     // Original XAttrs have been removed, but snapshot still has old XAttrs.
     hdfs.removeXAttr(path, name1);
@@ -280,12 +279,12 @@ public class TestXAttrWithSnapshot {
   private static void doSnapshotRootRemovalAssertions(Path path,
       Path snapshotPath) throws Exception {
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assertions.assertEquals(0, xattrs.size());
+    assertEquals(0, xattrs.size());
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(2, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(2, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
   }
 
   /**
@@ -300,45 +299,45 @@ public class TestXAttrWithSnapshot {
     hdfs.setXAttr(path, name1, value1);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
     Map<String, byte[]> xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(1, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    assertEquals(1, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
 
     // Second snapshot
     hdfs.setXAttr(path, name1, newValue1);
     hdfs.setXAttr(path, name2, value2);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName2);
     xattrs = hdfs.getXAttrs(snapshotPath2);
-    Assertions.assertEquals(2, xattrs.size());
-    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(2, xattrs.size());
+    assertArrayEquals(newValue1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     // Third snapshot
     hdfs.setXAttr(path, name1, value1);
     hdfs.removeXAttr(path, name2);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName3);
     xattrs = hdfs.getXAttrs(snapshotPath3);
-    Assertions.assertEquals(1, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    assertEquals(1, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
 
     // Check that the first and second snapshots'
     // XAttrs have stayed constant
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(1, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    assertEquals(1, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
     xattrs = hdfs.getXAttrs(snapshotPath2);
-    Assertions.assertEquals(2, xattrs.size());
-    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(2, xattrs.size());
+    assertArrayEquals(newValue1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
 
     // Remove the second snapshot and verify the first and
     // third snapshots' XAttrs have stayed constant
     hdfs.deleteSnapshot(path, snapshotName2);
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assertions.assertEquals(1, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    assertEquals(1, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
     xattrs = hdfs.getXAttrs(snapshotPath3);
-    Assertions.assertEquals(1, xattrs.size());
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    assertEquals(1, xattrs.size());
+    assertArrayEquals(value1, xattrs.get(name1));
 
     hdfs.deleteSnapshot(path, snapshotName);
     hdfs.deleteSnapshot(path, snapshotName3);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestXAttrWithSnapshot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestXAttrWithSnapshot.java
@@ -18,8 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.namenode.snapshot;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.EnumSet;
 import java.util.Map;
@@ -40,13 +41,12 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests interaction of XAttrs with snapshots.
@@ -67,17 +67,14 @@ public class TestXAttrWithSnapshot {
   private static final String name2 = "user.a2";
   private static final byte[] value2 = { 0x37, 0x38, 0x39 };
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_XATTRS_ENABLED_KEY, true);
     initCluster(true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws Exception {
     IOUtils.cleanupWithLogger(null, hdfs);
     if (cluster != null) {
@@ -85,7 +82,7 @@ public class TestXAttrWithSnapshot {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ++pathCount;
     path = new Path("/p" + pathCount);
@@ -100,7 +97,8 @@ public class TestXAttrWithSnapshot {
   /**
    * Tests modifying xattrs on a directory that has been snapshotted
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testModifyReadsCurrentState() throws Exception {
     // Init
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short) 0700));
@@ -150,11 +148,11 @@ public class TestXAttrWithSnapshot {
     SnapshotDiffReport report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assert.assertEquals(0, report.getDiffList().size());
+    Assertions.assertEquals(0, report.getDiffList().size());
     report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assert.assertEquals(0, report.getDiffList().size());
+    Assertions.assertEquals(0, report.getDiffList().size());
     hdfs.setSafeMode(SafeModeAction.ENTER);
     hdfs.saveNamespace();
     hdfs.setSafeMode(SafeModeAction.LEAVE);
@@ -162,13 +160,14 @@ public class TestXAttrWithSnapshot {
     report =
         hdfs.getSnapshotDiffReport(path, snapshotName, "");
     System.out.println(report);
-    Assert.assertEquals(0, report.getDiffList().size());
+    Assertions.assertEquals(0, report.getDiffList().size());
   }
 
   /**
    * Tests removing xattrs on a directory that has been snapshotted
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testRemoveReadsCurrentState() throws Exception {
     // Init
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short) 0700));
@@ -211,14 +210,14 @@ public class TestXAttrWithSnapshot {
 
     // Both original and snapshot have same XAttrs.
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     // Original XAttrs have changed, but snapshot still has old XAttrs.
     hdfs.setXAttr(path, name1, newValue1);
@@ -233,14 +232,14 @@ public class TestXAttrWithSnapshot {
   private static void doSnapshotRootChangeAssertions(Path path,
       Path snapshotPath) throws Exception {
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
   }
 
   /**
@@ -258,14 +257,14 @@ public class TestXAttrWithSnapshot {
 
     // Both original and snapshot have same XAttrs.
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     // Original XAttrs have been removed, but snapshot still has old XAttrs.
     hdfs.removeXAttr(path, name1);
@@ -281,12 +280,12 @@ public class TestXAttrWithSnapshot {
   private static void doSnapshotRootRemovalAssertions(Path path,
       Path snapshotPath) throws Exception {
     Map<String, byte[]> xattrs = hdfs.getXAttrs(path);
-    Assert.assertEquals(0, xattrs.size());
+    Assertions.assertEquals(0, xattrs.size());
 
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(2, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(2, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
   }
 
   /**
@@ -301,45 +300,45 @@ public class TestXAttrWithSnapshot {
     hdfs.setXAttr(path, name1, value1);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
     Map<String, byte[]> xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(1, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertEquals(1, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
 
     // Second snapshot
     hdfs.setXAttr(path, name1, newValue1);
     hdfs.setXAttr(path, name2, value2);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName2);
     xattrs = hdfs.getXAttrs(snapshotPath2);
-    Assert.assertEquals(2, xattrs.size());
-    Assert.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(2, xattrs.size());
+    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     // Third snapshot
     hdfs.setXAttr(path, name1, value1);
     hdfs.removeXAttr(path, name2);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName3);
     xattrs = hdfs.getXAttrs(snapshotPath3);
-    Assert.assertEquals(1, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertEquals(1, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
 
     // Check that the first and second snapshots'
     // XAttrs have stayed constant
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(1, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertEquals(1, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
     xattrs = hdfs.getXAttrs(snapshotPath2);
-    Assert.assertEquals(2, xattrs.size());
-    Assert.assertArrayEquals(newValue1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(2, xattrs.size());
+    Assertions.assertArrayEquals(newValue1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
 
     // Remove the second snapshot and verify the first and
     // third snapshots' XAttrs have stayed constant
     hdfs.deleteSnapshot(path, snapshotName2);
     xattrs = hdfs.getXAttrs(snapshotPath);
-    Assert.assertEquals(1, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertEquals(1, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
     xattrs = hdfs.getXAttrs(snapshotPath3);
-    Assert.assertEquals(1, xattrs.size());
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertEquals(1, xattrs.size());
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
 
     hdfs.deleteSnapshot(path, snapshotName);
     hdfs.deleteSnapshot(path, snapshotName3);
@@ -352,8 +351,9 @@ public class TestXAttrWithSnapshot {
   public void testSetXAttrSnapshotPath() throws Exception {
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short) 0700));
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.setXAttr(snapshotPath, name1, value1);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.setXAttr(snapshotPath, name1, value1);
+    });
   }
 
   /**
@@ -364,14 +364,16 @@ public class TestXAttrWithSnapshot {
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short) 0700));
     hdfs.setXAttr(path, name1, value1);
     SnapshotTestHelper.createSnapshot(hdfs, path, snapshotName);
-    exception.expect(SnapshotAccessControlException.class);
-    hdfs.removeXAttr(snapshotPath, name1);
+    assertThrows(SnapshotAccessControlException.class, () -> {
+      hdfs.removeXAttr(snapshotPath, name1);
+    });
   }
 
   /**
    * Test that users can copy a snapshot while preserving its xattrs.
    */
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testCopySnapshotShouldPreserveXAttrs() throws Exception {
     FileSystem.mkdirs(hdfs, path, FsPermission.createImmutable((short) 0700));
     hdfs.setXAttr(path, name1, value1);
@@ -381,7 +383,7 @@ public class TestXAttrWithSnapshot {
     String[] argv = new String[] { "-cp", "-px", snapshotPath.toUri().toString(),
         snapshotCopy.toUri().toString() };
     int ret = ToolRunner.run(new FsShell(conf), argv);
-    assertEquals("cp -px is not working on a snapshot", SUCCESS, ret);
+    assertEquals(SUCCESS, ret, "cp -px is not working on a snapshot");
 
     Map<String, byte[]> xattrs = hdfs.getXAttrs(snapshotCopy);
     assertArrayEquals(value1, xattrs.get(name1));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgress.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgress.java
@@ -21,7 +21,13 @@ import static org.apache.hadoop.hdfs.server.namenode.startupprogress.Phase.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgressTestHelper.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.Status.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StepType.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgress.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgress.java
@@ -21,7 +21,7 @@ import static org.apache.hadoop.hdfs.server.namenode.startupprogress.Phase.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgressTestHelper.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.Status.*;
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StepType.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,19 +34,21 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgress.Counter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestStartupProgress {
 
   private StartupProgress startupProgress;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     startupProgress = new StartupProgress();
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testCounter() {
     startupProgress.beginPhase(LOADING_FSIMAGE);
     Step loadingFsImageInodes = new Step(INODES);
@@ -70,10 +72,10 @@ public class TestStartupProgress {
     assertNotNull(view);
     assertEquals(100L, view.getCount(LOADING_FSIMAGE, loadingFsImageInodes));
     assertEquals(200L, view.getCount(LOADING_FSIMAGE,
-      loadingFsImageDelegationKeys));
+        loadingFsImageDelegationKeys));
     assertEquals(5000L, view.getCount(LOADING_EDITS, loadingEditsFile));
     assertEquals(0L, view.getCount(SAVING_CHECKPOINT,
-      new Step(INODES)));
+        new Step(INODES)));
 
     // Increment a counter again and check that the existing view was not
     // modified, but a new view shows the updated value.
@@ -87,7 +89,8 @@ public class TestStartupProgress {
     assertEquals(6000L, view.getCount(LOADING_EDITS, loadingEditsFile));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testElapsedTime() throws Exception {
     startupProgress.beginPhase(LOADING_FSIMAGE);
     Step loadingFsImageInodes = new Step(INODES);
@@ -140,14 +143,15 @@ public class TestStartupProgress {
 
     assertTrue(totalTime < view.getElapsedTime());
     assertEquals(loadingFsImageTime, view.getElapsedTime(LOADING_FSIMAGE));
-    assertEquals(loadingFsImageInodesTime, view.getElapsedTime(LOADING_FSIMAGE,
-      loadingFsImageInodes));
+    assertEquals(loadingFsImageInodesTime,
+        view.getElapsedTime(LOADING_FSIMAGE, loadingFsImageInodes));
     assertTrue(loadingEditsTime < view.getElapsedTime(LOADING_EDITS));
     assertTrue(loadingEditsFileTime < view.getElapsedTime(LOADING_EDITS,
       loadingEditsFile));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testFrozenAfterStartupCompletes() {
     // Do some updates and counter increments.
     startupProgress.beginPhase(LOADING_FSIMAGE);
@@ -233,7 +237,8 @@ public class TestStartupProgress {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testInitialState() {
     StartupProgressView view = startupProgress.createView();
     assertNotNull(view);
@@ -259,7 +264,8 @@ public class TestStartupProgress {
     assertArrayEquals(EnumSet.allOf(Phase.class).toArray(), phases.toArray());
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testPercentComplete() {
     startupProgress.beginPhase(LOADING_FSIMAGE);
     Step loadingFsImageInodes = new Step(INODES);
@@ -285,15 +291,16 @@ public class TestStartupProgress {
     assertEquals(0.167f, view.getPercentComplete(), 0.001f);
     assertEquals(0.167f, view.getPercentComplete(LOADING_FSIMAGE), 0.001f);
     assertEquals(0.10f, view.getPercentComplete(LOADING_FSIMAGE,
-      loadingFsImageInodes), 0.001f);
+        loadingFsImageInodes), 0.001f);
     assertEquals(0.25f, view.getPercentComplete(LOADING_FSIMAGE,
-      loadingFsImageDelegationKeys), 0.001f);
+            loadingFsImageDelegationKeys),
+        0.001f);
     assertEquals(0.5f, view.getPercentComplete(LOADING_EDITS), 0.001f);
     assertEquals(0.5f, view.getPercentComplete(LOADING_EDITS, loadingEditsFile),
-      0.001f);
+        0.001f);
     assertEquals(0.0f, view.getPercentComplete(SAVING_CHECKPOINT), 0.001f);
     assertEquals(0.0f, view.getPercentComplete(SAVING_CHECKPOINT,
-      new Step(INODES)), 0.001f);
+        new Step(INODES)), 0.001f);
 
     // End steps/phases, and confirm that they jump to 100% completion.
     startupProgress.endStep(LOADING_FSIMAGE, loadingFsImageInodes);
@@ -307,18 +314,18 @@ public class TestStartupProgress {
     assertEquals(0.5f, view.getPercentComplete(), 0.001f);
     assertEquals(1.0f, view.getPercentComplete(LOADING_FSIMAGE), 0.001f);
     assertEquals(1.0f, view.getPercentComplete(LOADING_FSIMAGE,
-      loadingFsImageInodes), 0.001f);
-    assertEquals(1.0f, view.getPercentComplete(LOADING_FSIMAGE,
-      loadingFsImageDelegationKeys), 0.001f);
+        loadingFsImageInodes), 0.001f);
+    assertEquals(1.0f, view.getPercentComplete(LOADING_FSIMAGE, loadingFsImageDelegationKeys),
+        0.001f);
     assertEquals(1.0f, view.getPercentComplete(LOADING_EDITS), 0.001f);
     assertEquals(1.0f, view.getPercentComplete(LOADING_EDITS, loadingEditsFile),
-      0.001f);
+        0.001f);
     assertEquals(0.0f, view.getPercentComplete(SAVING_CHECKPOINT), 0.001f);
-    assertEquals(0.0f, view.getPercentComplete(SAVING_CHECKPOINT,
-      new Step(INODES)), 0.001f);
+    assertEquals(0.0f, view.getPercentComplete(SAVING_CHECKPOINT, new Step(INODES)), 0.001f);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testStatus() {
     startupProgress.beginPhase(LOADING_FSIMAGE);
     startupProgress.endPhase(LOADING_FSIMAGE);
@@ -330,7 +337,8 @@ public class TestStartupProgress {
     assertEquals(PENDING, view.getStatus(SAVING_CHECKPOINT));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testStepSequence() {
     // Test that steps are returned in the correct sort order (by file and then
     // sequence number) by starting a few steps in a randomly shuffled order and
@@ -362,7 +370,8 @@ public class TestStartupProgress {
     assertArrayEquals(expectedSteps, actualSteps.toArray());
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testThreadSafety() throws Exception {
     // Test for thread safety by starting multiple threads that mutate the same
     // StartupProgress instance in various ways.  We expect no internal
@@ -418,20 +427,21 @@ public class TestStartupProgress {
     assertEquals(10000L, view.getTotal(LOADING_FSIMAGE, new Step(INODES)));
     assertEquals(2500L, view.getCount(LOADING_FSIMAGE, new Step(INODES)));
     assertEquals(20000L, view.getTotal(LOADING_FSIMAGE,
-      new Step(DELEGATION_KEYS)));
+        new Step(DELEGATION_KEYS)));
     assertEquals(2500L, view.getCount(LOADING_FSIMAGE,
-      new Step(DELEGATION_KEYS)));
+        new Step(DELEGATION_KEYS)));
 
     assertEquals("file2", view.getFile(LOADING_EDITS));
     assertEquals(2000L, view.getSize(LOADING_EDITS));
     assertEquals(30000L, view.getTotal(LOADING_EDITS, new Step(INODES)));
     assertEquals(2500L, view.getCount(LOADING_EDITS, new Step(INODES)));
     assertEquals(40000L, view.getTotal(LOADING_EDITS,
-      new Step(DELEGATION_KEYS)));
+        new Step(DELEGATION_KEYS)));
     assertEquals(2500L, view.getCount(LOADING_EDITS, new Step(DELEGATION_KEYS)));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testTotal() {
     startupProgress.beginPhase(LOADING_FSIMAGE);
     Step loadingFsImageInodes = new Step(INODES);
@@ -456,7 +466,7 @@ public class TestStartupProgress {
     assertNotNull(view);
     assertEquals(1000L, view.getTotal(LOADING_FSIMAGE, loadingFsImageInodes));
     assertEquals(800L, view.getTotal(LOADING_FSIMAGE,
-      loadingFsImageDelegationKeys));
+        loadingFsImageDelegationKeys));
     assertEquals(10000L, view.getTotal(LOADING_EDITS, loadingEditsFile));
 
     // Try adding another step to the completed phase

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgressMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgressMetrics.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdfs.server.namenode.startupprogress;
 
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgressTestHelper.*;
 import static org.apache.hadoop.test.MetricsAsserts.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.junit.jupiter.api.BeforeEach;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgressMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/startupprogress/TestStartupProgressMetrics.java
@@ -19,18 +19,18 @@ package org.apache.hadoop.hdfs.server.namenode.startupprogress;
 
 import static org.apache.hadoop.hdfs.server.namenode.startupprogress.StartupProgressTestHelper.*;
 import static org.apache.hadoop.test.MetricsAsserts.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestStartupProgressMetrics {
 
   private StartupProgress startupProgress;
   private StartupProgressMetrics metrics;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mockMetricsSystem();
     startupProgress = new StartupProgress();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.top.window;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRollingWindow {
 
@@ -30,28 +31,28 @@ public class TestRollingWindow {
   public void testBasics() {
     RollingWindow window = new RollingWindow(WINDOW_LEN, BUCKET_CNT);
     long time = 1;
-    Assertions.assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
+    assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
     time = WINDOW_LEN + BUCKET_LEN * 3 / 2;
-    Assertions.assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
+    assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
 
     window.incAt(time, 5);
-    Assertions.assertEquals(
+    assertEquals(
         5, window.getSum(time),
         "The sum of rolling window does not reflect the recent update");
 
     time += BUCKET_LEN;
     window.incAt(time, 6);
-    Assertions.assertEquals
+    assertEquals
         (11, window.getSum(time),
-        "The sum of rolling window does not reflect the recent update");
+            "The sum of rolling window does not reflect the recent update");
 
     time += WINDOW_LEN - BUCKET_LEN;
-    Assertions.assertEquals(
+    assertEquals(
         6, window.getSum(time),
         "The sum of rolling window does not reflect rolling effect");
 
     time += BUCKET_LEN;
-    Assertions.assertEquals(
+    assertEquals(
         0, window.getSum(time),
         "The sum of rolling window does not reflect rolling effect");
   }
@@ -63,18 +64,18 @@ public class TestRollingWindow {
     window.incAt(time, 5);
 
     time++;
-    Assertions.assertEquals(
+    assertEquals(
         5, window.getSum(time),
         "The sum of rolling window does not reflect the recent update");
 
     long reorderedTime = time - 2 * BUCKET_LEN;
     window.incAt(reorderedTime, 6);
-    Assertions.assertEquals(
+    assertEquals(
         11, window.getSum(time),
         "The sum of rolling window does not reflect the reordered update");
 
     time = reorderedTime + WINDOW_LEN;
-    Assertions.assertEquals(
+    assertEquals(
         5, window.getSum(time),
         "The sum of rolling window does not reflect rolling effect");
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.top.window;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestRollingWindow {
 
@@ -30,32 +30,30 @@ public class TestRollingWindow {
   public void testBasics() {
     RollingWindow window = new RollingWindow(WINDOW_LEN, BUCKET_CNT);
     long time = 1;
-    Assert.assertEquals("The initial sum of rolling window must be 0", 0,
-        window.getSum(time));
+    Assertions.assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
     time = WINDOW_LEN + BUCKET_LEN * 3 / 2;
-    Assert.assertEquals("The initial sum of rolling window must be 0", 0,
-        window.getSum(time));
+    Assertions.assertEquals(0, window.getSum(time), "The initial sum of rolling window must be 0");
 
     window.incAt(time, 5);
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect the recent update", 5,
-        window.getSum(time));
+    Assertions.assertEquals(
+        5, window.getSum(time),
+        "The sum of rolling window does not reflect the recent update");
 
     time += BUCKET_LEN;
     window.incAt(time, 6);
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect the recent update", 11,
-        window.getSum(time));
+    Assertions.assertEquals
+        (11, window.getSum(time),
+        "The sum of rolling window does not reflect the recent update");
 
     time += WINDOW_LEN - BUCKET_LEN;
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect rolling effect", 6,
-        window.getSum(time));
+    Assertions.assertEquals(
+        6, window.getSum(time),
+        "The sum of rolling window does not reflect rolling effect");
 
     time += BUCKET_LEN;
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect rolling effect", 0,
-        window.getSum(time));
+    Assertions.assertEquals(
+        0, window.getSum(time),
+        "The sum of rolling window does not reflect rolling effect");
   }
 
   @Test
@@ -65,20 +63,20 @@ public class TestRollingWindow {
     window.incAt(time, 5);
 
     time++;
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect the recent update", 5,
-        window.getSum(time));
+    Assertions.assertEquals(
+        5, window.getSum(time),
+        "The sum of rolling window does not reflect the recent update");
 
     long reorderedTime = time - 2 * BUCKET_LEN;
     window.incAt(reorderedTime, 6);
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect the reordered update", 11,
-        window.getSum(time));
+    Assertions.assertEquals(
+        11, window.getSum(time),
+        "The sum of rolling window does not reflect the reordered update");
 
     time = reorderedTime + WINDOW_LEN;
-    Assert.assertEquals(
-        "The sum of rolling window does not reflect rolling effect", 5,
-        window.getSum(time));
+    Assertions.assertEquals(
+        5, window.getSum(time),
+        "The sum of rolling window does not reflect rolling effect");
   }
 
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindow.java
@@ -42,9 +42,8 @@ public class TestRollingWindow {
 
     time += BUCKET_LEN;
     window.incAt(time, 6);
-    assertEquals
-        (11, window.getSum(time),
-            "The sum of rolling window does not reflect the recent update");
+    assertEquals(11, window.getSum(time),
+        "The sum of rolling window does not reflect the recent update");
 
     time += WINDOW_LEN - BUCKET_LEN;
     assertEquals(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.server.namenode.top.TopConf;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +33,7 @@ import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowMan
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.TopWindow;
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.User;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRollingWindowManager {
 
@@ -207,15 +207,15 @@ public class TestRollingWindowManager {
     rollingWindowManager.recordMetric(0, "op3", "user8", 1);
 
     TopWindow window = rollingWindowManager.snapshot(0);
-    Assertions.assertEquals(numOps + 1, window.getOps().size());
+    assertEquals(numOps + 1, window.getOps().size());
 
     Op allOp = window.getOps().get(0);
-    Assertions.assertEquals(TopConf.ALL_CMDS, allOp.getOpType());
+    assertEquals(TopConf.ALL_CMDS, allOp.getOpType());
     List<User> topUsers = allOp.getTopUsers();
-    Assertions.assertEquals(numTopUsers * numOps, topUsers.size());
+    assertEquals(numTopUsers * numOps, topUsers.size());
     // ensure all the top users for each op are present in the total op.
     for (int i = 1; i < numOps; i++) {
-      Assertions.assertTrue(topUsers.containsAll(window.getOps().get(i).getTopUsers()));
+      assertTrue(topUsers.containsAll(window.getOps().get(i).getTopUsers()));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/top/window/TestRollingWindowManager.java
@@ -26,14 +26,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.server.namenode.top.TopConf;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.Op;
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.TopWindow;
 import static org.apache.hadoop.hdfs.server.namenode.top.window.RollingWindowManager.User;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRollingWindowManager {
 
@@ -47,7 +47,7 @@ public class TestRollingWindowManager {
   final int N_TOP_USERS = 10;
   final int BUCKET_LEN = WINDOW_LEN_MS / BUCKET_CNT;
 
-  @Before
+  @BeforeEach
   public void init() {
     conf = new Configuration();
     conf.setInt(DFSConfigKeys.NNTOP_BUCKETS_PER_WINDOW_KEY, BUCKET_CNT);
@@ -70,40 +70,40 @@ public class TestRollingWindowManager {
     time++;
     TopWindow tops = manager.snapshot(time);
 
-    assertEquals("Unexpected number of ops", 3, tops.getOps().size());
+    assertEquals(3, tops.getOps().size(), "Unexpected number of ops");
     assertEquals(TopConf.ALL_CMDS, tops.getOps().get(0).getOpType());
     for (Op op : tops.getOps()) {
       final List<User> topUsers = op.getTopUsers();
-      assertEquals("Unexpected number of users", N_TOP_USERS, topUsers.size());
+      assertEquals(N_TOP_USERS, topUsers.size(), "Unexpected number of users");
       if (op.getOpType().equals("open")) {
         for (int i = 0; i < topUsers.size(); i++) {
           User user = topUsers.get(i);
-          assertEquals("Unexpected count for user " + user.getUser(),
-              (users.length-i)*2, user.getCount());
+          assertEquals((users.length - i) * 2, user.getCount(),
+              "Unexpected count for user " + user.getUser());
         }
         // Closed form of sum(range(2,42,2))
-        assertEquals("Unexpected total count for op", 
-            (2+(users.length*2))*(users.length/2),
-            op.getTotalCount());
+        assertEquals((2 + (users.length * 2)) * (users.length / 2),
+            op.getTotalCount(),
+            "Unexpected total count for op");
       }
     }
 
     // move the window forward not to see the "open" results
     time += WINDOW_LEN_MS - 2;
     tops = manager.snapshot(time);
-    assertEquals("Unexpected number of ops", 2, tops.getOps().size());
+    assertEquals(2, tops.getOps().size(), "Unexpected number of ops");
     assertEquals(TopConf.ALL_CMDS, tops.getOps().get(0).getOpType());
     final Op op = tops.getOps().get(1);
-    assertEquals("Should only see close ops", "close", op.getOpType());
+    assertEquals("close", op.getOpType(), "Should only see close ops");
     final List<User> topUsers = op.getTopUsers();
     for (int i = 0; i < topUsers.size(); i++) {
       User user = topUsers.get(i);
-      assertEquals("Unexpected count for user " + user.getUser(),
-          (users.length-i), user.getCount());
+      assertEquals((users.length - i), user.getCount(),
+          "Unexpected count for user " + user.getUser());
     }
     // Closed form of sum(range(1,21))
-    assertEquals("Unexpected total count for op",
-        (1 + users.length) * (users.length / 2), op.getTotalCount());
+    assertEquals((1 + users.length) * (users.length / 2), op.getTotalCount(),
+        "Unexpected total count for op");
   }
 
   @Test
@@ -207,16 +207,15 @@ public class TestRollingWindowManager {
     rollingWindowManager.recordMetric(0, "op3", "user8", 1);
 
     TopWindow window = rollingWindowManager.snapshot(0);
-    Assert.assertEquals(numOps + 1, window.getOps().size());
+    Assertions.assertEquals(numOps + 1, window.getOps().size());
 
     Op allOp = window.getOps().get(0);
-    Assert.assertEquals(TopConf.ALL_CMDS, allOp.getOpType());
+    Assertions.assertEquals(TopConf.ALL_CMDS, allOp.getOpType());
     List<User> topUsers = allOp.getTopUsers();
-    Assert.assertEquals(numTopUsers * numOps, topUsers.size());
+    Assertions.assertEquals(numTopUsers * numOps, topUsers.size());
     // ensure all the top users for each op are present in the total op.
     for (int i = 1; i < numOps; i++) {
-      Assert.assertTrue(
-          topUsers.containsAll(window.getOps().get(i).getTopUsers()));
+      Assertions.assertTrue(topUsers.containsAll(window.getOps().get(i).getTopUsers()));
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsCreatePermissions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsCreatePermissions.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**
@@ -47,13 +47,13 @@ public class TestWebHdfsCreatePermissions {
 
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void initializeMiniDFSCluster() throws Exception {
     final Configuration conf = WebHdfsTestUtil.createConf();
     this.cluster = new MiniDFSCluster.Builder(conf).build();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -79,12 +79,12 @@ public class TestWebHdfsCreatePermissions {
       URL url = new URL(uri.toString());
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("PUT");
-      Assert.assertEquals(expectedResponse, conn.getResponseCode());
+      Assertions.assertEquals(expectedResponse, conn.getResponseCode());
 
       NamenodeProtocols namenode = cluster.getNameNode().getRpcServer();
       FsPermission resultingPermission = namenode.getFileInfo(path).
             getPermission();
-      Assert.assertEquals(expectedPermission, resultingPermission.toString());
+      Assertions.assertEquals(expectedPermission, resultingPermission.toString());
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsCreatePermissions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsCreatePermissions.java
@@ -29,10 +29,11 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test WebHDFS files/directories creation to make sure it follows same rules
@@ -79,12 +80,12 @@ public class TestWebHdfsCreatePermissions {
       URL url = new URL(uri.toString());
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("PUT");
-      Assertions.assertEquals(expectedResponse, conn.getResponseCode());
+      assertEquals(expectedResponse, conn.getResponseCode());
 
       NamenodeProtocols namenode = cluster.getNameNode().getRpcServer();
       FsPermission resultingPermission = namenode.getFileInfo(path).
             getPermission();
-      Assertions.assertEquals(expectedPermission, resultingPermission.toString());
+      assertEquals(expectedPermission, resultingPermission.toString());
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
@@ -17,8 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.web.resources;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -47,7 +50,6 @@ import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.apache.hadoop.hdfs.web.resources.GetOpParam;
 import org.apache.hadoop.hdfs.web.resources.PostOpParam;
 import org.apache.hadoop.hdfs.web.resources.PutOpParam;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
@@ -101,7 +103,7 @@ public class TestWebHdfsDataLocality {
           final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
               namenode, f, PutOpParam.Op.CREATE, -1L, blocksize, null,
               LOCALHOST, null);
-          Assertions.assertEquals(ipAddr, chosen.getIpAddr());
+          assertEquals(ipAddr, chosen.getIpAddr());
         }
       }
   
@@ -115,9 +117,9 @@ public class TestWebHdfsDataLocality {
       final LocatedBlocks locatedblocks = NameNodeAdapter.getBlockLocations(
           namenode, f, 0, 1);
       final List<LocatedBlock> lb = locatedblocks.getLocatedBlocks();
-      Assertions.assertEquals(1, lb.size());
+      assertEquals(1, lb.size());
       final DatanodeInfo[] locations = lb.get(0).getLocations();
-      Assertions.assertEquals(1, locations.length);
+      assertEquals(1, locations.length);
       final DatanodeInfo expected = locations[0];
       
       //For GETFILECHECKSUM, OPEN and APPEND,
@@ -128,7 +130,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, GetOpParam.Op.GETFILECHECKSUM, -1L, blocksize, null,
             LOCALHOST, status);
-        Assertions.assertEquals(expected, chosen);
+        assertEquals(expected, chosen);
       }
   
       { //test OPEN
@@ -136,7 +138,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, GetOpParam.Op.OPEN, 0, blocksize, null,
             LOCALHOST, status);
-        Assertions.assertEquals(expected, chosen);
+        assertEquals(expected, chosen);
       }
 
       { //test APPEND
@@ -144,7 +146,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, PostOpParam.Op.APPEND, -1L, blocksize, null,
             LOCALHOST, status);
-        Assertions.assertEquals(expected, chosen);
+        assertEquals(expected, chosen);
       }
     } finally {
       cluster.shutdown();
@@ -185,9 +187,9 @@ public class TestWebHdfsDataLocality {
       final LocatedBlocks locatedblocks = NameNodeAdapter.getBlockLocations(
           namenode, f, 0, 1);
       final List<LocatedBlock> lb = locatedblocks.getLocatedBlocks();
-      Assertions.assertEquals(1, lb.size());
+      assertEquals(1, lb.size());
       final DatanodeInfo[] locations = lb.get(0).getLocations();
-      Assertions.assertEquals(3, locations.length);
+      assertEquals(3, locations.length);
       
       //For GETFILECHECKSUM, OPEN and APPEND,
       //the chosen datanode must be different with exclude nodes.
@@ -201,7 +203,7 @@ public class TestWebHdfsDataLocality {
               namenode, f, GetOpParam.Op.GETFILECHECKSUM, -1L, blocksize,
               sb.toString(), LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
+            assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
 
@@ -211,7 +213,7 @@ public class TestWebHdfsDataLocality {
               namenode, f, GetOpParam.Op.OPEN, 0, blocksize, sb.toString(),
               LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
+            assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
   
@@ -221,7 +223,7 @@ public class TestWebHdfsDataLocality {
               .chooseDatanode(namenode, f, PostOpParam.Op.APPEND, -1L,
                   blocksize, sb.toString(), LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
+            assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
         
@@ -249,7 +251,7 @@ public class TestWebHdfsDataLocality {
           DFSConfigKeys.DFS_BLOCK_SIZE_DEFAULT,
           "DataNode2", LOCALHOST, null);
     } catch (Exception e) {
-      Assertions.fail("Failed to exclude DataNode2" + e.getMessage());
+      fail("Failed to exclude DataNode2" + e.getMessage());
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/web/resources/TestWebHdfsDataLocality.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.web.resources;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -45,10 +47,8 @@ import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;
 import org.apache.hadoop.hdfs.web.resources.GetOpParam;
 import org.apache.hadoop.hdfs.web.resources.PostOpParam;
 import org.apache.hadoop.hdfs.web.resources.PutOpParam;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**
@@ -67,9 +67,6 @@ public class TestWebHdfsDataLocality {
 
   private static final String LOCALHOST =
       InetAddress.getLoopbackAddress().getHostName();
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testDataLocality() throws Exception {
@@ -104,7 +101,7 @@ public class TestWebHdfsDataLocality {
           final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
               namenode, f, PutOpParam.Op.CREATE, -1L, blocksize, null,
               LOCALHOST, null);
-          Assert.assertEquals(ipAddr, chosen.getIpAddr());
+          Assertions.assertEquals(ipAddr, chosen.getIpAddr());
         }
       }
   
@@ -118,9 +115,9 @@ public class TestWebHdfsDataLocality {
       final LocatedBlocks locatedblocks = NameNodeAdapter.getBlockLocations(
           namenode, f, 0, 1);
       final List<LocatedBlock> lb = locatedblocks.getLocatedBlocks();
-      Assert.assertEquals(1, lb.size());
+      Assertions.assertEquals(1, lb.size());
       final DatanodeInfo[] locations = lb.get(0).getLocations();
-      Assert.assertEquals(1, locations.length);
+      Assertions.assertEquals(1, locations.length);
       final DatanodeInfo expected = locations[0];
       
       //For GETFILECHECKSUM, OPEN and APPEND,
@@ -131,7 +128,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, GetOpParam.Op.GETFILECHECKSUM, -1L, blocksize, null,
             LOCALHOST, status);
-        Assert.assertEquals(expected, chosen);
+        Assertions.assertEquals(expected, chosen);
       }
   
       { //test OPEN
@@ -139,7 +136,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, GetOpParam.Op.OPEN, 0, blocksize, null,
             LOCALHOST, status);
-        Assert.assertEquals(expected, chosen);
+        Assertions.assertEquals(expected, chosen);
       }
 
       { //test APPEND
@@ -147,7 +144,7 @@ public class TestWebHdfsDataLocality {
         final DatanodeInfo chosen = NamenodeWebHdfsMethods.chooseDatanode(
             namenode, f, PostOpParam.Op.APPEND, -1L, blocksize, null,
             LOCALHOST, status);
-        Assert.assertEquals(expected, chosen);
+        Assertions.assertEquals(expected, chosen);
       }
     } finally {
       cluster.shutdown();
@@ -188,10 +185,9 @@ public class TestWebHdfsDataLocality {
       final LocatedBlocks locatedblocks = NameNodeAdapter.getBlockLocations(
           namenode, f, 0, 1);
       final List<LocatedBlock> lb = locatedblocks.getLocatedBlocks();
-      Assert.assertEquals(1, lb.size());
+      Assertions.assertEquals(1, lb.size());
       final DatanodeInfo[] locations = lb.get(0).getLocations();
-      Assert.assertEquals(3, locations.length);
-      
+      Assertions.assertEquals(3, locations.length);
       
       //For GETFILECHECKSUM, OPEN and APPEND,
       //the chosen datanode must be different with exclude nodes.
@@ -205,8 +201,7 @@ public class TestWebHdfsDataLocality {
               namenode, f, GetOpParam.Op.GETFILECHECKSUM, -1L, blocksize,
               sb.toString(), LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assert.assertNotEquals(locations[j].getHostName(),
-                chosen.getHostName());
+            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
 
@@ -216,8 +211,7 @@ public class TestWebHdfsDataLocality {
               namenode, f, GetOpParam.Op.OPEN, 0, blocksize, sb.toString(),
               LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assert.assertNotEquals(locations[j].getHostName(),
-                chosen.getHostName());
+            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
   
@@ -227,8 +221,7 @@ public class TestWebHdfsDataLocality {
               .chooseDatanode(namenode, f, PostOpParam.Op.APPEND, -1L,
                   blocksize, sb.toString(), LOCALHOST, status);
           for (int j = 0; j <= i; j++) {
-            Assert.assertNotEquals(locations[j].getHostName(),
-                chosen.getHostName());
+            Assertions.assertNotEquals(locations[j].getHostName(), chosen.getHostName());
           }
         }
         
@@ -256,7 +249,7 @@ public class TestWebHdfsDataLocality {
           DFSConfigKeys.DFS_BLOCK_SIZE_DEFAULT,
           "DataNode2", LOCALHOST, null);
     } catch (Exception e) {
-      Assert.fail("Failed to exclude DataNode2" + e.getMessage());
+      Assertions.fail("Failed to exclude DataNode2" + e.getMessage());
     } finally {
       cluster.shutdown();
     }
@@ -266,9 +259,11 @@ public class TestWebHdfsDataLocality {
   public void testChooseDatanodeBeforeNamesystemInit() throws Exception {
     NameNode nn = mock(NameNode.class);
     when(nn.getNamesystem()).thenReturn(null);
-    exception.expect(IOException.class);
-    exception.expectMessage("Namesystem has not been initialized yet.");
-    NamenodeWebHdfsMethods.chooseDatanode(nn, "/path", PutOpParam.Op.CREATE, 0,
-        DFSConfigKeys.DFS_BLOCK_SIZE_DEFAULT, null, LOCALHOST, null);
+
+    IOException ex = assertThrows(IOException.class, () -> {
+      NamenodeWebHdfsMethods.chooseDatanode(nn, "/path", PutOpParam.Op.CREATE, 0,
+          DFSConfigKeys.DFS_BLOCK_SIZE_DEFAULT, null, LOCALHOST, null);
+    });
+    assertTrue(ex.getMessage().contains("Namesystem has not been initialized yet."));
   }
 }


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part14.

### How was this patch tested?
Junit Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

