### PR TITLE
HADOOP-19343: Include hadoop-gcp in hadoop-cloud-storage.

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-cloud-storage/pom.xml
+++ b/hadoop-cloud-storage-project/hadoop-cloud-storage/pom.xml
@@ -130,5 +130,20 @@
       <artifactId>hadoop-tos</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-gcp</artifactId>
+      <scope>compile</scope>
+      <!--
+      Exclude transitive dependencies to prevent dependency convergence
+      problems. hadoop-gcp is a self-contained shaded jar.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -795,6 +795,12 @@
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-gcp</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-kms</artifactId>
         <version>${hadoop.version}</version>
       </dependency>


### PR DESCRIPTION
### Description of PR

Include hadoop-gcp in hadoop-cloud-storage.

### How was this patch tested?

* Ran a full build successfully.
* Reviewed output of `mvn dependency:tree` to confirm the transitive dependency.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
