### PR TITLE
HADOOP-19343: Manage hadoop-gcp Guava version directly in its pom.xml and mark exclusion in hadoop-tools-dist.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -108,7 +108,7 @@
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.6.1</dnsjava.version>
 
-    <guava.version>33.1.0-jre</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 
     <bouncycastle.version>1.78.1</bouncycastle.version>

--- a/hadoop-tools/hadoop-gcp/pom.xml
+++ b/hadoop-tools/hadoop-gcp/pom.xml
@@ -430,15 +430,20 @@
 
   <dependencyManagement>
     <dependencies>
+      <!--
+      Use specific Guava and Protobuf versions to ensure compatibility with the
+      Google Cloud Storage (GCS) client. The GCS client often relies on
+      particular Long-Term Support (LTS) versions. Keep these versions in sync
+      with the transitive dependencies of
+      com.google.cloud:google-cloud-storage. To prevent dependency conflicts,
+      these will be shaded in the hadoop-gcp jar.
+      -->
       <dependency>
-        <!--
-        We're using a specific Protobuf version to ensure compatibility with the
-        Google Cloud Storage (GCS) client. The GCS client often relies on
-        particular Long-Term Support (LTS) versions of Protobuf. When we upgrade
-        the GCS client, we'll likely need to update Protobuf too. To prevent
-        dependency conflicts, Protobuf will be shaded within the GCS connector's
-        fat JAR.
-        -->
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.4.0-jre</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.25.5</version>
@@ -460,6 +465,11 @@
           <groupId>javax.enterprise</groupId>
           <artifactId>cdi-api</artifactId>
         </exclusion>
+        <!-- Exclude guava 27.0-jre -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
         <!-- Exclude protobuf-java 2.5.0 -->
         <exclusion>
           <groupId>com.google.protobuf</groupId>
@@ -472,6 +482,13 @@
       <artifactId>hadoop-common</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
+      <exclusions>
+        <!-- Exclude guava 27.0-jre -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/hadoop-tools/hadoop-tools-dist/pom.xml
+++ b/hadoop-tools/hadoop-tools-dist/pom.xml
@@ -144,6 +144,16 @@
       <artifactId>hadoop-gcp</artifactId>
       <scope>compile</scope>
       <version>${project.version}</version>
+      <!--
+      Exclude transitive dependencies to prevent dependency convergence
+      problems. hadoop-gcp is a self-contained shaded jar.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### Description of PR

HADOOP-19343: Manage hadoop-gcp Guava version directly in its pom.xml and mark exclusion in hadoop-tools-dist.

### How was this patch tested?

1. Ran full distro: `mvn -Pdist -Dtar -DskipTests clean package`. Confirmed no dependency convergence errors.
2. Unpacked the distro and manually executed several `hadoop fs` commands against a GCS bucket.
3. Ran `mvn clean verify` in hadoop-gcp to confirm all integration tests pass.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

