### PR TITLE
HADOOP-19587. SSE-C integration changes.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -1919,7 +1919,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withCallbacks(createInputStreamCallbacks(auditSpan))
         .withContext(readContext.build())
         .withObjectAttributes(createObjectAttributes(path, fileStatus))
-        .withStreamStatistics(inputStreamStats);
+        .withStreamStatistics(inputStreamStats)
+        .withEncryptionSecrets(getEncryptionSecrets());
     return new FSDataInputStream(getStore().readObject(parameters));
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -21,14 +21,12 @@ package org.apache.hadoop.fs.s3a.impl.streams;
 
 import java.io.EOFException;
 import java.io.IOException;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
-
 import java.util.Optional;
 
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
@@ -259,7 +257,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
           .etag(parameters.getObjectAttributes().getETag()).build());
     }
 
-    if(parameters.getEncryptionSecrets().getEncryptionMethod() == S3AEncryptionMethods.SSE_C) {
+    if (parameters.getEncryptionSecrets().getEncryptionMethod() == S3AEncryptionMethods.SSE_C) {
       EncryptionSecretOperations.getSSECustomerKey(parameters.getEncryptionSecrets())
               .ifPresent(base64customerKey -> openStreamInformationBuilder.encryptionSecrets(
               EncryptionSecrets.builder().sseCustomerKey(Optional.of(base64customerKey)).build()));

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.impl.streams;
 
 import java.io.EOFException;
 import java.io.IOException;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +29,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
+import java.util.Optional;
+
+import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecretOperations;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 import software.amazon.s3.analyticsaccelerator.common.ObjectRange;
+import software.amazon.s3.analyticsaccelerator.request.EncryptionSecrets;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.util.InputPolicy;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
@@ -251,6 +257,12 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()
           .contentLength(parameters.getObjectAttributes().getLen())
           .etag(parameters.getObjectAttributes().getETag()).build());
+    }
+
+    if(parameters.getEncryptionSecrets().getEncryptionMethod() == S3AEncryptionMethods.SSE_C) {
+      EncryptionSecretOperations.getSSECustomerKey(parameters.getEncryptionSecrets())
+              .ifPresent(base64customerKey -> openStreamInformationBuilder.encryptionSecrets(
+              EncryptionSecrets.builder().sseCustomerKey(Optional.of(base64customerKey)).build()));
     }
 
     return openStreamInformationBuilder.build();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
 
 import static java.util.Objects.requireNonNull;
@@ -68,6 +69,29 @@ public final class ObjectReadParameters {
    * Allocator of local FS storage.
    */
   private LocalDirAllocator directoryAllocator;
+
+  /**
+   * Encryption secrets for this stream
+   */
+  private EncryptionSecrets encryptionSecrets;
+
+  /**
+   * Getter.
+   * @return Encryption secrets.
+   */
+  public EncryptionSecrets getEncryptionSecrets() {
+    return encryptionSecrets;
+  }
+
+  /**
+   * Set encryption secrets.
+   * @param value new value
+   * @return the builder
+   */
+  public ObjectReadParameters withEncryptionSecrets(final EncryptionSecrets value) {
+    encryptionSecrets = value;
+    return this;
+  }
 
   /**
    * @return Read operation context.
@@ -185,6 +209,7 @@ public final class ObjectReadParameters {
     requireNonNull(directoryAllocator, "directoryAllocator");
     requireNonNull(objectAttributes, "objectAttributes");
     requireNonNull(streamStatistics, "streamStatistics");
+    requireNonNull(encryptionSecrets, "encryptionSecrets");
     return this;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/ObjectReadParameters.java
@@ -71,7 +71,7 @@ public final class ObjectReadParameters {
   private LocalDirAllocator directoryAllocator;
 
   /**
-   * Encryption secrets for this stream
+   * Encryption secrets for this stream.
    */
   private EncryptionSecrets encryptionSecrets;
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -42,10 +42,10 @@ import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITH
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeStoreAwsHosted;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestBucketName;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.maybeSkipRootTests;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
 /**
@@ -99,8 +99,6 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
   @Override
   public void setup() throws Exception {
     super.setup();
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support SSE-C");
     assumeEnabled();
     // although not a root dir test, this confuses paths enough it shouldn't be run in
     // parallel with other jobs
@@ -329,6 +327,65 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
     intercept(AccessDeniedException.class,
         SERVICE_AMAZON_S3_STATUS_CODE_403,
         () -> fsKeyB.getFileChecksum(path));
+  }
+
+
+  /**
+   * Tests the creation and reading of a file using a different encryption key
+   * when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndReadWithDifferentEncryptionKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testCreateFileAndReadWithDifferentEncryptionKey();
+  }
+
+  /**
+   * Tests the creation and movement of a file using a different SSE-C key
+   * when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileThenMoveWithDifferentSSECKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testCreateFileThenMoveWithDifferentSSECKey();
+  }
+
+  /**
+   * Tests create and file rename operation when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndRenameFileWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testRenameFile();
+  }
+
+  /**
+   * Tests the creation and listing of encrypted files when Analytics Accelerator is enabled.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndListStatusEncryptedFileWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testListStatusEncryptedFile();
+  }
+
+  /**
+   * Tests the creation and deletion of an encrypted object using a different key
+   * when Analytics Accelerator is enabled.t.
+   *
+   * @throws Exception if any error occurs during the test execution
+   */
+  @Test
+  public void testCreateFileAndDeleteEncryptedObjectWithDifferentKeyWithAnalyticsAcceleratorEnabled() throws Exception {
+    enableAnalyticsAccelerator(getConfiguration());
+    testDeleteEncryptedObjectWithDifferentKey();
   }
 
   private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -352,8 +352,7 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
         SERVICE_AMAZON_S3_STATUS_CODE_403,
         () -> fsKeyB.getFileChecksum(path));
   }
-
-
+  
   private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws
       IOException {
     Configuration conf = this.createConfiguration();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.fs.s3a;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -56,6 +60,8 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
  * Equally "vexing" has been the optimizations of getFileStatus(), wherein
  * LIST comes before HEAD path + /
  */
+@ParameterizedClass(name="analytics-accelerator-enabled-{0}")
+@MethodSource("params")
 public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
 
   private static final String SERVICE_AMAZON_S3_STATUS_CODE_403
@@ -75,6 +81,19 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
    */
   private S3AFileSystem fsKeyB;
 
+  private final boolean analyticsAcceleratorEnabled;
+
+  public static Collection<Object[]> params() {
+    return Arrays.asList(new Object[][]{
+            {true},
+            {false}
+    });
+  }
+
+  public ITestS3AEncryptionSSEC (final boolean analyticsAcceleratorEnabled) {
+    this.analyticsAcceleratorEnabled = analyticsAcceleratorEnabled;
+  }
+
 
   @SuppressWarnings("deprecation")
   @Override
@@ -92,6 +111,11 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
         getSSEAlgorithm().getMethod());
     conf.set(S3_ENCRYPTION_KEY, KEY_1);
     conf.setBoolean(ETAG_CHECKSUM_ENABLED, true);
+
+    if (analyticsAcceleratorEnabled) {
+      enableAnalyticsAccelerator(conf);
+    }
+
     return conf;
   }
 
@@ -329,64 +353,6 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
         () -> fsKeyB.getFileChecksum(path));
   }
 
-
-  /**
-   * Tests the creation and reading of a file using a different encryption key
-   * when Analytics Accelerator is enabled.
-   *
-   * @throws Exception if any error occurs during the test execution
-   */
-  @Test
-  public void testCreateFileAndReadWithDifferentEncryptionKeyWithAnalyticsAcceleratorEnabled() throws Exception {
-    enableAnalyticsAccelerator(getConfiguration());
-    testCreateFileAndReadWithDifferentEncryptionKey();
-  }
-
-  /**
-   * Tests the creation and movement of a file using a different SSE-C key
-   * when Analytics Accelerator is enabled.
-   *
-   * @throws Exception if any error occurs during the test execution
-   */
-  @Test
-  public void testCreateFileThenMoveWithDifferentSSECKeyWithAnalyticsAcceleratorEnabled() throws Exception {
-    enableAnalyticsAccelerator(getConfiguration());
-    testCreateFileThenMoveWithDifferentSSECKey();
-  }
-
-  /**
-   * Tests create and file rename operation when Analytics Accelerator is enabled.
-   *
-   * @throws Exception if any error occurs during the test execution
-   */
-  @Test
-  public void testCreateFileAndRenameFileWithAnalyticsAcceleratorEnabled() throws Exception {
-    enableAnalyticsAccelerator(getConfiguration());
-    testRenameFile();
-  }
-
-  /**
-   * Tests the creation and listing of encrypted files when Analytics Accelerator is enabled.
-   *
-   * @throws Exception if any error occurs during the test execution
-   */
-  @Test
-  public void testCreateFileAndListStatusEncryptedFileWithAnalyticsAcceleratorEnabled() throws Exception {
-    enableAnalyticsAccelerator(getConfiguration());
-    testListStatusEncryptedFile();
-  }
-
-  /**
-   * Tests the creation and deletion of an encrypted object using a different key
-   * when Analytics Accelerator is enabled.t.
-   *
-   * @throws Exception if any error occurs during the test execution
-   */
-  @Test
-  public void testCreateFileAndDeleteEncryptedObjectWithDifferentKeyWithAnalyticsAcceleratorEnabled() throws Exception {
-    enableAnalyticsAccelerator(getConfiguration());
-    testDeleteEncryptedObjectWithDifferentKey();
-  }
 
   private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws
       IOException {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AEncryptionSSEC.java
@@ -352,7 +352,7 @@ public class ITestS3AEncryptionSSEC extends AbstractTestS3AEncryption {
         SERVICE_AMAZON_S3_STATUS_CODE_403,
         () -> fsKeyB.getFileChecksum(path));
   }
-  
+
   private S3AFileSystem createNewFileSystemWithSSECKey(String sseCKey) throws
       IOException {
     Configuration conf = this.createConfiguration();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ITestS3AHugeFilesSSECDiskBlocks.java
@@ -34,7 +34,6 @@ import static org.apache.hadoop.fs.s3a.Constants.S3_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM;
 import static org.apache.hadoop.fs.s3a.Constants.SERVER_SIDE_ENCRYPTION_KEY;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfEncryptionTestsDisabled;
 
 /**
@@ -60,8 +59,6 @@ public class ITestS3AHugeFilesSSECDiskBlocks
   public void setup() throws Exception {
     try {
       super.setup();
-      skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-          "Analytics Accelerator currently does not support SSE-C");
     } catch (AccessDeniedException | AWSUnsupportedFeatureException e) {
       skip("Bucket does not allow " + S3AEncryptionMethods.SSE_C + " encryption method");
     }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Based off of https://github.com/apache/hadoop/pull/7738/files, continuing the work here.

### How was this patch tested?

tested in eu-west-1, with AAL enabled and encryption method set to SSE-C.

All good, other than failures when reading from a public bucket with SSE-C enabled.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

