### PR TITLE
HADOOP-19667: Clarify constraints for hadoop.security.crypto.buffer.size (min=512; floor to cipher block size)

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/TransparentEncryption.md
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/TransparentEncryption.md
@@ -133,7 +133,7 @@ The JCE provider name used in CryptoCodec.
 
 Default: `8192`
 
-The buffer size used by CryptoInputStream and CryptoOutputStream.
+The buffer size used by CryptoInputStream and CryptoOutputStream. Minimum is 512 bytes; the effective value is floored to the nearest multiple of the cipher algorithm block size.
 
 ### Namenode configuration
 


### PR DESCRIPTION
### Description of PR

Docs-only change to **TransparentEncryption.md** clarifying the hidden constraints for
`hadoop.security.crypto.buffer.size`:

- **Minimum value is 512 bytes** (values <512 throw `IllegalArgumentException` at stream construction).
- **Block alignment:** the effective value is **floored** to the nearest multiple of the cipher algorithm
  **block size** (e.g., 16 for AES/CTR/NoPadding). Examples: `4100 -> 4096`, `8195 -> 8192`.

This is a minimal wording update (single-sentence addition) to avoid operator surprise, with no behavior change.

**Target branch:** `trunk` (per contributor guide)

**JIRA:** HADOOP-19667

**Files changed:**
- `hadoop-hdfs-project/hadoop-hdfs/src/site/markdown/TransparentEncryption.md`

### How was this patch tested?

- Docs-only; built site/module locally to validate formatting:
