### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part15.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/MetricsAsserts.java
@@ -449,8 +449,8 @@ public class MetricsAsserts {
    */
   public static void assertTag(String name, String expected,
       MetricsRecordBuilder rb) {
-    assertEquals("Bad Tag for metric " + name,
-        expected, getStringTag(name, rb));
+    assertEquals(expected, getStringTag(name, rb),
+        "Bad Tag for metric " + name);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdfs.qjournal.client;
 import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.FAKE_NSINFO;
 import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.JID;
 import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.writeSegment;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Closeable;
@@ -257,9 +257,8 @@ public class TestQJMWithFaults {
             checkException(t);
             continue;
           }
-          assertTrue("Recovered only up to txnid " + recovered +
-              " but had gotten an ack for " + lastAcked,
-              recovered >= lastAcked);
+          assertTrue(recovered >= lastAcked, "Recovered only up to txnid " + recovered
+              + " but had gotten an ack for " + lastAcked);
           
           txid = recovered + 1;
           

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
@@ -24,11 +24,11 @@ import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.writeSegment;
 import static org.apache.hadoop.hdfs.qjournal.QJMTestUtil.writeTxns;
 import static org.apache.hadoop.hdfs.qjournal.client.SpyQJournalUtil.spyGetJournaledEdits;
 import static org.apache.hadoop.hdfs.qjournal.client.TestQuorumJournalManagerUnit.futureThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import java.io.Closeable;
 import java.io.File;
@@ -46,9 +46,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hdfs.server.common.Util;
 import org.apache.hadoop.hdfs.server.protocol.RemoteEditLogManifest;
 import org.apache.hadoop.net.MockDomainNameResolver;
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.SettableFuture;
 import org.apache.hadoop.util.Lists;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,11 +71,10 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeLayoutVersion;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine2;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
 
@@ -98,10 +99,11 @@ public class TestQuorumJournalManager {
     GenericTestUtils.setLogLevel(ProtobufRpcEngine2.LOG, Level.TRACE);
   }
 
-  @Rule
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName name = new TestName();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new Configuration();
     if (!name.getMethodName().equals("testSelectThreadCounts")) {
@@ -127,7 +129,7 @@ public class TestQuorumJournalManager {
     assertEquals(1, qjm.getLoggerSetForTests().getEpoch());
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException, InterruptedException,
       TimeoutException {
     IOUtils.cleanupWithLogger(LOG, toClose.toArray(new Closeable[0]));
@@ -808,7 +810,8 @@ public class TestQuorumJournalManager {
     }
   }
   
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testCrashBetweenSyncLogAndPersistPaxosData() throws Exception {
     JournalFaultInjector faultInjector =
         JournalFaultInjector.instance = Mockito.mock(JournalFaultInjector.class);
@@ -1073,8 +1076,8 @@ public class TestQuorumJournalManager {
         .filter((t) -> t.getName().contains(expectedName)).count();
     // The number of threads for the stopped jn shouldn't be more than the
     // configured value.
-    assertTrue("Number of threads are : " + num,
-        num <= DFSConfigKeys.DFS_QJOURNAL_PARALLEL_READ_NUM_THREADS_DEFAULT);
+    assertTrue(num <= DFSConfigKeys.DFS_QJOURNAL_PARALLEL_READ_NUM_THREADS_DEFAULT,
+        "Number of threads are : " + num);
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.qjournal.server;
 
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Bytes;
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 import org.apache.hadoop.conf.Configuration;
@@ -40,13 +41,13 @@ import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StopWatch;
-import org.junit.After;
-import org.junit.Assert;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -62,7 +63,9 @@ import java.util.concurrent.TimeUnit;
 public class TestJournalNode {
   private static final NamespaceInfo FAKE_NSINFO = new NamespaceInfo(
       12345, "mycluster", "my-bp", 0L);
-  @Rule
+
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName testName = new TestName();
 
   private static final File TEST_BUILD_DATA = PathUtils.getTestDir(TestJournalNode.class);
@@ -78,7 +81,7 @@ public class TestJournalNode {
     DefaultMetricsSystem.setMiniClusterMode(true);
   }
   
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     File editsDir = new File(MiniDFSCluster.getBaseDirectory() +
         File.separator + "TestJournalNode");
@@ -194,12 +197,13 @@ public class TestJournalNode {
         "qjournal://journalnode0:9900;journalnode1:9901/test-journalid-ns2");
   }
   
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     jn.stop(0);
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testJournalDirPerNameSpace() {
     Collection<String> nameServiceIds = DFSUtilClient.getNameServiceIds(conf);
     setupStaticHostResolution(2, "journalnode");
@@ -214,7 +218,8 @@ public class TestJournalNode {
     }
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testJournalCommonDirAcrossNameSpace() {
     Collection<String> nameServiceIds = DFSUtilClient.getNameServiceIds(conf);
     setupStaticHostResolution(2, "journalnode");
@@ -228,7 +233,8 @@ public class TestJournalNode {
     }
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testJournalDefaultDirForOneNameSpace() {
     Collection<String> nameServiceIds = DFSUtilClient.getNameServiceIds(conf);
     setupStaticHostResolution(2, "journalnode");
@@ -247,7 +253,8 @@ public class TestJournalNode {
     assertEquals(editsDir.toString(), journalStorage.getRoot().toString());
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testJournalMetricTags() {
     setupStaticHostResolution(2, "journalnode");
     String jid = "test-journalid-ns1";
@@ -263,7 +270,8 @@ public class TestJournalNode {
     MetricsAsserts.assertTag("JournalId", jid, metrics);
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testJournal() throws Exception {
     MetricsRecordBuilder metrics = MetricsAsserts.getMetrics(
         journal.getMetrics().getName());
@@ -305,7 +313,8 @@ public class TestJournalNode {
   }
   
   
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testReturnsSegmentInfoAtEpochTransition() throws Exception {
     ch.newEpoch(1).get();
     ch.setEpoch(1);
@@ -333,15 +342,15 @@ public class TestJournalNode {
     assertEquals(1, response.getLastSegmentTxId());
   }
   
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testHttpServer() throws Exception {
     String urlRoot = jn.getHttpServerURI();
     
     // Check default servlets.
     String pageContents = DFSTestUtil.urlGet(new URL(urlRoot + "/jmx"));
-    assertTrue("Bad contents: " + pageContents,
-        pageContents.contains(
-            "Hadoop:service=JournalNode,name=JvmMetrics"));
+    assertTrue(pageContents.contains("Hadoop:service=JournalNode,name=JvmMetrics"),
+        "Bad contents: " + pageContents);
 
     // Create some edits on server side
     byte[] EDITS_DATA = QJMTestUtil.createTxnData(1, 3);
@@ -379,7 +388,8 @@ public class TestJournalNode {
    * Test that the JournalNode performs correctly as a Paxos
    * <em>Acceptor</em> process.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testAcceptRecoveryBehavior() throws Exception {
     // We need to run newEpoch() first, or else we have no way to distinguish
     // different proposals for the same decision.
@@ -439,7 +449,8 @@ public class TestJournalNode {
     }
   }
   
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testFailToStartWithBadConfig() throws Exception {
     Configuration conf = new Configuration();
     conf.set(DFSConfigKeys.DFS_JOURNALNODE_EDITS_DIR_KEY, "non-absolute-path");
@@ -482,7 +493,8 @@ public class TestJournalNode {
    * At the time of development, this test ran in ~4sec on an
    * SSD-enabled laptop (1.8ms/batch).
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testPerformance() throws Exception {
     doPerfTest(8192, 1024); // 8MB
   }
@@ -532,18 +544,14 @@ public class TestJournalNode {
     //JournalSyncer will not be started, as journalsync is not enabled
     conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_KEY, false);
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId still journalnodesyncer should not start
     // IstriedJournalSyncerStartWithnsId should also be false
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -553,20 +561,16 @@ public class TestJournalNode {
     //JournalSyncer will not be started,
     // as shared edits hostnames are not resolved
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId, now
     // IstriedJournalSyncerStartWithnsId should be set
     // but journalnode syncer will not be started,
     // as hostnames are not resolved
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(true,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -576,20 +580,16 @@ public class TestJournalNode {
     //JournalSyncer will not be started,
     // as shared edits hostnames are not resolved
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
     setupStaticHostResolution(2, "jn");
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assert.assertEquals(true,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(true,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -601,20 +601,16 @@ public class TestJournalNode {
     // but configured shared edits dir is appended with nameserviceId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assert.assertEquals(true,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(true,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
   @Test
@@ -625,20 +621,16 @@ public class TestJournalNode {
     // namenodeId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assert.assertEquals(true,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(true,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
   @Test
@@ -650,10 +642,8 @@ public class TestJournalNode {
     // namenodeId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(false,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should  be set
@@ -661,10 +651,8 @@ public class TestJournalNode {
     // as for each nnId, different shared Edits dir value is configured
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assert.assertEquals(false,
-        jn.getJournalSyncerStatus(journalId));
-    Assert.assertEquals(true,
-        jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
 
@@ -694,8 +682,6 @@ public class TestJournalNode {
         DFSConfigKeys.DFS_JOURNALNODE_HANDLER_COUNT_DEFAULT);
     assertTrue(confHandlerCount <= 0);
     int handlerCount = jn.getRpcServer().getHandlerCount();
-    assertEquals(
-        DFSConfigKeys.DFS_JOURNALNODE_HANDLER_COUNT_DEFAULT,
-        handlerCount);
+    assertEquals(DFSConfigKeys.DFS_JOURNALNODE_HANDLER_COUNT_DEFAULT, handlerCount);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNode.java
@@ -42,8 +42,6 @@ import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StopWatch;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -58,6 +56,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class TestJournalNode {
@@ -544,14 +548,14 @@ public class TestJournalNode {
     //JournalSyncer will not be started, as journalsync is not enabled
     conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_KEY, false);
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId still journalnodesyncer should not start
     // IstriedJournalSyncerStartWithnsId should also be false
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -561,16 +565,16 @@ public class TestJournalNode {
     //JournalSyncer will not be started,
     // as shared edits hostnames are not resolved
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId, now
     // IstriedJournalSyncerStartWithnsId should be set
     // but journalnode syncer will not be started,
     // as hostnames are not resolved
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -580,16 +584,16 @@ public class TestJournalNode {
     //JournalSyncer will not be started,
     // as shared edits hostnames are not resolved
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
     setupStaticHostResolution(2, "jn");
     jn.getOrCreateJournal(journalId, "mycluster");
-    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
   }
 
@@ -601,16 +605,16 @@ public class TestJournalNode {
     // but configured shared edits dir is appended with nameserviceId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
   @Test
@@ -621,16 +625,16 @@ public class TestJournalNode {
     // namenodeId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should be set
     // and also journalnode syncer will also be started
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assertions.assertEquals(true, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(true, jn.getJournalSyncerStatus(journalId));
+    assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
   @Test
@@ -642,8 +646,8 @@ public class TestJournalNode {
     // namenodeId
     setupStaticHostResolution(2, "journalnode");
     jn.getOrCreateJournal(journalId);
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(false, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
 
     //Trying by passing nameserviceId and resolve hostnames
     // now IstriedJournalSyncerStartWithnsId should  be set
@@ -651,8 +655,8 @@ public class TestJournalNode {
     // as for each nnId, different shared Edits dir value is configured
 
     jn.getOrCreateJournal(journalId, "ns1");
-    Assertions.assertEquals(false, jn.getJournalSyncerStatus(journalId));
-    Assertions.assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
+    assertEquals(false, jn.getJournalSyncerStatus(journalId));
+    assertEquals(true, jn.getJournal(journalId).getTriedJournalSyncerStartedwithnsId());
   }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -38,6 +38,8 @@ import static org.apache.hadoop.hdfs.server.namenode.FileJournalManager
     .getLogFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -141,8 +143,8 @@ public class TestJournalNodeSync {
   public void testJournalNodeSync() throws Exception {
 
     //As by default 3 journal nodes are started;
-    for(int i=0; i<3; i++) {
-        assertEquals(true, jCluster.getJournalNode(i).getJournalSyncerStatus("ns1"));
+    for (int i = 0; i < 3; i++) {
+      assertEquals(true, jCluster.getJournalNode(i).getJournalSyncerStatus("ns1"));
     }
 
     File firstJournalDir = jCluster.getJournalDir(0, jid);
@@ -360,7 +362,7 @@ public class TestJournalNodeSync {
     // JournalNodeSyncer alone (as the edit log queueing has been disabled)
     long numEditLogsSynced = jCluster.getJournalNode(0).getOrCreateJournal(jid)
         .getMetrics().getNumEditLogsSynced().value();
-    Assertions.assertTrue(numEditLogsSynced >= 8,
+    assertTrue(numEditLogsSynced >= 8,
         "Edit logs downloaded outside syncer. Expected 8 or " + "more downloads, got "
             + numEditLogsSynced + " downloads instead");
   }
@@ -461,8 +463,8 @@ public class TestJournalNodeSync {
     standbyNNindex=((activeNNindex+1)%2);
     dfsActive = dfsCluster.getFileSystem(activeNNindex);
 
-    Assertions.assertTrue(dfsCluster.getNameNode(activeNNindex).isActiveState());
-    Assertions.assertFalse(dfsCluster.getNameNode(standbyNNindex).isActiveState());
+    assertTrue(dfsCluster.getNameNode(activeNNindex).isActiveState());
+    assertFalse(dfsCluster.getNameNode(standbyNNindex).isActiveState());
 
     // Restart the current standby NN (previously active)
     dfsCluster.restartNameNode(standbyNNindex, true,
@@ -479,12 +481,12 @@ public class TestJournalNodeSync {
     //finalize rolling upgrade
     final RollingUpgradeInfo finalize = dfsActive.rollingUpgrade(
         HdfsConstants.RollingUpgradeAction.FINALIZE);
-    Assertions.assertTrue(finalize.isFinalized());
+    assertTrue(finalize.isFinalized());
 
     // Check the missing edit logs exist after finalizing rolling upgrade
     for (File editLog : missingLogs) {
-        Assertions.assertTrue(editLog.exists(),
-            "Edit log missing after finalizing rolling upgrade");
+      assertTrue(editLog.exists(),
+          "Edit log missing after finalizing rolling upgrade");
     }
   }
 
@@ -524,7 +526,7 @@ public class TestJournalNodeSync {
       logFile = getLogFile(currentDir, startTxId);
     }
     File deleteFile = logFile.getFile();
-    Assertions.assertTrue(deleteFile.delete(), "Couldn't delete edit log file");
+    assertTrue(deleteFile.delete(), "Couldn't delete edit log file");
 
     return deleteFile;
   }
@@ -599,7 +601,7 @@ public class TestJournalNodeSync {
     long lastWrittenTxId = dfsCluster.getNameNode(activeNNindex).getFSImage()
         .getEditLog().getLastWrittenTxId();
     for (int i = 1; i <= numEdits; i++) {
-        Assertions.assertTrue(doAnEdit(), "Failed to do an edit");
+      assertTrue(doAnEdit(), "Failed to do an edit");
     }
     dfsCluster.getNameNode(activeNNindex).getRpcServer().rollEditLog();
     return lastWrittenTxId;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournalNodeSync.java
@@ -37,17 +37,18 @@ import org.apache.hadoop.hdfs.server.namenode.FileJournalManager.EditLogFile;
 import static org.apache.hadoop.hdfs.server.namenode.FileJournalManager
     .getLogFile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.hdfs.server.protocol.NamespaceInfo;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.TestName;
 import org.apache.hadoop.util.Lists;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,10 +69,11 @@ public class TestJournalNodeSync {
   private int activeNNindex=0;
   private static final int DFS_HA_TAILEDITS_PERIOD_SECONDS=1;
 
-  @Rule
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @RegisterExtension
   public TestName testName = new TestName();
 
-  @Before
+  @BeforeEach
   public void setUpMiniCluster() throws IOException {
     conf = new HdfsConfiguration();
     conf.setBoolean(DFSConfigKeys.DFS_JOURNALNODE_ENABLE_SYNC_KEY, true);
@@ -94,7 +96,7 @@ public class TestJournalNodeSync {
     namesystem = dfsCluster.getNamesystem(0);
   }
 
-  @After
+  @AfterEach
   public void shutDownMiniCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
@@ -134,13 +136,13 @@ public class TestJournalNodeSync {
     assertEquals(2, boundHostAddrList.size());
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testJournalNodeSync() throws Exception {
 
     //As by default 3 journal nodes are started;
     for(int i=0; i<3; i++) {
-      assertEquals(true,
-          jCluster.getJournalNode(i).getJournalSyncerStatus("ns1"));
+        assertEquals(true, jCluster.getJournalNode(i).getJournalSyncerStatus("ns1"));
     }
 
     File firstJournalDir = jCluster.getJournalDir(0, jid);
@@ -159,7 +161,8 @@ public class TestJournalNodeSync {
         500, 10000);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSyncForMultipleMissingLogs() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -176,7 +179,8 @@ public class TestJournalNodeSync {
     GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 10000);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testSyncForDiscontinuousMissingLogs() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -194,7 +198,8 @@ public class TestJournalNodeSync {
     GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 10000);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testMultipleJournalsMissingLogs() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -215,7 +220,8 @@ public class TestJournalNodeSync {
     GenericTestUtils.waitFor(editLogExists(missingLogs), 500, 10000);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testMultipleJournalsMultipleMissingLogs() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -245,7 +251,8 @@ public class TestJournalNodeSync {
 
   // Test JournalNode Sync by randomly deleting edit logs from one or two of
   // the journals.
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRandomJournalMissingLogs() throws Exception {
     List<File> missingLogs = deleteEditLogsFromRandomJN();
 
@@ -254,7 +261,8 @@ public class TestJournalNodeSync {
 
   // Test JournalNode Sync when a JN id down while NN is actively writing
   // logs and comes back up after some time.
-  @Test (timeout=300_000)
+  @Test
+  @Timeout(value = 300)
   public void testSyncAfterJNdowntime() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -301,7 +309,8 @@ public class TestJournalNodeSync {
    * Queuing disabled during the cluster setup {@link #setUpMiniCluster()}
    * @throws Exception
    */
-  @Test (timeout=300_000)
+  @Test
+  @Timeout(value = 300)
   public void testSyncAfterJNdowntimeWithoutQJournalQueue() throws Exception{
     // QJournal Queuing is disabled during the cluster setup
     // {@link #setUpMiniCluster()}
@@ -351,14 +360,15 @@ public class TestJournalNodeSync {
     // JournalNodeSyncer alone (as the edit log queueing has been disabled)
     long numEditLogsSynced = jCluster.getJournalNode(0).getOrCreateJournal(jid)
         .getMetrics().getNumEditLogsSynced().value();
-    Assert.assertTrue("Edit logs downloaded outside syncer. Expected 8 or " +
-            "more downloads, got " + numEditLogsSynced + " downloads instead",
-        numEditLogsSynced >= 8);
+    Assertions.assertTrue(numEditLogsSynced >= 8,
+        "Edit logs downloaded outside syncer. Expected 8 or " + "more downloads, got "
+            + numEditLogsSynced + " downloads instead");
   }
 
   // Test JournalNode Sync when a JN is formatted while NN is actively writing
   // logs.
-  @Test (timeout=300_000)
+  @Test
+  @Timeout(value = 300)
   public void testSyncAfterJNformat() throws Exception{
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -404,7 +414,8 @@ public class TestJournalNodeSync {
   }
 
   // Test JournalNode Sync during a Rolling Upgrade of NN.
-  @Test (timeout=300_000)
+  @Test
+  @Timeout(value = 300)
   public void testSyncDuringRollingUpgrade() throws Exception {
 
     DistributedFileSystem dfsActive;
@@ -424,14 +435,12 @@ public class TestJournalNodeSync {
           HdfsConstants.RollingUpgradeAction.PREPARE);
 
     //query rolling upgrade
-    assertEquals(info, dfsActive.rollingUpgrade(
-        HdfsConstants.RollingUpgradeAction.QUERY));
+    assertEquals(info, dfsActive.rollingUpgrade(HdfsConstants.RollingUpgradeAction.QUERY));
 
     // Restart the Standby NN with rollingUpgrade option
     dfsCluster.restartNameNode(standbyNNindex, true,
         "-rollingUpgrade", "started");
-    assertEquals(info, dfsActive.rollingUpgrade(
-        HdfsConstants.RollingUpgradeAction.QUERY));
+    assertEquals(info, dfsActive.rollingUpgrade(HdfsConstants.RollingUpgradeAction.QUERY));
 
     // Do some edits and delete some edit logs
     List<File> missingLogs = deleteEditLogsFromRandomJN();
@@ -452,14 +461,13 @@ public class TestJournalNodeSync {
     standbyNNindex=((activeNNindex+1)%2);
     dfsActive = dfsCluster.getFileSystem(activeNNindex);
 
-    Assert.assertTrue(dfsCluster.getNameNode(activeNNindex).isActiveState());
-    Assert.assertFalse(dfsCluster.getNameNode(standbyNNindex).isActiveState());
+    Assertions.assertTrue(dfsCluster.getNameNode(activeNNindex).isActiveState());
+    Assertions.assertFalse(dfsCluster.getNameNode(standbyNNindex).isActiveState());
 
     // Restart the current standby NN (previously active)
     dfsCluster.restartNameNode(standbyNNindex, true,
         "-rollingUpgrade", "started");
-    assertEquals(info, dfsActive.rollingUpgrade(
-        HdfsConstants.RollingUpgradeAction.QUERY));
+    assertEquals(info, dfsActive.rollingUpgrade(HdfsConstants.RollingUpgradeAction.QUERY));
     dfsCluster.waitActive();
 
     // Do some edits and delete some edit logs
@@ -471,16 +479,17 @@ public class TestJournalNodeSync {
     //finalize rolling upgrade
     final RollingUpgradeInfo finalize = dfsActive.rollingUpgrade(
         HdfsConstants.RollingUpgradeAction.FINALIZE);
-    Assert.assertTrue(finalize.isFinalized());
+    Assertions.assertTrue(finalize.isFinalized());
 
     // Check the missing edit logs exist after finalizing rolling upgrade
     for (File editLog : missingLogs) {
-      Assert.assertTrue("Edit log missing after finalizing rolling upgrade",
-          editLog.exists());
+        Assertions.assertTrue(editLog.exists(),
+            "Edit log missing after finalizing rolling upgrade");
     }
   }
 
-  @Test(timeout=300_000)
+  @Test
+  @Timeout(value = 300)
   public void testFormatWithSyncer() throws Exception {
     File firstJournalDir = jCluster.getJournalDir(0, jid);
     File firstJournalCurrentDir = new StorageDirectory(firstJournalDir)
@@ -515,7 +524,7 @@ public class TestJournalNodeSync {
       logFile = getLogFile(currentDir, startTxId);
     }
     File deleteFile = logFile.getFile();
-    Assert.assertTrue("Couldn't delete edit log file", deleteFile.delete());
+    Assertions.assertTrue(deleteFile.delete(), "Couldn't delete edit log file");
 
     return deleteFile;
   }
@@ -590,7 +599,7 @@ public class TestJournalNodeSync {
     long lastWrittenTxId = dfsCluster.getNameNode(activeNNindex).getFSImage()
         .getEditLog().getLastWrittenTxId();
     for (int i = 1; i <= numEdits; i++) {
-      Assert.assertTrue("Failed to do an edit", doAnEdit());
+        Assertions.assertTrue(doAnEdit(), "Failed to do an edit");
     }
     dfsCluster.getNameNode(activeNNindex).getRpcServer().rollEditLog();
     return lastWrittenTxId;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapAliasmap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapAliasmap.java
@@ -30,15 +30,15 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.TransferFsImage;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URL;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test for aliasmap bootstrap.
@@ -47,7 +47,7 @@ public class TestBootstrapAliasmap {
 
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration conf = new Configuration();
     MiniDFSCluster.setupNamenodeProvidedConfiguration(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.server.namenode.ha.BootstrapStandby.ERR_CODE_INVALID_VERSION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -57,9 +57,10 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
@@ -73,7 +74,7 @@ public class TestBootstrapStandby {
   private MiniDFSCluster cluster;
   private NameNode nn0;
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws IOException {
     Configuration conf = new Configuration();
 
@@ -100,7 +101,7 @@ public class TestBootstrapStandby {
     }
   }
 
-  @After
+  @AfterEach
   public void shutdownCluster() {
     if (cluster != null) {
       cluster.shutdown();
@@ -178,8 +179,7 @@ public class TestBootstrapStandby {
     FSImageTestUtil.assertNNFilesMatch(cluster);
 
     // Make sure the seen_txid was not modified by the standby
-    assertEquals(seen_txid_shared,
-        FSImageTestUtil.getStorageTxId(nn0, editsUri));
+    assertEquals(seen_txid_shared, FSImageTestUtil.getStorageTxId(nn0, editsUri));
 
     // We should now be able to start the standby successfully.
     restartNameNodesFromIndex(1);
@@ -211,8 +211,8 @@ public class TestBootstrapStandby {
     // BootstrapStandby should fail if the node has a future version
     // and the cluster isn't in rolling upgrade
     bs.setConf(cluster.getConfiguration(2));
-    assertEquals("BootstrapStandby should return ERR_CODE_INVALID_VERSION",
-        ERR_CODE_INVALID_VERSION, bs.run(new String[]{"-force"}));
+    assertEquals(ERR_CODE_INVALID_VERSION, bs.run(new String[] { "-force" }),
+        "BootstrapStandby should return ERR_CODE_INVALID_VERSION");
 
     // Start rolling upgrade
     fs.rollingUpgrade(RollingUpgradeAction.PREPARE);
@@ -268,10 +268,9 @@ public class TestBootstrapStandby {
 
     for (int i = 1; i < maxNNCount; i++) {
       NameNode nn = cluster.getNameNode(i);
-      assertTrue("NameNodes should all have the rollback FSImage",
-          nn.getFSImage().hasRollbackFSImage());
-      assertTrue("NameNodes should all be inRollingUpgrade",
-          nn.getNamesystem().isRollingUpgrade());
+      assertTrue(nn.getFSImage().hasRollbackFSImage(),
+          "NameNodes should all have the rollback FSImage");
+      assertTrue(nn.getNamesystem().isRollingUpgrade(), "NameNodes should all be inRollingUpgrade");
     }
 
     // Cleanup standby dirs
@@ -291,14 +290,20 @@ public class TestBootstrapStandby {
 
     for (int i = 1; i < maxNNCount; i++) {
       bs.setConf(cluster.getConfiguration(i));
-      assertThrows("BootstrapStandby should fail the image transfer request",
-          HttpGetFailedException.class, () -> {
+      assertThrows(
+          HttpGetFailedException.class,
+          () -> {
             try {
               bs.run(new String[]{"-force"});
             } catch (RuntimeException e) {
-              throw e.getCause();
+              // 和原来一样，把包装的 cause 抛出来以匹配期望异常类型
+              Throwable cause = e.getCause();
+              if (cause != null) throw cause;
+              throw e; // 没有 cause 就把原异常抛出
             }
-          });
+          },
+          "BootstrapStandby should fail the image transfer request"
+      );
     }
   }
 
@@ -359,7 +364,8 @@ public class TestBootstrapStandby {
    * Test that, even if the other node is not active, we are able
    * to bootstrap standby from it.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testOtherNodeNotActive() throws Exception {
     cluster.transitionToStandby(0);
     assertSuccessfulBootstrapFromIndex(1);
@@ -371,7 +377,8 @@ public class TestBootstrapStandby {
    * {@link DFSConfigKeys#DFS_IMAGE_TRANSFER_BOOTSTRAP_STANDBY_RATE_KEY}
    * created by HDFS-8808.
    */
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testRateThrottling() throws Exception {
     cluster.getConfiguration(0).setLong(
         DFSConfigKeys.DFS_IMAGE_TRANSFER_RATE_KEY, 1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
@@ -211,7 +211,7 @@ public class TestBootstrapStandby {
     // BootstrapStandby should fail if the node has a future version
     // and the cluster isn't in rolling upgrade
     bs.setConf(cluster.getConfiguration(2));
-    assertEquals(ERR_CODE_INVALID_VERSION, bs.run(new String[] { "-force" }),
+    assertEquals(ERR_CODE_INVALID_VERSION, bs.run(new String[]{"-force"}),
         "BootstrapStandby should return ERR_CODE_INVALID_VERSION");
 
     // Start rolling upgrade
@@ -296,10 +296,9 @@ public class TestBootstrapStandby {
             try {
               bs.run(new String[]{"-force"});
             } catch (RuntimeException e) {
-              // 和原来一样，把包装的 cause 抛出来以匹配期望异常类型
               Throwable cause = e.getCause();
               if (cause != null) throw cause;
-              throw e; // 没有 cause 就把原异常抛出
+              throw e;
             }
           },
           "BootstrapStandby should fail the image transfer request"

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandby.java
@@ -297,7 +297,9 @@ public class TestBootstrapStandby {
               bs.run(new String[]{"-force"});
             } catch (RuntimeException e) {
               Throwable cause = e.getCause();
-              if (cause != null) throw cause;
+              if (cause != null) {
+                throw cause;
+              }
               throw e;
             }
           },

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandbyWithQJM.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestBootstrapStandbyWithQJM.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,9 +34,9 @@ import org.apache.hadoop.hdfs.server.namenode.FSImage;
 import org.apache.hadoop.hdfs.server.namenode.FSImageTestUtil;
 import org.apache.hadoop.hdfs.server.namenode.NNStorage;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
@@ -64,7 +64,7 @@ public class TestBootstrapStandbyWithQJM {
     return conf;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration conf = createConfig();
 
@@ -82,7 +82,7 @@ public class TestBootstrapStandbyWithQJM {
     dfs.close();
   }
   
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -63,7 +64,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Test consistency of reads while accessing an ObserverNode.
@@ -252,10 +252,10 @@ public class TestConsistentReadsObserver {
 
   @Test
   public void testAutoMsyncLongPeriod() throws Exception {
-      Assertions.assertThrows(TimeoutException.class, () -> {
-          testMsync(true, Long.MAX_VALUE);
-      });
-      // This should fail since the auto-msync is never activated
+    assertThrows(TimeoutException.class, () -> {
+      testMsync(true, Long.MAX_VALUE);
+    });
+    // This should fail since the auto-msync is never activated
   }
 
   // A new client should first contact the active, before using an observer,
@@ -479,8 +479,8 @@ public class TestConsistentReadsObserver {
   }
 
   private void assertSentTo(int nnIdx) throws IOException {
-      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
-          "Request was not sent to the expected namenode " + nnIdx);
+    assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
+        "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private DistributedFileSystem setObserverRead(boolean flag) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestConsistentReadsObserver.java
@@ -21,9 +21,9 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_EN
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -55,13 +55,15 @@ import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Test consistency of reads while accessing an ObserverNode.
@@ -78,7 +80,7 @@ public class TestConsistentReadsObserver {
 
   private final Path testPath= new Path("/TestConsistentReadsObserver");
 
-  @BeforeClass
+  @BeforeAll
   public static void startUpCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
@@ -90,17 +92,17 @@ public class TestConsistentReadsObserver {
     dfsCluster = qjmhaCluster.getDfsCluster();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     dfs = setObserverRead(true);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     dfs.delete(testPath, true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDownCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
@@ -248,10 +250,12 @@ public class TestConsistentReadsObserver {
     testMsync(true, 5);
   }
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testAutoMsyncLongPeriod() throws Exception {
-    // This should fail since the auto-msync is never activated
-    testMsync(true, Long.MAX_VALUE);
+      Assertions.assertThrows(TimeoutException.class, () -> {
+          testMsync(true, Long.MAX_VALUE);
+      });
+      // This should fail since the auto-msync is never activated
   }
 
   // A new client should first contact the active, before using an observer,
@@ -389,20 +393,20 @@ public class TestConsistentReadsObserver {
       fail("listStatus should have thrown exception");
     } catch (RemoteException re) {
       IOException e = re.unwrapRemoteException();
-      assertTrue("should have thrown StandbyException but got "
-              + e.getClass().getSimpleName(),
-          e instanceof StandbyException);
+      assertTrue(e instanceof StandbyException,
+          "should have thrown StandbyException but got " + e.getClass().getSimpleName());
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testMsyncFileContext() throws Exception {
     NameNode nn0 = dfsCluster.getNameNode(0);
     NameNode nn2 = dfsCluster.getNameNode(2);
     HAServiceStatus st = nn0.getRpcServer().getServiceStatus();
-    assertEquals("nn0 is not active", HAServiceState.ACTIVE, st.getState());
+    assertEquals(HAServiceState.ACTIVE, st.getState(), "nn0 is not active");
     st = nn2.getRpcServer().getServiceStatus();
-    assertEquals("nn2 is not observer", HAServiceState.OBSERVER, st.getState());
+    assertEquals(HAServiceState.OBSERVER, st.getState(), "nn2 is not observer");
 
     FileContext fc = FileContext.getFileContext(conf);
     // initialize observer proxy for FileContext
@@ -475,8 +479,8 @@ public class TestConsistentReadsObserver {
   }
 
   private void assertSentTo(int nnIdx) throws IOException {
-    assertTrue("Request was not sent to the expected namenode " + nnIdx,
-        HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx));
+      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
+          "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private DistributedFileSystem setObserverRead(boolean flag) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
@@ -132,9 +132,9 @@ public class TestDFSUpgradeWithHA {
       boolean shouldExist) {
     File previousDir = new File(rootDir, "previous");
     if (shouldExist) {
-        assertTrue(previousDir.exists(), previousDir + " does not exist");
+      assertTrue(previousDir.exists(), previousDir + " does not exist");
     } else {
-        assertFalse(previousDir.exists(), previousDir + " does exist");
+      assertFalse(previousDir.exists(), previousDir + " does exist");
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDFSUpgradeWithHA.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +50,8 @@ import org.apache.hadoop.hdfs.util.BestEffortLongFile;
 import org.apache.hadoop.hdfs.util.PersistentLongFile;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
@@ -65,7 +65,7 @@ public class TestDFSUpgradeWithHA {
   
   private Configuration conf;
   
-  @Before
+  @BeforeEach
   public void createConfiguration() {
     conf = new HdfsConfiguration();
     // Turn off persistent IPC, so that the DFSClient can survive NN restart
@@ -121,8 +121,8 @@ public class TestDFSUpgradeWithHA {
           PersistentLongFile prevLongFile = new PersistentLongFile(prevFile, -10);
           PersistentLongFile currLongFile = new PersistentLongFile(new File(currDir,
               fileName), -11);
-          assertTrue("Value in " + fileName + " has decreased on upgrade in "
-              + journalDir, prevLongFile.get() <= currLongFile.get());
+          assertTrue(prevLongFile.get() <= currLongFile.get(),
+              "Value in " + fileName + " has decreased on upgrade in " + journalDir);
         }
       }
     }
@@ -132,9 +132,9 @@ public class TestDFSUpgradeWithHA {
       boolean shouldExist) {
     File previousDir = new File(rootDir, "previous");
     if (shouldExist) {
-      assertTrue(previousDir + " does not exist", previousDir.exists());
+        assertTrue(previousDir.exists(), previousDir + " does not exist");
     } else {
-      assertFalse(previousDir + " does exist", previousDir.exists());
+        assertFalse(previousDir.exists(), previousDir + " does exist");
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencing.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencing.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
@@ -59,9 +59,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
@@ -85,7 +85,7 @@ public class TestDNFencing {
     DFSTestUtil.setNameNodeLogLevel(Level.TRACE);
   }
   
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, SMALL_BLOCK);
@@ -114,7 +114,7 @@ public class TestDNFencing {
     fs = HATestUtil.configureFailoverFs(cluster, conf);
   }
   
-  @After
+  @AfterEach
   public void shutdownCluster() throws Exception {
     if (cluster != null) {
       banner("Shutting down cluster. NN1 metadata:");
@@ -148,8 +148,7 @@ public class TestDNFencing {
     cluster.transitionToActive(1);
     
     // Check that the standby picked up the replication change.
-    assertEquals(1,
-        nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
+    assertEquals(1, nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
 
     // Dump some info for debugging purposes.
     banner("NN2 Metadata immediately after failover");
@@ -239,8 +238,7 @@ public class TestDNFencing {
     cluster.transitionToActive(1);
 
     // Check that the standby picked up the replication change.
-    assertEquals(1,
-        nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
+    assertEquals(1, nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
 
     // Dump some info for debugging purposes.
     banner("Metadata immediately after failover");
@@ -339,8 +337,7 @@ public class TestDNFencing {
     cluster.transitionToActive(1);
 
     // Check that the standby picked up the replication change.
-    assertEquals(1,
-        nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
+    assertEquals(1, nn2.getRpcServer().getFileInfo(TEST_FILE).getReplication());
 
     // Dump some info for debugging purposes.
     banner("Metadata immediately after failover");
@@ -443,8 +440,8 @@ public class TestDNFencing {
     }
 
     cluster.triggerBlockReports();
-    assertEquals("The queue should only have the latest report for each DN",
-        3, nn2.getNamesystem().getPendingDataNodeMessageCount());
+    assertEquals(3, nn2.getNamesystem().getPendingDataNodeMessageCount(),
+        "The queue should only have the latest report for each DN");
 
     // case 2: append to file and call hflush after write
     try {
@@ -456,8 +453,8 @@ public class TestDNFencing {
       IOUtils.closeStream(out);
       cluster.triggerHeartbeats();
     }
-    assertEquals("The queue should only have the latest report for each DN",
-        3, nn2.getNamesystem().getPendingDataNodeMessageCount());
+    assertEquals(3, nn2.getNamesystem().getPendingDataNodeMessageCount(),
+        "The queue should only have the latest report for each DN");
 
     // case 3: similar to case 2, except no hflush is called.
     try {
@@ -480,8 +477,8 @@ public class TestDNFencing {
 
     cluster.triggerBlockReports();
 
-    assertEquals("The queue should only have the latest report for each DN",
-        3, nn2.getNamesystem().getPendingDataNodeMessageCount());
+    assertEquals(3, nn2.getNamesystem().getPendingDataNodeMessageCount(),
+        "The queue should only have the latest report for each DN");
 
     cluster.transitionToStandby(0);
     cluster.transitionToActive(1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
@@ -32,11 +32,12 @@ import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**
@@ -86,8 +87,8 @@ public class TestDNFencingWithReplication {
             try {
               cluster.waitActive();
               BlockLocation[] blocks = fs.getFileBlockLocations(path, 0, 10);
-                    Assertions.assertEquals(1, blocks.length);
-                    return blocks[0].getHosts().length == replicas;
+              assertEquals(1, blocks.length);
+              return blocks[0].getHosts().length == replicas;
             } catch (IOException e) {
               throw new RuntimeException(e);
             }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDNFencingWithReplication.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
@@ -86,8 +86,8 @@ public class TestDNFencingWithReplication {
             try {
               cluster.waitActive();
               BlockLocation[] blocks = fs.getFileBlockLocations(path, 0, 10);
-              Assert.assertEquals(1, blocks.length);
-              return blocks[0].getHosts().length == replicas;
+                    Assertions.assertEquals(1, blocks.length);
+                    return blocks[0].getHosts().length == replicas;
             } catch (IOException e) {
               throw new RuntimeException(e);
             }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDelegationTokensWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDelegationTokensWithHA.java
@@ -61,7 +61,12 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.OBSERVER_PROBE_RETRY_PERIOD_KEY;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test case for client support of delegation tokens in an HA cluster.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDelegationTokensWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestDelegationTokensWithHA.java
@@ -45,9 +45,10 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.io.ByteArrayInputStream;
@@ -60,7 +61,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.OBSERVER_PROBE_RETRY_PERIOD_KEY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test case for client support of delegation tokens in an HA cluster.
@@ -79,7 +80,7 @@ public class TestDelegationTokensWithHA {
 
   private volatile boolean catchup = false;
   
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     SecurityUtilTestHelper.setTokenServiceUseIp(true);
     
@@ -107,7 +108,7 @@ public class TestDelegationTokensWithHA {
         nn0.getNamesystem());
   }
 
-  @After
+  @AfterEach
   public void shutdownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -119,7 +120,8 @@ public class TestDelegationTokensWithHA {
    * Test that, when using ObserverReadProxyProvider with DT authentication,
    * the ORPP gracefully handles when the Standby NN throws a StandbyException.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testObserverReadProxyProviderWithDT() throws Exception {
     // Make the first node standby, so that the ORPP will try it first
     // instead of just using and succeeding on the active
@@ -160,7 +162,8 @@ public class TestDelegationTokensWithHA {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDelegationTokenDFSApi() throws Exception {
     final Token<DelegationTokenIdentifier> token =
         getDelegationToken(fs, "JobTracker");
@@ -223,7 +226,8 @@ public class TestDelegationTokensWithHA {
    * Test if correct exception (StandbyException or RetriableException) can be
    * thrown during the NN failover. 
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDelegationTokenDuringNNFailover() throws Exception {
     EditLogTailer editLogTailer = nn1.getNamesystem().getEditLogTailer();
     // stop the editLogTailer of nn1
@@ -291,7 +295,8 @@ public class TestDelegationTokensWithHA {
     doRenewOrCancel(token, clientConf, TokenTestAction.CANCEL);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDelegationTokenWithDoAs() throws Exception {
     final Token<DelegationTokenIdentifier> token =
         getDelegationToken(fs, "JobTracker");
@@ -323,7 +328,8 @@ public class TestDelegationTokensWithHA {
     });
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testHAUtilClonesDelegationTokens() throws Exception {
     final Token<DelegationTokenIdentifier> token =
         getDelegationToken(fs, "JobTracker");
@@ -385,7 +391,8 @@ public class TestDelegationTokensWithHA {
    * exception if the URI is a logical URI. This bug fails the combination of
    * ha + mapred + security.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDFSGetCanonicalServiceName() throws Exception {
     URI hAUri = HATestUtil.getLogicalUri(cluster);
     String haService = HAUtilClient.buildTokenServiceForLogicalUri(hAUri,
@@ -400,7 +407,8 @@ public class TestDelegationTokensWithHA {
     token.cancel(dfs.getConf());
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testHdfsGetCanonicalServiceName() throws Exception {
     Configuration conf = dfs.getConf();
     URI haUri = HATestUtil.getLogicalUri(cluster);
@@ -416,7 +424,8 @@ public class TestDelegationTokensWithHA {
     token.cancel(conf);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testCancelAndUpdateDelegationTokens() throws Exception {
     // Create UGI with token1
     String user = UserGroupInformation.getCurrentUser().getShortUserName();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogTailer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogTailer.java
@@ -17,9 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,21 +61,19 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.FakeTimer;
 import org.slf4j.event.Level;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.function.Supplier;
 import org.mockito.Mockito;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestEditLogTailer {
   static {
     GenericTestUtils.setLogLevel(FSEditLog.LOG, Level.DEBUG);
   }
 
-  @Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> params = new ArrayList<Object[]>();
     params.add(new Object[]{ Boolean.FALSE });
@@ -132,9 +132,9 @@ public class TestEditLogTailer {
       }
       
       HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
-      assertEquals("Inconsistent number of applied txns on Standby",
-          nn1.getNamesystem().getEditLog().getLastWrittenTxId(),
-          nn2.getNamesystem().getFSImage().getLastAppliedTxId() + 1);
+      assertEquals(nn1.getNamesystem().getEditLog().getLastWrittenTxId(),
+          nn2.getNamesystem().getFSImage().getLastAppliedTxId() + 1,
+          "Inconsistent number of applied txns on Standby");
 
       for (int i = 0; i < DIRS_TO_MAKE / 2; i++) {
         assertTrue(NameNodeAdapter.getFileInfo(nn2,
@@ -148,9 +148,9 @@ public class TestEditLogTailer {
       }
       
       HATestUtil.waitForStandbyToCatchUp(nn1, nn2);
-      assertEquals("Inconsistent number of applied txns on Standby",
-          nn1.getNamesystem().getEditLog().getLastWrittenTxId(),
-          nn2.getNamesystem().getFSImage().getLastAppliedTxId() + 1);
+      assertEquals(nn1.getNamesystem().getEditLog().getLastWrittenTxId(),
+          nn2.getNamesystem().getFSImage().getLastAppliedTxId() + 1,
+          "Inconsistent number of applied txns on Standby");
 
       for (int i = DIRS_TO_MAKE / 2; i < DIRS_TO_MAKE; i++) {
         assertTrue(NameNodeAdapter.getFileInfo(nn2,
@@ -302,7 +302,8 @@ public class TestEditLogTailer {
     }, 100, 10000);
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testRollEditTimeoutForActiveNN() throws IOException {
     Configuration conf = getConf();
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_ROLLEDITS_TIMEOUT_KEY, 5); // 5s

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogsDuringFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestEditLogsDuringFailover.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -44,7 +44,7 @@ import org.apache.hadoop.util.Lists;
 
 import static org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter.getFileInfo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailoverWithBlockTokensEnabled.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailoverWithBlockTokensEnabled.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -45,9 +45,9 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -61,7 +61,7 @@ public class TestFailoverWithBlockTokensEnabled {
   private Configuration conf;
   private MiniDFSCluster cluster;
 
-  @Before
+  @BeforeEach
   public void startCluster() throws IOException {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, true);
@@ -73,7 +73,7 @@ public class TestFailoverWithBlockTokensEnabled {
         .build();
   }
   
-  @After
+  @AfterEach
   public void shutDownCluster() {
     if (cluster != null) {
       cluster.shutdown();
@@ -110,8 +110,8 @@ public class TestFailoverWithBlockTokensEnabled {
         }
         int first = btsms[i].getSerialNoForTesting();
         int second = btsms[j].getSerialNoForTesting();
-        assertFalse("Overlap found for set serial number (" + serialNumber + ") is " + i + ": "
-            + first + " == " + j + ": " + second, first == second);
+        assertFalse(first == second, "Overlap found for set serial number (" + serialNumber
+            + ") is " + i + ": " + first + " == " + j + ": " + second);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureOfSharedDir.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureOfSharedDir.java
@@ -89,7 +89,7 @@ public class TestFailureOfSharedDir {
       FSNamesystem.getNamespaceEditsDirs(conf);
       fail("Allowed multiple shared edits directories");
     } catch (IOException ioe) {
-        assertEquals("Multiple shared edits directories are not yet supported", ioe.getMessage());
+      assertEquals("Multiple shared edits directories are not yet supported", ioe.getMessage());
     }
   }
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureOfSharedDir.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureOfSharedDir.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RESOURCE_CHECK_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RESOURCE_CHECK_INTERVAL_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +43,7 @@ import org.apache.hadoop.hdfs.server.namenode.NNStorage;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
@@ -66,8 +66,8 @@ public class TestFailureOfSharedDir {
     conf.set(DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY, bar.toString());
     Collection<URI> requiredEditsDirs = FSNamesystem
         .getRequiredNamespaceEditsDirs(conf); 
-    assertTrue(Joiner.on(",").join(requiredEditsDirs) + " does not contain " + bar,
-        requiredEditsDirs.contains(bar));
+    assertTrue(requiredEditsDirs.contains(bar),
+        Joiner.on(",").join(requiredEditsDirs) + " does not contain " + bar);
   }
 
   /**
@@ -89,8 +89,7 @@ public class TestFailureOfSharedDir {
       FSNamesystem.getNamespaceEditsDirs(conf);
       fail("Allowed multiple shared edits directories");
     } catch (IOException ioe) {
-      assertEquals("Multiple shared edits directories are not yet supported",
-          ioe.getMessage());
+        assertEquals("Multiple shared edits directories are not yet supported", ioe.getMessage());
     }
   }
   
@@ -114,11 +113,9 @@ public class TestFailureOfSharedDir {
     conf.set(DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY,
         Joiner.on(",").join(localC, localB, localA));
     List<URI> dirs = FSNamesystem.getNamespaceEditsDirs(conf);
-    assertEquals(
+    assertEquals(Joiner.on(",").join(sharedA, localC, localB, localA), Joiner.on(",").join(dirs),
         "Shared dirs should come first, then local dirs, in the order " +
-        "they were listed in the configuration.",
-        Joiner.on(",").join(sharedA, localC, localB, localA),
-        Joiner.on(",").join(dirs));
+            "they were listed in the configuration.");
   }
   
   /**
@@ -150,8 +147,7 @@ public class TestFailureOfSharedDir {
       // Blow away the shared edits dir.
       URI sharedEditsUri = cluster.getSharedEditsDir(0, 1);
       sharedEditsDir = new File(sharedEditsUri);
-      assertEquals(0, FileUtil.chmod(sharedEditsDir.getAbsolutePath(), "-w",
-          true));
+      assertEquals(0, FileUtil.chmod(sharedEditsDir.getAbsolutePath(), "-w", true));
 
       Thread.sleep(conf.getLong(DFS_NAMENODE_RESOURCE_CHECK_INTERVAL_KEY,
           DFS_NAMENODE_RESOURCE_CHECK_INTERVAL_DEFAULT) * 2);
@@ -159,8 +155,9 @@ public class TestFailureOfSharedDir {
       NameNode nn1 = cluster.getNameNode(1);
       assertTrue(nn1.isStandbyState());
       assertFalse(
-          "StandBy NameNode should not go to SafeMode on resource unavailability",
-          nn1.isInSafeMode());
+
+          nn1.isInSafeMode(),
+          "StandBy NameNode should not go to SafeMode on resource unavailability");
 
       NameNode nn0 = cluster.getNameNode(0);
       try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureToReadEdits.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestFailureToReadEdits.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +33,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Random;
 
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -53,18 +55,16 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapterMockitoUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestFailureToReadEdits {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestFailureToReadEdits.class);
@@ -95,7 +95,6 @@ public class TestFailureToReadEdits {
    * TODO: Enable the test cases with async edit logging on. See HDFS-12603
    * and HDFS-12660.
    */
-  @Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {TestType.SHARED_DIR_HA, Boolean.FALSE},
@@ -111,7 +110,7 @@ public class TestFailureToReadEdits {
     this.useAsyncEditLogging = useAsyncEditLogging;
   }
 
-  @Before
+  @BeforeEach
   public void setUpCluster() throws Exception {
     conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_CHECKPOINT_CHECK_PERIOD_KEY, 1);
@@ -162,7 +161,7 @@ public class TestFailureToReadEdits {
     fs = HATestUtil.configureFailoverFs(cluster, conf);
   }
   
-  @After
+  @AfterEach
   public void tearDownCluster() throws Exception {
     if (fs != null) {
       fs.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAAppend.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAAppend.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.TestFileTruncate;
 import org.apache.hadoop.hdfs.tools.DFSck;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHAAppend {
   static final int COUNT = 5;
@@ -114,8 +114,8 @@ public class TestHAAppend {
           new String[] { "/", "-files", "-blocks" });
       assertEquals(0, rc);
       
-      assertEquals("CorruptBlocks should be empty.", 0, cluster.getNameNode(1)
-          .getNamesystem().getCorruptReplicaBlocks());
+      assertEquals(0, cluster.getNameNode(1).getNamesystem().getCorruptReplicaBlocks(),
+          "CorruptBlocks should be empty.");
 
       AppendTestUtil.checkFullFile(fs, fileToAppend, data.length, data,
           fileToAppend.toString());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAConfiguration.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAConfiguration.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_EDITS_DIR_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SHARED_EDITS_DIR_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.SecondaryNameNode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -107,8 +107,8 @@ public class TestHAConfiguration {
     NameNode.initializeGenericKeys(conf, "ns1", "nn1");
 
     checkpointer = new StandbyCheckpointer(conf, fsn);
-    assertEquals("Got an unexpected number of possible active NNs", 2, checkpointer
-        .getActiveNNAddresses().size());
+    assertEquals(2, checkpointer.getActiveNNAddresses().size(),
+        "Got an unexpected number of possible active NNs");
     assertEquals(new URL("http", "1.2.3.2", DFSConfigKeys.DFS_NAMENODE_HTTP_PORT_DEFAULT, ""),
         checkpointer.getActiveNNAddresses().get(0));
     assertAddressMatches("1.2.3.2", checkpointer.getActiveNNAddresses().get(0));
@@ -168,7 +168,7 @@ public class TestHAConfiguration {
     NameNode.initializeGenericKeys(conf, "ns1", "nn1");
     List<Configuration> others = HAUtil.getConfForOtherNodes(conf);
     Configuration nn2Conf = others.get(0);
-    assertEquals(nn2Conf.get(DFSConfigKeys.DFS_HA_NAMENODE_ID_KEY),"nn2");
+    assertEquals(nn2Conf.get(DFSConfigKeys.DFS_HA_NAMENODE_ID_KEY), "nn2");
     assertTrue(!conf.get(DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY)
         .equals(nn2Conf.get(DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY)));
     assertNull(nn2Conf.get(DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAFsck.java
@@ -21,7 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.slf4j.event.Level;
@@ -36,8 +36,8 @@ import org.apache.hadoop.hdfs.tools.DFSck;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHAFsck {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAMetrics.java
@@ -33,14 +33,15 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Make sure HA-related metrics are updated and reported appropriately.
@@ -50,7 +51,8 @@ public class TestHAMetrics {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestHAMetrics.class);
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testHAMetrics() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
@@ -77,7 +79,7 @@ public class TestHAMetrics {
           new ObjectName("Hadoop:service=NameNode,name=NameNodeStatus");
       final Long ltt1 =
           (Long) mbs.getAttribute(mxbeanName, "LastHATransitionTime");
-      assertTrue("lastHATransitionTime should be > 0", ltt1 > 0);
+      assertTrue(ltt1 > 0, "lastHATransitionTime should be > 0");
       
       assertEquals("active", nn0.getHAState());
       assertEquals(0, nn0.getMillisSinceLastLoadedEdits());
@@ -87,7 +89,7 @@ public class TestHAMetrics {
       cluster.transitionToStandby(0);
       final Long ltt2 =
           (Long) mbs.getAttribute(mxbeanName, "LastHATransitionTime");
-      assertTrue("lastHATransitionTime should be > " + ltt1, ltt2 > ltt1);
+      assertTrue(ltt2 > ltt1, "lastHATransitionTime should be > " + ltt1);
       cluster.transitionToActive(1);
       
       assertEquals("standby", nn0.getHAState());
@@ -117,9 +119,8 @@ public class TestHAMetrics {
       long newMillisSinceLastLoadedEdits = nn0.getMillisSinceLastLoadedEdits();
       // Since we just waited for the standby to catch up, the time since we
       // last loaded edits should be very low.
-      assertTrue("expected " + millisSinceLastLoadedEdits + " > " +
-          newMillisSinceLastLoadedEdits,
-          millisSinceLastLoadedEdits > newMillisSinceLastLoadedEdits);
+      assertTrue(millisSinceLastLoadedEdits > newMillisSinceLastLoadedEdits,
+          "expected " + millisSinceLastLoadedEdits + " > " + newMillisSinceLastLoadedEdits);
     } finally {
       IOUtils.cleanupWithLogger(LOG, fs);
       cluster.shutdown();
@@ -201,34 +202,26 @@ public class TestHAMetrics {
     NameNode nn2 = cluster.getNameNode(2);
 
     // All namenodes are in standby by default
-    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(),
-        nn0.getNameNodeState());
-    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(),
-        nn1.getNameNodeState());
-    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(),
-        nn2.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(), nn0.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(), nn1.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(), nn2.getNameNodeState());
 
     // Transition nn0 to be active
     cluster.transitionToActive(0);
-    assertEquals(HAServiceProtocol.HAServiceState.ACTIVE.ordinal(),
-        nn0.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.ACTIVE.ordinal(), nn0.getNameNodeState());
 
     // Transition nn1 to be active
     cluster.transitionToStandby(0);
     cluster.transitionToActive(1);
-    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(),
-        nn0.getNameNodeState());
-    assertEquals(HAServiceProtocol.HAServiceState.ACTIVE.ordinal(),
-        nn1.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.STANDBY.ordinal(), nn0.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.ACTIVE.ordinal(), nn1.getNameNodeState());
 
     // Transition nn2 to observer
     cluster.transitionToObserver(2);
-    assertEquals(HAServiceProtocol.HAServiceState.OBSERVER.ordinal(),
-        nn2.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.OBSERVER.ordinal(), nn2.getNameNodeState());
 
     // Shutdown nn2. Now getNameNodeState should return the INITIALIZING state.
     cluster.shutdownNameNode(2);
-    assertEquals(HAServiceProtocol.HAServiceState.INITIALIZING.ordinal(),
-        nn2.getNameNodeState());
+    assertEquals(HAServiceProtocol.HAServiceState.INITIALIZING.ordinal(), nn2.getNameNodeState());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
@@ -499,28 +499,28 @@ public class TestHASafeMode {
     int numNodes, int nodeThresh) {
     String status = nn.getNamesystem().getSafemode();
     if (total == 0 && nodeThresh == 0) {
-        assertTrue(status.isEmpty()
+      assertTrue(status.isEmpty()
               || status.startsWith("Safe mode is ON. The reported blocks 0 " +
               "has reached the threshold 0.9990 of total blocks 0. The " +
               "minimum number of live datanodes is not required. In safe " +
               "mode extension. Safe mode will be turned off automatically " +
-                "in 0 seconds."),
-            "Bad safemode status: '" + status + "'");
+              "in 0 seconds."),
+          "Bad safemode status: '" + status + "'");
     } else if (safe == total) {
       if (nodeThresh == 0) {
-          assertTrue(status.startsWith("Safe mode is ON. The reported blocks " + safe
-                + " has reached the " + "threshold 0.9990 of total blocks "
-                + total + ". The minimum number of live datanodes is not "
-                + "required. In safe mode extension. Safe mode will be turned "
-              + "off automatically"), "Bad safemode status: '" + status + "'");
+        assertTrue(status.startsWith("Safe mode is ON. The reported blocks " + safe
+            + " has reached the " + "threshold 0.9990 of total blocks "
+            + total + ". The minimum number of live datanodes is not "
+            + "required. In safe mode extension. Safe mode will be turned "
+            + "off automatically"), "Bad safemode status: '" + status + "'");
       } else {
-          assertTrue(status.startsWith(
+        assertTrue(status.startsWith(
                 "Safe mode is ON. The reported blocks " + safe + " has reached "
                     + "the threshold 0.9990 of total blocks " + total + ". The "
                     + "number of live datanodes " + numNodes + " has reached "
                     + "the minimum number " + nodeThresh + ". In safe mode "
-                  + "extension. Safe mode will be turned off automatically"),
-              "Bad safemode status: '" + status + "'");
+                    + "extension. Safe mode will be turned off automatically"),
+            "Bad safemode status: '" + status + "'");
       }
     } else {
       int additional = (int) (total * 0.9990) - safe;
@@ -799,11 +799,11 @@ public class TestHASafeMode {
       fail("StandBy should throw exception for isInSafeMode");
     } catch (IOException e) {
       if (e instanceof RemoteException) {
-          assertEquals(RpcErrorCodeProto.ERROR_APPLICATION, ((RemoteException) e).getErrorCode(),
-              "RPC Error code should indicate app failure.");
-          IOException sbExcpetion = ((RemoteException) e).unwrapRemoteException();
-          assertTrue(sbExcpetion instanceof StandbyException,
-              "StandBy nn should not support isInSafeMode");
+        assertEquals(RpcErrorCodeProto.ERROR_APPLICATION, ((RemoteException) e).getErrorCode(),
+            "RPC Error code should indicate app failure.");
+        IOException sbExcpetion = ((RemoteException) e).unwrapRemoteException();
+        assertTrue(sbExcpetion instanceof StandbyException,
+            "StandBy nn should not support isInSafeMode");
       } else {
         throw e;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHASafeMode.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NN_NOT_BECOME_ACTIVE_IN_SAFEMODE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,9 +69,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.Lists;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
@@ -93,7 +94,7 @@ public class TestHASafeMode {
     GenericTestUtils.setLogLevel(FSImage.LOG, Level.TRACE);
   }
   
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
@@ -115,7 +116,7 @@ public class TestHASafeMode {
     cluster.transitionToActive(0);
   }
   
-  @After
+  @AfterEach
   public void shutdownCluster() {
     if (cluster != null) {
       cluster.shutdown();
@@ -126,7 +127,8 @@ public class TestHASafeMode {
   /**
    * Make sure the client retries when the active NN is in safemode
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testClientRetrySafeMode() throws Exception {
     final Map<Path, Boolean> results = Collections
         .synchronizedMap(new HashMap<Path, Boolean>());
@@ -157,8 +159,7 @@ public class TestHASafeMode {
     }.start();
     
     // make sure the client's call has actually been handled by the active NN
-    assertFalse("The directory should not be created while NN in safemode",
-        fs.exists(test));
+    assertFalse(fs.exists(test), "The directory should not be created while NN in safemode");
     
     Thread.sleep(1000);
     // let nn0 leave safemode
@@ -203,14 +204,11 @@ public class TestHASafeMode {
 
     FSNamesystem namesystem = nn0.getNamesystem();
     String status = namesystem.getSafemode();
-    assertTrue("Bad safemode status: '" + status + "'", status
-        .startsWith("Safe mode is ON."));
+    assertTrue(status.startsWith("Safe mode is ON."), "Bad safemode status: '" + status + "'");
     NameNodeAdapter.enterSafeMode(nn0, false);
-    assertTrue("Failed to enter into safemode in active", namesystem
-        .isInSafeMode());
+    assertTrue(namesystem.isInSafeMode(), "Failed to enter into safemode in active");
     NameNodeAdapter.enterSafeMode(nn0, false);
-    assertTrue("Failed to enter into safemode in active", namesystem
-        .isInSafeMode());
+    assertTrue(namesystem.isInSafeMode(), "Failed to enter into safemode in active");
   }
 
   /**
@@ -234,14 +232,11 @@ public class TestHASafeMode {
     restartStandby();
     FSNamesystem namesystem = nn1.getNamesystem();
     String status = namesystem.getSafemode();
-    assertTrue("Bad safemode status: '" + status + "'", status
-        .startsWith("Safe mode is ON."));
+    assertTrue(status.startsWith("Safe mode is ON."), "Bad safemode status: '" + status + "'");
     NameNodeAdapter.enterSafeMode(nn1, false);
-    assertTrue("Failed to enter into safemode in standby", namesystem
-        .isInSafeMode());
+    assertTrue(namesystem.isInSafeMode(), "Failed to enter into safemode in standby");
     NameNodeAdapter.enterSafeMode(nn1, false);
-    assertTrue("Failed to enter into safemode in standby", namesystem
-        .isInSafeMode());
+    assertTrue(namesystem.isInSafeMode(), "Failed to enter into safemode in standby");
   }
 
   private void restartActive() throws IOException {
@@ -504,37 +499,36 @@ public class TestHASafeMode {
     int numNodes, int nodeThresh) {
     String status = nn.getNamesystem().getSafemode();
     if (total == 0 && nodeThresh == 0) {
-      assertTrue("Bad safemode status: '" + status + "'",
-          status.isEmpty()
+        assertTrue(status.isEmpty()
               || status.startsWith("Safe mode is ON. The reported blocks 0 " +
               "has reached the threshold 0.9990 of total blocks 0. The " +
               "minimum number of live datanodes is not required. In safe " +
               "mode extension. Safe mode will be turned off automatically " +
-              "in 0 seconds."));
+                "in 0 seconds."),
+            "Bad safemode status: '" + status + "'");
     } else if (safe == total) {
       if (nodeThresh == 0) {
-        assertTrue("Bad safemode status: '" + status + "'",
-            status.startsWith("Safe mode is ON. The reported blocks " + safe
+          assertTrue(status.startsWith("Safe mode is ON. The reported blocks " + safe
                 + " has reached the " + "threshold 0.9990 of total blocks "
                 + total + ". The minimum number of live datanodes is not "
                 + "required. In safe mode extension. Safe mode will be turned "
-                + "off automatically"));
+              + "off automatically"), "Bad safemode status: '" + status + "'");
       } else {
-        assertTrue("Bad safemode status: '" + status + "'",
-            status.startsWith(
+          assertTrue(status.startsWith(
                 "Safe mode is ON. The reported blocks " + safe + " has reached "
                     + "the threshold 0.9990 of total blocks " + total + ". The "
                     + "number of live datanodes " + numNodes + " has reached "
                     + "the minimum number " + nodeThresh + ". In safe mode "
-                    + "extension. Safe mode will be turned off automatically"));
+                  + "extension. Safe mode will be turned off automatically"),
+              "Bad safemode status: '" + status + "'");
       }
     } else {
       int additional = (int) (total * 0.9990) - safe;
-      assertTrue("Bad safemode status: '" + status + "'",
-          status.startsWith(
+      assertTrue(status.startsWith(
               "Safe mode is ON. " +
               "The reported blocks " + safe + " needs additional " +
-              additional + " blocks"));
+              additional + " blocks"),
+          "Bad safemode status: '" + status + "'");
     }
   }
 
@@ -593,12 +587,12 @@ public class TestHASafeMode {
     
     // It will initially have all of the blocks necessary.
     String status = nn1.getNamesystem().getSafemode();
-    assertTrue("Bad safemode status: '" + status + "'",
-      status.startsWith(
+    assertTrue(status.startsWith(
         "Safe mode is ON. The reported blocks 10 has reached the threshold "
         + "0.9990 of total blocks 10. The minimum number of live datanodes is "
         + "not required. In safe mode extension. Safe mode will be turned off "
-        + "automatically"));
+            + "automatically"),
+        "Bad safemode status: '" + status + "'");
 
     // Delete those blocks while the SBN is in safe mode.
     // Immediately roll the edit log before the actual deletions are sent
@@ -792,7 +786,7 @@ public class TestHASafeMode {
   public void testIsInSafemode() throws Exception {
     // Check for the standby nn without client failover.
     NameNode nn2 = cluster.getNameNode(1);
-    assertTrue("nn2 should be in standby state", nn2.isStandbyState());
+    assertTrue(nn2.isStandbyState(), "nn2 should be in standby state");
 
     InetSocketAddress nameNodeAddress = nn2.getNameNodeAddress();
     Configuration conf = new Configuration();
@@ -805,11 +799,11 @@ public class TestHASafeMode {
       fail("StandBy should throw exception for isInSafeMode");
     } catch (IOException e) {
       if (e instanceof RemoteException) {
-        assertEquals("RPC Error code should indicate app failure.", RpcErrorCodeProto.ERROR_APPLICATION,
-            ((RemoteException) e).getErrorCode());
-        IOException sbExcpetion = ((RemoteException) e).unwrapRemoteException();
-        assertTrue("StandBy nn should not support isInSafeMode",
-            sbExcpetion instanceof StandbyException);
+          assertEquals(RpcErrorCodeProto.ERROR_APPLICATION, ((RemoteException) e).getErrorCode(),
+              "RPC Error code should indicate app failure.");
+          IOException sbExcpetion = ((RemoteException) e).unwrapRemoteException();
+          assertTrue(sbExcpetion instanceof StandbyException,
+              "StandBy nn should not support isInSafeMode");
       } else {
         throw e;
       }
@@ -824,14 +818,15 @@ public class TestHASafeMode {
     cluster.transitionToActive(1);
     cluster.getNameNodeRpc(1).setSafeMode(SafeModeAction.SAFEMODE_ENTER, false);
     DistributedFileSystem dfsWithFailOver = (DistributedFileSystem) fs;
-    assertTrue("ANN should be in SafeMode", dfsWithFailOver.isInSafeMode());
+    assertTrue(dfsWithFailOver.isInSafeMode(), "ANN should be in SafeMode");
 
     cluster.getNameNodeRpc(1).setSafeMode(SafeModeAction.SAFEMODE_LEAVE, false);
-    assertFalse("ANN should be out of SafeMode", dfsWithFailOver.isInSafeMode());
+    assertFalse(dfsWithFailOver.isInSafeMode(), "ANN should be out of SafeMode");
   }
 
   /** Test NN crash and client crash/stuck immediately after block allocation */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testOpenFileWhenNNAndClientCrashAfterAddBlock() throws Exception {
     cluster.getConfiguration(0).set(
         DFSConfigKeys.DFS_NAMENODE_SAFEMODE_THRESHOLD_PCT_KEY, "1.0f");
@@ -874,13 +869,14 @@ public class TestHASafeMode {
       FSDataInputStream is = dfs.open(filePath);
       is.close();
       dfs.recoverLease(filePath);// initiate recovery
-      assertTrue("Recovery also should be success", dfs.recoverLease(filePath));
+      assertTrue(dfs.recoverLease(filePath), "Recovery also should be success");
     } finally {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSafeModeExitAfterTransition() throws Exception {
     DFSTestUtil.createFile(fs, new Path("/test"), 5 * BLOCK_SIZE, (short) 3,
         1L);
@@ -1004,6 +1000,6 @@ public class TestHASafeMode {
   public void testTransitionToStandbyWhenSafeModeWithResourcesLow() throws Exception {
     NameNodeAdapter.enterSafeMode(nn0, true);
     cluster.transitionToStandby(0);
-    assertFalse("SNN should not enter safe mode when resources low", nn0.isInSafeMode());
+    assertFalse(nn0.isInSafeMode(), "SNN should not enter safe mode when resources low");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
@@ -56,7 +56,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests state transition from active->standby, and manual failover

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
@@ -43,8 +43,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
@@ -56,7 +57,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests state transition from active->standby, and manual failover
@@ -82,7 +83,8 @@ public class TestHAStateTransitions {
    * active and standby mode, making sure it doesn't
    * double-play any edits.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testTransitionActiveToStandby() throws Exception {
     Configuration conf = new Configuration();
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
@@ -138,7 +140,8 @@ public class TestHAStateTransitions {
    * Test that transitioning a service to the state that it is already
    * in is a nop, specifically, an exception is not thrown.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testTransitionToCurrentStateIsANop() throws Exception {
     Configuration conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_NAMENODE_PATH_BASED_CACHE_REFRESH_INTERVAL_MS, 1L);
@@ -194,8 +197,7 @@ public class TestHAStateTransitions {
       cluster.transitionToStandby(nn1);
       cluster.transitionToActive(nn0);
       assertTrue(fs.exists(TEST_DIR));
-      assertEquals(TEST_FILE_DATA, 
-          DFSTestUtil.readFile(fs, TEST_FILE_PATH));
+      assertEquals(TEST_FILE_DATA, DFSTestUtil.readFile(fs, TEST_FILE_PATH));
 
       LOG.info("Removing test file");
       fs.delete(TEST_DIR, true);
@@ -210,7 +212,8 @@ public class TestHAStateTransitions {
   /**
    * Tests manual failover back and forth between two NameNodes.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testManualFailoverAndFailback() throws Exception {
     Configuration conf = new Configuration();
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
@@ -233,7 +236,8 @@ public class TestHAStateTransitions {
    * This test case starts up several client threads which do mutation operations
    * while flipping a NN back and forth from active to standby.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testTransitionSynchronization() throws Exception {
     Configuration conf = new Configuration();
     final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
@@ -286,7 +290,8 @@ public class TestHAStateTransitions {
    * accidentally mark the leases as expired when the failover
    * proceeds.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testLeasesRenewedOnTransition() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
@@ -309,15 +314,13 @@ public class TestHAStateTransitions {
       long nn0t0 = NameNodeAdapter.getLeaseRenewalTime(nn0, TEST_FILE_STR);
       assertTrue(nn0t0 > 0);
       long nn1t0 = NameNodeAdapter.getLeaseRenewalTime(nn1, TEST_FILE_STR);
-      assertEquals("Lease should not yet exist on nn1",
-          -1, nn1t0);
+      assertEquals(-1, nn1t0, "Lease should not yet exist on nn1");
       
       Thread.sleep(5); // make sure time advances!
 
       HATestUtil.waitForStandbyToCatchUp(nn0, nn1);
       long nn1t1 = NameNodeAdapter.getLeaseRenewalTime(nn1, TEST_FILE_STR);
-      assertTrue("Lease should have been created on standby. Time was: " +
-          nn1t1, nn1t1 > nn0t0);
+      assertTrue(nn1t1 > nn0t0, "Lease should have been created on standby. Time was: " + nn1t1);
           
       Thread.sleep(5); // make sure time advances!
       
@@ -325,8 +328,7 @@ public class TestHAStateTransitions {
       cluster.transitionToStandby(0);
       cluster.transitionToActive(1);
       long nn1t2 = NameNodeAdapter.getLeaseRenewalTime(nn1, TEST_FILE_STR);
-      assertTrue("Lease should have been renewed by failover process",
-          nn1t2 > nn1t1);
+      assertTrue(nn1t2 > nn1t1, "Lease should have been renewed by failover process");
     } finally {
       IOUtils.closeStream(stm);
       cluster.shutdown();
@@ -336,7 +338,8 @@ public class TestHAStateTransitions {
   /**
    * Test that delegation tokens continue to work after the failover.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDelegationTokensAfterFailover() throws IOException {
     Configuration conf = new Configuration();
     conf.setBoolean(
@@ -363,7 +366,7 @@ public class TestHAStateTransitions {
       nn2.getRpcServer().renewDelegationToken(token);
       nn2.getRpcServer().cancelDelegationToken(token);
       token = nn2.getRpcServer().getDelegationToken(new Text(renewer));
-      Assert.assertTrue(token != null);
+      Assertions.assertTrue(token != null);
     } finally {
       cluster.shutdown();
     }
@@ -373,7 +376,8 @@ public class TestHAStateTransitions {
    * Tests manual failover back and forth between two NameNodes
    * for federation cluster with two namespaces.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testManualFailoverFailbackFederationHA() throws Exception {
     Configuration conf = new Configuration();
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
@@ -393,12 +397,14 @@ public class TestHAStateTransitions {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testFailoverWithEmptyInProgressEditLog() throws Exception {
     testFailoverAfterCrashDuringLogRoll(false);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testFailoverWithEmptyInProgressEditLogWithHeader()
       throws Exception {
     testFailoverAfterCrashDuringLogRoll(true);
@@ -434,8 +440,7 @@ public class TestHAStateTransitions {
     StorageDirectory storageDir = new StorageDirectory(sharedEditsDir);
     File inProgressFile = NameNodeAdapter.getInProgressEditsFile(storageDir,
         txid + 1);
-    assertTrue("Failed to create in-progress edits file",
-        inProgressFile.createNewFile());
+    assertTrue(inProgressFile.createNewFile(), "Failed to create in-progress edits file");
     
     if (writeHeader) {
       DataOutputStream out = new DataOutputStream(new FileOutputStream(
@@ -462,7 +467,8 @@ public class TestHAStateTransitions {
    * Active    3 <------> 4
    * </pre>
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSecretManagerState() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(
@@ -560,7 +566,8 @@ public class TestHAStateTransitions {
    * by virtue of the fact that it wouldn't work properly if the proxies
    * returned were not for the correct NNs.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testIsAtLeastOneActive() throws Exception {
     MiniDFSCluster cluster = new MiniDFSCluster.Builder(new HdfsConfiguration())
         .nnTopology(MiniDFSNNTopology.simpleHATopology())

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHAStateTransitions.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
 import org.slf4j.event.Level;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
@@ -177,36 +176,36 @@ public class TestHAStateTransitions {
    * @param nsIndex namespace index starting from zero
    * @throws Exception
    */
-  private void testManualFailoverFailback(MiniDFSCluster cluster, 
+  private void testManualFailoverFailback(MiniDFSCluster cluster,
 		  Configuration conf, int nsIndex) throws Exception {
-      int nn0 = 2 * nsIndex, nn1 = 2 * nsIndex + 1;
+    int nn0 = 2 * nsIndex, nn1 = 2 * nsIndex + 1;
 
-      cluster.transitionToActive(nn0);
-      
-      LOG.info("Starting with NN 0 active in namespace " + nsIndex);
-      FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
-      fs.mkdirs(TEST_DIR);
+    cluster.transitionToActive(nn0);
 
-      LOG.info("Failing over to NN 1 in namespace " + nsIndex);
-      cluster.transitionToStandby(nn0);
-      cluster.transitionToActive(nn1);
-      assertTrue(fs.exists(TEST_DIR));
-      DFSTestUtil.writeFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
+    LOG.info("Starting with NN 0 active in namespace " + nsIndex);
+    FileSystem fs = HATestUtil.configureFailoverFs(cluster, conf);
+    fs.mkdirs(TEST_DIR);
 
-      LOG.info("Failing over to NN 0 in namespace " + nsIndex);
-      cluster.transitionToStandby(nn1);
-      cluster.transitionToActive(nn0);
-      assertTrue(fs.exists(TEST_DIR));
-      assertEquals(TEST_FILE_DATA, DFSTestUtil.readFile(fs, TEST_FILE_PATH));
+    LOG.info("Failing over to NN 1 in namespace " + nsIndex);
+    cluster.transitionToStandby(nn0);
+    cluster.transitionToActive(nn1);
+    assertTrue(fs.exists(TEST_DIR));
+    DFSTestUtil.writeFile(fs, TEST_FILE_PATH, TEST_FILE_DATA);
 
-      LOG.info("Removing test file");
-      fs.delete(TEST_DIR, true);
-      assertFalse(fs.exists(TEST_DIR));
+    LOG.info("Failing over to NN 0 in namespace " + nsIndex);
+    cluster.transitionToStandby(nn1);
+    cluster.transitionToActive(nn0);
+    assertTrue(fs.exists(TEST_DIR));
+    assertEquals(TEST_FILE_DATA, DFSTestUtil.readFile(fs, TEST_FILE_PATH));
 
-      LOG.info("Failing over to NN 1 in namespace " + nsIndex);
-      cluster.transitionToStandby(nn0);
-      cluster.transitionToActive(nn1);
-      assertFalse(fs.exists(TEST_DIR));
+    LOG.info("Removing test file");
+    fs.delete(TEST_DIR, true);
+    assertFalse(fs.exists(TEST_DIR));
+
+    LOG.info("Failing over to NN 1 in namespace " + nsIndex);
+    cluster.transitionToStandby(nn0);
+    cluster.transitionToActive(nn1);
+    assertFalse(fs.exists(TEST_DIR));
   }
   
   /**
@@ -366,7 +365,7 @@ public class TestHAStateTransitions {
       nn2.getRpcServer().renewDelegationToken(token);
       nn2.getRpcServer().cancelDelegationToken(token);
       token = nn2.getRpcServer().getDelegationToken(new Text(renewer));
-      Assertions.assertTrue(token != null);
+      assertTrue(token != null);
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHarFileSystemWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestHarFileSystemWithHA.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHarFileSystemWithHA {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestInitializeSharedEdits.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestInitializeSharedEdits.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,9 +44,9 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestInitializeSharedEdits {
 
@@ -57,7 +57,7 @@ public class TestInitializeSharedEdits {
   private Configuration conf;
   private MiniDFSCluster cluster;
   
-  @Before
+  @BeforeEach
   public void setupCluster() throws IOException {
     conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HA_LOGROLL_PERIOD_KEY, 1);
@@ -75,7 +75,7 @@ public class TestInitializeSharedEdits {
     shutdownClusterAndRemoveSharedEditsDir();
   }
   
-  @After
+  @AfterEach
   public void shutdownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestLossyRetryInvocationHandler.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestLossyRetryInvocationHandler.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test makes sure that when

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
@@ -155,7 +155,7 @@ public class TestMultiObserverNode {
   }
 
   private void assertSentTo(int... nnIndices) throws IOException {
-      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIndices),
-          "Request was not sent to any of the expected namenodes.");
+    assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIndices),
+        "Request was not sent to any of the expected namenodes.");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestMultiObserverNode.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -28,10 +28,10 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.qjournal.MiniQJMHACluster;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests multiple ObserverNodes.
@@ -44,7 +44,7 @@ public class TestMultiObserverNode {
 
   private final Path testPath= new Path("/TestMultiObserverNode");
 
-  @BeforeClass
+  @BeforeAll
   public static void startUpCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
@@ -54,12 +54,12 @@ public class TestMultiObserverNode {
         dfsCluster, conf, ObserverReadProxyProvider.class, true);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     dfs.delete(testPath, true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDownCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
@@ -155,7 +155,7 @@ public class TestMultiObserverNode {
   }
 
   private void assertSentTo(int... nnIndices) throws IOException {
-    assertTrue("Request was not sent to any of the expected namenodes.",
-        HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIndices));
+      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIndices),
+          "Request was not sent to any of the expected namenodes.");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestNNHealthCheck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestNNHealthCheck.java
@@ -22,9 +22,9 @@ import static org.apache.hadoop.fs.CommonConfigurationKeys.HA_HM_RPC_TIMEOUT_KEY
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_NN_NOT_BECOME_ACTIVE_IN_SAFEMODE;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LIFELINE_RPC_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -40,21 +40,21 @@ import org.apache.hadoop.hdfs.tools.NNHAServiceTarget;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestNNHealthCheck {
 
   private MiniDFSCluster cluster;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
   }
 
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -111,9 +111,8 @@ public class TestNNHealthCheck {
         DFSUtil.getNamenodeNameServiceId(conf), "nn1");
     final String expectedTargetString = haTarget.getAddress().toString();
 
-    assertTrue("Expected haTarget " + haTarget + " containing " +
-            expectedTargetString,
-        haTarget.toString().contains(expectedTargetString));
+    assertTrue(haTarget.toString().contains(expectedTargetString),
+        "Expected haTarget " + haTarget + " containing " + expectedTargetString);
     HAServiceProtocol rpc = haTarget.getHealthMonitorProxy(conf, 5000);
 
     LambdaTestUtils.intercept(RemoteException.class,
@@ -136,9 +135,8 @@ public class TestNNHealthCheck {
     } else {
       expectedTargetString = haTarget.getAddress().toString();
     }
-    assertTrue("Expected haTarget " + haTarget + " containing " +
-        expectedTargetString,
-        haTarget.toString().contains(expectedTargetString));
+    assertTrue(haTarget.toString().contains(expectedTargetString),
+        "Expected haTarget " + haTarget + " containing " + expectedTargetString);
     HAServiceProtocol rpc = haTarget.getHealthMonitorProxy(conf, conf.getInt(
         HA_HM_RPC_TIMEOUT_KEY, HA_HM_RPC_TIMEOUT_DEFAULT));
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -126,7 +126,7 @@ public class TestObserverNode {
         "NN[2] should be observer");
   }
 
-@AfterAll
+  @AfterAll
   public static void shutDownCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
@@ -667,11 +667,11 @@ public class TestObserverNode {
         dfsCluster.getNameNode(2).getFSImage().getLastAppliedOrWrittenTxId(),
         "Active and Observer stateIds don't match");
     for (int i = 0; i < numThreads; i++) {
-        assertTrue(clientStates[i].lastSeenStateId >= activStateId && clientStates[i].fnfe == null,
-            "Client #" + i
-                + " lastSeenStateId=" + clientStates[i].lastSeenStateId
-          + " activStateId=" + activStateId
-                + "\n" + clientStates[i].fnfe);
+      assertTrue(clientStates[i].lastSeenStateId >= activStateId && clientStates[i].fnfe == null,
+          "Client #" + i
+              + " lastSeenStateId=" + clientStates[i].lastSeenStateId
+              + " activStateId=" + activStateId
+              + "\n" + clientStates[i].fnfe);
     }
 
     // Restore edit log
@@ -750,13 +750,13 @@ public class TestObserverNode {
 
   private static void assertSentTo(DistributedFileSystem fs, int nnIdx)
       throws IOException {
-      assertTrue(HATestUtil.isSentToAnyOfNameNodes(fs, dfsCluster, nnIdx),
-          "Request was not sent to the expected namenode " + nnIdx);
+    assertTrue(HATestUtil.isSentToAnyOfNameNodes(fs, dfsCluster, nnIdx),
+        "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private void assertSentTo(int nnIdx) throws IOException {
-      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
-          "Request was not sent to the expected namenode " + nnIdx);
+    assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
+        "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private static void setObserverRead(boolean flag) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverNode.java
@@ -21,10 +21,10 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_OBSERVER_ENABLED
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY;
 import static org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter.getServiceState;
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -75,11 +75,11 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +98,7 @@ public class TestObserverNode {
 
   private final Path testPath= new Path("/TestObserverNode");
 
-  @BeforeClass
+  @BeforeAll
   public static void startUpCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFS_NAMENODE_STATE_CONTEXT_ENABLED_KEY, true);
@@ -110,23 +110,23 @@ public class TestObserverNode {
     dfsCluster = qjmhaCluster.getDfsCluster();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     setObserverRead(true);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     dfs.delete(testPath, true);
-    assertEquals("NN[0] should be active", HAServiceState.ACTIVE,
-        getServiceState(dfsCluster.getNameNode(0)));
-    assertEquals("NN[1] should be standby", HAServiceState.STANDBY,
-        getServiceState(dfsCluster.getNameNode(1)));
-    assertEquals("NN[2] should be observer", HAServiceState.OBSERVER,
-        getServiceState(dfsCluster.getNameNode(2)));
+    assertEquals(HAServiceState.ACTIVE, getServiceState(dfsCluster.getNameNode(0)),
+        "NN[0] should be active");
+    assertEquals(HAServiceState.STANDBY, getServiceState(dfsCluster.getNameNode(1)),
+        "NN[1] should be standby");
+    assertEquals(HAServiceState.OBSERVER, getServiceState(dfsCluster.getNameNode(2)),
+        "NN[2] should be observer");
   }
 
-  @AfterClass
+@AfterAll
   public static void shutDownCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
@@ -228,8 +228,8 @@ public class TestObserverNode {
     }
 
     // Confirm that the namenode at nnIdx is standby
-    assertTrue("The NameNode is observer despite being transitioned to standby",
-        dfsCluster.getNameNode(nnIdx).isStandbyState());
+    assertTrue(dfsCluster.getNameNode(nnIdx).isStandbyState(),
+        "The NameNode is observer despite being transitioned to standby");
 
     // Restart the NameNode with observer startup option as false
     dfsCluster.getConfiguration(nnIdx)
@@ -238,9 +238,9 @@ public class TestObserverNode {
 
     // Verify that the NameNode is not in Observer state
     dfsCluster.waitNameNodeUp(nnIdx);
-    assertTrue("The NameNode started as Observer despite "
-        + DFS_NAMENODE_OBSERVER_ENABLED_KEY + " being false",
-        dfsCluster.getNameNode(nnIdx).isStandbyState());
+    assertTrue(dfsCluster.getNameNode(nnIdx).isStandbyState(),
+        "The NameNode started as Observer despite " + DFS_NAMENODE_OBSERVER_ENABLED_KEY
+            + " being false");
 
     dfs.mkdir(testPath, FsPermission.getDefault());
     assertSentTo(0);
@@ -260,9 +260,9 @@ public class TestObserverNode {
 
     // Check that the NameNode is in Observer state
     dfsCluster.waitNameNodeUp(nnIdx);
-    assertTrue("The NameNode did not start as Observer despite "
-        + DFS_NAMENODE_OBSERVER_ENABLED_KEY + " being true",
-        dfsCluster.getNameNode(nnIdx).isObserverState());
+    assertTrue(dfsCluster.getNameNode(nnIdx).isObserverState(),
+        "The NameNode did not start as Observer despite " + DFS_NAMENODE_OBSERVER_ENABLED_KEY
+            + " being true");
 
     dfs.mkdir(testPath2, FsPermission.getDefault());
     assertSentTo(0);
@@ -563,16 +563,15 @@ public class TestObserverNode {
     dfsCluster.rollEditLogAndTail(0);
     // No Observers present, should still go to Active
     dfsCluster.transitionToStandby(2);
-    assertEquals("NN[2] should be standby", HAServiceState.STANDBY,
-        getServiceState(dfsCluster.getNameNode(2)));
+    assertEquals(HAServiceState.STANDBY, getServiceState(dfsCluster.getNameNode(2)),
+        "NN[2] should be standby");
     newFs.open(testFile).close();
     assertSentTo(0);
     // Restore Observer
     int newObserver = 1;
     dfsCluster.transitionToObserver(newObserver);
-    assertEquals("NN[" + newObserver + "] should be observer",
-        HAServiceState.OBSERVER,
-        getServiceState(dfsCluster.getNameNode(newObserver)));
+    assertEquals(HAServiceState.OBSERVER, getServiceState(dfsCluster.getNameNode(newObserver)),
+        "NN[" + newObserver + "] should be observer");
     long startTime = Time.monotonicNow();
     try {
       while(Time.monotonicNow() - startTime <= 5000) {
@@ -661,19 +660,18 @@ public class TestObserverNode {
         LOG.warn("MkDirRunner thread failed", e.getCause());
       }
     }
-    assertTrue("Not all threads finished", finished);
+    assertTrue(finished, "Not all threads finished");
     threadPool.shutdown();
 
-    assertEquals("Active and Observer stateIds don't match",
-        dfsCluster.getNameNode(0).getFSImage().getLastAppliedOrWrittenTxId(),
-        dfsCluster.getNameNode(2).getFSImage().getLastAppliedOrWrittenTxId());
+    assertEquals(dfsCluster.getNameNode(0).getFSImage().getLastAppliedOrWrittenTxId(),
+        dfsCluster.getNameNode(2).getFSImage().getLastAppliedOrWrittenTxId(),
+        "Active and Observer stateIds don't match");
     for (int i = 0; i < numThreads; i++) {
-      assertTrue("Client #" + i
-          + " lastSeenStateId=" + clientStates[i].lastSeenStateId
+        assertTrue(clientStates[i].lastSeenStateId >= activStateId && clientStates[i].fnfe == null,
+            "Client #" + i
+                + " lastSeenStateId=" + clientStates[i].lastSeenStateId
           + " activStateId=" + activStateId
-          + "\n" + clientStates[i].fnfe,
-          clientStates[i].lastSeenStateId >= activStateId &&
-          clientStates[i].fnfe == null);
+                + "\n" + clientStates[i].fnfe);
     }
 
     // Restore edit log
@@ -707,7 +705,7 @@ public class TestObserverNode {
 
         FileStatus stat = fs.getFileStatus(DIR_PATH);
         assertSentTo(fs, 2);
-        assertTrue("Should be a directory", stat.isDirectory());
+        assertTrue(stat.isDirectory(), "Should be a directory");
       } catch (FileNotFoundException ioe) {
         clientState.fnfe = ioe;
       } catch (Exception e) {
@@ -752,13 +750,13 @@ public class TestObserverNode {
 
   private static void assertSentTo(DistributedFileSystem fs, int nnIdx)
       throws IOException {
-    assertTrue("Request was not sent to the expected namenode " + nnIdx,
-        HATestUtil.isSentToAnyOfNameNodes(fs, dfsCluster, nnIdx));
+      assertTrue(HATestUtil.isSentToAnyOfNameNodes(fs, dfsCluster, nnIdx),
+          "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private void assertSentTo(int nnIdx) throws IOException {
-    assertTrue("Request was not sent to the expected namenode " + nnIdx,
-        HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx));
+      assertTrue(HATestUtil.isSentToAnyOfNameNodes(dfs, dfsCluster, nnIdx),
+          "Request was not sent to the expected namenode " + nnIdx);
   }
 
   private static void setObserverRead(boolean flag) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -264,7 +264,7 @@ public class TestObserverReadProxyProvider {
       doWrite();
       fail("Write should fail; failover required");
     } catch (RemoteException re) {
-        assertEquals(re.getClassName(), StandbyException.class.getCanonicalName());
+      assertEquals(re.getClassName(), StandbyException.class.getCanonicalName());
     }
     proxyProvider.performFailover(proxyProvider.getProxy().proxy);
     doWrite();
@@ -530,7 +530,7 @@ public class TestObserverReadProxyProvider {
   }
 
   private void assertHandledBy(int namenodeIdx) {
-      assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo);
+    assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo);
   }
 
   private static void doWrite(ClientProtocol client) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -42,9 +42,10 @@ import org.apache.hadoop.ipc.StandbyException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.tools.GetUserMappingsProtocol;
 import org.apache.hadoop.util.StopWatch;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -53,11 +54,11 @@ import org.slf4j.event.Level;
 import static org.apache.hadoop.ha.HAServiceProtocol.HAServiceState;
 
 import static org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider.*;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -86,12 +87,12 @@ public class TestObserverReadProxyProvider {
   private NameNodeAnswer[] namenodeAnswers;
   private String[] namenodeAddrs;
 
-  @BeforeClass
+  @BeforeAll
   public static void setLogLevel() {
     GenericTestUtils.setLogLevel(ObserverReadProxyProvider.LOG, Level.DEBUG);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ns = "testcluster";
     nnURI = URI.create("hdfs://" + ns);
@@ -179,8 +180,7 @@ public class TestObserverReadProxyProvider {
     ObserverReadProxyProvider<GetUserMappingsProtocol> userProxyProvider =
         new ObserverReadProxyProvider<>(proxyProvider.conf, nnURI,
             GetUserMappingsProtocol.class, proxyFactory);
-    assertArrayEquals(fakeGroups,
-        userProxyProvider.getProxy().proxy.getGroupsForUser(fakeUser));
+    assertArrayEquals(fakeGroups, userProxyProvider.getProxy().proxy.getGroupsForUser(fakeUser));
   }
 
   @Test
@@ -264,8 +264,7 @@ public class TestObserverReadProxyProvider {
       doWrite();
       fail("Write should fail; failover required");
     } catch (RemoteException re) {
-      assertEquals(re.getClassName(),
-          StandbyException.class.getCanonicalName());
+        assertEquals(re.getClassName(), StandbyException.class.getCanonicalName());
     }
     proxyProvider.performFailover(proxyProvider.getProxy().proxy);
     doWrite();
@@ -503,15 +502,16 @@ public class TestObserverReadProxyProvider {
     watch.start();
     doRead();
     long runtime = watch.now(TimeUnit.MILLISECONDS);
-    assertTrue("Read operation finished earlier than we expected",
-        runtime > SLOW_RESPONSE_SLEEP_TIME);
+    assertTrue(runtime > SLOW_RESPONSE_SLEEP_TIME,
+        "Read operation finished earlier than we expected");
   }
 
   /**
    * Test getHAServiceState using a 2s timeout with a slow standby.
    * Fail the test if we don't complete it in 4s.
    */
-  @Test(timeout = 4000)
+  @Test
+  @Timeout(value = 4)
   public void testStandbyGetHAServiceStateTimeout() throws Exception {
     setupProxyProvider(4, NAMENODE_HA_STATE_PROBE_TIMEOUT_SHORT);
     namenodeAnswers[0].setActiveState();
@@ -530,8 +530,7 @@ public class TestObserverReadProxyProvider {
   }
 
   private void assertHandledBy(int namenodeIdx) {
-    assertEquals(namenodeAddrs[namenodeIdx],
-        proxyProvider.getLastProxy().proxyInfo);
+      assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo);
   }
 
   private static void doWrite(ClientProtocol client) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPendingCorruptDnMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPendingCorruptDnMessages.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,13 +43,15 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestPendingCorruptDnMessages {
   
   private static final Path filePath = new Path("/foo.txt");
   
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testChangedStorageId() throws IOException, URISyntaxException,
       InterruptedException, TimeoutException {
     HdfsConfiguration conf = new HdfsConfiguration();
@@ -110,8 +112,7 @@ public class TestPendingCorruptDnMessages {
         }
       }, 1000, 30000);
       
-      assertEquals(0, cluster.getNamesystem(1).getBlockManager()
-          .getPendingDataNodeMessageCount());
+      assertEquals(0, cluster.getNamesystem(1).getBlockManager().getPendingDataNodeMessageCount());
       
       // Now try to fail over.
       cluster.transitionToStandby(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPipelinesFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestPipelinesFailover.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -58,7 +58,8 @@ import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Shell.ShellCommandExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
@@ -120,19 +121,22 @@ public class TestPipelinesFailover {
   /**
    * Tests continuing a write pipeline over a failover.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testWriteOverGracefulFailover() throws Exception {
     doWriteOverFailoverTest(TestScenario.GRACEFUL_FAILOVER,
         MethodToTestIdempotence.ALLOCATE_BLOCK);
   }
   
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAllocateBlockAfterCrashFailover() throws Exception {
     doWriteOverFailoverTest(TestScenario.ORIGINAL_ACTIVE_CRASHED,
         MethodToTestIdempotence.ALLOCATE_BLOCK);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testCompleteFileAfterCrashFailover() throws Exception {
     doWriteOverFailoverTest(TestScenario.ORIGINAL_ACTIVE_CRASHED,
         MethodToTestIdempotence.COMPLETE_FILE);
@@ -205,12 +209,14 @@ public class TestPipelinesFailover {
    * after the failover - ensures that updating the pipeline succeeds
    * even when the pipeline was constructed on a different NN.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testWriteOverGracefulFailoverWithDnFail() throws Exception {
     doTestWriteOverFailoverWithDnFail(TestScenario.GRACEFUL_FAILOVER);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testWriteOverCrashFailoverWithDnFail() throws Exception {
     doTestWriteOverFailoverWithDnFail(TestScenario.ORIGINAL_ACTIVE_CRASHED);
   }
@@ -272,7 +278,8 @@ public class TestPipelinesFailover {
    * Tests lease recovery if a client crashes. This approximates the
    * use case of HBase WALs being recovered after a NN failover.
    */
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testLeaseRecoveryAfterFailover() throws Exception {
     final Configuration conf = new Configuration();
     // Disable permissions so that another user can recover the lease.
@@ -324,7 +331,8 @@ public class TestPipelinesFailover {
    * DN running the recovery should then fail to commit the synchronization
    * and a later retry will succeed.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFailoverRightBeforeCommitSynchronization() throws Exception {
     final Configuration conf = new Configuration();
     // Disable permissions so that another user can recover the lease.
@@ -426,7 +434,8 @@ public class TestPipelinesFailover {
    * break the lease. While these threads run, failover proceeds
    * back and forth between two namenodes.
    */
-  @Test(timeout=STRESS_RUNTIME*3)
+  @Test
+  @Timeout(STRESS_RUNTIME*3)
   public void testPipelineRecoveryStress() throws Exception {
 
     // The following section of code is to help debug HDFS-6694 about

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestQuotasWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestQuotasWithHA.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdfs.server.namenode.ha;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
@@ -40,7 +41,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 public class TestQuotasWithHA {
   private static final Path TEST_DIR = new Path("/test");
@@ -143,13 +143,12 @@ public class TestQuotasWithHA {
    */
   @Test
   public void testGetContentSummaryOnStandby() throws Exception {
-      Assertions.assertThrows(StandbyException.class, () -> {
-          Configuration nn1conf = cluster.getConfiguration(1);
-          HAUtil.setAllowStandbyReads(nn1conf, false);
-          cluster.restartNameNode(1);
-          cluster.getNameNodeRpc(1).getContentSummary("/");
-      });
-
+    assertThrows(StandbyException.class, () -> {
+      Configuration nn1conf = cluster.getConfiguration(1);
+      HAUtil.setAllowStandbyReads(nn1conf, false);
+      cluster.restartNameNode(1);
+      cluster.getNameNodeRpc(1).getContentSummary("/");
+    });
   }
 
   /**
@@ -157,12 +156,11 @@ public class TestQuotasWithHA {
    */
   @Test
   public void testGetQuotaUsageOnStandby() throws Exception {
-      Assertions.assertThrows(StandbyException.class, () -> {
-          Configuration nn1conf = cluster.getConfiguration(1);
-          HAUtil.setAllowStandbyReads(nn1conf, false);
-          cluster.restartNameNode(1);
-          cluster.getNameNodeRpc(1).getQuotaUsage("/");
-      });
-
+    assertThrows(StandbyException.class, () -> {
+      Configuration nn1conf = cluster.getConfiguration(1);
+      HAUtil.setAllowStandbyReads(nn1conf, false);
+      cluster.restartNameNode(1);
+      cluster.getNameNodeRpc(1).getQuotaUsage("/");
+    });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestQuotasWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestQuotasWithHA.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -36,9 +36,11 @@ import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.StandbyException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Assertions;
 
 public class TestQuotasWithHA {
   private static final Path TEST_DIR = new Path("/test");
@@ -54,7 +56,7 @@ public class TestQuotasWithHA {
   private NameNode nn1;
   private FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
@@ -76,7 +78,7 @@ public class TestQuotasWithHA {
     cluster.transitionToActive(0);
   }
   
-  @After
+  @AfterEach
   public void shutdownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -88,7 +90,8 @@ public class TestQuotasWithHA {
    * Test that quotas are properly tracked by the standby through
    * create, append, delete.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testQuotasTrackedOnStandby() throws Exception {
     fs.mkdirs(TEST_DIR);
     DistributedFileSystem dfs = (DistributedFileSystem)fs;
@@ -138,24 +141,28 @@ public class TestQuotasWithHA {
    * Test that getContentSummary on Standby should should throw standby
    * exception.
    */
-  @Test(expected = StandbyException.class)
+  @Test
   public void testGetContentSummaryOnStandby() throws Exception {
-    Configuration nn1conf =cluster.getConfiguration(1);
-    // just reset the standby reads to default i.e False on standby.
-    HAUtil.setAllowStandbyReads(nn1conf, false);
-    cluster.restartNameNode(1);
-    cluster.getNameNodeRpc(1).getContentSummary("/");
+      Assertions.assertThrows(StandbyException.class, () -> {
+          Configuration nn1conf = cluster.getConfiguration(1);
+          HAUtil.setAllowStandbyReads(nn1conf, false);
+          cluster.restartNameNode(1);
+          cluster.getNameNodeRpc(1).getContentSummary("/");
+      });
+
   }
 
   /**
    * Test that getQuotaUsage on Standby should should throw standby exception.
    */
-  @Test(expected = StandbyException.class)
+  @Test
   public void testGetQuotaUsageOnStandby() throws Exception {
-    Configuration nn1conf =cluster.getConfiguration(1);
-    // just reset the standby reads to default i.e False on standby.
-    HAUtil.setAllowStandbyReads(nn1conf, false);
-    cluster.restartNameNode(1);
-    cluster.getNameNodeRpc(1).getQuotaUsage("/");
+      Assertions.assertThrows(StandbyException.class, () -> {
+          Configuration nn1conf = cluster.getConfiguration(1);
+          HAUtil.setAllowStandbyReads(nn1conf, false);
+          cluster.restartNameNode(1);
+          cluster.getNameNodeRpc(1).getQuotaUsage("/");
+      });
+
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRemoteNameNodeInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRemoteNameNodeInfo.java
@@ -21,11 +21,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test that we correctly obtain remote namenode information

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,8 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -91,9 +90,10 @@ import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ipc.RetryCache.CacheEntry;
 import org.apache.hadoop.util.LightWeightCache;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestRetryCacheWithHA {
   private static final Logger LOG =
@@ -109,8 +109,9 @@ public class TestRetryCacheWithHA {
   private static final int CHECKTIMES = 10;
   private static final int ResponseSize = 3;
 
-  @Rule
-  public TemporaryFolder baseDir = new TemporaryFolder();
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @TempDir
+  java.nio.file.Path baseDir;
 
   private MiniDFSCluster cluster;
   private DistributedFileSystem dfs;
@@ -142,14 +143,14 @@ public class TestRetryCacheWithHA {
     }
   }
   
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BlockSize);
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_LIST_CACHE_DIRECTIVES_NUM_RESPONSES, ResponseSize);
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_LIST_CACHE_POOLS_NUM_RESPONSES, ResponseSize);
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_ACLS_ENABLED_KEY, true);
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_XATTRS_ENABLED_KEY, true);
-    cluster = new MiniDFSCluster.Builder(conf, baseDir.getRoot())
+    cluster = new MiniDFSCluster.Builder(conf, baseDir.toFile())
         .nnTopology(MiniDFSNNTopology.simpleHATopology())
         .numDataNodes(DataNodes).build();
     cluster.waitActive();
@@ -159,7 +160,7 @@ public class TestRetryCacheWithHA {
     dfs = (DistributedFileSystem) HATestUtil.configureFailoverFs(cluster, conf);
   }
   
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -172,7 +173,8 @@ public class TestRetryCacheWithHA {
    * 2. Trigger the NN failover
    * 3. Check the retry cache on the original standby NN
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRetryCacheOnStandbyNN() throws Exception {
     // 1. run operations
     DFSTestUtil.runOperations(cluster, dfs, conf, BlockSize, 0);
@@ -181,7 +183,7 @@ public class TestRetryCacheWithHA {
     FSNamesystem fsn0 = cluster.getNamesystem(0);
     LightWeightCache<CacheEntry, CacheEntry> cacheSet = 
         (LightWeightCache<CacheEntry, CacheEntry>) fsn0.getRetryCache().getCacheSet();
-    assertEquals("Retry cache size is wrong", 39, cacheSet.size());
+    assertEquals(39, cacheSet.size(), "Retry cache size is wrong");
     
     Map<CacheEntry, CacheEntry> oldEntries = 
         new HashMap<CacheEntry, CacheEntry>();
@@ -202,7 +204,7 @@ public class TestRetryCacheWithHA {
     FSNamesystem fsn1 = cluster.getNamesystem(1);
     cacheSet = (LightWeightCache<CacheEntry, CacheEntry>) fsn1
         .getRetryCache().getCacheSet();
-    assertEquals("Retry cache size is wrong", 39, cacheSet.size());
+    assertEquals(39, cacheSet.size(), "Retry cache size is wrong");
     iter = cacheSet.iterator();
     while (iter.hasNext()) {
       CacheEntry entry = iter.next();
@@ -1153,84 +1155,96 @@ public class TestRetryCacheWithHA {
     }
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreateSnapshot() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new CreateSnapshotOp(client, "/test", "s1");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeleteSnapshot() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new DeleteSnapshotOp(client, "/test", "s1");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRenameSnapshot() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new RenameSnapshotOp(client, "/test", "s1", "s2");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreate() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new CreateOp(client, "/testfile");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAppend() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new AppendOp(client, "/testfile");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRename() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new RenameOp(client, "/file1", "/file2");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRename2() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new Rename2Op(client, "/file1", "/file2");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testConcat() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new ConcatOp(client, new Path("/test/file"), 5);
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDelete() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new DeleteOp(client, "/testfile");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreateSymlink() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new CreateSymlinkOp(client, "/testfile", "/testlink");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdatePipeline() throws Exception {
     final DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new UpdatePipelineOp(client, "/testfile");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAddCacheDirectiveInfo() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new AddCacheDirectiveInfoOp(client, 
@@ -1241,7 +1255,8 @@ public class TestRetryCacheWithHA {
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testModifyCacheDirectiveInfo() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new ModifyCacheDirectiveInfoOp(client, 
@@ -1253,7 +1268,8 @@ public class TestRetryCacheWithHA {
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRemoveCacheDescriptor() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new RemoveCacheDirectiveInfoOp(client, "pool",
@@ -1261,35 +1277,40 @@ public class TestRetryCacheWithHA {
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAddCachePool() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new AddCachePoolOp(client, "pool");
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testModifyCachePool() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new ModifyCachePoolOp(client, "pool");
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRemoveCachePool() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new RemoveCachePoolOp(client, "pool");
     testClientRetryWithFailover(op);
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSetXAttr() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new SetXAttrOp(client, "/setxattr");
     testClientRetryWithFailover(op);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testRemoveXAttr() throws Exception {
     DFSClient client = genClientWithDummyHandler();
     AtMostOnceOp op = new RemoveXAttrOp(client, "/removexattr");
@@ -1326,9 +1347,8 @@ public class TestRetryCacheWithHA {
     }.start();
     
     // make sure the client's call has actually been handled by the active NN
-    assertTrue("After waiting the operation " + op.name
-        + " still has not taken effect on NN yet",
-        op.checkNamenodeBeforeReturn());
+    assertTrue(op.checkNamenodeBeforeReturn(),
+        "After waiting the operation " + op.name + " still has not taken effect on NN yet");
     
     // force the failover
     cluster.transitionToStandby(0);
@@ -1356,8 +1376,7 @@ public class TestRetryCacheWithHA {
       return (hitsNN[0] + hitsNN[1]) > 0;
     }, 5, 10000);
 
-    assertTrue("CacheHit: " + hitsNN[0] + ", " + hitsNN[1],
-        +hitsNN[0] + hitsNN[1] > 0);
+    assertTrue(+hitsNN[0] + hitsNN[1] > 0, "CacheHit: " + hitsNN[0] + ", " + hitsNN[1]);
     final long[] updatesNN = new long[]{0, 0};
     GenericTestUtils.waitFor(() -> {
       updatesNN[0] = cluster.getNamesystem(0).getRetryCache()
@@ -1369,15 +1388,13 @@ public class TestRetryCacheWithHA {
       return updatesNN[0] > 0 && updatesNN[1] > 0;
     }, 5, 10000);
     // Cache updated metrics on NN0 should be >0 since the op was process on NN0
-    assertTrue("CacheUpdated on NN0: " + updatesNN[0], updatesNN[0] > 0);
+    assertTrue(updatesNN[0] > 0, "CacheUpdated on NN0: " + updatesNN[0]);
     // Cache updated metrics on NN0 should be >0 since NN1 applied the editlog
-    assertTrue("CacheUpdated on NN1: " + updatesNN[1], updatesNN[1] > 0);
+    assertTrue(updatesNN[1] > 0, "CacheUpdated on NN1: " + updatesNN[1]);
     long expectedUpdateCount = op.getExpectedCacheUpdateCount();
     if (expectedUpdateCount > 0) {
-      assertEquals("CacheUpdated on NN0: " + updatesNN[0], expectedUpdateCount,
-          updatesNN[0]);
-      assertEquals("CacheUpdated on NN0: " + updatesNN[1], expectedUpdateCount,
-          updatesNN[1]);
+        assertEquals(expectedUpdateCount, updatesNN[0], "CacheUpdated on NN0: " + updatesNN[0]);
+        assertEquals(expectedUpdateCount, updatesNN[1], "CacheUpdated on NN0: " + updatesNN[1]);
     }
   }
 
@@ -1385,7 +1402,8 @@ public class TestRetryCacheWithHA {
    * Add a list of cache pools, list cache pools,
    * switch active NN, and list cache pools again.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testListCachePools() throws Exception {
     final int poolCount = 7;
     HashSet<String> poolNames = new HashSet<String>(poolCount);
@@ -1406,7 +1424,8 @@ public class TestRetryCacheWithHA {
    * Add a list of cache directives, list cache directives,
    * switch active NN, and list cache directives again.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testListCacheDirectives() throws Exception {
     final int poolCount = 7;
     HashSet<String> poolNames = new HashSet<String>(poolCount);
@@ -1436,7 +1455,7 @@ public class TestRetryCacheWithHA {
     for (int i=0; i<poolCount; i++) {
       CachePoolEntry pool = pools.next();
       String pollName = pool.getInfo().getPoolName();
-      assertTrue("The pool name should be expected", tmpNames.remove(pollName));
+      assertTrue(tmpNames.remove(pollName), "The pool name should be expected");
       if (i % 2 == 0) {
         int standby = active;
         active = (standby == 0) ? 1 : 0;
@@ -1445,7 +1464,7 @@ public class TestRetryCacheWithHA {
         cluster.waitActive(active);
       }
     }
-    assertTrue("All pools must be found", tmpNames.isEmpty());
+    assertTrue(tmpNames.isEmpty(), "All pools must be found");
   }
 
   @SuppressWarnings("unchecked")
@@ -1457,7 +1476,7 @@ public class TestRetryCacheWithHA {
     for (int i=0; i<poolCount; i++) {
       CacheDirectiveEntry directive = directives.next();
       String pollName = directive.getInfo().getPool();
-      assertTrue("The pool name should be expected", tmpNames.remove(pollName));
+      assertTrue(tmpNames.remove(pollName), "The pool name should be expected");
       if (i % 2 == 0) {
         int standby = active;
         active = (standby == 0) ? 1 : 0;
@@ -1466,6 +1485,6 @@ public class TestRetryCacheWithHA {
         cluster.waitActive(active);
       }
     }
-    assertTrue("All pools must be found", tmpNames.isEmpty());
+    assertTrue(tmpNames.isEmpty(), "All pools must be found");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestRetryCacheWithHA.java
@@ -1393,8 +1393,8 @@ public class TestRetryCacheWithHA {
     assertTrue(updatesNN[1] > 0, "CacheUpdated on NN1: " + updatesNN[1]);
     long expectedUpdateCount = op.getExpectedCacheUpdateCount();
     if (expectedUpdateCount > 0) {
-        assertEquals(expectedUpdateCount, updatesNN[0], "CacheUpdated on NN0: " + updatesNN[0]);
-        assertEquals(expectedUpdateCount, updatesNN[1], "CacheUpdated on NN0: " + updatesNN[1]);
+      assertEquals(expectedUpdateCount, updatesNN[0], "CacheUpdated on NN0: " + updatesNN[0]);
+      assertEquals(expectedUpdateCount, updatesNN[1], "CacheUpdated on NN0: " + updatesNN[1]);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestSeveralNameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestSeveralNameNodes.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.test.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that we can start several and run with namenodes on the same minicluster
@@ -92,10 +92,8 @@ public class TestSeveralNameNodes {
           }
         }
       }
-      assertEquals(
-          "Some writers didn't complete in expected runtime! Current writer state:"
-              + writers, 0,
-          writers.size());
+      assertEquals(0, writers.size(),
+          "Some writers didn't complete in expected runtime! Current writer state:" + writers);
 
       harness.stopThreads();
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyBlockManagement.java
@@ -29,10 +29,11 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockManagerTestUtil;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Makes sure that standby doesn't do the unnecessary block management such as
@@ -49,7 +50,8 @@ public class TestStandbyBlockManagement {
     DFSTestUtil.setNameNodeLogLevel(Level.TRACE);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testInvalidateBlock() throws Exception {
     Configuration conf = new Configuration();
     HAUtil.setAllowStandbyReads(conf, true);
@@ -82,15 +84,13 @@ public class TestStandbyBlockManagement {
       nn1.getRpcServer().rollEditLog();
 
       // standby nn doesn't need to invalidate blocks.
-      assertEquals(0,
-          nn2.getNamesystem().getBlockManager().getPendingDeletionBlocksCount());
+      assertEquals(0, nn2.getNamesystem().getBlockManager().getPendingDeletionBlocksCount());
 
       cluster.triggerHeartbeats();
       cluster.triggerBlockReports();
 
       // standby nn doesn't need to invalidate blocks.
-      assertEquals(0,
-          nn2.getNamesystem().getBlockManager().getPendingDeletionBlocksCount());
+      assertEquals(0, nn2.getNamesystem().getBlockManager().getPendingDeletionBlocksCount());
 
     } finally {
       cluster.shutdown();
@@ -102,7 +102,8 @@ public class TestStandbyBlockManagement {
    * when set decrease replication.
    * @throws Exception
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testNotHandleRedundantReplica() throws Exception {
     Configuration conf = new Configuration();
     HAUtil.setAllowStandbyReads(conf, true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
@@ -54,9 +54,10 @@ import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
@@ -65,7 +66,7 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
 public class TestStandbyCheckpoints {
@@ -80,7 +81,7 @@ public class TestStandbyCheckpoints {
   private static final Logger LOG = LoggerFactory.getLogger(TestStandbyCheckpoints.class);
 
   @SuppressWarnings("rawtypes")
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     Configuration conf = setupCommonConfig();
 
@@ -143,7 +144,7 @@ public class TestStandbyCheckpoints {
     return conf;
   }
 
-  @After
+  @AfterEach
   public void shutdownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -155,7 +156,8 @@ public class TestStandbyCheckpoints {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSBNCheckpoints() throws Exception {
     JournalSet standbyJournalSet = NameNodeAdapterMockitoUtil.spyOnJournalSet(nns[1]);
 
@@ -177,7 +179,7 @@ public class TestStandbyCheckpoints {
     }, 1000, 60000);
     
     // It should have saved the oiv image too.
-    assertEquals("One file is expected", 1, tmpOivImgDir.list().length);
+    assertEquals(1, tmpOivImgDir.list().length, "One file is expected");
     
     // It should also upload it back to the active.
     HATestUtil.waitForCheckpoint(cluster, 0, ImmutableList.of(12));
@@ -234,7 +236,8 @@ public class TestStandbyCheckpoints {
    * checkpoint for the given txid, but this should not cause
    * an abort, etc.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBothNodesInStandbyState() throws Exception {
     doEdits(0, 10);
     
@@ -247,10 +250,8 @@ public class TestStandbyCheckpoints {
     HATestUtil.waitForCheckpoint(cluster, 1, ImmutableList.of(12));
     HATestUtil.waitForCheckpoint(cluster, 0, ImmutableList.of(12));
     
-    assertEquals(12, nns[0].getNamesystem().getFSImage()
-        .getMostRecentCheckpointTxId());
-    assertEquals(12, nns[1].getNamesystem().getFSImage()
-        .getMostRecentCheckpointTxId());
+    assertEquals(12, nns[0].getNamesystem().getFSImage().getMostRecentCheckpointTxId());
+    assertEquals(12, nns[1].getNamesystem().getFSImage().getMostRecentCheckpointTxId());
     
     List<File> dirs = Lists.newArrayList();
     dirs.addAll(FSImageTestUtil.getNameNodeCurrentDirs(cluster, 0));
@@ -262,7 +263,8 @@ public class TestStandbyCheckpoints {
    * Test for the case of when there are observer NameNodes, Standby node is
    * able to upload fsImage to Observer node as well.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testStandbyAndObserverState() throws Exception {
     // Transition 2 to observer
     cluster.transitionToObserver(2);
@@ -277,10 +279,8 @@ public class TestStandbyCheckpoints {
     HATestUtil.waitForCheckpoint(cluster, 0, ImmutableList.of(12));
     HATestUtil.waitForCheckpoint(cluster, 2, ImmutableList.of(12));
 
-    assertEquals(12, nns[2].getNamesystem().getFSImage()
-        .getMostRecentCheckpointTxId());
-    assertEquals(12, nns[1].getNamesystem().getFSImage()
-        .getMostRecentCheckpointTxId());
+    assertEquals(12, nns[2].getNamesystem().getFSImage().getMostRecentCheckpointTxId());
+    assertEquals(12, nns[1].getNamesystem().getFSImage().getMostRecentCheckpointTxId());
 
     List<File> dirs = Lists.newArrayList();
     // observer and standby both have this same image.
@@ -296,7 +296,8 @@ public class TestStandbyCheckpoints {
    * If putImage is called while a NameNode is still starting up, the FSImage
    * may not have been initialized yet. See HDFS-15290.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testCheckpointBeforeNameNodeInitializationIsComplete()
       throws Exception {
     final LogVerificationAppender appender = new LogVerificationAppender();
@@ -341,7 +342,8 @@ public class TestStandbyCheckpoints {
    * same txid, which is a no-op. This test makes sure this doesn't
    * cause any problem.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testCheckpointWhenNoNewTransactionsHappened()
       throws Exception {
     // Checkpoint as fast as we can, in a tight loop.
@@ -370,7 +372,8 @@ public class TestStandbyCheckpoints {
    * Test cancellation of ongoing checkpoints when failover happens
    * mid-checkpoint. 
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testCheckpointCancellation() throws Exception {
     cluster.transitionToStandby(0);
     
@@ -414,7 +417,8 @@ public class TestStandbyCheckpoints {
    * Test cancellation of ongoing checkpoints when failover happens
    * mid-checkpoint during image upload from standby to active NN.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCheckpointCancellationDuringUpload() throws Exception {
     // Set dfs.namenode.checkpoint.txns differently on the first NN to avoid it
     // doing checkpoint when it becomes a standby
@@ -482,7 +486,8 @@ public class TestStandbyCheckpoints {
    * checkpoint is in progress on the SBN, and therefore the StandbyCheckpointer
    * thread will have FSNS lock. Regression test for HDFS-4591.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testStandbyExceptionThrownDuringCheckpoint() throws Exception {
     
     // Set it up so that we know when the SBN checkpoint starts and ends.
@@ -496,8 +501,8 @@ public class TestStandbyCheckpoints {
     doEdits(0, 1000);
     nns[0].getRpcServer().rollEditLog();
     answerer.waitForCall();
-    assertTrue("SBN is not performing checkpoint but it should be.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 0);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 0,
+        "SBN is not performing checkpoint but it should be.");
     
     // Make sure that the lock has actually been taken by the checkpointing
     // thread.
@@ -519,15 +524,16 @@ public class TestStandbyCheckpoints {
     
     // Make sure that the checkpoint is still going on, implying that the client
     // RPC to the SBN happened during the checkpoint.
-    assertTrue("SBN should have still been checkpointing.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 0);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 0,
+        "SBN should have still been checkpointing.");
     answerer.proceed();
     answerer.waitForResult();
-    assertTrue("SBN should have finished checkpointing.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 1);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 1,
+        "SBN should have finished checkpointing.");
   }
   
-  @Test(timeout=300000)
+@Test
+@Timeout(value = 300)
   public void testReadsAllowedDuringCheckpoint() throws Exception {
     
     // Set it up so that we know when the SBN checkpoint starts and ends.
@@ -542,8 +548,8 @@ public class TestStandbyCheckpoints {
     doEdits(0, 1000);
     nns[0].getRpcServer().rollEditLog();
     answerer.waitForCall();
-    assertTrue("SBN is not performing checkpoint but it should be.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 0);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 0,
+        "SBN is not performing checkpoint but it should be.");
     
     // Make sure that the lock has actually been taken by the checkpointing
     // thread.
@@ -578,12 +584,12 @@ public class TestStandbyCheckpoints {
     
     // Make sure that the checkpoint is still going on, implying that the client
     // RPC to the SBN happened during the checkpoint.
-    assertTrue("SBN should have still been checkpointing.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 0);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 0,
+        "SBN should have still been checkpointing.");
     answerer.proceed();
     answerer.waitForResult();
-    assertTrue("SBN should have finished checkpointing.",
-        answerer.getFireCount() == 1 && answerer.getResultCount() == 1);
+    assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 1,
+        "SBN should have finished checkpointing.");
     
     t.join();
   }
@@ -592,7 +598,8 @@ public class TestStandbyCheckpoints {
    * Test for the case standby NNs can upload FSImage to ANN after
    * become non-primary standby NN. HDFS-9787
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testNonPrimarySBNUploadFSImage() throws Exception {
     // Shutdown all standby NNs.
     for (int i = 1; i < NUM_NNS; i++) {
@@ -634,7 +641,8 @@ public class TestStandbyCheckpoints {
    * Test that checkpointing is still successful even if an issue
    * was encountered while writing the legacy OIV image.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testCheckpointSucceedsWithLegacyOIVException() throws Exception {
     // Delete the OIV image dir to cause an IOException while saving
     FileUtil.fullyDelete(tmpOivImgDir);
@@ -652,7 +660,8 @@ public class TestStandbyCheckpoints {
   /**
    * Test that lastCheckpointTime is correctly updated at each checkpoint.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testLastCheckpointTime() throws Exception {
     for (int i = 1; i < NUM_NNS; i++) {
       cluster.shutdownNameNode(i);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
@@ -531,9 +531,9 @@ public class TestStandbyCheckpoints {
     assertTrue(answerer.getFireCount() == 1 && answerer.getResultCount() == 1,
         "SBN should have finished checkpointing.");
   }
-  
-@Test
-@Timeout(value = 300)
+
+  @Test
+  @Timeout(value = 300)
   public void testReadsAllowedDuringCheckpoint() throws Exception {
     
     // Set it up so that we know when the SBN checkpoint starts and ends.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyCheckpoints.java
@@ -66,7 +66,10 @@ import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 public class TestStandbyCheckpoints {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyInProgressTail.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyInProgressTail.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -45,9 +45,9 @@ import org.apache.hadoop.util.Lists;
 import static org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter.getFileInfo;
 import static org.apache.hadoop.hdfs.qjournal.client.QuorumJournalManager.QJM_RPC_MAX_TXNS_KEY;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +66,7 @@ public class TestStandbyInProgressTail {
   private NameNode nn0;
   private NameNode nn1;
 
-  @Before
+  @BeforeEach
   public void startUp() throws IOException {
     conf = new Configuration();
     // Set period of tail edits to a large value (20 mins) for test purposes
@@ -85,7 +85,7 @@ public class TestStandbyInProgressTail {
     nn1 = cluster.getNameNode(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyIsHot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyIsHot.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -39,8 +39,9 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.util.function.Supplier;
@@ -60,7 +61,8 @@ public class TestStandbyIsHot {
     DFSTestUtil.setNameNodeLogLevel(Level.TRACE);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testStandbyIsHot() throws Exception {
     Configuration conf = new Configuration();
     // We read from the standby to watch block locations
@@ -132,7 +134,8 @@ public class TestStandbyIsHot {
    * In the bug, the standby node would only very slowly notice the blocks returning
    * to the cluster.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testDatanodeRestarts() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024);
@@ -175,8 +178,8 @@ public class TestStandbyIsHot {
       
       LocatedBlocks locs = nn1.getRpcServer().getBlockLocations(
           TEST_FILE, 0, 1);
-      assertEquals("Standby should have registered that the block has no replicas",
-          0, locs.get(0).getLocations().length);
+      assertEquals(0, locs.get(0).getLocations().length,
+          "Standby should have registered that the block has no replicas");
       
       cluster.restartDataNode(dnProps);
       // Wait for both NNs to re-register the DN.
@@ -192,8 +195,8 @@ public class TestStandbyIsHot {
       
       locs = nn1.getRpcServer().getBlockLocations(
           TEST_FILE, 0, 1);
-      assertEquals("Standby should have registered that the block has replicas again",
-          1, locs.get(0).getLocations().length);
+      assertEquals(1, locs.get(0).getLocations().length,
+          "Standby should have registered that the block has replicas again");
     } finally {
       cluster.shutdown();
     }
@@ -211,8 +214,8 @@ public class TestStandbyIsHot {
           LocatedBlocks locs = NameNodeAdapter.getBlockLocations(nn, path, 0, 1000);
           DatanodeInfo[] dnis = locs.getLastLocatedBlock().getLocations();
           for (DatanodeInfo dni : dnis) {
-            Assert.assertNotNull(dni);
-          }
+                    Assertions.assertNotNull(dni);
+                }
           int numReplicas = dnis.length;
           
           LOG.info("Got " + numReplicas + " locs: " + locs);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyIsHot.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStandbyIsHot.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 
@@ -39,7 +40,6 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
@@ -214,8 +214,8 @@ public class TestStandbyIsHot {
           LocatedBlocks locs = NameNodeAdapter.getBlockLocations(nn, path, 0, 1000);
           DatanodeInfo[] dnis = locs.getLastLocatedBlock().getLocations();
           for (DatanodeInfo dni : dnis) {
-                    Assertions.assertNotNull(dni);
-                }
+            assertNotNull(dni);
+          }
           int numReplicas = dnis.length;
           
           LOG.info("Got " + numReplicas + " locs: " + locs);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStateTransitionFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestStateTransitionFailure.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.util.ExitUtil.ExitException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests to verify the behavior of failing to fully start transition HA states.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestUpdateBlockTailing.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestUpdateBlockTailing.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HA_TAILEDITS_INPROGRESS_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -46,11 +46,10 @@ import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.protocol.ReceivedDeletedBlockInfo;
 import org.apache.hadoop.hdfs.server.protocol.StorageReceivedDeletedBlocks;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the race condition that IBR and update block may result
@@ -67,7 +66,7 @@ public class TestUpdateBlockTailing {
   private static FSNamesystem fsn1;
   private static DataNode dn0;
 
-  @BeforeClass
+  @BeforeAll
   public static void startUpCluster() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(DFS_HA_TAILEDITS_INPROGRESS_KEY, true);
@@ -85,14 +84,14 @@ public class TestUpdateBlockTailing {
     dn0 = dfsCluster.getDataNodes().get(0);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutDownCluster() throws IOException {
     if (qjmhaCluster != null) {
       qjmhaCluster.shutdown();
     }
   }
 
-  @Before
+  @BeforeEach
   public void reset() throws Exception {
     dfsCluster.transitionToStandby(1);
     dfsCluster.transitionToActive(0);
@@ -103,9 +102,8 @@ public class TestUpdateBlockTailing {
     String testFile = TEST_DIR +"/testStandbyAddBlockIBRRace";
 
     // initial global generation stamp check
-    assertEquals("Global Generation stamps on NNs should be the same",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NNs should be the same");
 
     // create a file, add a block on NN0
     // do not journal addBlock yet
@@ -123,10 +121,9 @@ public class TestUpdateBlockTailing {
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
 
-    assertEquals("Global Generation stamps on NN0 and "
-            + "impending on NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getImpendingGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0),
+        NameNodeAdapter.getImpendingGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "impending on NN1 should be equal");
 
     // NN1 processes IBR with the replica
     StorageReceivedDeletedBlocks[] report = DFSTestUtil
@@ -143,20 +140,18 @@ public class TestUpdateBlockTailing {
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
 
-    assertEquals("Global Generation stamps on NN0 and "
-            + "impending on NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getImpendingGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0),
+        NameNodeAdapter.getImpendingGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "impending on NN1 should be equal");
 
     // The new block on NN1 should have the replica
     BlockInfo newBlock1 = NameNodeAdapter.getStoredBlock(fsn1, newBlock);
-    assertTrue("New block on NN1 should contain the replica",
-        newBlock1.getStorageInfos().hasNext());
-    assertEquals("Generation stamps of the block on NNs should be the same",
-        newBlock.getGenerationStamp(), newBlock1.getGenerationStamp());
-    assertEquals("Global Generation stamps on NNs should be the same",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertTrue(newBlock1.getStorageInfos().hasNext(),
+        "New block on NN1 should contain the replica");
+    assertEquals(newBlock.getGenerationStamp(), newBlock1.getGenerationStamp(),
+        "Generation stamps of the block on NNs should be the same");
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NNs should be the same");
 
     // Check that the generation stamp restores on Standby after failover
     ClientProtocol rpc0 = dfsCluster.getNameNode(0).getRpcServer();
@@ -166,9 +161,8 @@ public class TestUpdateBlockTailing {
     long gs0 = NameNodeAdapter.getGenerationStamp(fsn0);
     dfsCluster.transitionToStandby(0);
     dfsCluster.transitionToActive(1);
-    assertEquals("Global Generation stamps on new active should be "
-            + "the same as on the old one", gs0,
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(gs0, NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on new active should be " + "the same as on the old one");
 
     rpc1.delete(testFile, false);
   }
@@ -182,10 +176,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_SET_GENSTAMP_V2 and OP_ADD_BLOCK
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Append block without newBlock flag
     try (FSDataOutputStream out = dfs.append(new Path(testFile))) {
@@ -197,10 +189,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_APPEND, OP_SET_GENSTAMP_V2, and OP_UPDATE_BLOCKS
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Remove the testFile
     final ClientProtocol rpc0 = dfsCluster.getNameNode(0).getRpcServer();
@@ -216,10 +206,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_SET_GENSTAMP_V2 and OP_ADD_BLOCK
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Append block with newBlock flag
     try (FSDataOutputStream out = dfs.append(new Path(testFile),
@@ -232,10 +220,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_APPEND, OP_SET_GENSTAMP_V2, and OP_ADD_BLOCK
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Remove the testFile
     final ClientProtocol rpc0 = dfsCluster.getNameNode(0).getRpcServer();
@@ -251,10 +237,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_SET_GENSTAMP_V2 and OP_ADD_BLOCK
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Truncate block
     dfs.truncate(new Path(testFile), fileLen/2);
@@ -262,10 +246,8 @@ public class TestUpdateBlockTailing {
     // NN1 tails OP_SET_GENSTAMP_V2 and OP_TRUNCATE
     fsn0.getEditLog().logSync();
     fsn1.getEditLogTailer().doTailEdits();
-    assertEquals("Global Generation stamps on NN0 and "
-            + "NN1 should be equal",
-        NameNodeAdapter.getGenerationStamp(fsn0),
-        NameNodeAdapter.getGenerationStamp(fsn1));
+    assertEquals(NameNodeAdapter.getGenerationStamp(fsn0), NameNodeAdapter.getGenerationStamp(fsn1),
+        "Global Generation stamps on NN0 and " + "NN1 should be equal");
 
     // Remove the testFile
     final ClientProtocol rpc0 = dfsCluster.getNameNode(0).getRpcServer();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestXAttrsWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestXAttrsWithHA.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -107,9 +107,9 @@ public class TestXAttrsWithHA {
     cluster.transitionToActive(1);
     
     Map<String, byte[]> xattrs = fs.getXAttrs(path);
-    Assertions.assertEquals(xattrs.size(), 2);
-    Assertions.assertArrayEquals(value1, xattrs.get(name1));
-    Assertions.assertArrayEquals(value2, xattrs.get(name2));
+    assertEquals(xattrs.size(), 2);
+    assertArrayEquals(value1, xattrs.get(name1));
+    assertArrayEquals(value2, xattrs.get(name2));
     
     fs.delete(path, true);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestXAttrsWithHA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestXAttrsWithHA.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode.ha;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -34,10 +34,11 @@ import org.apache.hadoop.hdfs.HAUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests interaction of XAttrs with HA failover.
@@ -58,7 +59,7 @@ public class TestXAttrsWithHA {
   private NameNode nn1;
   private FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);
@@ -78,7 +79,7 @@ public class TestXAttrsWithHA {
     cluster.transitionToActive(0);
   }
   
-  @After
+  @AfterEach
   public void shutdownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -89,7 +90,8 @@ public class TestXAttrsWithHA {
   /**
    * Test that xattrs are properly tracked by the standby
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testXAttrsTrackedOnStandby() throws Exception {
     fs.create(path).close();
     fs.setXAttr(path, name1, value1, EnumSet.of(XAttrSetFlag.CREATE));
@@ -105,9 +107,9 @@ public class TestXAttrsWithHA {
     cluster.transitionToActive(1);
     
     Map<String, byte[]> xattrs = fs.getXAttrs(path);
-    Assert.assertEquals(xattrs.size(), 2);
-    Assert.assertArrayEquals(value1, xattrs.get(name1));
-    Assert.assertArrayEquals(value2, xattrs.get(name2));
+    Assertions.assertEquals(xattrs.size(), 2);
+    Assertions.assertArrayEquals(value1, xattrs.get(name1));
+    Assertions.assertArrayEquals(value2, xattrs.get(name2));
     
     fs.delete(path, true);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
@@ -246,8 +246,8 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
         "Bind address not expected to be wildcard by default.");
   }
 
-@Test
-@Timeout(value = 30)
+  @Test
+  @Timeout(value = 30)
   public void testWithBindAddressSet() throws Exception {
     startCluster();
     conf.set(DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY, WILDCARD_ADDRESS);
@@ -283,10 +283,10 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     startCluster();
     DFSHAAdmin tool = new DFSHAAdmin();
     tool.setConf(conf);
-    assertEquals(0, tool.run(new String[] { "-failover", "nn1", "nn2" }));
+    assertEquals(0, tool.run(new String[]{"-failover", "nn1", "nn2"}));
     waitForHAState(0, HAServiceState.STANDBY);
     waitForHAState(1, HAServiceState.ACTIVE);
-    assertEquals(0, tool.run(new String[] { "-failover", "nn2", "nn1" }));
+    assertEquals(0, tool.run(new String[]{"-failover", "nn2", "nn1"}));
     waitForHAState(0, HAServiceState.ACTIVE);
     waitForHAState(1, HAServiceState.STANDBY);
     // Answer "yes" to the prompt for --forcemanual

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/tools/TestDFSZKFailoverController.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.tools;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -52,9 +52,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestContext;
 import org.apache.hadoop.test.MultithreadedTestUtil.TestingThread;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.function.Supplier;
 
@@ -72,7 +73,7 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     EditLogFileOutputStream.setShouldSkipFsyncForTesting(true);
   }
   
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new Configuration();
     // Specify the quorum per-nameservice, to ensure that these configs
@@ -129,7 +130,7 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     fs = HATestUtil.configureFailoverFs(cluster, conf);
   }
   
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -150,7 +151,8 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   /**
    * Ensure the cluster simply starts with a hdfs jceks credential provider
    * configured. HDFS-14013.
@@ -167,7 +169,8 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
   /**
    * Test that thread dump is captured after NN state changes.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testThreadDumpCaptureAfterNNStateChange() throws Exception {
     startCluster();
     MockNameNodeResourceChecker mockResourceChecker =
@@ -185,7 +188,8 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
    * Test that automatic failover is triggered by shutting the
    * active NN down.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFailoverAndBackOnNNShutdown() throws Exception {
     startCluster();
     Path p1 = new Path("/dir1");
@@ -218,7 +222,8 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
         thr2.zkfc.getLocalTarget().getAddress());
   }
   
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testManualFailover() throws Exception {
     startCluster();
     thr2.zkfc.getLocalTarget().getZKFCProxy(conf, 15000).gracefulFailover();
@@ -230,18 +235,19 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     waitForHAState(1, HAServiceState.STANDBY);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testWithoutBindAddressSet() throws Exception {
     startCluster();
     DFSZKFailoverController zkfc = DFSZKFailoverController.create(
         conf);
 
-    assertEquals("Bind address not expected to be wildcard by default.",
-        zkfc.getRpcAddressToBindTo().getHostString(),
-        LOCALHOST_SERVER_ADDRESS);
+    assertEquals(zkfc.getRpcAddressToBindTo().getHostString(), LOCALHOST_SERVER_ADDRESS,
+        "Bind address not expected to be wildcard by default.");
   }
 
-  @Test(timeout=30000)
+@Test
+@Timeout(value = 30)
   public void testWithBindAddressSet() throws Exception {
     startCluster();
     conf.set(DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY, WILDCARD_ADDRESS);
@@ -249,8 +255,7 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
         conf);
     String addr = zkfc.getRpcAddressToBindTo().getHostString();
 
-    assertEquals("Bind address " + addr + " is not wildcard.",
-        addr, WILDCARD_ADDRESS);
+    assertEquals(addr, WILDCARD_ADDRESS, "Bind address " + addr + " is not wildcard.");
   }
 
   /**
@@ -272,17 +277,16 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
             new StateChangeRequestInfo(RequestSource.REQUEST_BY_ZKFC)));
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testManualFailoverWithDFSHAAdmin() throws Exception {
     startCluster();
     DFSHAAdmin tool = new DFSHAAdmin();
     tool.setConf(conf);
-    assertEquals(0, 
-        tool.run(new String[]{"-failover", "nn1", "nn2"}));
+    assertEquals(0, tool.run(new String[] { "-failover", "nn1", "nn2" }));
     waitForHAState(0, HAServiceState.STANDBY);
     waitForHAState(1, HAServiceState.ACTIVE);
-    assertEquals(0,
-        tool.run(new String[]{"-failover", "nn2", "nn1"}));
+    assertEquals(0, tool.run(new String[] { "-failover", "nn2", "nn1" }));
     waitForHAState(0, HAServiceState.ACTIVE);
     waitForHAState(1, HAServiceState.STANDBY);
     // Answer "yes" to the prompt for --forcemanual
@@ -290,18 +294,19 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
     System.setIn(new ByteArrayInputStream("yes\n".getBytes()));
     int result = tool.run(
         new String[]{"-transitionToObserver", "-forcemanual", "nn2"});
-    assertEquals("State transition returned: " + result, 0, result);
+    assertEquals(0, result, "State transition returned: " + result);
     waitForHAState(1, HAServiceState.OBSERVER);
     // Answer "yes" to the prompt for --forcemanual
     System.setIn(new ByteArrayInputStream("yes\n".getBytes()));
     result = tool.run(
         new String[]{"-transitionToStandby", "-forcemanual", "nn2"});
     System.setIn(inOriginial);
-    assertEquals("State transition returned: " + result, 0, result);
+    assertEquals(0, result, "State transition returned: " + result);
     waitForHAState(1, HAServiceState.STANDBY);
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testElectionOnObserver() throws Exception{
     startCluster();
     InputStream inOriginial = System.in;
@@ -313,7 +318,7 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
       System.setIn(new ByteArrayInputStream("yes\n".getBytes()));
       int result = tool.run(
           new String[]{"-transitionToObserver", "-forcemanual", "nn2"});
-      assertEquals("State transition returned: " + result, 0, result);
+      assertEquals(0, result, "State transition returned: " + result);
       waitForHAState(1, HAServiceState.OBSERVER);
       waitForZKFCState(thr2.zkfc, HAServiceState.OBSERVER);
 
@@ -321,8 +326,7 @@ public class TestDFSZKFailoverController extends ClientBaseWithFixes {
       thr2.zkfc.getLocalTarget().getZKFCProxy(conf, 15000).cedeActive(-1);
 
       // This namenode is in observer state, it shouldn't join election
-      assertEquals(false,
-          thr2.zkfc.getElectorForTests().getWantToBeInElection());
+      assertEquals(false, thr2.zkfc.getElectorForTests().getWantToBeInElection());
     } finally {
       System.setIn(inOriginial);
     }


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part15.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

