### PR TITLE
HADOOP-19662. Remove duplicate include of gcc_optimizations.h

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/util/bulk_crc32_x86.c
+++ b/hadoop-common-project/hadoop-common/src/main/native/src/org/apache/hadoop/util/bulk_crc32_x86.c
@@ -27,7 +27,6 @@
 
 #include  "bulk_crc32.h"
 #include "gcc_optimizations.h"
-#include "gcc_optimizations.h"
 
 ///////////////////////////////////////////////////////////////////////////
 // Begin code for SSE4.2 specific hardware support of CRC32C


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Removes duplicate include statement for `gcc_optimizations.h` in `bulk_crc32_x86.c`.

### How was this patch tested?

- [x] Code compiles without issues
- [x] No functional changes expected

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

