### PR TITLE
MAPREDUCE-7502. TestPipeApplication silently hangs

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Application.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Application.java
@@ -110,7 +110,8 @@ class Application<K1 extends WritableComparable, V1 extends Writable,
     String localPasswordFile = new File(".") + Path.SEPARATOR
         + "jobTokenPassword";
     writePasswordToLocalFile(localPasswordFile, password, conf);
-    env.put("hadoop.pipes.shared.secret.location", localPasswordFile);
+    // FIXME This doesn't seem to be read anywhere
+    env.put("hadoop_pipes_shared_secret_location", localPasswordFile);
  
     List<String> cmd = new ArrayList<String>();
     String interpretor = conf.get(Submitter.INTERPRETOR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Submitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Submitter.java
@@ -82,7 +82,9 @@ public class Submitter extends Configured implements Tool {
   public static final String IS_JAVA_REDUCE = "mapreduce.pipes.isjavareducer";
   public static final String PARTITIONER = "mapreduce.pipes.partitioner";
   public static final String INPUT_FORMAT = "mapreduce.pipes.inputformat";
-  public static final String PORT = "mapreduce.pipes.command.port";
+  // This is used as an environment variable, which doesn't allow dots.
+  // FIXME This also seems to be used only for tests
+  public static final String PORT = "mapreduce_pipes_command_port";
   
   public Submitter() {
     this(new Configuration());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/CommonStub.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/CommonStub.java
@@ -99,7 +99,7 @@ public class CommonStub {
   }
 
   protected void initSoket() throws Exception {
-    int port = Integer.parseInt(System.getenv("mapreduce.pipes.command.port"));
+    int port = Integer.parseInt(System.getenv(Submitter.PORT));
 
     java.net.InetAddress address = java.net.InetAddress.getLocalHost();
 


### PR DESCRIPTION
### Description of PR

Fixes TestPipeApplication hang.
TestPipeApplication tries to pass data in environment variables with dots in the names, which doesn't work.

### How was this patch tested?

`mvn clean verify -am -pl hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient -Dtest=TestPipeApplication`

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

