### PR TITLE
HADOOP-19660: Add support for custom ClientAssertionProvider in WorkloadIdentityTokenProvider

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -1278,24 +1278,24 @@ public class AbfsConfiguration{
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
           String clientId =
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
-          
+
           // Check if a custom ClientAssertionProvider is configured
           String clientAssertionProviderType =
               getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
-          
+
           if (clientAssertionProviderType != null && !clientAssertionProviderType.trim().isEmpty()) {
             // Use custom ClientAssertionProvider
             try {
               Class<?> providerClass = Class.forName(clientAssertionProviderType.trim());
-              ClientAssertionProvider clientAssertionProvider = 
+              ClientAssertionProvider clientAssertionProvider =
                   (ClientAssertionProvider) providerClass.getDeclaredConstructor().newInstance();
-              
+
               // Initialize the provider with configuration
               clientAssertionProvider.initialize(rawConfig, accountName);
-              
+
               tokenProvider = new WorkloadIdentityTokenProvider(
                   authority, tenantGuid, clientId, clientAssertionProvider);
-              LOG.trace("WorkloadIdentityTokenProvider initialized with custom ClientAssertionProvider: {}", 
+              LOG.trace("WorkloadIdentityTokenProvider initialized with custom ClientAssertionProvider: {}",
                   clientAssertionProviderType);
             } catch (Exception e) {
               throw new TokenAccessProviderException(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -1280,13 +1280,13 @@ public class AbfsConfiguration{
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
           
           // Check if a custom ClientAssertionProvider is configured
-          String clientAssertionProviderClassName = 
-              getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_CLASS);
+          String clientAssertionProviderType =
+              getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
           
-          if (clientAssertionProviderClassName != null && !clientAssertionProviderClassName.trim().isEmpty()) {
+          if (clientAssertionProviderType != null && !clientAssertionProviderType.trim().isEmpty()) {
             // Use custom ClientAssertionProvider
             try {
-              Class<?> providerClass = Class.forName(clientAssertionProviderClassName.trim());
+              Class<?> providerClass = Class.forName(clientAssertionProviderType.trim());
               ClientAssertionProvider clientAssertionProvider = 
                   (ClientAssertionProvider) providerClass.getDeclaredConstructor().newInstance();
               
@@ -1296,10 +1296,10 @@ public class AbfsConfiguration{
               tokenProvider = new WorkloadIdentityTokenProvider(
                   authority, tenantGuid, clientId, clientAssertionProvider);
               LOG.trace("WorkloadIdentityTokenProvider initialized with custom ClientAssertionProvider: {}", 
-                  clientAssertionProviderClassName);
+                  clientAssertionProviderType);
             } catch (Exception e) {
               throw new TokenAccessProviderException(
-                  "Failed to initialize custom ClientAssertionProvider: " + clientAssertionProviderClassName, e);
+                  "Failed to initialize custom ClientAssertionProvider: " + clientAssertionProviderType, e);
             }
           } else {
             // Use file-based approach (backward compatibility)

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.fs.azurebfs.extensions.CustomTokenProviderAdaptee;
 import org.apache.hadoop.fs.azurebfs.extensions.EncryptionContextProvider;
 import org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
+import org.apache.hadoop.fs.azurebfs.oauth2.ClientAssertionProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.CustomTokenProviderAdapter;
 import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
@@ -1277,12 +1278,38 @@ public class AbfsConfiguration{
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT);
           String clientId =
               getMandatoryPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID);
-          String tokenFile =
-              getTrimmedPasswordString(FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE,
-              AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE);
-          tokenProvider = new WorkloadIdentityTokenProvider(
-              authority, tenantGuid, clientId, tokenFile);
-          LOG.trace("WorkloadIdentityTokenProvider initialized");
+          
+          // Check if a custom ClientAssertionProvider is configured
+          String clientAssertionProviderClassName = 
+              getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_CLASS);
+          
+          if (clientAssertionProviderClassName != null && !clientAssertionProviderClassName.trim().isEmpty()) {
+            // Use custom ClientAssertionProvider
+            try {
+              Class<?> providerClass = Class.forName(clientAssertionProviderClassName.trim());
+              ClientAssertionProvider clientAssertionProvider = 
+                  (ClientAssertionProvider) providerClass.getDeclaredConstructor().newInstance();
+              
+              // Initialize the provider with configuration
+              clientAssertionProvider.initialize(rawConfig, accountName);
+              
+              tokenProvider = new WorkloadIdentityTokenProvider(
+                  authority, tenantGuid, clientId, clientAssertionProvider);
+              LOG.trace("WorkloadIdentityTokenProvider initialized with custom ClientAssertionProvider: {}", 
+                  clientAssertionProviderClassName);
+            } catch (Exception e) {
+              throw new TokenAccessProviderException(
+                  "Failed to initialize custom ClientAssertionProvider: " + clientAssertionProviderClassName, e);
+            }
+          } else {
+            // Use file-based approach (backward compatibility)
+            String tokenFile =
+                getTrimmedPasswordString(FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE,
+                AuthConfigurations.DEFAULT_FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE);
+            tokenProvider = new WorkloadIdentityTokenProvider(
+                authority, tenantGuid, clientId, tokenFile);
+            LOG.trace("WorkloadIdentityTokenProvider initialized with file-based token");
+          }
         } else {
           throw new IllegalArgumentException("Failed to initialize " + tokenProviderClass);
         }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -339,7 +339,6 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN_ENDPOINT = "fs.azure.account.oauth2.refresh.token.endpoint";
   /** Key for oauth AAD workload identity token file path: {@value}. */
   public static final String FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE = "fs.azure.account.oauth2.token.file";
-  
   /** Key for custom client assertion provider class for WorkloadIdentityTokenProvider */
   public static final String FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE = "fs.azure.account.oauth2.client.assertion.provider.type";
   /** Key for enabling the tracking of ABFS API latency and sending the latency numbers to the ABFS API service */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -341,7 +341,7 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE = "fs.azure.account.oauth2.token.file";
   
   /** Key for custom client assertion provider class for WorkloadIdentityTokenProvider */
-  public static final String FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_CLASS = "fs.azure.account.oauth2.client.assertion.provider.class";
+  public static final String FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE = "fs.azure.account.oauth2.client.assertion.provider.type";
   /** Key for enabling the tracking of ABFS API latency and sending the latency numbers to the ABFS API service */
   public static final String FS_AZURE_ABFS_LATENCY_TRACK = "fs.azure.abfs.latency.track";
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -339,6 +339,9 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN_ENDPOINT = "fs.azure.account.oauth2.refresh.token.endpoint";
   /** Key for oauth AAD workload identity token file path: {@value}. */
   public static final String FS_AZURE_ACCOUNT_OAUTH_TOKEN_FILE = "fs.azure.account.oauth2.token.file";
+  
+  /** Key for custom client assertion provider class for WorkloadIdentityTokenProvider */
+  public static final String FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_CLASS = "fs.azure.account.oauth2.client.assertion.provider.class";
   /** Key for enabling the tracking of ABFS API latency and sending the latency numbers to the ABFS API service */
   public static final String FS_AZURE_ABFS_LATENCY_TRACK = "fs.azure.abfs.latency.track";
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ClientAssertionProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ClientAssertionProvider.java
@@ -26,13 +26,13 @@ import org.apache.hadoop.conf.Configuration;
 
 /**
  * Interface for providing client assertions for Azure Workload Identity authentication.
- * 
+ *
  * This interface allows custom implementations to provide JWT tokens through various mechanisms:
  * - Kubernetes Token Request API
  * - HashiCorp Vault
  * - Custom token services
  * - File-based tokens with custom logic
- * 
+ *
  * Implementations should be thread-safe as they may be called concurrently.
  */
 @InterfaceAudience.Public
@@ -42,7 +42,7 @@ public interface ClientAssertionProvider {
   /**
    * Initializes the provider with the given configuration.
    * This method is called once after the provider is instantiated via reflection.
-   * 
+   *
    * @param configuration Hadoop configuration containing provider-specific settings
    * @param accountName Azure storage account name for account-specific configuration
    * @throws IOException if initialization fails
@@ -51,10 +51,10 @@ public interface ClientAssertionProvider {
 
   /**
    * Retrieves a client assertion (JWT token) for Azure Workload Identity authentication.
-   * 
+   *
    * The returned string should be a valid JWT token that can be used as a client assertion
    * in OAuth 2.0 client credentials flow with JWT bearer assertion.
-   * 
+   *
    * @return JWT token as a string
    * @throws IOException if token retrieval fails
    */
@@ -63,7 +63,7 @@ public interface ClientAssertionProvider {
   /**
    * Optional: Cleanup resources when the provider is no longer needed.
    * Default implementation does nothing.
-   * 
+   *
    * @throws IOException if cleanup fails
    */
   default void close() throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ClientAssertionProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/ClientAssertionProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.oauth2;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Interface for providing client assertions for Azure Workload Identity authentication.
+ * 
+ * This interface allows custom implementations to provide JWT tokens through various mechanisms:
+ * - Kubernetes Token Request API
+ * - HashiCorp Vault
+ * - Custom token services
+ * - File-based tokens with custom logic
+ * 
+ * Implementations should be thread-safe as they may be called concurrently.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface ClientAssertionProvider {
+
+  /**
+   * Initializes the provider with the given configuration.
+   * This method is called once after the provider is instantiated via reflection.
+   * 
+   * @param configuration Hadoop configuration containing provider-specific settings
+   * @param accountName Azure storage account name for account-specific configuration
+   * @throws IOException if initialization fails
+   */
+  void initialize(Configuration configuration, String accountName) throws IOException;
+
+  /**
+   * Retrieves a client assertion (JWT token) for Azure Workload Identity authentication.
+   * 
+   * The returned string should be a valid JWT token that can be used as a client assertion
+   * in OAuth 2.0 client credentials flow with JWT bearer assertion.
+   * 
+   * @return JWT token as a string
+   * @throws IOException if token retrieval fails
+   */
+  String getClientAssertion() throws IOException;
+
+  /**
+   * Optional: Cleanup resources when the provider is no longer needed.
+   * Default implementation does nothing.
+   * 
+   * @throws IOException if cleanup fails
+   */
+  default void close() throws IOException {
+    // Default: no-op
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
@@ -20,13 +20,18 @@ package org.apache.hadoop.fs.azurebfs.oauth2;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.EMPTY_STRING;
 
 /**
  * Provides tokens based on Azure AD Workload Identity.
@@ -45,7 +50,7 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
   private static class FileBasedClientAssertionProvider implements ClientAssertionProvider {
     private final String tokenFile;
 
-    public FileBasedClientAssertionProvider(String tokenFile) {
+    FileBasedClientAssertionProvider(String tokenFile) {
       this.tokenFile = tokenFile;
     }
 
@@ -56,13 +61,14 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
 
     @Override
     public String getClientAssertion() throws IOException {
-      String clientAssertion = "";
+      String clientAssertion = EMPTY_STRING;
       try {
         File file = new File(tokenFile);
-        clientAssertion = FileUtils.readFileToString(file, "UTF-8");
+        clientAssertion = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
       } catch (Exception e) {
         throw new IOException(TOKEN_FILE_READ_ERROR + tokenFile, e);
       }
+      clientAssertion = clientAssertion.trim();
       if (Strings.isNullOrEmpty(clientAssertion)) {
         throw new IOException(EMPTY_TOKEN_FILE_ERROR + tokenFile);
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
@@ -20,13 +20,13 @@ package org.apache.hadoop.fs.azurebfs.oauth2;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides tokens based on Azure AD Workload Identity.
@@ -38,11 +38,72 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
   private static final String EMPTY_TOKEN_FILE_ERROR = "Empty token file found at specified path: ";
   private static final String TOKEN_FILE_READ_ERROR = "Error reading token file at specified path: ";
 
+  /**
+   * Internal implementation of ClientAssertionProvider for file-based token reading.
+   * This provides backward compatibility for the file-based constructor.
+   */
+  private static class FileBasedClientAssertionProvider implements ClientAssertionProvider {
+    private final String tokenFile;
+
+    public FileBasedClientAssertionProvider(String tokenFile) {
+      this.tokenFile = tokenFile;
+    }
+
+    @Override
+    public void initialize(Configuration configuration, String accountName) throws IOException {
+      // No initialization needed for file-based provider
+    }
+
+    @Override
+    public String getClientAssertion() throws IOException {
+      String clientAssertion = "";
+      try {
+        File file = new File(tokenFile);
+        clientAssertion = FileUtils.readFileToString(file, "UTF-8");
+      } catch (Exception e) {
+        throw new IOException(TOKEN_FILE_READ_ERROR + tokenFile, e);
+      }
+      if (Strings.isNullOrEmpty(clientAssertion)) {
+        throw new IOException(EMPTY_TOKEN_FILE_ERROR + tokenFile);
+      }
+      return clientAssertion;
+    }
+  }
+
   private final String authEndpoint;
   private final String clientId;
-  private final String tokenFile;
+  private final ClientAssertionProvider clientAssertionProvider;
   private long tokenFetchTime = -1;
 
+  /**
+   * Constructor with custom ClientAssertionProvider.
+   * Use this for custom token retrieval mechanisms like Kubernetes Token Request API.
+   * 
+   * @param authority OAuth authority URL
+   * @param tenantId Azure AD tenant ID
+   * @param clientId Azure AD client ID 
+   * @param clientAssertionProvider Custom provider for client assertions
+   */
+  public WorkloadIdentityTokenProvider(final String authority, final String tenantId,
+                                       final String clientId, ClientAssertionProvider clientAssertionProvider) {
+    Preconditions.checkNotNull(authority, "authority");
+    Preconditions.checkNotNull(tenantId, "tenantId");
+    Preconditions.checkNotNull(clientId, "clientId");
+    Preconditions.checkNotNull(clientAssertionProvider, "clientAssertionProvider");
+
+    this.authEndpoint = authority + tenantId + OAUTH2_TOKEN_PATH;
+    this.clientId = clientId;
+    this.clientAssertionProvider = clientAssertionProvider;
+  }
+
+  /**
+   * Constructor with file-based token reading (backward compatibility).
+   * 
+   * @param authority OAuth authority URL
+   * @param tenantId Azure AD tenant ID
+   * @param clientId Azure AD client ID
+   * @param tokenFile Path to file containing the JWT token
+   */
   public WorkloadIdentityTokenProvider(final String authority, final String tenantId,
       final String clientId, final String tokenFile) {
     Preconditions.checkNotNull(authority, "authority");
@@ -52,13 +113,13 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
 
     this.authEndpoint = authority + tenantId + OAUTH2_TOKEN_PATH;
     this.clientId = clientId;
-    this.tokenFile = tokenFile;
+    this.clientAssertionProvider = new FileBasedClientAssertionProvider(tokenFile);
   }
 
   @Override
   protected AzureADToken refreshToken() throws IOException {
     LOG.debug("AADToken: refreshing token from JWT Assertion");
-    String clientAssertion = getClientAssertion();
+    String clientAssertion = clientAssertionProvider.getClientAssertion();
     AzureADToken token = getTokenUsingJWTAssertion(clientAssertion);
     tokenFetchTime = System.currentTimeMillis();
     return token;
@@ -88,31 +149,6 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
     }
 
     return expiring;
-  }
-
-  /**
-   * Gets the client assertion from the token file.
-   * The token file should contain the client assertion in JWT format.
-   * It should be a String containing Base64Url encoded JSON Web Token (JWT).
-   * See <a href="https://azure.github.io/azure-workload-identity/docs/faq.html#does-workload-identity-work-in-disconnected-environments">
-   * Azure Workload Identity FAQ</a>.
-   *
-   * @return the client assertion.
-   * @throws IOException if the token file is empty.
-   */
-  private String getClientAssertion()
-      throws IOException {
-    String clientAssertion = "";
-    try {
-      File file = new File(tokenFile);
-      clientAssertion = FileUtils.readFileToString(file, "UTF-8");
-    } catch (Exception e) {
-      throw new IOException(TOKEN_FILE_READ_ERROR + tokenFile, e);
-    }
-    if (Strings.isNullOrEmpty(clientAssertion)) {
-      throw new IOException(EMPTY_TOKEN_FILE_ERROR + tokenFile);
-    }
-    return clientAssertion;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/WorkloadIdentityTokenProvider.java
@@ -84,10 +84,10 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
   /**
    * Constructor with custom ClientAssertionProvider.
    * Use this for custom token retrieval mechanisms like Kubernetes Token Request API.
-   * 
+   *
    * @param authority OAuth authority URL
    * @param tenantId Azure AD tenant ID
-   * @param clientId Azure AD client ID 
+   * @param clientId Azure AD client ID
    * @param clientAssertionProvider Custom provider for client assertions
    */
   public WorkloadIdentityTokenProvider(final String authority, final String tenantId,
@@ -104,7 +104,7 @@ public class WorkloadIdentityTokenProvider extends AccessTokenProvider {
 
   /**
    * Constructor with file-based token reading (backward compatibility).
-   * 
+   *
    * @param authority OAuth authority URL
    * @param tenantId Azure AD tenant ID
    * @param clientId Azure AD client ID

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
@@ -640,22 +640,22 @@ public class TestAccountConfiguration {
 
     // Set up OAuth with WorkloadIdentityTokenProvider
     abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
-    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix,
                  WorkloadIdentityTokenProvider.class.getName());
-    
+
     // Set required OAuth parameters
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
-    
+
     // Set custom ClientAssertionProvider
-    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix,
                  TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
 
     AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
     Assertions.assertThat(tokenProvider)
         .describedAs("Should create WorkloadIdentityTokenProvider with custom ClientAssertionProvider")
         .isInstanceOf(WorkloadIdentityTokenProvider.class);
-    
+
     // Verify that the custom provider configuration was read and used
     String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
     Assertions.assertThat(customProviderType)
@@ -676,13 +676,13 @@ public class TestAccountConfiguration {
 
     // Set up OAuth with WorkloadIdentityTokenProvider
     abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
-    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix,
                  WorkloadIdentityTokenProvider.class.getName());
-    
+
     // Set required OAuth parameters
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
-    
+
     // Don't set custom provider - should fallback to file-based approach
     // abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, ...);
 
@@ -690,7 +690,7 @@ public class TestAccountConfiguration {
     Assertions.assertThat(tokenProvider)
         .describedAs("Should create WorkloadIdentityTokenProvider with file-based fallback")
         .isInstanceOf(WorkloadIdentityTokenProvider.class);
-    
+
     // Verify that no custom provider is configured (should be null or empty)
     String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
     Assertions.assertThat(customProviderType)
@@ -711,21 +711,21 @@ public class TestAccountConfiguration {
 
     // Set up OAuth with WorkloadIdentityTokenProvider
     abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
-    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix,
                  WorkloadIdentityTokenProvider.class.getName());
-    
+
     // Set required OAuth parameters
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
-    
+
     // Set invalid custom ClientAssertionProvider class
-    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix,
                  "non.existent.InvalidProvider");
 
     TokenAccessProviderException exception = LambdaTestUtils.intercept(
-        TokenAccessProviderException.class, 
+        TokenAccessProviderException.class,
         () -> abfsConf.getTokenProvider());
-    
+
     Assertions.assertThat(exception.getMessage())
         .describedAs("Should contain error about unable to load OAuth token provider class")
         .contains("Unable to load OAuth token provider class");
@@ -744,13 +744,13 @@ public class TestAccountConfiguration {
 
     // Set up OAuth with WorkloadIdentityTokenProvider
     abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
-    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix,
                  WorkloadIdentityTokenProvider.class.getName());
-    
+
     // Set required OAuth parameters
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
-    
+
     // Set empty custom ClientAssertionProvider - should fallback to file-based
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, "   ");
 
@@ -758,13 +758,13 @@ public class TestAccountConfiguration {
     Assertions.assertThat(tokenProvider)
         .describedAs("Should create WorkloadIdentityTokenProvider with file-based fallback when provider config is empty")
         .isInstanceOf(WorkloadIdentityTokenProvider.class);
-    
+
     // Verify that the empty provider configuration is read but treated as empty
     String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
     Assertions.assertThat(customProviderType)
         .describedAs("Empty custom provider config should be present but whitespace-only")
         .isEqualTo("   ");
-    
+
     // Verify that when trimmed, it's empty (this is what triggers file-based fallback)
     Assertions.assertThat(customProviderType.trim())
         .describedAs("Trimmed custom provider config should be empty")
@@ -772,10 +772,10 @@ public class TestAccountConfiguration {
   }
 
   /**
-   * Test that configuration precedence works for custom ClientAssertionProvider 
+   * Test that configuration precedence works for custom ClientAssertionProvider
    * (account-specific vs account-agnostic)
    */
-  @Test 
+  @Test
   public void testWorkloadIdentityCustomProviderConfigPrecedence() throws Exception {
     final String accountName = "account";
     final Configuration conf = new Configuration();
@@ -785,31 +785,31 @@ public class TestAccountConfiguration {
 
     // Set up OAuth with WorkloadIdentityTokenProvider
     abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
-    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix,
                  WorkloadIdentityTokenProvider.class.getName());
-    
+
     // Set required OAuth parameters
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
-    
+
     // Set account-agnostic custom provider (should be overridden by account-specific)
     abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE, "some.other.Provider");
-    
+
     // Set account-specific custom provider (should take precedence)
-    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix,
                  TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
 
     AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
     Assertions.assertThat(tokenProvider)
         .describedAs("Should create WorkloadIdentityTokenProvider with account-specific custom provider taking precedence")
         .isInstanceOf(WorkloadIdentityTokenProvider.class);
-    
+
     // Verify that account-specific configuration takes precedence over account-agnostic
     String accountSpecificProvider = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
     Assertions.assertThat(accountSpecificProvider)
         .describedAs("Account-specific custom provider should take precedence")
         .isEqualTo(TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
-    
+
     // Verify that the account-agnostic setting exists but isn't used
     String accountAgnosticProvider = abfsConf.getRawConfiguration().get(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
     Assertions.assertThat(accountAgnosticProvider)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestAccountConfiguration.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.RefreshTokenBasedTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.UserPasswordTokenProvider;
 import org.apache.hadoop.fs.azurebfs.oauth2.WorkloadIdentityTokenProvider;
+import org.apache.hadoop.fs.azurebfs.oauth2.ClientAssertionProvider;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -49,6 +50,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_USER_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_USER_PASSWORD;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_SAS_TOKEN_PROVIDER_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,6 +81,8 @@ public class TestAccountConfiguration {
   private static final String TEST_USER_PASSWORD = "userPassword";
   private static final String TEST_MSI_TENANT = "msiTenant";
   private static final String TEST_REFRESH_TOKEN = "refreshToken";
+  private static final String TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER = "org.apache.hadoop.fs.azurebfs.TestAccountConfiguration$MockClientAssertionProvider";
+  private static final String TEST_TOKEN_FILE = "/tmp/test-token-file";
 
   private static final List<String> CLIENT_CREDENTIAL_OAUTH_CONFIG_KEYS =
       Collections.unmodifiableList(Arrays.asList(
@@ -605,6 +609,212 @@ public class TestAccountConfiguration {
     abfsConf.unset(FS_AZURE_ACCOUNT_OAUTH_USER_PASSWORD + accountNameSuffix);
     abfsConf.unset(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix);
     abfsConf.unset(FS_AZURE_ACCOUNT_OAUTH_REFRESH_TOKEN + accountNameSuffix);
+    abfsConf.unset(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix);
+  }
+
+  /**
+   * Mock implementation of ClientAssertionProvider for testing
+   */
+  public static class MockClientAssertionProvider implements ClientAssertionProvider {
+    @Override
+    public void initialize(Configuration configuration, String accountName) throws IOException {
+      // Mock implementation
+    }
+
+    @Override
+    public String getClientAssertion() throws IOException {
+      return "mock-jwt-token";
+    }
+  }
+
+  /**
+   * Test that WorkloadIdentityTokenProvider can be configured with custom ClientAssertionProvider
+   */
+  @Test
+  public void testWorkloadIdentityTokenProviderWithCustomClientAssertionProvider() throws Exception {
+    final String accountName = "account";
+    final Configuration conf = new Configuration();
+    final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+    final String accountNameSuffix = "." + abfsConf.getAccountName();
+
+    // Set up OAuth with WorkloadIdentityTokenProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+                 WorkloadIdentityTokenProvider.class.getName());
+    
+    // Set required OAuth parameters
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
+    
+    // Set custom ClientAssertionProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+                 TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
+
+    AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
+    Assertions.assertThat(tokenProvider)
+        .describedAs("Should create WorkloadIdentityTokenProvider with custom ClientAssertionProvider")
+        .isInstanceOf(WorkloadIdentityTokenProvider.class);
+    
+    // Verify that the custom provider configuration was read and used
+    String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
+    Assertions.assertThat(customProviderType)
+        .describedAs("Custom provider type should be configured")
+        .isEqualTo(TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
+  }
+
+  /**
+   * Test that WorkloadIdentityTokenProvider falls back to file-based approach when no custom provider is configured
+   */
+  @Test
+  public void testWorkloadIdentityTokenProviderWithFileBasedFallback() throws Exception {
+    final String accountName = "account";
+    final Configuration conf = new Configuration();
+    final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+    final String accountNameSuffix = "." + abfsConf.getAccountName();
+
+    // Set up OAuth with WorkloadIdentityTokenProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+                 WorkloadIdentityTokenProvider.class.getName());
+    
+    // Set required OAuth parameters
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
+    
+    // Don't set custom provider - should fallback to file-based approach
+    // abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, ...);
+
+    AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
+    Assertions.assertThat(tokenProvider)
+        .describedAs("Should create WorkloadIdentityTokenProvider with file-based fallback")
+        .isInstanceOf(WorkloadIdentityTokenProvider.class);
+    
+    // Verify that no custom provider is configured (should be null or empty)
+    String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
+    Assertions.assertThat(customProviderType)
+        .describedAs("No custom provider should be configured for file-based fallback")
+        .isNull();
+  }
+
+  /**
+   * Test that invalid custom ClientAssertionProvider class name throws appropriate exception
+   */
+  @Test
+  public void testWorkloadIdentityTokenProviderWithInvalidCustomProvider() throws Exception {
+    final String accountName = "account";
+    final Configuration conf = new Configuration();
+    final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+    final String accountNameSuffix = "." + abfsConf.getAccountName();
+
+    // Set up OAuth with WorkloadIdentityTokenProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+                 WorkloadIdentityTokenProvider.class.getName());
+    
+    // Set required OAuth parameters
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
+    
+    // Set invalid custom ClientAssertionProvider class
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+                 "non.existent.InvalidProvider");
+
+    TokenAccessProviderException exception = LambdaTestUtils.intercept(
+        TokenAccessProviderException.class, 
+        () -> abfsConf.getTokenProvider());
+    
+    Assertions.assertThat(exception.getMessage())
+        .describedAs("Should contain error about unable to load OAuth token provider class")
+        .contains("Unable to load OAuth token provider class");
+  }
+
+  /**
+   * Test that empty/whitespace custom ClientAssertionProvider config falls back to file-based approach
+   */
+  @Test
+  public void testWorkloadIdentityTokenProviderWithEmptyCustomProviderConfig() throws Exception {
+    final String accountName = "account";
+    final Configuration conf = new Configuration();
+    final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+    final String accountNameSuffix = "." + abfsConf.getAccountName();
+
+    // Set up OAuth with WorkloadIdentityTokenProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+                 WorkloadIdentityTokenProvider.class.getName());
+    
+    // Set required OAuth parameters
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
+    
+    // Set empty custom ClientAssertionProvider - should fallback to file-based
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, "   ");
+
+    AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
+    Assertions.assertThat(tokenProvider)
+        .describedAs("Should create WorkloadIdentityTokenProvider with file-based fallback when provider config is empty")
+        .isInstanceOf(WorkloadIdentityTokenProvider.class);
+    
+    // Verify that the empty provider configuration is read but treated as empty
+    String customProviderType = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
+    Assertions.assertThat(customProviderType)
+        .describedAs("Empty custom provider config should be present but whitespace-only")
+        .isEqualTo("   ");
+    
+    // Verify that when trimmed, it's empty (this is what triggers file-based fallback)
+    Assertions.assertThat(customProviderType.trim())
+        .describedAs("Trimmed custom provider config should be empty")
+        .isEmpty();
+  }
+
+  /**
+   * Test that configuration precedence works for custom ClientAssertionProvider 
+   * (account-specific vs account-agnostic)
+   */
+  @Test 
+  public void testWorkloadIdentityCustomProviderConfigPrecedence() throws Exception {
+    final String accountName = "account";
+    final Configuration conf = new Configuration();
+    final AbfsConfiguration abfsConf = new AbfsConfiguration(conf, accountName);
+
+    final String accountNameSuffix = "." + abfsConf.getAccountName();
+
+    // Set up OAuth with WorkloadIdentityTokenProvider
+    abfsConf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME + accountNameSuffix, AuthType.OAuth.toString());
+    abfsConf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + accountNameSuffix, 
+                 WorkloadIdentityTokenProvider.class.getName());
+    
+    // Set required OAuth parameters
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT + accountNameSuffix, TEST_MSI_TENANT);
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ID + accountNameSuffix, TEST_CLIENT_ID);
+    
+    // Set account-agnostic custom provider (should be overridden by account-specific)
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE, "some.other.Provider");
+    
+    // Set account-specific custom provider (should take precedence)
+    abfsConf.set(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE + accountNameSuffix, 
+                 TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
+
+    AccessTokenProvider tokenProvider = abfsConf.getTokenProvider();
+    Assertions.assertThat(tokenProvider)
+        .describedAs("Should create WorkloadIdentityTokenProvider with account-specific custom provider taking precedence")
+        .isInstanceOf(WorkloadIdentityTokenProvider.class);
+    
+    // Verify that account-specific configuration takes precedence over account-agnostic
+    String accountSpecificProvider = abfsConf.getPasswordString(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
+    Assertions.assertThat(accountSpecificProvider)
+        .describedAs("Account-specific custom provider should take precedence")
+        .isEqualTo(TEST_CUSTOM_CLIENT_ASSERTION_PROVIDER);
+    
+    // Verify that the account-agnostic setting exists but isn't used
+    String accountAgnosticProvider = abfsConf.getRawConfiguration().get(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ASSERTION_PROVIDER_TYPE);
+    Assertions.assertThat(accountAgnosticProvider)
+        .describedAs("Account-agnostic setting should exist but not be used")
+        .isEqualTo("some.other.Provider");
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/TestWorkloadIdentityTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/oauth2/TestWorkloadIdentityTokenProvider.java
@@ -141,4 +141,185 @@ public class TestWorkloadIdentityTokenProvider extends AbstractAbfsTestWithTimeo
         .describedAs("Exception should be thrown when the token file not found")
         .contains("Error reading token file");
   }
+
+  /**
+   * Test that tokens with whitespace are properly trimmed.
+   *
+   * @throws IOException if file I/O fails.
+   */
+  @Test
+  public void testTokenTrimsWhitespace() throws Exception {
+    String tokenWithWhitespace = "  " + CLIENT_ASSERTION + "  \n\t  ";
+    AzureADToken adToken = new AzureADToken();
+    adToken.setAccessToken(TOKEN);
+    adToken.setExpiry(new Date(System.currentTimeMillis() + FIVE_MINUTES));
+
+    File tokenFile = File.createTempFile("azure-identity-token", "txt");
+    FileUtils.write(tokenFile, tokenWithWhitespace, StandardCharsets.UTF_8);
+
+    WorkloadIdentityTokenProvider mockedTokenProvider = Mockito.spy(
+        new WorkloadIdentityTokenProvider(AUTHORITY, TENANT_ID, CLIENT_ID,
+            tokenFile.getPath()));
+    Mockito.doReturn(adToken).when(mockedTokenProvider).getTokenUsingJWTAssertion(CLIENT_ASSERTION);
+
+    Assertions.assertThat(mockedTokenProvider.getToken().getAccessToken())
+        .describedAs("Token should be fetched successfully with trimmed whitespace")
+        .isEqualTo(TOKEN);
+
+    // Verify that the trimmed token (without whitespace) was passed to getTokenUsingJWTAssertion
+    Mockito.verify(mockedTokenProvider).getTokenUsingJWTAssertion(CLIENT_ASSERTION);
+  }
+
+  /**
+   * Test that tokens with only whitespace are treated as empty.
+   *
+   * @throws IOException if file I/O fails.
+   */
+  @Test
+  public void testTokenFileWithOnlyWhitespace() throws Exception {
+    String whitespaceOnlyToken = "   \n\t  \r  ";
+    File tokenFile = File.createTempFile("azure-identity-token", "txt");
+    FileUtils.write(tokenFile, whitespaceOnlyToken, StandardCharsets.UTF_8);
+
+    WorkloadIdentityTokenProvider tokenProvider = new WorkloadIdentityTokenProvider(
+        AUTHORITY, TENANT_ID, CLIENT_ID, tokenFile.getPath());
+
+    IOException ex = intercept(IOException.class, () -> {
+      tokenProvider.getToken();
+    });
+    Assertions.assertThat(ex.getMessage())
+        .describedAs("Exception should be thrown when the token file contains only whitespace")
+        .contains("Empty token file");
+  }
+
+  /**
+   * Test constructor with a custom ClientAssertionProvider.
+   *
+   * @throws IOException if the assertion provider fails.
+   */
+  @Test
+  public void testCustomClientAssertionProvider() throws Exception {
+    AzureADToken adToken = new AzureADToken();
+    adToken.setAccessToken(TOKEN);
+    adToken.setExpiry(new Date(System.currentTimeMillis() + FIVE_MINUTES));
+
+    ClientAssertionProvider mockProvider = Mockito.mock(ClientAssertionProvider.class);
+    Mockito.when(mockProvider.getClientAssertion()).thenReturn(CLIENT_ASSERTION);
+
+    WorkloadIdentityTokenProvider mockedTokenProvider = Mockito.spy(
+        new WorkloadIdentityTokenProvider(AUTHORITY, TENANT_ID, CLIENT_ID, mockProvider));
+    Mockito.doReturn(adToken).when(mockedTokenProvider).getTokenUsingJWTAssertion(CLIENT_ASSERTION);
+
+    Assertions.assertThat(mockedTokenProvider.getToken().getAccessToken())
+        .describedAs("Token should be fetched using custom provider")
+        .isEqualTo(TOKEN);
+
+    Mockito.verify(mockProvider).getClientAssertion();
+    Mockito.verify(mockedTokenProvider).getTokenUsingJWTAssertion(CLIENT_ASSERTION);
+  }
+
+  /**
+   * Test that custom ClientAssertionProvider initialize method is called.
+   *
+   * @throws IOException if assertion provider fails.
+   */
+  @Test
+  public void testCustomClientAssertionProviderInitialize() throws Exception {
+    ClientAssertionProvider mockProvider = Mockito.mock(ClientAssertionProvider.class);
+    Mockito.when(mockProvider.getClientAssertion()).thenReturn(CLIENT_ASSERTION);
+
+    WorkloadIdentityTokenProvider tokenProvider = new WorkloadIdentityTokenProvider(
+        AUTHORITY, TENANT_ID, CLIENT_ID, mockProvider);
+
+    // The provider should be ready to use without explicit initialization
+    // but we can verify it's properly integrated
+    Assertions.assertThat(tokenProvider)
+        .describedAs("Token provider should be created successfully")
+        .isNotNull();
+  }
+
+  /**
+   * Test that a custom ClientAssertionProvider can throw IOException.
+   *
+   * @throws IOException if the assertion provider fails.
+   */
+  @Test
+  public void testCustomClientAssertionProviderThrowsException() throws Exception {
+    ClientAssertionProvider mockProvider = Mockito.mock(ClientAssertionProvider.class);
+    Mockito.when(mockProvider.getClientAssertion())
+        .thenThrow(new IOException("Custom provider error"));
+
+    WorkloadIdentityTokenProvider tokenProvider = new WorkloadIdentityTokenProvider(
+        AUTHORITY, TENANT_ID, CLIENT_ID, mockProvider);
+
+    IOException ex = intercept(IOException.class, () -> {
+      tokenProvider.getToken();
+    });
+    Assertions.assertThat(ex.getMessage())
+        .describedAs("Exception from custom provider should be propagated")
+        .contains("Custom provider error");
+  }
+
+  /**
+   * Test that null parameters are properly validated in a custom provider constructor.
+   */
+  @Test
+  public void testCustomProviderConstructorValidation() throws Exception {
+    ClientAssertionProvider mockProvider = Mockito.mock(ClientAssertionProvider.class);
+
+    // Test null authority
+    Throwable ex1 = intercept(RuntimeException.class, () -> {
+      new WorkloadIdentityTokenProvider(null, TENANT_ID, CLIENT_ID, mockProvider);
+    });
+    Assertions.assertThat(ex1.getMessage())
+        .describedAs("Should validate authority parameter")
+        .contains("authority");
+
+    // Test null tenantId
+    Throwable ex2 = intercept(RuntimeException.class, () -> {
+      new WorkloadIdentityTokenProvider(AUTHORITY, null, CLIENT_ID, mockProvider);
+    });
+    Assertions.assertThat(ex2.getMessage())
+        .describedAs("Should validate tenantId parameter")
+        .contains("tenantId");
+
+    // Test null clientId
+    Throwable ex3 = intercept(RuntimeException.class, () -> {
+      new WorkloadIdentityTokenProvider(AUTHORITY, TENANT_ID, null, mockProvider);
+    });
+    Assertions.assertThat(ex3.getMessage())
+        .describedAs("Should validate clientId parameter")
+        .contains("clientId");
+
+    // Test null clientAssertionProvider
+    Throwable ex4 = intercept(RuntimeException.class, () -> {
+      new WorkloadIdentityTokenProvider(AUTHORITY, TENANT_ID, CLIENT_ID, (ClientAssertionProvider) null);
+    });
+    Assertions.assertThat(ex4.getMessage())
+        .describedAs("Should validate clientAssertionProvider parameter")
+        .contains("clientAssertionProvider");
+  }
+
+  /**
+   * Test that a file-based provider implements ClientAssertionProvider correctly.
+   *
+   * @throws IOException if file operations fail.
+   */
+  @Test
+  public void testFileBasedProviderImplementsInterface() throws Exception {
+    File tokenFile = File.createTempFile("azure-identity-token", "txt");
+    FileUtils.write(tokenFile, CLIENT_ASSERTION, StandardCharsets.UTF_8);
+
+    // Create provider with file-based constructor
+    WorkloadIdentityTokenProvider provider = new WorkloadIdentityTokenProvider(
+        AUTHORITY, TENANT_ID, CLIENT_ID, tokenFile.getPath());
+
+    // The internal FileBasedClientAssertionProvider should work correctly
+    Assertions.assertThat(provider)
+        .describedAs("File-based provider should be created successfully")
+        .isNotNull();
+
+    // Clean up
+    tokenFile.delete();
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
[HADOOP-19660](https://issues.apache.org/jira/browse/HADOOP-19660)

### How was this patch tested?
This patch was tested using [this](https://github.com/kunalmnnit/hadoop-custom-client-assertion-provider) code.
```
bash-5.2# java -jar abfs-wi-demo-1.2.3.jar
java -jar abfs-wi-demo-1.2.3.jar
+ java -jar abfs-wi-demo-1.2.3.jar
Connected to abfs://topics@azurecspi.dfs.core.windows.net/
Wrote: /hello.txt
Read: hello world
```
<img width="1584" height="572" alt="image" src="https://github.com/user-attachments/assets/b513965a-9dc8-49b1-ab70-afc7ae4c91d0" />



### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

