### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part16.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/aliasmap/ITestInMemoryAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/aliasmap/ITestInMemoryAliasMap.java
@@ -22,13 +22,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.ProvidedStorageLocation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class ITestInMemoryAliasMap {
   private File tempDirectory;
   private static String bpid = "bpid-0";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration conf = new Configuration();
     File temp = Files.createTempDirectory("seagull").toFile();
@@ -57,7 +57,7 @@ public class ITestInMemoryAliasMap {
     aliasMap = InMemoryAliasMap.init(conf, bpid);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     aliasMap.close();
     FileUtils.deleteDirectory(tempDirectory);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/aliasmap/TestSecureAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/aliasmap/TestSecureAliasMap.java
@@ -39,18 +39,18 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test DN & NN communication in secured hdfs with alias map.
@@ -66,7 +66,7 @@ public class TestSecureAliasMap {
   private HdfsConfiguration conf;
   private FileSystem fs;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     baseDir =
         GenericTestUtils.getTestDir(TestSecureAliasMap.class.getSimpleName());
@@ -81,8 +81,8 @@ public class TestSecureAliasMap {
     SecurityUtil.setAuthenticationMethod(
         UserGroupInformation.AuthenticationMethod.KERBEROS, baseConf);
     UserGroupInformation.setConfiguration(baseConf);
-    assertTrue("Expected configuration to enable security",
-        UserGroupInformation.isSecurityEnabled());
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Expected configuration to enable security");
 
     String userName = UserGroupInformation.getLoginUser().getShortUserName();
     File keytabFile = new File(baseDir, userName + ".keytab");
@@ -98,7 +98,7 @@ public class TestSecureAliasMap {
         kdc.getRealm(), keytab, keystoresDir, sslConfDir);
   }
 
-  @AfterClass
+  @AfterAll
   public static void destroy() throws Exception {
     if (kdc != null) {
       kdc.stop();
@@ -107,7 +107,7 @@ public class TestSecureAliasMap {
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     IOUtils.cleanupWithLogger(null, fs);
     if (cluster != null) {
@@ -146,10 +146,10 @@ public class TestSecureAliasMap {
     }
 
     String[] bps = providedVolume.getBlockPoolList();
-    assertEquals("Missing provided volume", 1, bps.length);
+    assertEquals(1, bps.length, "Missing provided volume");
 
     BlockAliasMap aliasMap = blockManager.getProvidedStorageMap().getAliasMap();
     BlockAliasMap.Reader reader = aliasMap.getReader(null, bps[0]);
-    assertNotNull("Failed to create blockAliasMap reader", reader);
+    assertNotNull(reader, "Failed to create blockAliasMap reader");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BaseReplicationPolicyTest.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.event.Level;
 
 abstract public class BaseReplicationPolicyTest {
@@ -69,7 +69,7 @@ abstract public class BaseReplicationPolicyTest {
 
   abstract DatanodeDescriptor[] getDatanodeDescriptors(Configuration conf);
 
-  @Before
+  @BeforeEach
   public void setupCluster() throws Exception {
     Configuration conf = new HdfsConfiguration();
     dataNodes = getDatanodeDescriptors(conf);
@@ -117,7 +117,7 @@ abstract public class BaseReplicationPolicyTest {
     return striptedPolicy;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     namenode.stop();
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
@@ -35,9 +35,10 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.util.Preconditions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BlockManagerTestUtil {
 
@@ -259,7 +260,7 @@ public class BlockManagerTestUtil {
           theDND = dnd;
         }
       }
-      Assertions.assertNotNull(theDND, "Could not find DN with name: " + dnName);
+      assertNotNull(theDND, "Could not find DN with name: " + dnName);
       
       synchronized (hbm) {
         DFSTestUtil.setDatanodeDead(theDND);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManagerTestUtil.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.util.Preconditions;
 
@@ -259,7 +259,7 @@ public class BlockManagerTestUtil {
           theDND = dnd;
         }
       }
-      Assert.assertNotNull("Could not find DN with name: " + dnName, theDND);
+      Assertions.assertNotNull(theDND, "Could not find DN with name: " + dnName);
       
       synchronized (hbm) {
         DFSTestUtil.setDatanodeDead(theDND);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
@@ -28,9 +28,9 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -53,7 +53,7 @@ public class TestAvailableSpaceBPPBalanceLocal {
   private static NameNode namenode;
   private static NetworkTopology cluster;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCluster() throws Exception {
     conf = new HdfsConfiguration();
     conf.setFloat(
@@ -137,8 +137,8 @@ public class TestAvailableSpaceBPPBalanceLocal {
               .chooseTarget(FILE, 1, localNode,
                   new ArrayList<DatanodeStorageInfo>(), false, null, BLOCK_SIZE,
                   TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
-      Assert.assertEquals(1, targets.length);
-      Assert.assertEquals(localNode, targets[0].getDatanodeDescriptor());
+      Assertions.assertEquals(1, targets.length);
+      Assertions.assertEquals(localNode, targets[0].getDatanodeDescriptor());
     }
   }
 
@@ -154,11 +154,11 @@ public class TestAvailableSpaceBPPBalanceLocal {
                   new ArrayList<DatanodeStorageInfo>(), false, null, BLOCK_SIZE,
                   TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
 
-      Assert.assertEquals(1, targets.length);
+      Assertions.assertEquals(1, targets.length);
       if (localNode == targets[0].getDatanodeDescriptor()) {
         numLocalChosen++;
       }
     }
-    Assert.assertTrue(numLocalChosen < (CHOOSE_TIMES - numLocalChosen));
+    Assertions.assertTrue(numLocalChosen < (CHOOSE_TIMES - numLocalChosen));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBPPBalanceLocal.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.io.File;
 import java.util.ArrayList;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_AVAILABLE_SPACE_BLOCK_PLACEMENT_POLICY_BALANCE_LOCAL_NODE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests AvailableSpaceBlockPlacementPolicy with balance local.
@@ -137,8 +138,8 @@ public class TestAvailableSpaceBPPBalanceLocal {
               .chooseTarget(FILE, 1, localNode,
                   new ArrayList<DatanodeStorageInfo>(), false, null, BLOCK_SIZE,
                   TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
-      Assertions.assertEquals(1, targets.length);
-      Assertions.assertEquals(localNode, targets[0].getDatanodeDescriptor());
+      assertEquals(1, targets.length);
+      assertEquals(localNode, targets[0].getDatanodeDescriptor());
     }
   }
 
@@ -154,11 +155,11 @@ public class TestAvailableSpaceBPPBalanceLocal {
                   new ArrayList<DatanodeStorageInfo>(), false, null, BLOCK_SIZE,
                   TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
 
-      Assertions.assertEquals(1, targets.length);
+      assertEquals(1, targets.length);
       if (localNode == targets[0].getDatanodeDescriptor()) {
         numLocalChosen++;
       }
     }
-    Assertions.assertTrue(numLocalChosen < (CHOOSE_TIMES - numLocalChosen));
+    assertTrue(numLocalChosen < (CHOOSE_TIMES - numLocalChosen));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceBlockPlacementPolicy.java
@@ -34,11 +34,11 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestAvailableSpaceBlockPlacementPolicy {
   private final static int numRacks = 4;
@@ -55,7 +55,7 @@ public class TestAvailableSpaceBlockPlacementPolicy {
   private static BlockPlacementPolicy placementPolicy;
   private static NetworkTopology cluster;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCluster() throws Exception {
     conf = new HdfsConfiguration();
     conf.setFloat(DFSConfigKeys.
@@ -294,7 +294,7 @@ public class TestAvailableSpaceBlockPlacementPolicy {
         tolerateDataNodes[2], false) == -1);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardownCluster() {
     if (namenode != null) {
       namenode.stop();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
@@ -131,16 +131,16 @@ public class TestBlockInfo {
     assertThat(blockInfos[NUM_BLOCKS / 2].getStorageInfo(0)).isEqualTo(storage2);
   }
 
-@Test
+  @Test
   public void testAddStorageWithDifferentBlock() throws Exception {
-  Assertions.assertThrows(IllegalArgumentException.class, () -> {
-    BlockInfo blockInfo1 = new BlockInfoContiguous(new Block(1000L), (short) 3);
-    BlockInfo blockInfo2 = new BlockInfoContiguous(new Block(1001L), (short) 3);
-    final DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
-        "storageID", "127.0.0.1");
-    blockInfo1.addStorage(storage, blockInfo2);
-  });
-}
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      BlockInfo blockInfo1 = new BlockInfoContiguous(new Block(1000L), (short) 3);
+      BlockInfo blockInfo2 = new BlockInfoContiguous(new Block(1001L), (short) 3);
+      final DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
+          "storageID", "127.0.0.1");
+      blockInfo1.addStorage(storage, blockInfo2);
+    });
+  }
 
   @Test
   public void testBlockListMoveToHead() throws Exception {
@@ -204,8 +204,8 @@ public class TestBlockInfo {
     assertNotNull(temp, "Head should not be null");
     int c = maxBlocks - 1;
     while (temp != null) {
-        assertEquals(blockInfoList.get(c--), temp, "Expected element is not on the list");
-        temp = temp.getNext(0);
+      assertEquals(blockInfoList.get(c--), temp, "Expected element is not on the list");
+      temp = temp.getNext(0);
     }
 
     LOG.info("Moving random blocks to the head of the list...");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
@@ -18,15 +18,15 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Random;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.fs.StorageType;
 import org.slf4j.Logger;
@@ -36,8 +36,8 @@ import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo.AddBlockResult;
 import org.apache.hadoop.hdfs.server.common.GenerationStamp;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -56,9 +56,9 @@ public class TestBlockInfo {
     BlockInfo blockInfo = new BlockInfoContiguous((short) 3);
     BlockCollection bc = Mockito.mock(BlockCollection.class);
     blockInfo.setBlockCollectionId(1000);
-    Assert.assertFalse(blockInfo.isDeleted());
+    Assertions.assertFalse(blockInfo.isDeleted());
     blockInfo.setBlockCollectionId(INVALID_INODE_ID);
-    Assert.assertTrue(blockInfo.isDeleted());
+    Assertions.assertTrue(blockInfo.isDeleted());
   }
 
   @Test
@@ -70,8 +70,8 @@ public class TestBlockInfo {
 
     boolean added = blockInfo.addStorage(storage, blockInfo);
 
-    Assert.assertTrue(added);
-    Assert.assertEquals(storage, blockInfo.getStorageInfo(0));
+    Assertions.assertTrue(added);
+    Assertions.assertEquals(storage, blockInfo.getStorageInfo(0));
   }
 
   @Test
@@ -81,9 +81,9 @@ public class TestBlockInfo {
     DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
     when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
     boolean added = blockInfo.addStorage(providedStorage, blockInfo);
-    Assert.assertTrue(added);
-    Assert.assertEquals(providedStorage, blockInfo.getStorageInfo(0));
-    Assert.assertTrue(blockInfo.isProvided());
+    Assertions.assertTrue(added);
+    Assertions.assertEquals(providedStorage, blockInfo.getStorageInfo(0));
+    Assertions.assertTrue(blockInfo.isProvided());
   }
 
   @Test
@@ -95,16 +95,16 @@ public class TestBlockInfo {
     when(diskStorage.getDatanodeDescriptor()).thenReturn(mockDN);
     when(diskStorage.getStorageType()).thenReturn(StorageType.DISK);
     boolean added = blockInfo.addStorage(diskStorage, blockInfo);
-    Assert.assertTrue(added);
-    Assert.assertEquals(diskStorage, blockInfo.getStorageInfo(0));
-    Assert.assertFalse(blockInfo.isProvided());
+    Assertions.assertTrue(added);
+    Assertions.assertEquals(diskStorage, blockInfo.getStorageInfo(0));
+    Assertions.assertFalse(blockInfo.isProvided());
 
     // now add provided storage
     DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
     when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
     added = blockInfo.addStorage(providedStorage, blockInfo);
-    Assert.assertTrue(added);
-    Assert.assertTrue(blockInfo.isProvided());
+    Assertions.assertTrue(added);
+    Assertions.assertTrue(blockInfo.isProvided());
   }
 
   @Test
@@ -127,19 +127,20 @@ public class TestBlockInfo {
     // Try to move one of the blocks to a different storage.
     boolean added =
         storage2.addBlock(blockInfos[NUM_BLOCKS / 2]) == AddBlockResult.ADDED;
-    Assert.assertThat(added, is(false));
-    Assert.assertThat(blockInfos[NUM_BLOCKS/2].getStorageInfo(0), is(storage2));
+    assertThat(added).isEqualTo(false);
+    assertThat(blockInfos[NUM_BLOCKS / 2].getStorageInfo(0)).isEqualTo(storage2);
   }
 
-  @Test(expected=IllegalArgumentException.class)
+@Test
   public void testAddStorageWithDifferentBlock() throws Exception {
+  Assertions.assertThrows(IllegalArgumentException.class, () -> {
     BlockInfo blockInfo1 = new BlockInfoContiguous(new Block(1000L), (short) 3);
     BlockInfo blockInfo2 = new BlockInfoContiguous(new Block(1001L), (short) 3);
-
     final DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
         "storageID", "127.0.0.1");
     blockInfo1.addStorage(storage, blockInfo2);
-  }
+  });
+}
 
   @Test
   public void testBlockListMoveToHead() throws Exception {
@@ -161,20 +162,20 @@ public class TestBlockInfo {
       dd.addBlock(blockInfoList.get(i));
 
       // index of the datanode should be 0
-      assertEquals("Find datanode should be 0", 0, blockInfoList.get(i)
-          .findStorageInfo(dd));
+      assertEquals(0, blockInfoList.get(i).findStorageInfo(dd),
+          "Find datanode should be 0");
     }
 
     // list length should be equal to the number of blocks we inserted
     LOG.info("Checking list length...");
-    assertEquals("Length should be MAX_BLOCK", maxBlocks, dd.numBlocks());
+    assertEquals(maxBlocks, dd.numBlocks(), "Length should be MAX_BLOCK");
     Iterator<BlockInfo> it = dd.getBlockIterator();
     int len = 0;
     while (it.hasNext()) {
       it.next();
       len++;
     }
-    assertEquals("There should be MAX_BLOCK blockInfo's", maxBlocks, len);
+    assertEquals(maxBlocks, len, "There should be MAX_BLOCK blockInfo's");
 
     headIndex = dd.getBlockListHeadForTesting().findStorageInfo(dd);
 
@@ -183,8 +184,8 @@ public class TestBlockInfo {
       curIndex = blockInfoList.get(i).findStorageInfo(dd);
       headIndex = dd.moveBlockToHead(blockInfoList.get(i), curIndex, headIndex);
       // the moved element must be at the head of the list
-      assertEquals("Block should be at the head of the list now.",
-          blockInfoList.get(i), dd.getBlockListHeadForTesting());
+      assertEquals(blockInfoList.get(i), dd.getBlockListHeadForTesting(),
+          "Block should be at the head of the list now.");
     }
 
     // move head of the list to the head - this should not change the list
@@ -194,19 +195,17 @@ public class TestBlockInfo {
     curIndex = 0;
     headIndex = 0;
     dd.moveBlockToHead(temp, curIndex, headIndex);
-    assertEquals(
-        "Moving head to the head of the list shopuld not change the list",
-        temp, dd.getBlockListHeadForTesting());
+    assertEquals(temp, dd.getBlockListHeadForTesting(),
+        "Moving head to the head of the list shopuld not change the list");
 
     // check all elements of the list against the original blockInfoList
     LOG.info("Checking elements of the list...");
     temp = dd.getBlockListHeadForTesting();
-    assertNotNull("Head should not be null", temp);
+    assertNotNull(temp, "Head should not be null");
     int c = maxBlocks - 1;
     while (temp != null) {
-      assertEquals("Expected element is not on the list",
-          blockInfoList.get(c--), temp);
-      temp = temp.getNext(0);
+        assertEquals(blockInfoList.get(c--), temp, "Expected element is not on the list");
+        temp = temp.getNext(0);
     }
 
     LOG.info("Moving random blocks to the head of the list...");
@@ -217,8 +216,8 @@ public class TestBlockInfo {
       curIndex = blockInfoList.get(j).findStorageInfo(dd);
       headIndex = dd.moveBlockToHead(blockInfoList.get(j), curIndex, headIndex);
       // the moved element must be at the head of the list
-      assertEquals("Block should be at the head of the list now.",
-          blockInfoList.get(j), dd.getBlockListHeadForTesting());
+      assertEquals(blockInfoList.get(j), dd.getBlockListHeadForTesting(),
+          "Block should be at the head of the list now.");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfo.java
@@ -18,15 +18,19 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.server.namenode.INodeId.INVALID_INODE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.fs.StorageType;
 import org.slf4j.Logger;
@@ -36,7 +40,6 @@ import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo.AddBlockResult;
 import org.apache.hadoop.hdfs.server.common.GenerationStamp;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -56,9 +59,9 @@ public class TestBlockInfo {
     BlockInfo blockInfo = new BlockInfoContiguous((short) 3);
     BlockCollection bc = Mockito.mock(BlockCollection.class);
     blockInfo.setBlockCollectionId(1000);
-    Assertions.assertFalse(blockInfo.isDeleted());
+    assertFalse(blockInfo.isDeleted());
     blockInfo.setBlockCollectionId(INVALID_INODE_ID);
-    Assertions.assertTrue(blockInfo.isDeleted());
+    assertTrue(blockInfo.isDeleted());
   }
 
   @Test
@@ -70,8 +73,8 @@ public class TestBlockInfo {
 
     boolean added = blockInfo.addStorage(storage, blockInfo);
 
-    Assertions.assertTrue(added);
-    Assertions.assertEquals(storage, blockInfo.getStorageInfo(0));
+    assertTrue(added);
+    assertEquals(storage, blockInfo.getStorageInfo(0));
   }
 
   @Test
@@ -81,9 +84,9 @@ public class TestBlockInfo {
     DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
     when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
     boolean added = blockInfo.addStorage(providedStorage, blockInfo);
-    Assertions.assertTrue(added);
-    Assertions.assertEquals(providedStorage, blockInfo.getStorageInfo(0));
-    Assertions.assertTrue(blockInfo.isProvided());
+    assertTrue(added);
+    assertEquals(providedStorage, blockInfo.getStorageInfo(0));
+    assertTrue(blockInfo.isProvided());
   }
 
   @Test
@@ -95,16 +98,16 @@ public class TestBlockInfo {
     when(diskStorage.getDatanodeDescriptor()).thenReturn(mockDN);
     when(diskStorage.getStorageType()).thenReturn(StorageType.DISK);
     boolean added = blockInfo.addStorage(diskStorage, blockInfo);
-    Assertions.assertTrue(added);
-    Assertions.assertEquals(diskStorage, blockInfo.getStorageInfo(0));
-    Assertions.assertFalse(blockInfo.isProvided());
+    assertTrue(added);
+    assertEquals(diskStorage, blockInfo.getStorageInfo(0));
+    assertFalse(blockInfo.isProvided());
 
     // now add provided storage
     DatanodeStorageInfo providedStorage = mock(DatanodeStorageInfo.class);
     when(providedStorage.getStorageType()).thenReturn(StorageType.PROVIDED);
     added = blockInfo.addStorage(providedStorage, blockInfo);
-    Assertions.assertTrue(added);
-    Assertions.assertTrue(blockInfo.isProvided());
+    assertTrue(added);
+    assertTrue(blockInfo.isProvided());
   }
 
   @Test
@@ -133,7 +136,7 @@ public class TestBlockInfo {
 
   @Test
   public void testAddStorageWithDifferentBlock() throws Exception {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       BlockInfo blockInfo1 = new BlockInfoContiguous(new Block(1000L), (short) 3);
       BlockInfo blockInfo2 = new BlockInfoContiguous(new Block(1001L), (short) 3);
       final DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -87,7 +87,6 @@ import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.GSet;
 import org.apache.hadoop.util.LightWeightGSet;
 import org.slf4j.event.Level;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -1403,11 +1402,11 @@ public class TestBlockManager {
     BlockPlacementPolicyDefault policyDefault =
         (BlockPlacementPolicyDefault) bm.getBlockPlacementPolicy();
     excessTypes.add(StorageType.DEFAULT);
-    Assertions.assertTrue(policyDefault.useDelHint(delHint, null, moreThan1Racks,
+    assertTrue(policyDefault.useDelHint(delHint, null, moreThan1Racks,
         null, excessTypes));
     excessTypes.remove(0);
     excessTypes.add(StorageType.SSD);
-    Assertions.assertFalse(policyDefault.useDelHint(delHint, null, moreThan1Racks,
+    assertFalse(policyDefault.useDelHint(delHint, null, moreThan1Racks,
         null, excessTypes));
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManager.java
@@ -87,9 +87,10 @@ import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.GSet;
 import org.apache.hadoop.util.LightWeightGSet;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.BufferedReader;
@@ -122,11 +123,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState.UNDER_CONSTRUCTION;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -159,7 +160,7 @@ public class TestBlockManager {
   private long mockINodeId;
 
 
-  @Before
+  @BeforeEach
   public void setupMockCluster() throws IOException {
     Configuration conf = new HdfsConfiguration();
     conf.set(DFSConfigKeys.NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
@@ -240,12 +241,12 @@ public class TestBlockManager {
 
     DatanodeStorageInfo[] pipeline = scheduleSingleReplication(blockInfo);
     assertEquals(2, pipeline.length);
-    assertTrue("Source of replication should be one of the nodes the block " +
-        "was on. Was: " + pipeline[0],
-        origStorages.contains(pipeline[0]));
-    assertTrue("Destination of replication should be on the other rack. " +
-        "Was: " + pipeline[1],
-        rackB.contains(pipeline[1].getDatanodeDescriptor()));
+    assertTrue(origStorages.contains(pipeline[0]),
+        "Source of replication should be one of the nodes the block " + "was on. Was: "
+            + pipeline[0]);
+    assertTrue(rackB.contains(pipeline[1].getDatanodeDescriptor()),
+        "Destination of replication should be on the other rack. " +
+            "Was: " + pipeline[1]);
   }
   
 
@@ -274,10 +275,10 @@ public class TestBlockManager {
     List<DatanodeDescriptor> decomNodes = startDecommission(0, 1);
     
     DatanodeStorageInfo[] pipeline = scheduleSingleReplication(blockInfo);
-    assertTrue("Source of replication should be one of the nodes the block " +
-        "was on. Was: " + pipeline[0],
-        origStorages.contains(pipeline[0]));
-    assertEquals("Should have three targets", 3, pipeline.length);
+    assertTrue(origStorages.contains(pipeline[0]),
+        "Source of replication should be one of the nodes the block " + "was on. Was: "
+            + pipeline[0]);
+    assertEquals(3, pipeline.length, "Should have three targets");
     
     boolean foundOneOnRackA = false;
     for (int i = 1; i < pipeline.length; i++) {
@@ -288,10 +289,10 @@ public class TestBlockManager {
       assertFalse(decomNodes.contains(target));
       assertFalse(origNodes.contains(target));
     }
-    
-    assertTrue("Should have at least one target on rack A. Pipeline: " +
-        Joiner.on(",").join(pipeline),
-        foundOneOnRackA);
+
+    assertTrue(foundOneOnRackA,
+        "Should have at least one target on rack A. Pipeline: " +
+            Joiner.on(",").join(pipeline));
   }
   
 
@@ -318,10 +319,10 @@ public class TestBlockManager {
     List<DatanodeDescriptor> decomNodes = startDecommission(0, 1, 3);
     
     DatanodeStorageInfo[] pipeline = scheduleSingleReplication(blockInfo);
-    assertTrue("Source of replication should be one of the nodes the block " +
-        "was on. Was: " + pipeline[0],
-        origStorages.contains(pipeline[0]));
-    assertEquals("Should have three targets", 4, pipeline.length);
+    assertTrue(origStorages.contains(pipeline[0]),
+        "Source of replication should be one of the nodes the block " + "was on. Was: "
+            + pipeline[0]);
+    assertEquals(4, pipeline.length, "Should have three targets");
     
     boolean foundOneOnRackA = false;
     boolean foundOneOnRackB = false;
@@ -336,12 +337,12 @@ public class TestBlockManager {
       assertFalse(origNodes.contains(target));
     }
     
-    assertTrue("Should have at least one target on rack A. Pipeline: " +
-        Joiner.on(",").join(pipeline),
-        foundOneOnRackA);
-    assertTrue("Should have at least one target on rack B. Pipeline: " +
-        Joiner.on(",").join(pipeline),
-        foundOneOnRackB);
+    assertTrue(foundOneOnRackA,
+        "Should have at least one target on rack A. Pipeline: " +
+            Joiner.on(",").join(pipeline));
+    assertTrue(foundOneOnRackB,
+        "Should have at least one target on rack B. Pipeline: " +
+            Joiner.on(",").join(pipeline));
   }
 
   /**
@@ -373,11 +374,11 @@ public class TestBlockManager {
     List<DatanodeDescriptor> decomNodes = startDecommission(0, 1, 2);
     
     DatanodeStorageInfo[] pipeline = scheduleSingleReplication(blockInfo);
-    assertTrue("Source of replication should be one of the nodes the block " +
-        "was on. Was: " + pipeline[0],
-        origStorages.contains(pipeline[0]));
+    assertTrue(origStorages.contains(pipeline[0]),
+        "Source of replication should be one of the nodes the block " + "was on. Was: "
+            + pipeline[0]);
     // Only up to two nodes can be picked per rack when there are two racks.
-    assertEquals("Should have two targets", 2, pipeline.length);
+    assertEquals(2, pipeline.length, "Should have two targets");
     
     boolean foundOneOnRackB = false;
     for (int i = 1; i < pipeline.length; i++) {
@@ -389,9 +390,8 @@ public class TestBlockManager {
       assertFalse(origNodes.contains(target));
     }
     
-    assertTrue("Should have at least one target on rack B. Pipeline: " +
-        Joiner.on(",").join(pipeline),
-        foundOneOnRackB);
+    assertTrue(foundOneOnRackB,
+        "Should have at least one target on rack B. Pipeline: " + Joiner.on(",").join(pipeline));
     
     // Mark the block as received on the target nodes in the pipeline
     fulfillPipeline(blockInfo, pipeline);
@@ -428,14 +428,15 @@ public class TestBlockManager {
     List<DatanodeDescriptor> origNodes = rackA;
     BlockInfo blockInfo = addBlockOnNodes(testIndex, origNodes);
     DatanodeStorageInfo pipeline[] = scheduleSingleReplication(blockInfo);
-    
-    assertEquals(2, pipeline.length); // single new copy
-    assertTrue("Source of replication should be one of the nodes the block " +
-        "was on. Was: " + pipeline[0],
-        origNodes.contains(pipeline[0].getDatanodeDescriptor()));
-    assertTrue("Destination of replication should be on the other rack. " +
-        "Was: " + pipeline[1],
-        rackB.contains(pipeline[1].getDatanodeDescriptor()));
+
+    assertEquals(2,
+        pipeline.length); // single new copy
+    assertTrue(origNodes.contains(pipeline[0].getDatanodeDescriptor()),
+        "Source of replication should be one of the nodes the block " + "was on. Was: " +
+            pipeline[0]);
+    assertTrue(rackB.contains(pipeline[1].getDatanodeDescriptor()),
+        "Destination of replication should be on the other rack. " +
+            "Was: " + pipeline[1]);
   }
   
   @Test
@@ -464,7 +465,8 @@ public class TestBlockManager {
         bm.countNodes(block, fsn.isInStartupSafeMode())));
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testNeededReconstructionWhileAppending() throws IOException {
     Configuration conf = new HdfsConfiguration();
     String src = "/test-file";
@@ -516,7 +518,8 @@ public class TestBlockManager {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDeleteCorruptReplicaWithStatleStorages() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(HdfsClientConfigKeys.BlockWrite.ReplaceDatanodeOnFailure.
@@ -645,13 +648,13 @@ public class TestBlockManager {
     list_all.add(new ArrayList<BlockInfo>()); // for priority 0
     list_all.add(list_p1); // for priority 1
 
-    assertEquals("Block not initially pending reconstruction", 0,
-        bm.pendingReconstruction.getNumReplicas(block));
+    assertEquals(0, bm.pendingReconstruction.getNumReplicas(block),
+        "Block not initially pending reconstruction");
     assertEquals(
-        "computeBlockReconstructionWork should indicate reconstruction is needed",
-        1, bm.computeReconstructionWorkForBlocks(list_all));
-    assertTrue("reconstruction is pending after work is computed",
-        bm.pendingReconstruction.getNumReplicas(block) > 0);
+        1, bm.computeReconstructionWorkForBlocks(list_all),
+        "computeBlockReconstructionWork should indicate reconstruction is needed");
+    assertTrue(bm.pendingReconstruction.getNumReplicas(block) > 0,
+        "reconstruction is pending after work is computed");
 
     LinkedListMultimap<DatanodeStorageInfo, BlockTargetPair> repls =
         getAllPendingReconstruction();
@@ -701,10 +704,7 @@ public class TestBlockManager {
     List<DatanodeDescriptor> cntNodes = new LinkedList<DatanodeDescriptor>();
     List<DatanodeStorageInfo> liveNodes = new LinkedList<DatanodeStorageInfo>();
 
-    assertNotNull("Chooses source node for a highest-priority replication"
-        + " even if all available source nodes have reached their replication"
-        + " limits below the hard limit.",
-        bm.chooseSourceDatanodes(
+    assertNotNull(bm.chooseSourceDatanodes(
             bm.getStoredBlock(aBlock),
             cntNodes,
             liveNodes,
@@ -712,11 +712,12 @@ public class TestBlockManager {
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
-            LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY)[0]);
+            LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY)[0],
+        "Chooses source node for a highest-priority replication"
+            + " even if all available source nodes have reached their replication"
+            + " limits below the hard limit.");
 
-    assertEquals("Does not choose a source node for a less-than-highest-priority"
-            + " replication since all available source nodes have reached"
-            + " their replication limits.", 0,
+    assertEquals(0,
         bm.chooseSourceDatanodes(
             bm.getStoredBlock(aBlock),
             cntNodes,
@@ -725,14 +726,16 @@ public class TestBlockManager {
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
-            LowRedundancyBlocks.QUEUE_VERY_LOW_REDUNDANCY).length);
+            LowRedundancyBlocks.QUEUE_VERY_LOW_REDUNDANCY).length,
+        "Does not choose a source node for a less-than-highest-priority"
+            + " replication since all available source nodes have reached"
+            + " their replication limits.");
 
     // Increase the replication count to test replication count > hard limit
     DatanodeStorageInfo targets[] = { origNodes.get(1).getStorageInfos()[0] };
     origNodes.get(0).addBlockToBeReplicated(aBlock, targets);
 
-    assertEquals("Does not choose a source node for a highest-priority"
-            + " replication when all available nodes exceed the hard limit.", 0,
+    assertEquals(0,
         bm.chooseSourceDatanodes(
             bm.getStoredBlock(aBlock),
             cntNodes,
@@ -741,7 +744,9 @@ public class TestBlockManager {
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
-            LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY).length);
+            LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY).length,
+        "Does not choose a source node for a highest-priority"
+            + " replication when all available nodes exceed the hard limit.");
   }
 
   @Test
@@ -798,15 +803,15 @@ public class TestBlockManager {
             excludeReconstructedIndices,
             LowRedundancyBlocks.QUEUE_VERY_LOW_REDUNDANCY);
 
-    assertEquals("Choose the source node for reconstruction with one node reach"
+    assertEquals(4, numReplicas.liveReplicas(),
+        "Choose the source node for reconstruction with one node reach"
             + " the MAX maxReplicationStreams, the numReplicas still return the"
-            + " correct live replicas.", 4,
-            numReplicas.liveReplicas());
+            + " correct live replicas.");
 
-    assertEquals("Choose the source node for reconstruction with one node reach"
+    assertEquals(1, numReplicas.redundantInternalBlocks(),
+        "Choose the source node for reconstruction with one node reach"
             + " the MAX maxReplicationStreams, the numReplicas should return"
-            + " the correct redundant Internal Blocks.", 1,
-            numReplicas.redundantInternalBlocks());
+            + " the correct redundant Internal Blocks.");
   }
 
   @Test
@@ -862,12 +867,10 @@ public class TestBlockManager {
         liveBusyBlockIndices,
         excludeReconstructedIndices,
         LowRedundancyBlocks.QUEUE_HIGHEST_PRIORITY);
-    assertEquals("There are 5 live replicas in " +
-            "[ds2, ds3, ds4, ds5, ds6] datanodes ",
-        5, numReplicas.liveReplicas());
-    assertEquals("The ds1 datanode is in decommissioning, " +
-            "so there is no redundant replica",
-        0, numReplicas.redundantInternalBlocks());
+    assertEquals(5, numReplicas.liveReplicas(),
+        "There are 5 live replicas in " + "[ds2, ds3, ds4, ds5, ds6] datanodes ");
+    assertEquals(0, numReplicas.redundantInternalBlocks(),
+        "The ds1 datanode is in decommissioning, " + "so there is no redundant replica");
   }
 
   @Test
@@ -1035,10 +1038,7 @@ public class TestBlockManager {
     List<DatanodeDescriptor> cntNodes = new LinkedList<DatanodeDescriptor>();
     List<DatanodeStorageInfo> liveNodes = new LinkedList<DatanodeStorageInfo>();
 
-    assertNotNull("Chooses decommissioning source node for a normal replication"
-        + " if all available source nodes have reached their replication"
-        + " limits below the hard limit.",
-        bm.chooseSourceDatanodes(
+    assertNotNull(bm.chooseSourceDatanodes(
             bm.getStoredBlock(aBlock),
             cntNodes,
             liveNodes,
@@ -1046,15 +1046,16 @@ public class TestBlockManager {
             new LinkedList<Byte>(),
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
-            LowRedundancyBlocks.QUEUE_LOW_REDUNDANCY)[0]);
-
+            LowRedundancyBlocks.QUEUE_LOW_REDUNDANCY)[0],
+        "Chooses decommissioning source node for a normal replication"
+            + " if all available source nodes have reached their replication"
+            + " limits below the hard limit.");
 
     // Increase the replication count to test replication count > hard limit
     DatanodeStorageInfo targets[] = { origNodes.get(1).getStorageInfos()[0] };
     origNodes.get(0).addBlockToBeReplicated(aBlock, targets);
 
-    assertEquals("Does not choose a source decommissioning node for a normal"
-        + " replication when all available nodes exceed the hard limit.", 0,
+    assertEquals(0,
         bm.chooseSourceDatanodes(
             bm.getStoredBlock(aBlock),
             cntNodes,
@@ -1063,7 +1064,9 @@ public class TestBlockManager {
             new LinkedList<Byte>(),
             new ArrayList<Byte>(),
             new ArrayList<Byte>(),
-            LowRedundancyBlocks.QUEUE_LOW_REDUNDANCY).length);
+            LowRedundancyBlocks.QUEUE_LOW_REDUNDANCY).length,
+        "Does not choose a source decommissioning node for a normal"
+            + " replication when all available nodes exceed the hard limit.");
   }
 
   @Test
@@ -1304,8 +1307,8 @@ public class TestBlockManager {
     bm.setInitializedReplQueues(true);
     bm.processIncrementalBlockReport(node, srdb);
     // Needed replications should still be 0.
-    assertEquals("UC block was incorrectly added to needed Replications",
-        0, bm.neededReconstruction.size());
+    assertEquals(0, bm.neededReconstruction.size(),
+        "UC block was incorrectly added to needed Replications");
     bm.setInitializedReplQueues(false);
   }
 
@@ -1400,11 +1403,11 @@ public class TestBlockManager {
     BlockPlacementPolicyDefault policyDefault =
         (BlockPlacementPolicyDefault) bm.getBlockPlacementPolicy();
     excessTypes.add(StorageType.DEFAULT);
-    Assert.assertTrue(policyDefault.useDelHint(delHint, null, moreThan1Racks,
+    Assertions.assertTrue(policyDefault.useDelHint(delHint, null, moreThan1Racks,
         null, excessTypes));
     excessTypes.remove(0);
     excessTypes.add(StorageType.SSD);
-    Assert.assertFalse(policyDefault.useDelHint(delHint, null, moreThan1Racks,
+    Assertions.assertFalse(policyDefault.useDelHint(delHint, null, moreThan1Racks,
         null, excessTypes));
   }
 
@@ -1571,7 +1574,8 @@ public class TestBlockManager {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBlockManagerMachinesArray() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     final MiniDFSCluster cluster =
@@ -1592,7 +1596,7 @@ public class TestBlockManager {
       final String bpid = cluster.getNamesystem().getBlockPoolId();
       File storageDir = cluster.getInstanceStorageDir(0, 0);
       File dataDir = MiniDFSCluster.getFinalizedDir(storageDir, bpid);
-      assertTrue("Data directory does not exist", dataDir.exists());
+      assertTrue(dataDir.exists(), "Data directory does not exist");
       BlockInfo blockInfo =
           blockManager.blocksMap.getBlocks().iterator().next();
       ExtendedBlock blk = new ExtendedBlock(bpid, blockInfo.getBlockId(),
@@ -1644,9 +1648,8 @@ public class TestBlockManager {
       LocatedBlocks locatedBlocks =
           blockManager.createLocatedBlocks(blockInfos, 3L, false, 0L, 3L,
               false, false, null, null);
-      assertTrue("Located Blocks should exclude corrupt" +
-              "replicas and failed storages",
-          locatedBlocks.getLocatedBlocks().size() == 1);
+      assertTrue(locatedBlocks.getLocatedBlocks().size() == 1,
+          "Located Blocks should exclude corrupt" + "replicas and failed storages");
       ns.readUnlock(RwLockMode.BM, "open");
     } finally {
       if (cluster != null) {
@@ -1676,18 +1679,18 @@ public class TestBlockManager {
           break;
         }
       }
-      assertTrue("Unexpected text in metasave," +
-              "was expecting corrupt blocks section!", foundIt);
+      assertTrue(foundIt, "Unexpected text in metasave," +
+          "was expecting corrupt blocks section!");
       corruptBlocksLine = reader.readLine();
       String regex = "Block=blk_[0-9]+_[0-9]+\\tSize=.*\\tNode=.*" +
           "\\tStorageID=.*\\tStorageState.*" +
           "\\tTotalReplicas=.*\\tReason=GENSTAMP_MISMATCH";
-      assertTrue("Unexpected corrupt block section in metasave!",
-          corruptBlocksLine.matches(regex));
+      assertTrue(corruptBlocksLine.matches(regex),
+          "Unexpected corrupt block section in metasave!");
       corruptBlocksLine = reader.readLine();
       regex = "Metasave: Number of datanodes.*";
-      assertTrue("Unexpected corrupt block section in metasave!",
-          corruptBlocksLine.matches(regex));
+      assertTrue(corruptBlocksLine.matches(regex),
+          "Unexpected corrupt block section in metasave!");
     } finally {
       if (reader != null)
         reader.close();
@@ -1714,7 +1717,8 @@ public class TestBlockManager {
             any(DatanodeDescriptor.class));
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testPlacementPolicySatisfied() throws Exception {
     LOG.info("Starting testPlacementPolicySatisfied.");
     final String[] initialRacks = new String[]{
@@ -1809,13 +1813,11 @@ public class TestBlockManager {
           + ", DataNode: " + dn.getDatanodeDescriptor().getXferAddr());
     }
     if (isBlockPlacementSatisfied) {
-      assertTrue("Block group of " + file + "should be placement" +
-              " policy satisfied, currently!",
-          blockManager.isPlacementPolicySatisfied(blockInfo));
+      assertTrue(blockManager.isPlacementPolicySatisfied(blockInfo),
+          "Block group of " + file + "should be placement" + " policy satisfied, currently!");
     } else {
-      assertFalse("Block group of " + file + " should be placement" +
-              " policy unsatisfied, currently!",
-          blockManager.isPlacementPolicySatisfied(blockInfo));
+      assertFalse(blockManager.isPlacementPolicySatisfied(blockInfo),
+          "Block group of " + file + " should be placement" + " policy unsatisfied, currently!");
     }
   }
 
@@ -1845,8 +1847,8 @@ public class TestBlockManager {
         buffer.append(line);
       }
       String output = buffer.toString();
-      assertTrue("Metasave output should not have null block ",
-          output.contains("Block blk_0_0 is Null"));
+      assertTrue(output.contains("Block blk_0_0 is Null"),
+          "Metasave output should not have null block ");
 
     } finally {
       reader.close();
@@ -1873,14 +1875,14 @@ public class TestBlockManager {
         buffer.append(line);
       }
       String output = buffer.toString();
-      assertTrue("Metasave output should have reported missing blocks.",
-          output.contains("Metasave: Blocks currently missing: 1"));
-      assertTrue("There should be 0 blocks waiting for reconstruction",
-          output.contains("Metasave: Blocks waiting for reconstruction: 0"));
+      assertTrue(output.contains("Metasave: Blocks currently missing: 1"),
+          "Metasave output should have reported missing blocks.");
+      assertTrue(output.contains("Metasave: Blocks waiting for reconstruction: 0"),
+          "There should be 0 blocks waiting for reconstruction");
       String blockNameGS = block.getBlockName() + "_" +
           block.getGenerationStamp();
-      assertTrue("Block " + blockNameGS + " should be MISSING.",
-          output.contains(blockNameGS + " MISSING"));
+      assertTrue(output.contains(blockNameGS + " MISSING"),
+          "Block " + blockNameGS + " should be MISSING.");
     } finally {
       reader.close();
       file.delete();
@@ -1946,18 +1948,18 @@ public class TestBlockManager {
         System.out.println(line);
       }
       String output = buffer.toString();
-      assertTrue("Metasave output should not have reported " +
-              "missing blocks.",
-          output.contains("Metasave: Blocks currently missing: 0"));
-      assertTrue("There should be 1 block waiting for reconstruction",
-          output.contains("Metasave: Blocks waiting for reconstruction: 1"));
+      assertTrue(output.contains("Metasave: Blocks currently missing: 0"),
+          "Metasave output should not have reported " +
+              "missing blocks.");
+      assertTrue(output.contains("Metasave: Blocks waiting for reconstruction: 1"),
+          "There should be 1 block waiting for reconstruction");
       String blockNameGS = block.getBlockName() + "_" +
           block.getGenerationStamp();
-      assertTrue("Block " + blockNameGS +
-              " should be list as maintenance.",
-          output.contains(blockNameGS + " (replicas: live: 1 decommissioning " +
+      assertTrue(output.contains(blockNameGS +
+              " (replicas: live: 1 decommissioning " +
               "and decommissioned: 0 corrupt: 0 in excess: " +
-              "0 maintenance mode: 1)"));
+              "0 maintenance mode: 1)"),
+          "Block " + blockNameGS + " should be list as maintenance.");
     } finally {
       reader.close();
       file.delete();
@@ -2001,18 +2003,18 @@ public class TestBlockManager {
         buffer.append(line);
       }
       String output = buffer.toString();
-      assertTrue("Metasave output should not have reported " +
-              "missing blocks.",
-          output.contains("Metasave: Blocks currently missing: 0"));
-      assertTrue("There should be 1 block waiting for reconstruction",
-          output.contains("Metasave: Blocks waiting for reconstruction: 1"));
+      assertTrue(output.contains("Metasave: Blocks currently missing: 0"),
+          "Metasave output should not have reported " +
+              "missing blocks.");
+      assertTrue(output.contains("Metasave: Blocks waiting for reconstruction: 1"),
+          "There should be 1 block waiting for reconstruction");
       String blockNameGS = block.getBlockName() + "_" +
           block.getGenerationStamp();
-      assertTrue("Block " + blockNameGS +
-              " should be list as maintenance.",
-          output.contains(blockNameGS + " (replicas: live: 1 decommissioning " +
-              "and decommissioned: 1 corrupt: 0 in excess: " +
-              "0 maintenance mode: 0)"));
+      assertTrue(output.contains(blockNameGS +
+          " (replicas: live: 1 decommissioning " +
+          "and decommissioned: 1 corrupt: 0 in excess: " +
+          "0 maintenance mode: 0)"), "Block " + blockNameGS +
+          " should be list as maintenance.");
     } finally {
       reader.close();
       file.delete();
@@ -2135,7 +2137,8 @@ public class TestBlockManager {
    * to set the numBytes of the block to NO_ACK,
    * the DataNode processing will not report incremental blocks.
    */
-  @Test(timeout = 360000)
+  @Test
+  @Timeout(value = 360)
   public void testBlockReportSetNoAckBlockToInvalidate() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY, 500);
@@ -2215,7 +2218,8 @@ public class TestBlockManager {
    * @throws InterruptedException
    * @throws TimeoutException
    */
-  @Test(timeout = 360000)
+  @Test
+  @Timeout(value = 360)
   public void testProcessTimedOutExcessBlocks() throws IOException,
       InterruptedException, TimeoutException {
     Configuration config = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManagerSafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManagerSafeMode.java
@@ -31,18 +31,19 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SAFEMODE_EXTENSION_DEFAULT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -83,7 +84,7 @@ public class TestBlockManagerSafeMode {
    *
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void setupMockCluster() throws IOException {
     Configuration conf = new HdfsConfiguration();
     conf.setDouble(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_THRESHOLD_PCT_KEY,
@@ -117,11 +118,12 @@ public class TestBlockManagerSafeMode {
    * The block total is set which will call checkSafeMode for the first time
    * and bmSafeMode transfers from OFF to PENDING_THRESHOLD status
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testInitialize() {
-    assertFalse("Block manager should not be in safe mode at beginning.",
-        bmSafeMode.isInSafeMode());
-    bmSafeMode.activate(BLOCK_TOTAL);
+      assertFalse(bmSafeMode.isInSafeMode(),
+          "Block manager should not be in safe mode at beginning.");
+      bmSafeMode.activate(BLOCK_TOTAL);
     assertEquals(BMSafeModeStatus.PENDING_THRESHOLD, getSafeModeStatus());
     assertTrue(bmSafeMode.isInSafeMode());
   }
@@ -141,7 +143,8 @@ public class TestBlockManagerSafeMode {
    * stage and will stop if the safe mode leaves to OFF state. Across different
    * test cases, this thread should be reset.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode1() {
     // stays in PENDING_THRESHOLD: pending block threshold
     bmSafeMode.activate(BLOCK_TOTAL);
@@ -154,7 +157,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check safe mode transition from PENDING_THRESHOLD to EXTENSION. */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode2() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", Integer.MAX_VALUE);
@@ -165,7 +169,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check safe mode transition from PENDING_THRESHOLD to OFF. */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode3() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", 0);
@@ -176,7 +181,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check safe mode stays in EXTENSION pending threshold. */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode4() {
     bmSafeMode.activate(BLOCK_TOTAL);
     setBlockSafe(0);
@@ -187,7 +193,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check safe mode stays in EXTENSION pending extension period. */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode5() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", Integer.MAX_VALUE);
@@ -198,7 +205,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check it will not leave safe mode during NN transitionToActive. */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode6() {
     doReturn(true).when(fsn).inTransitionToActive();
     bmSafeMode.activate(BLOCK_TOTAL);
@@ -210,7 +218,8 @@ public class TestBlockManagerSafeMode {
   }
 
   /** Check smmthread will leave safe mode if NN is not in transitionToActive.*/
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testCheckSafeMode7() throws Exception {
     doReturn(false).when(fsn).inTransitionToActive();
     bmSafeMode.activate(BLOCK_TOTAL);
@@ -234,7 +243,8 @@ public class TestBlockManagerSafeMode {
     assertEquals(BMSafeModeStatus.OFF, getSafeModeStatus());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testCheckSafeMode9() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_RECHECK_INTERVAL_KEY, 3000);
@@ -246,7 +256,8 @@ public class TestBlockManagerSafeMode {
     assertTrue(content.contains("Using 3000 as SafeModeMonitor Interval"));
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testCheckSafeMode10(){
     Configuration conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_NAMENODE_SAFEMODE_RECHECK_INTERVAL_KEY, -1);
@@ -255,7 +266,7 @@ public class TestBlockManagerSafeMode {
     BlockManagerSafeMode blockManagerSafeMode = new BlockManagerSafeMode(bm,
             fsn, true, conf);
     String content = logs.getOutput();
-    Assertions.assertThat(content).contains("Invalid value for " +
+    assertThat(content).contains("Invalid value for " +
             DFSConfigKeys.DFS_NAMENODE_SAFEMODE_RECHECK_INTERVAL_KEY +
             ". Should be greater than 0, but is -1");
   }
@@ -267,7 +278,8 @@ public class TestBlockManagerSafeMode {
    * increment will be a no-op.
    * The safe mode status lifecycle: OFF -> PENDING_THRESHOLD -> OFF
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testIncrementSafeBlockCount() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", 0);
@@ -287,7 +299,8 @@ public class TestBlockManagerSafeMode {
    * increment will be a no-op.
    * The safe mode status lifecycle: OFF -> PENDING_THRESHOLD -> EXTENSION-> OFF
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testIncrementSafeBlockCountWithExtension() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
 
@@ -309,7 +322,8 @@ public class TestBlockManagerSafeMode {
    * The block manager stays in safe mode.
    * The safe mode status lifecycle: OFF -> PENDING_THRESHOLD
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testDecrementSafeBlockCount() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", 0);
@@ -331,7 +345,8 @@ public class TestBlockManagerSafeMode {
    * Both the increment and decrement will be a no-op if the safe mode is OFF.
    * The safe mode status lifecycle: OFF -> PENDING_THRESHOLD -> OFF
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testIncrementAndDecrementSafeBlockCount() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", 0);
@@ -356,7 +371,8 @@ public class TestBlockManagerSafeMode {
    * Both the increment and decrement will be a no-op if the safe mode is OFF.
    * The safe mode status lifecycle: OFF -> PENDING_THRESHOLD -> OFF
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testIncrementAndDecrementStripedSafeBlockCount() {
     bmSafeMode.activate(BLOCK_TOTAL);
     Whitebox.setInternalState(bmSafeMode, "extension", 0);
@@ -384,7 +400,8 @@ public class TestBlockManagerSafeMode {
    * The monitor will make block manager leave the safe mode after  extension
    * period.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testSafeModeMonitor() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
 
@@ -400,7 +417,8 @@ public class TestBlockManagerSafeMode {
   /**
    * Test block manager won't leave safe mode if datanode threshold is not met.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testDatanodeThreshodShouldBeMet() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
 
@@ -421,7 +439,8 @@ public class TestBlockManagerSafeMode {
    * Test block manager won't leave safe mode if datanode threshold is not met
    * only if datanodeThreshold is configured > 0.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testDatanodeThreshodShouldBeMetOnlyIfConfigured()
           throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
@@ -502,7 +521,8 @@ public class TestBlockManagerSafeMode {
    * Test block manager won't leave safe mode if there are blocks with
    * generation stamp (GS) in future.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testStayInSafeModeWhenBytesInFuture() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
 
@@ -516,17 +536,18 @@ public class TestBlockManagerSafeMode {
     // PENDING_THRESHOLD -> EXTENSION
     bmSafeMode.checkSafeMode();
 
-    assertFalse("Shouldn't leave safe mode in case of blocks with future GS! ",
-        bmSafeMode.leaveSafeMode(false));
-    assertTrue("Leaving safe mode forcefully should succeed regardless of " +
-        "blocks with future GS.", bmSafeMode.leaveSafeMode(true));
-    assertEquals("Number of blocks with future GS should have been cleared " +
-        "after leaving safe mode", 0L, bmSafeMode.getBytesInFuture());
-    assertTrue("Leaving safe mode should succeed after blocks with future GS " +
-        "are cleared.", bmSafeMode.leaveSafeMode(false));
+    assertFalse(bmSafeMode.leaveSafeMode(false),
+        "Shouldn't leave safe mode in case of blocks with future GS! ");
+    assertTrue(bmSafeMode.leaveSafeMode(true),
+        "Leaving safe mode forcefully should succeed regardless of " + "blocks with future GS.");
+    assertEquals(0L, bmSafeMode.getBytesInFuture(),
+        "Number of blocks with future GS should have been cleared " + "after leaving safe mode");
+    assertTrue(bmSafeMode.leaveSafeMode(false),
+        "Leaving safe mode should succeed after blocks with future GS " + "are cleared.");
   }
 
-  @Test(timeout = 10000)
+@Test
+@Timeout(value = 10)
   public void testExtensionConfig() {
     final Configuration conf = new HdfsConfiguration();
     bmSafeMode = new BlockManagerSafeMode(bm, fsn, false, conf);
@@ -548,7 +569,8 @@ public class TestBlockManagerSafeMode {
   /**
    * Test get safe mode tip.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testGetSafeModeTip() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
     String tip = bmSafeMode.getSafeModeTip();
@@ -617,7 +639,8 @@ public class TestBlockManagerSafeMode {
   /**
    * Test get safe mode tip in case of blocks with future GS.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testGetSafeModeTipForBlocksWithFutureGS() throws Exception {
     bmSafeMode.activate(BLOCK_TOTAL);
 
@@ -736,16 +759,16 @@ public class TestBlockManagerSafeMode {
 
   private void assertSafeModeIsLeftAtThreshold(long blockIndex) {
     if (blockIndex < BLOCK_THRESHOLD) {
-      assertEquals("Current block index should be equal to " +
-          "the safe block counter.", blockIndex, getblockSafe());
-      assertTrue("Block Manager should stay in safe mode until " +
-          "the safe block threshold is reached.", bmSafeMode.isInSafeMode());
+      assertEquals(blockIndex, getblockSafe(),
+          "Current block index should be equal to " + "the safe block counter.");
+      assertTrue(bmSafeMode.isInSafeMode(), "Block Manager should stay in safe mode until "
+          + "the safe block threshold is reached.");
     } else {
-      assertEquals("If safe block threshold is reached, safe block " +
-          "counter should not increase further.",
-          BLOCK_THRESHOLD, getblockSafe());
-      assertFalse("Block manager leaves safe mode if block " +
-          "threshold is met.", bmSafeMode.isInSafeMode());
+      assertEquals(BLOCK_THRESHOLD, getblockSafe(),
+          "If safe block threshold is reached, safe block "
+              + "counter should not increase further.");
+      assertFalse(bmSafeMode.isInSafeMode(),
+          "Block manager leaves safe mode if block " + "threshold is met.");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManagerSafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockManagerSafeMode.java
@@ -121,9 +121,9 @@ public class TestBlockManagerSafeMode {
   @Test
   @Timeout(value = 30)
   public void testInitialize() {
-      assertFalse(bmSafeMode.isInSafeMode(),
-          "Block manager should not be in safe mode at beginning.");
-      bmSafeMode.activate(BLOCK_TOTAL);
+    assertFalse(bmSafeMode.isInSafeMode(),
+        "Block manager should not be in safe mode at beginning.");
+    bmSafeMode.activate(BLOCK_TOTAL);
     assertEquals(BMSafeModeStatus.PENDING_THRESHOLD, getSafeModeStatus());
     assertTrue(bmSafeMode.isInSafeMode());
   }
@@ -546,8 +546,8 @@ public class TestBlockManagerSafeMode {
         "Leaving safe mode should succeed after blocks with future GS " + "are cleared.");
   }
 
-@Test
-@Timeout(value = 10)
+  @Test
+  @Timeout(value = 10)
   public void testExtensionConfig() {
     final Configuration conf = new HdfsConfiguration();
     bmSafeMode = new BlockManagerSafeMode(bm, fsn, false, conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementPolicyDebugLoggingBuilder.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementPolicyDebugLoggingBuilder.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementStatusDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementStatusDefault.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests to validate the BlockPlacementStatusDefault policy, focusing on

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementStatusWithUpgradeDomain.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockPlacementStatusWithUpgradeDomain.java
@@ -17,17 +17,17 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for BlockPlacementStatusWithUpgradeDomain class.
@@ -38,7 +38,7 @@ public class TestBlockPlacementStatusWithUpgradeDomain {
   private BlockPlacementStatusDefault bpsd =
       mock(BlockPlacementStatusDefault.class);
 
-  @Before
+  @BeforeEach
   public void setup() {
     upgradeDomains = new HashSet<String>();
     upgradeDomains.add("1");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
@@ -312,16 +313,19 @@ public class TestBlockReportLease {
           any(DatanodeStorageInfo.class),
           any(BlockListAsLongs.class));
 
-      ExecutorService pool = Executors.newFixedThreadPool(2);
+      ExecutorService pool = Executors.newFixedThreadPool(1);
       // Trigger sendBlockReport.
       BlockReportContext brContext = new BlockReportContext(1, 0,
           rand.nextLong(), hbResponse.getFullBlockReportLeaseId());
       // Build every storage with 100 blocks for sending report.
-      DatanodeStorage[] datanodeStorages
-          = new DatanodeStorage[storages.length];
       for (int i = 0; i < storages.length; i++) {
-        datanodeStorages[i] = storages[i].getStorage();
-        StorageBlockReport[] reports = createReports(datanodeStorages, 100);
+        DatanodeStorage s = storages[i].getStorage();
+        StorageBlockReport[] reports = createReports(new DatanodeStorage[]{s}, 100);
+        DatanodeStorageInfo target = Arrays.stream(datanodeDescriptor.getStorageInfos())
+            .filter(info -> info.getStorageID().equals(s.getStorageID()))
+            .findFirst()
+            .get();
+        int before = target.getBlockReportCount();
 
         Future<DatanodeCommand> f1 = null;
         // The first multiple send once, simulating the failure of the first report,
@@ -334,9 +338,15 @@ public class TestBlockReportLease {
           f1.get();
         }
 
+        HeartbeatResponse hbResponse2 = rpcServer.sendHeartbeat(
+            dnRegistration, storages, 0, 0, 0, 0, 0, null, true,
+            SlowPeerReports.EMPTY_REPORT, SlowDiskReports.EMPTY_REPORT);
+
+        BlockReportContext brContext2 = new BlockReportContext(
+            1, 0, rand.nextLong(), hbResponse2.getFullBlockReportLeaseId());
         // Send blockReport.
         Future<DatanodeCommand> f2 = pool.submit(() ->
-            rpcServer.blockReport(dnRegistration, poolId, reports, brContext));
+            rpcServer.blockReport(dnRegistration, poolId, reports, brContext2));
 
         // Wait until BlockManager calls processReport.
         delayer.waitForCall();
@@ -350,9 +360,11 @@ public class TestBlockReportLease {
         assertEquals(poolId, ((FinalizeCommand) datanodeCommand)
             .getBlockPoolId());
         if(i == 0){
-          assertEquals(2, datanodeDescriptor.getStorageInfos()[i].getBlockReportCount());
-        }else{
-          assertEquals(1, datanodeDescriptor.getStorageInfos()[i].getBlockReportCount());
+          assertEquals(2,
+              target.getBlockReportCount() - before);
+        } else {
+          assertEquals(1,
+              target.getBlockReportCount() - before);
         }
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportLease.java
@@ -39,7 +39,8 @@ import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
 import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,8 +50,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -137,8 +138,7 @@ public class TestBlockReportLease {
       // Get result, it will not null if process successfully
       DatanodeCommand datanodeCommand = sendBRfuturea.get();
       assertTrue(datanodeCommand instanceof FinalizeCommand);
-      assertEquals(poolId, ((FinalizeCommand)datanodeCommand)
-          .getBlockPoolId());
+      assertEquals(poolId, ((FinalizeCommand) datanodeCommand).getBlockPoolId());
     }
   }
 
@@ -203,8 +203,7 @@ public class TestBlockReportLease {
         exception = e;
       }
       assertNotNull(exception);
-      assertEquals(InvalidBlockReportLeaseException.class,
-          exception.getCause().getClass());
+      assertEquals(InvalidBlockReportLeaseException.class, exception.getCause().getClass());
     }
   }
 
@@ -272,7 +271,8 @@ public class TestBlockReportLease {
     return storageBlockReports;
   }
 
-  @Test(timeout = 360000)
+  @Test
+  @Timeout(value = 360)
   public void testFirstIncompleteBlockReport() throws Exception {
     HdfsConfiguration conf = new HdfsConfiguration();
     Random rand = new Random();
@@ -312,6 +312,7 @@ public class TestBlockReportLease {
           any(DatanodeStorageInfo.class),
           any(BlockListAsLongs.class));
 
+      ExecutorService pool = Executors.newFixedThreadPool(2);
       // Trigger sendBlockReport.
       BlockReportContext brContext = new BlockReportContext(1, 0,
           rand.nextLong(), hbResponse.getFullBlockReportLeaseId());
@@ -322,15 +323,20 @@ public class TestBlockReportLease {
         datanodeStorages[i] = storages[i].getStorage();
         StorageBlockReport[] reports = createReports(datanodeStorages, 100);
 
+        Future<DatanodeCommand> f1 = null;
         // The first multiple send once, simulating the failure of the first report,
         // only send successfully once.
-        if(i == 0){
-          rpcServer.blockReport(dnRegistration, poolId, reports, brContext);
+        if (i == 0) {
+          f1 = pool.submit(() ->
+              rpcServer.blockReport(dnRegistration, poolId, reports, brContext));
+          delayer.waitForCall();
+          delayer.proceed();
+          f1.get();
         }
 
         // Send blockReport.
-        DatanodeCommand datanodeCommand = rpcServer.blockReport(dnRegistration, poolId, reports,
-            brContext);
+        Future<DatanodeCommand> f2 = pool.submit(() ->
+            rpcServer.blockReport(dnRegistration, poolId, reports, brContext));
 
         // Wait until BlockManager calls processReport.
         delayer.waitForCall();
@@ -338,9 +344,10 @@ public class TestBlockReportLease {
         // Allow blockreport to proceed.
         delayer.proceed();
 
+        DatanodeCommand datanodeCommand = f2.get();
         // Get result, it will not null if process successfully.
         assertTrue(datanodeCommand instanceof FinalizeCommand);
-        assertEquals(poolId, ((FinalizeCommand)datanodeCommand)
+        assertEquals(poolId, ((FinalizeCommand) datanodeCommand)
             .getBlockPoolId());
         if(i == 0){
           assertEquals(2, datanodeDescriptor.getStorageInfos()[i].getBlockReportCount());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportRateLimiting.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportRateLimiting.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_MAX_FULL_BLOCK_REPORT_LEASES;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_FULL_BLOCK_REPORT_LEASE_LENGTH_MS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 import java.util.function.Supplier;
@@ -31,7 +34,6 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.server.protocol.BlockReportContext;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -157,7 +159,7 @@ public class TestBlockReportRateLimiting {
       }, 25, 50000);
     }
     cluster.shutdown();
-    Assertions.assertEquals("", failure.get());
+    assertEquals("", failure.get());
   }
 
   /**
@@ -210,9 +212,9 @@ public class TestBlockReportRateLimiting {
       BlockManagerFaultInjector.instance = injector;
       cluster.set(new MiniDFSCluster.Builder(conf).numDataNodes(2).build());
       cluster.get().waitActive();
-      Assertions.assertNotNull(cluster.get().stopDataNode(datanodeToStop.get()));
+      assertNotNull(cluster.get().stopDataNode(datanodeToStop.get()));
       gotFbrSem.acquire();
-      Assertions.assertNull(failure.get());
+      assertNull(failure.get());
     } finally {
       if (cluster.get() != null) {
         cluster.get().shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportRateLimiting.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockReportRateLimiting.java
@@ -31,10 +31,11 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.server.protocol.BlockReportContext;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
@@ -53,18 +54,19 @@ public class TestBlockReportRateLimiting {
     LOG.error("Test error: " + what);
   }
 
-  @After
+  @AfterEach
   public void restoreNormalBlockManagerFaultInjector() {
     BlockManagerFaultInjector.instance = new BlockManagerFaultInjector();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void raiseBlockManagerLogLevels() {
     GenericTestUtils.setLogLevel(BlockManager.LOG, Level.TRACE);
     GenericTestUtils.setLogLevel(BlockReportLeaseManager.LOG, Level.TRACE);
   }
 
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testRateLimitingDuringDataNodeStartup() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFS_NAMENODE_MAX_FULL_BLOCK_REPORT_LEASES, 1);
@@ -155,7 +157,7 @@ public class TestBlockReportRateLimiting {
       }, 25, 50000);
     }
     cluster.shutdown();
-    Assert.assertEquals("", failure.get());
+    Assertions.assertEquals("", failure.get());
   }
 
   /**
@@ -163,7 +165,8 @@ public class TestBlockReportRateLimiting {
    * first datanode gets a lease, kill it.  Then wait for the lease to
    * expire, and the second datanode to send a full block report.
    */
-  @Test(timeout=180000)
+  @Test
+  @Timeout(value = 180)
   public void testLeaseExpiration() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(DFS_NAMENODE_MAX_FULL_BLOCK_REPORT_LEASES, 1);
@@ -207,9 +210,9 @@ public class TestBlockReportRateLimiting {
       BlockManagerFaultInjector.instance = injector;
       cluster.set(new MiniDFSCluster.Builder(conf).numDataNodes(2).build());
       cluster.get().waitActive();
-      Assert.assertNotNull(cluster.get().stopDataNode(datanodeToStop.get()));
+      Assertions.assertNotNull(cluster.get().stopDataNode(datanodeToStop.get()));
       gotFbrSem.acquire();
-      Assert.assertNull(failure.get());
+      Assertions.assertNull(failure.get());
     } finally {
       if (cluster.get() != null) {
         cluster.get().shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockUnderConstructionFeature.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockUnderConstructionFeature.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.common.GenerationStamp;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class provides tests for {@link BlockUnderConstructionFeature} class

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
@@ -42,10 +42,10 @@ import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.util.HostsFileWriter;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBlocksWithNotEnoughRacks {
   public static final Logger LOG =
@@ -299,7 +299,7 @@ public class TestBlocksWithNotEnoughRacks {
       for (int i = 0; i < racks.length; i++) {
         byte[] blockContent = cluster.readBlockOnDataNodeAsBytes(i, b);
         if (blockContent != null && i != dnToCorrupt) {
-          assertArrayEquals("Corrupt replica", fileContent, blockContent);
+          assertArrayEquals(fileContent, blockContent, "Corrupt replica");
         }
       }
     } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlocksWithNotEnoughRacks.java
@@ -45,7 +45,11 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestBlocksWithNotEnoughRacks {
   public static final Logger LOG =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestComputeInvalidateWork.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestComputeInvalidateWork.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -44,9 +44,10 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.VersionInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test if FSNamesystem handles heartbeat right
@@ -65,7 +66,7 @@ public class TestComputeInvalidateWork {
   private int totalBlockGroups, blockGroupSize, stripesPerBlock, cellSize;
   private LocatedStripedBlock locatedStripedBlock;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ecPolicy = SystemErasureCodingPolicies.getByID(
         SystemErasureCodingPolicies.XOR_2_1_POLICY_ID);
@@ -100,7 +101,7 @@ public class TestComputeInvalidateWork {
     locatedStripedBlock = (LocatedStripedBlock)(lbs.get(0));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -128,7 +129,8 @@ public class TestComputeInvalidateWork {
    * Test if {@link BlockManager#computeInvalidateWork(int)}
    * can schedule invalidate work correctly for the replicas.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testComputeInvalidateReplicas() throws Exception {
     final int blockInvalidateLimit = bm.getDatanodeManager()
         .getBlockInvalidateLimit();
@@ -151,7 +153,8 @@ public class TestComputeInvalidateWork {
    * Test if {@link BlockManager#computeInvalidateWork(int)}
    * can schedule invalidate work correctly for the striped block groups.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testComputeInvalidateStripedBlockGroups() throws Exception {
     final int blockInvalidateLimit =
         bm.getDatanodeManager().getBlockInvalidateLimit();
@@ -177,7 +180,8 @@ public class TestComputeInvalidateWork {
    * can schedule invalidate work correctly for both replicas and striped
    * block groups, combined.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testComputeInvalidate() throws Exception {
     final int blockInvalidateLimit =
         bm.getDatanodeManager().getBlockInvalidateLimit();
@@ -211,7 +215,8 @@ public class TestComputeInvalidateWork {
    * {@link DatanodeManager#datanodeMap}. This tests if block
    * invalidation work on the original DataNode can be skipped.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testDatanodeReformat() throws Exception {
     namesystem.writeLock(RwLockMode.BM);
     try {
@@ -239,7 +244,8 @@ public class TestComputeInvalidateWork {
     }
   }
 
-  @Test(timeout=12000)
+  @Test
+  @Timeout(value = 12)
   public void testDatanodeReRegistration() throws Exception {
     // Create a test file
     final DistributedFileSystem dfs = cluster.getFileSystem();
@@ -265,13 +271,13 @@ public class TestComputeInvalidateWork {
       invalidateBlocks = (InvalidateBlocks) Whitebox
           .getInternalState(cluster.getNamesystem().getBlockManager(),
               "invalidateBlocks");
-      assertEquals("Invalidate blocks should include both Replicas and " +
-          "Striped BlockGroups!",
-          (long) expected, invalidateBlocks.numBlocks());
-      assertEquals("Unexpected invalidate count for replicas!",
-          totalReplicas, invalidateBlocks.getBlocks());
-      assertEquals("Unexpected invalidate count for striped block groups!",
-          totalStripedDataBlocks, invalidateBlocks.getECBlocks());
+      assertEquals((long) expected, invalidateBlocks.numBlocks(),
+          "Invalidate blocks should include both Replicas and " +
+              "Striped BlockGroups!");
+      assertEquals(totalReplicas, invalidateBlocks.getBlocks(),
+          "Unexpected invalidate count for replicas!");
+      assertEquals(totalStripedDataBlocks, invalidateBlocks.getECBlocks(),
+          "Unexpected invalidate count for striped block groups!");
     } finally {
       namesystem.writeUnlock(RwLockMode.BM, "testDatanodeReRegistration");
     }
@@ -289,8 +295,8 @@ public class TestComputeInvalidateWork {
       try {
         bm.getDatanodeManager().registerDatanode(reg);
         expected -= (totalReplicasPerDataNode + totalBlockGroupsPerDataNode);
-        assertEquals("Expected number of invalidate blocks to decrease",
-            (long) expected, invalidateBlocks.numBlocks());
+        assertEquals((long) expected, invalidateBlocks.numBlocks(),
+            "Expected number of invalidate blocks to decrease");
       } finally {
         namesystem.writeUnlock(RwLockMode.BM, "testDatanodeReRegistration");
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeAdminMonitorBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeAdminMonitorBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +28,9 @@ import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestDatanodeAdminMonitorBase {
   public static final Logger LOG = LoggerFactory.getLogger(TestDatanodeAdminMonitorBase.class);
@@ -67,8 +69,8 @@ public class TestDatanodeAdminMonitorBase {
 
     for (int i = 0; i < NUM_DATANODE; i++) {
       final DatanodeDescriptor dn = pendingNodes.poll();
-      Assertions.assertNotNull(dn);
-      Assertions.assertEquals(ORDERED_LAST_UPDATE_TIMES[i], dn.getLastUpdate());
+      assertNotNull(dn);
+      assertEquals(ORDERED_LAST_UPDATE_TIMES[i], dn.getLastUpdate());
     }
   }
 
@@ -83,9 +85,9 @@ public class TestDatanodeAdminMonitorBase {
         nodes.stream().sorted(DatanodeAdminMonitorBase.PENDING_NODES_QUEUE_COMPARATOR.reversed())
             .collect(Collectors.toList());
 
-    Assertions.assertEquals(NUM_DATANODE, reverseOrderNodes.size());
+    assertEquals(NUM_DATANODE, reverseOrderNodes.size());
     for (int i = 0; i < NUM_DATANODE; i++) {
-      Assertions.assertEquals(REVERSE_ORDER_LAST_UPDATE_TIMES[i],
+      assertEquals(REVERSE_ORDER_LAST_UPDATE_TIMES[i],
           reverseOrderNodes.get(i).getLastUpdate());
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeAdminMonitorBase.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeAdminMonitorBase.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,8 +67,8 @@ public class TestDatanodeAdminMonitorBase {
 
     for (int i = 0; i < NUM_DATANODE; i++) {
       final DatanodeDescriptor dn = pendingNodes.poll();
-      Assert.assertNotNull(dn);
-      Assert.assertEquals(ORDERED_LAST_UPDATE_TIMES[i], dn.getLastUpdate());
+      Assertions.assertNotNull(dn);
+      Assertions.assertEquals(ORDERED_LAST_UPDATE_TIMES[i], dn.getLastUpdate());
     }
   }
 
@@ -83,9 +83,9 @@ public class TestDatanodeAdminMonitorBase {
         nodes.stream().sorted(DatanodeAdminMonitorBase.PENDING_NODES_QUEUE_COMPARATOR.reversed())
             .collect(Collectors.toList());
 
-    Assert.assertEquals(NUM_DATANODE, reverseOrderNodes.size());
+    Assertions.assertEquals(NUM_DATANODE, reverseOrderNodes.size());
     for (int i = 0; i < NUM_DATANODE; i++) {
-      Assert.assertEquals(REVERSE_ORDER_LAST_UPDATE_TIMES[i],
+      Assertions.assertEquals(REVERSE_ORDER_LAST_UPDATE_TIMES[i],
           reverseOrderNodes.get(i).getLastUpdate());
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeDescriptor.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 
@@ -28,7 +28,7 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo.AddBlockResult;
 import org.apache.hadoop.hdfs.server.common.GenerationStamp;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests that methods in DatanodeDescriptor
@@ -80,6 +80,6 @@ public class TestDatanodeDescriptor {
     assertEquals(1, dd.numBlocks());
     // remove second block
     assertTrue(BlocksMap.removeBlock(dd, blk1));
-    assertEquals(0, dd.numBlocks());    
+    assertEquals(0, dd.numBlocks());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -69,14 +69,15 @@ import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDatanodeManager {
   
@@ -141,9 +142,9 @@ public class TestDatanodeManager {
 
     //Verify DatanodeManager has the correct count
     Map<String, Integer> mapToCheck = dm.getDatanodesSoftwareVersions();
-    assertNull("should be no more version0 nodes", mapToCheck.get("version0"));
-    assertEquals("should be one version1 node",
-        mapToCheck.get("version1").intValue(), 1);
+    assertNull(mapToCheck.get("version0"), "should be no more version0 nodes");
+    assertEquals(mapToCheck.get("version1").intValue(), 1,
+        "should be one version1 node");
   }
 
   /**
@@ -172,8 +173,8 @@ public class TestDatanodeManager {
             new DatanodeID(ipNew, "", storageID, 9000, 0, 0, 0),
             null, null, "version"));
 
-    assertNull("should be no node with old ip", dm.getDatanodeByHost(ipOld));
-    assertNotNull("should be a node with new ip", dm.getDatanodeByHost(ipNew));
+    assertNull(dm.getDatanodeByHost(ipOld), "should be no node with old ip");
+    assertNotNull(dm.getDatanodeByHost(ipNew), "should be a node with new ip");
 
     storageID = "someStorageID2";
     String hostnameOld = "someHostNameOld" + storageID;
@@ -187,8 +188,8 @@ public class TestDatanodeManager {
             new DatanodeID("ip", hostnameNew, storageID, 9000, 0, 0, 0),
             null, null, "version"));
 
-    assertNull("should be no node with old hostname", dm.getDatanodeByHostName(hostnameOld));
-    assertNotNull("should be a node with new hostname", dm.getDatanodeByHostName(hostnameNew));
+    assertNull(dm.getDatanodeByHostName(hostnameOld), "should be no node with old hostname");
+    assertNotNull(dm.getDatanodeByHostName(hostnameNew), "should be a node with new hostname");
   }
 
   /**
@@ -254,9 +255,11 @@ public class TestDatanodeManager {
         } else { //This storageID has never been registered
           //Ensure IP address is unique to storageID
           String ip = "someIP" + storageID;
+          String hostname = "hostname" + storageID;
           Mockito.when(dr.getIpAddr()).thenReturn(ip);
           Mockito.when(dr.getXferAddr()).thenReturn(ip + ":9000");
           Mockito.when(dr.getXferPort()).thenReturn(9000);
+          Mockito.when(dr.getHostName()).thenReturn(hostname);
         }
         //Pick a random version to register with
         Mockito.when(dr.getSoftwareVersion()).thenReturn(
@@ -264,7 +267,7 @@ public class TestDatanodeManager {
 
         LOG.info("Registering node storageID: " + dr.getDatanodeUuid() +
           ", version: " + dr.getSoftwareVersion() + ", IP address: "
-          + dr.getXferAddr());
+          + dr.getXferAddr()+ ", hostname: " + dr.getHostName());
 
         //Register this random node
         dm.registerDatanode(dr);
@@ -291,13 +294,14 @@ public class TestDatanodeManager {
         LOG.info("Still in map: " + entry.getKey() + " has "
           + entry.getValue());
       }
-      assertEquals("The map of version counts returned by DatanodeManager was"
-        + " not what it was expected to be on iteration " + i, 0,
-        mapToCheck.size());
+      assertEquals(0, mapToCheck.size(),
+          "The map of version counts returned by DatanodeManager was"
+              + " not what it was expected to be on iteration " + i);
     }
   }
   
-  @Test (timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testRejectUnresolvedDatanodes() throws IOException {
     //Create the DatanodeManager which will be tested
     FSNamesystem fsn = Mockito.mock(FSNamesystem.class);
@@ -327,12 +331,12 @@ public class TestDatanodeManager {
     try {
       //Register this node
       dm.registerDatanode(dr);
-      Assert.fail("Expected an UnresolvedTopologyException");
+      Assertions.fail("Expected an UnresolvedTopologyException");
     } catch (UnresolvedTopologyException ute) {
       LOG.info("Expected - topology is not resolved and " +
           "registration is rejected.");
     } catch (Exception e) {
-      Assert.fail("Expected an UnresolvedTopologyException");
+      Assertions.fail("Expected an UnresolvedTopologyException");
     }
   }
   
@@ -487,29 +491,29 @@ public class TestDatanodeManager {
     DatanodeInfo[] sortedLocs = block.getLocations();
     storageIDs = block.getStorageIDs();
     storageTypes = block.getStorageTypes();
-    assertThat(sortedLocs.length, is(totalDNs));
-    assertThat(storageIDs.length, is(totalDNs));
-    assertThat(storageTypes.length, is(totalDNs));
+    assertThat(sortedLocs.length).isEqualTo(totalDNs);
+    assertThat(storageIDs.length).isEqualTo(totalDNs);
+    assertThat(storageTypes.length).isEqualTo(totalDNs);
     for (int i = 0; i < sortedLocs.length; i++) {
-      assertThat(((DatanodeInfoWithStorage) sortedLocs[i]).getStorageID(),
-        is(storageIDs[i]));
-      assertThat(((DatanodeInfoWithStorage) sortedLocs[i]).getStorageType(),
-        is(storageTypes[i]));
+      assertThat(((DatanodeInfoWithStorage) sortedLocs[i]).getStorageID())
+          .isEqualTo(storageIDs[i]);
+      assertThat(((DatanodeInfoWithStorage) sortedLocs[i]).getStorageType())
+          .isEqualTo(storageTypes[i]);
     }
     // Ensure the local node is first.
-    assertThat(sortedLocs[0].getIpAddr(), is(targetIp));
+    assertThat(sortedLocs[0].getIpAddr()).isEqualTo(targetIp);
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[sortedLocs.length - 1].getAdminState(),
-      is(DatanodeInfo.AdminStates.DECOMMISSIONED));
-    assertThat(sortedLocs[sortedLocs.length - 2].getAdminState(),
-      is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[sortedLocs.length - 1].getAdminState())
+        .isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
+    assertThat(sortedLocs[sortedLocs.length - 2].getAdminState())
+        .isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     // check that the StorageType of datanoodes immediately
     // preceding the decommissioned datanodes is PROVIDED
     for (int i = 0; i < providedStorages; i++) {
       assertThat(
           ((DatanodeInfoWithStorage)
-              sortedLocs[sortedLocs.length - 3 - i]).getStorageType(),
-          is(StorageType.PROVIDED));
+              sortedLocs[sortedLocs.length - 3 - i]).getStorageType())
+          .isEqualTo(StorageType.PROVIDED);
     }
   }
 
@@ -640,8 +644,7 @@ public class TestDatanodeManager {
     assertEquals(locs[1].getIpAddr(), sortedLocs[2].getIpAddr());
     assertEquals(locs[4].getIpAddr(), sortedLocs[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs[4].getIpAddr());
 
     // Test client not in cluster but same rack with locs[3].
@@ -656,8 +659,8 @@ public class TestDatanodeManager {
     assertEquals(locs[1].getIpAddr(), sortedLocs2[2].getIpAddr());
     assertEquals(locs[4].getIpAddr(), sortedLocs2[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).
+        isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs2[4].getIpAddr());
   }
 
@@ -793,8 +796,7 @@ public class TestDatanodeManager {
     assertEquals(locs[4].getIpAddr(), sortedLocs[2].getIpAddr());
     assertEquals(locs[1].getIpAddr(), sortedLocs[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs[4].getIpAddr());
 
     // Test client not in cluster but same rack with locs[3].
@@ -809,8 +811,8 @@ public class TestDatanodeManager {
     assertEquals(locs[4].getIpAddr(), sortedLocs2[2].getIpAddr());
     assertEquals(locs[1].getIpAddr(), sortedLocs2[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).
+        isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs2[4].getIpAddr());
   }
 
@@ -884,8 +886,8 @@ public class TestDatanodeManager {
     assertEquals(locs[1].getIpAddr(), sortedLocs[2].getIpAddr());
     assertEquals(locs[4].getIpAddr(), sortedLocs[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).
+        isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs[4].getIpAddr());
 
     // Test client not in cluster but same rack with locs[3].
@@ -900,8 +902,8 @@ public class TestDatanodeManager {
     assertEquals(locs[1].getIpAddr(), sortedLocs2[2].getIpAddr());
     assertEquals(locs[4].getIpAddr(), sortedLocs2[3].getIpAddr());
     // Ensure the two decommissioned DNs were moved to the end.
-    assertThat(sortedLocs[4].getAdminState(),
-        is(DatanodeInfo.AdminStates.DECOMMISSIONED));
+    assertThat(sortedLocs[4].getAdminState()).
+        isEqualTo(DatanodeInfo.AdminStates.DECOMMISSIONED);
     assertEquals(locs[0].getIpAddr(), sortedLocs2[4].getIpAddr());
   }
 
@@ -954,12 +956,11 @@ public class TestDatanodeManager {
     // Sort the list so that we know which one is which
     Collections.sort(both);
 
-    Assert.assertEquals("Incorrect number of hosts reported",
-        2, both.size());
-    Assert.assertEquals("Unexpected host or host in unexpected position",
-        "127.0.0.1:12345", both.get(0).getInfoAddr());
-    Assert.assertEquals("Unexpected host or host in unexpected position",
-        "127.0.0.1:23456", both.get(1).getInfoAddr());
+    Assertions.assertEquals(2, both.size(), "Incorrect number of hosts reported");
+    Assertions.assertEquals("127.0.0.1:12345", both.get(0).getInfoAddr(),
+        "Unexpected host or host in unexpected position");
+    Assertions.assertEquals("127.0.0.1:23456", both.get(1).getInfoAddr(),
+        "Unexpected host or host in unexpected position");
 
     // Remove one node from includes, but do not add it to excludes.
     hm.refresh(oneNode, noNodes);
@@ -968,10 +969,10 @@ public class TestDatanodeManager {
     List<DatanodeDescriptor> onlyOne =
         dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.ALL);
 
-    Assert.assertEquals("Incorrect number of hosts reported",
-        1, onlyOne.size());
-    Assert.assertEquals("Unexpected host reported",
-        "127.0.0.1:23456", onlyOne.get(0).getInfoAddr());
+    Assertions.assertEquals(1, onlyOne.size(),
+        "Incorrect number of hosts reported");
+    Assertions.assertEquals("127.0.0.1:23456", onlyOne.get(0).getInfoAddr(),
+        "Unexpected host reported");
 
     // Remove all nodes from includes
     hm.refresh(noNodes, noNodes);
@@ -983,12 +984,12 @@ public class TestDatanodeManager {
     // Sort the list so that we know which one is which
     Collections.sort(bothAgain);
 
-    Assert.assertEquals("Incorrect number of hosts reported",
-        2, bothAgain.size());
-    Assert.assertEquals("Unexpected host or host in unexpected position",
-        "127.0.0.1:12345", bothAgain.get(0).getInfoAddr());
-    Assert.assertEquals("Unexpected host or host in unexpected position",
-        "127.0.0.1:23456", bothAgain.get(1).getInfoAddr());
+    Assertions.assertEquals(2, bothAgain.size(),
+        "Incorrect number of hosts reported");
+    Assertions.assertEquals("127.0.0.1:12345", bothAgain.get(0).getInfoAddr(),
+        "Unexpected host or host in unexpected position");
+    Assertions.assertEquals("127.0.0.1:23456", bothAgain.get(1).getInfoAddr(),
+        "Unexpected host or host in unexpected position");
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -266,8 +266,8 @@ public class TestDatanodeManager {
           "version" + rng.nextInt(5));
 
         LOG.info("Registering node storageID: " + dr.getDatanodeUuid() +
-          ", version: " + dr.getSoftwareVersion() + ", IP address: "
-          + dr.getXferAddr()+ ", hostname: " + dr.getHostName());
+            ", version: " + dr.getSoftwareVersion() + ", IP address: "
+            + dr.getXferAddr() + ", hostname: " + dr.getHostName());
 
         //Register this random node
         dm.registerDatanode(dr);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestDatanodeManager.java
@@ -69,15 +69,18 @@ import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestDatanodeManager {
   
@@ -331,12 +334,12 @@ public class TestDatanodeManager {
     try {
       //Register this node
       dm.registerDatanode(dr);
-      Assertions.fail("Expected an UnresolvedTopologyException");
+      fail("Expected an UnresolvedTopologyException");
     } catch (UnresolvedTopologyException ute) {
       LOG.info("Expected - topology is not resolved and " +
           "registration is rejected.");
     } catch (Exception e) {
-      Assertions.fail("Expected an UnresolvedTopologyException");
+      fail("Expected an UnresolvedTopologyException");
     }
   }
   
@@ -956,10 +959,10 @@ public class TestDatanodeManager {
     // Sort the list so that we know which one is which
     Collections.sort(both);
 
-    Assertions.assertEquals(2, both.size(), "Incorrect number of hosts reported");
-    Assertions.assertEquals("127.0.0.1:12345", both.get(0).getInfoAddr(),
+    assertEquals(2, both.size(), "Incorrect number of hosts reported");
+    assertEquals("127.0.0.1:12345", both.get(0).getInfoAddr(),
         "Unexpected host or host in unexpected position");
-    Assertions.assertEquals("127.0.0.1:23456", both.get(1).getInfoAddr(),
+    assertEquals("127.0.0.1:23456", both.get(1).getInfoAddr(),
         "Unexpected host or host in unexpected position");
 
     // Remove one node from includes, but do not add it to excludes.
@@ -969,9 +972,9 @@ public class TestDatanodeManager {
     List<DatanodeDescriptor> onlyOne =
         dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.ALL);
 
-    Assertions.assertEquals(1, onlyOne.size(),
+    assertEquals(1, onlyOne.size(),
         "Incorrect number of hosts reported");
-    Assertions.assertEquals("127.0.0.1:23456", onlyOne.get(0).getInfoAddr(),
+    assertEquals("127.0.0.1:23456", onlyOne.get(0).getInfoAddr(),
         "Unexpected host reported");
 
     // Remove all nodes from includes
@@ -984,11 +987,11 @@ public class TestDatanodeManager {
     // Sort the list so that we know which one is which
     Collections.sort(bothAgain);
 
-    Assertions.assertEquals(2, bothAgain.size(),
+    assertEquals(2, bothAgain.size(),
         "Incorrect number of hosts reported");
-    Assertions.assertEquals("127.0.0.1:12345", bothAgain.get(0).getInfoAddr(),
+    assertEquals("127.0.0.1:12345", bothAgain.get(0).getInfoAddr(),
         "Unexpected host or host in unexpected position");
-    Assertions.assertEquals("127.0.0.1:23456", bothAgain.get(1).getInfoAddr(),
+    assertEquals("127.0.0.1:23456", bothAgain.get(1).getInfoAddr(),
         "Unexpected host or host in unexpected position");
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHost2NodesMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHost2NodesMap.java
@@ -18,20 +18,20 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.hdfs.DFSTestUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestHost2NodesMap {
   private final Host2NodesMap map = new Host2NodesMap();
   private DatanodeDescriptor dataNodes[];
   
-  @Before
+  @BeforeEach
   public void setup() {
     dataNodes = new DatanodeDescriptor[] {
         DFSTestUtil.getDatanodeDescriptor("1.1.1.1", "/d1/r1"),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
@@ -46,8 +46,9 @@ import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import java.io.BufferedReader;
@@ -61,13 +62,11 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.UUID;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestNameNodePrunesMissingStorages {
   static final Logger LOG =
@@ -95,7 +94,7 @@ public class TestNameNodePrunesMissingStorages {
       final DatanodeID dnId = dn0.getDatanodeId();
       final DatanodeDescriptor dnDescriptor =
           cluster.getNamesystem().getBlockManager().getDatanodeManager().getDatanode(dnId);
-      assertThat(dnDescriptor.getStorageInfos().length, is(numInitialStorages));
+      assertThat(dnDescriptor.getStorageInfos().length).isEqualTo(numInitialStorages);
 
       final String bpid = cluster.getNamesystem().getBlockPoolId();
       final DatanodeRegistration dnReg = dn0.getDNRegistrationForBP(bpid);
@@ -121,7 +120,7 @@ public class TestNameNodePrunesMissingStorages {
           SlowDiskReports.EMPTY_REPORT);
 
       // Check that the missing storage was pruned.
-      assertThat(dnDescriptor.getStorageInfos().length, is(expectedStoragesAfterTest));
+      assertThat(dnDescriptor.getStorageInfos().length).isEqualTo(expectedStoragesAfterTest);
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -134,7 +133,8 @@ public class TestNameNodePrunesMissingStorages {
    * reported by the DataNode.
    * @throws IOException
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testUnusedStorageIsPruned() throws IOException {
     // Run the test with 1 storage, after the text expect 0 storages.
     runTest(GenericTestUtils.getMethodName(), false, 1, 0);
@@ -146,7 +146,8 @@ public class TestNameNodePrunesMissingStorages {
    *
    * @throws IOException
    */
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testStorageWithBlocksIsNotPruned() throws IOException {
     // Run the test with 1 storage, after the text still expect 1 storage.
     runTest(GenericTestUtils.getMethodName(), true, 1, 1);
@@ -158,7 +159,8 @@ public class TestNameNodePrunesMissingStorages {
    * Shutting down a datanode, removing a storage directory, and restarting
    * the DataNode should not produce zombie storages.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testRemovingStorageDoesNotProduceZombies() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_DATANODE_FAILED_VOLUMES_TOLERATED_KEY, 1);
@@ -173,9 +175,10 @@ public class TestNameNodePrunesMissingStorages {
       cluster.waitActive();
       for (DataNode dn : cluster.getDataNodes()) {
         assertEquals(NUM_STORAGES_PER_DN,
-          cluster.getNamesystem().getBlockManager().
-              getDatanodeManager().getDatanode(dn.getDatanodeId()).
-              getStorageInfos().length);
+            cluster.getNamesystem().getBlockManager().
+                getDatanodeManager()
+                .getDatanode(dn.getDatanodeId()).
+                getStorageInfos().length);
       }
       // Create a file which will end up on all 3 datanodes.
       final Path TEST_PATH = new Path("/foo1");
@@ -209,7 +212,7 @@ public class TestNameNodePrunesMissingStorages {
       int datanodeToRemoveStorageFromIdx = 0;
       while (true) {
         if (datanodeToRemoveStorageFromIdx >= cluster.getDataNodes().size()) {
-          Assert.fail("failed to find datanode with uuid " + datanodeUuid);
+          Assertions.fail("failed to find datanode with uuid " + datanodeUuid);
           datanodeToRemoveStorageFrom = null;
           break;
         }
@@ -313,7 +316,8 @@ public class TestNameNodePrunesMissingStorages {
     }
   }
 
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testRenamingStorageIds() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_DATANODE_FAILED_VOLUMES_TOLERATED_KEY, 0);
@@ -379,7 +383,8 @@ public class TestNameNodePrunesMissingStorages {
     }
   }
 
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testNameNodePrunesUnreportedStorages() throws Exception {
     Configuration conf = new HdfsConfiguration();
     // Create a cluster with one datanode with two storages

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNameNodePrunesMissingStorages.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.hdfs.server.protocol.SlowPeerReports;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
@@ -67,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestNameNodePrunesMissingStorages {
   static final Logger LOG =
@@ -212,7 +212,7 @@ public class TestNameNodePrunesMissingStorages {
       int datanodeToRemoveStorageFromIdx = 0;
       while (true) {
         if (datanodeToRemoveStorageFromIdx >= cluster.getDataNodes().size()) {
-          Assertions.fail("failed to find datanode with uuid " + datanodeUuid);
+          fail("failed to find datanode with uuid " + datanodeUuid);
           datanodeToRemoveStorageFrom = null;
           break;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNodeCount.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestNodeCount.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeoutException;
 
@@ -34,7 +34,8 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test if live nodes count per node is correct 
@@ -48,7 +49,8 @@ public class TestNodeCount {
   Block lastBlock = null;
   NumberReplicas lastNum = null;
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testNodeCount() throws Exception {
     final Configuration conf = new HdfsConfiguration();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
@@ -187,9 +187,10 @@ public class TestOverReplicatedBlocks {
       assertEquals(SMALL_FILE_LENGTH / SMALL_BLOCK_SIZE, dnBlocks,
           "Replicas on node " + lastDNid + " should have been deleted");
       namesystem.readUnlock(RwLockMode.BM, "excessSize4Testing");
-      for (BlockLocation location : locs)
+      for (BlockLocation location : locs) {
         assertEquals(4, location.getNames().length,
             "Block should still have 4 replicas");
+      }
     } finally {
       if(fs != null) fs.close();
       if(cluster != null) cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestOverReplicatedBlocks.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.util.Time.monotonicNow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -41,7 +41,7 @@ import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOverReplicatedBlocks {
   /** Test processOverReplicatedBlock can handle corrupt replicas fine.
@@ -76,8 +76,8 @@ public class TestOverReplicatedBlocks {
           "scanner.cursor");
       //wait for one minute for deletion to succeed;
       for(int i = 0; !scanCursor.delete(); i++) {
-        assertTrue("Could not delete " + scanCursor.getAbsolutePath() +
-            " in one minute", i < 60);
+        assertTrue(i < 60, "Could not delete " +
+            scanCursor.getAbsolutePath() + " in one minute");
         try {
           Thread.sleep(1000);
         } catch (InterruptedException ignored) {}
@@ -184,12 +184,12 @@ public class TestOverReplicatedBlocks {
       // And should not actually be deleted, because lastDN does not heartbeat.
       namesystem.readLock(RwLockMode.BM);
       final int dnBlocks = bm.getExcessSize4Testing(dnReg.getDatanodeUuid());
-      assertEquals("Replicas on node " + lastDNid + " should have been deleted",
-          SMALL_FILE_LENGTH / SMALL_BLOCK_SIZE, dnBlocks);
+      assertEquals(SMALL_FILE_LENGTH / SMALL_BLOCK_SIZE, dnBlocks,
+          "Replicas on node " + lastDNid + " should have been deleted");
       namesystem.readUnlock(RwLockMode.BM, "excessSize4Testing");
-      for(BlockLocation location : locs)
-        assertEquals("Block should still have 4 replicas",
-            4, location.getNames().length);
+      for (BlockLocation location : locs)
+        assertEquals(4, location.getNames().length,
+            "Block should still have 4 replicas");
     } finally {
       if(fs != null) fs.close();
       if(cluster != null) cluster.shutdown();
@@ -216,8 +216,8 @@ public class TestOverReplicatedBlocks {
       fs.setReplication(p, (short) 1);
       out.close();
       ExtendedBlock block = DFSTestUtil.getFirstBlock(fs, p);
-      assertEquals("Expected only one live replica for the block", 1, bm
-          .countNodes(bm.getStoredBlock(block.getLocalBlock())).liveReplicas());
+      assertEquals(1, bm.countNodes(bm.getStoredBlock(block.getLocalBlock())).liveReplicas(),
+          "Expected only one live replica for the block");
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingDataNodeMessages.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.PendingDataNodeMessages.Rep
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.ReplicaState;
 import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.base.Joiner;
 
@@ -119,8 +119,8 @@ public class TestPendingDataNodeMessages {
       // processing IBR
       int pendingIBRMsg = cluster.getNameNode(1).getNamesystem()
           .getBlockManager().getPendingDataNodeMessageCount();
-      assertEquals("All DN message should processed after tail edits", 0,
-          pendingIBRMsg);
+      assertEquals(0, pendingIBRMsg,
+          "All DN message should processed after tail edits");
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingReconstruction.java
@@ -22,10 +22,10 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTER
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,7 +60,8 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -97,24 +98,23 @@ public class TestPendingReconstruction {
       System.arraycopy(storages, 0, targets, 0, i);
       pendingReconstructions.increment(block, targets);
     }
-    assertEquals("Size of pendingReconstruction ",
-                 10, pendingReconstructions.size());
-
+    assertEquals(10, pendingReconstructions.size(),
+        "Size of pendingReconstruction ");
 
     //
     // remove one item
     //
     BlockInfo blk = genBlockInfo(8, 8, 0);
     pendingReconstructions.decrement(blk, storages[7]); // removes one replica
-    assertEquals("pendingReconstructions.getNumReplicas ",
-                 7, pendingReconstructions.getNumReplicas(blk));
+    assertEquals(7, pendingReconstructions.getNumReplicas(blk),
+        "pendingReconstructions.getNumReplicas ");
 
     //
     // insert the same item twice should be counted as once
     //
     pendingReconstructions.increment(blk, storages[0]);
-    assertEquals("pendingReconstructions.getNumReplicas ",
-        7, pendingReconstructions.getNumReplicas(blk));
+    assertEquals(7, pendingReconstructions.getNumReplicas(blk),
+        "pendingReconstructions.getNumReplicas ");
 
     for (int i = 0; i < 7; i++) {
       // removes all replicas
@@ -174,7 +174,7 @@ public class TestPendingReconstruction {
     //
     // Verify that everything has timed out.
     //
-    assertEquals("Size of pendingReconstructions ", 0, pendingReconstructions.size());
+    assertEquals(0, pendingReconstructions.size(), "Size of pendingReconstructions ");
     assertEquals(15L, pendingReconstructions.getNumTimedOuts());
     Block[] timedOut = pendingReconstructions.getTimedOutBlocks();
     assertNotNull(timedOut);
@@ -228,8 +228,8 @@ public class TestPendingReconstruction {
       //Save it for later.
       BlockInfo storedBlock = blockInfo;
 
-      assertEquals("Size of pendingReconstructions ", 1,
-          pendingReconstruction.size());
+      assertEquals(1, pendingReconstruction.size(),
+          "Size of pendingReconstructions ");
 
       // Add a second block to pendingReconstructions that has no
       // corresponding entry in blocksmap
@@ -239,8 +239,8 @@ public class TestPendingReconstruction {
           DFSTestUtil.createDatanodeStorageInfos(1));
 
       // verify 2 blocks in pendingReconstructions
-      assertEquals("Size of pendingReconstructions ", 2,
-          pendingReconstruction.size());
+      assertEquals(2, pendingReconstruction.size(),
+          "Size of pendingReconstructions ");
 
       //
       // Wait for everything to timeout.
@@ -265,13 +265,13 @@ public class TestPendingReconstruction {
       // Verify that the generation stamp we will try to replicate
       // is now 1
       for (Block b: neededReconstruction) {
-        assertEquals("Generation stamp is 1 ", 1,
-            b.getGenerationStamp());
+        assertEquals(1, b.getGenerationStamp(),
+            "Generation stamp is 1 ");
       }
 
       // Verify size of neededReconstruction is exactly 1.
-      assertEquals("size of neededReconstruction is 1 ", 1,
-          neededReconstruction.size());
+      assertEquals(1, neededReconstruction.size(),
+          "size of neededReconstruction is 1 ");
 
       // Verify HDFS-11960
       // Stop the replication/redundancy monitor
@@ -284,8 +284,8 @@ public class TestPendingReconstruction {
       // Add a stored block to the pendingReconstruction.
       pendingReconstruction.increment(blockInfo,
           DFSTestUtil.createDatanodeStorageInfos(1));
-      assertEquals("Size of pendingReconstructions ", 1,
-          pendingReconstruction.size());
+      assertEquals(1, pendingReconstruction.size(),
+          "Size of pendingReconstructions ");
 
       // A received IBR processing calls addBlock(). If the gen stamp in the
       // report is not the same, it should stay in pending.
@@ -299,8 +299,8 @@ public class TestPendingReconstruction {
       }
 
       // The block should still be pending
-      assertEquals("Size of pendingReconstructions ", 1,
-          pendingReconstruction.size());
+      assertEquals(1, pendingReconstruction.size(),
+          "Size of pendingReconstructions ");
 
       // A block report with the correct gen stamp should remove the record
       // from the pending queue.
@@ -315,8 +315,8 @@ public class TestPendingReconstruction {
       GenericTestUtils.waitFor(() -> pendingReconstruction.size() == 0, 500,
           10000);
       // The pending queue should be empty.
-      assertEquals("Size of pendingReconstructions ", 0,
-          pendingReconstruction.size());
+      assertEquals(0, pendingReconstruction.size(),
+          "Size of pendingReconstructions ");
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -498,7 +498,8 @@ public class TestPendingReconstruction {
    * @throws InterruptedException
    * @throws TimeoutException
    */
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testReplicationCounter() throws IOException,
       InterruptedException, TimeoutException {
     HdfsConfiguration conf = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingRecoveryBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingRecoveryBlocks.java
@@ -18,12 +18,12 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import org.apache.hadoop.hdfs.protocol.Block;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains unit tests for PendingRecoveryBlocks.java functionality.
@@ -37,7 +37,7 @@ public class TestPendingRecoveryBlocks {
   private final BlockInfo blk2 = getBlock(2);
   private final BlockInfo blk3 = getBlock(3);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     pendingRecoveryBlocks =
         Mockito.spy(new PendingRecoveryBlocks(recoveryTimeout));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestProvidedStorageMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestProvidedStorageMap.java
@@ -27,12 +27,12 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.TestProvidedImpl;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.util.RwLock;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +47,7 @@ public class TestProvidedStorageMap {
   private String providedStorageID;
   private String blockPoolID;
 
-  @Before
+  @BeforeEach
   public void setup() {
     providedStorageID = DFSConfigKeys.DFS_PROVIDER_STORAGEUUID_DEFAULT;
     conf = new HdfsConfiguration();
@@ -93,15 +93,15 @@ public class TestProvidedStorageMap {
         providedMap.getStorage(dn1, dn1ProvidedStorage);
     DatanodeStorageInfo dns1Disk = providedMap.getStorage(dn1, dn1DiskStorage);
 
-    assertTrue("The provided storages should be equal",
-        dns1Provided == providedMapStorage);
-    assertTrue("Disk storage has not yet been registered with block manager",
-        dns1Disk == null);
+    assertTrue(dns1Provided == providedMapStorage,
+        "The provided storages should be equal");
+    assertTrue(dns1Disk == null,
+        "Disk storage has not yet been registered with block manager");
     // add the disk storage to the datanode.
     DatanodeStorageInfo dnsDisk = new DatanodeStorageInfo(dn1, dn1DiskStorage);
     dn1.injectStorage(dnsDisk);
-    assertTrue("Disk storage must match the injected storage info",
-        dnsDisk == providedMap.getStorage(dn1, dn1DiskStorage));
+    assertTrue(dnsDisk == providedMap.getStorage(dn1, dn1DiskStorage),
+        "Disk storage must match the injected storage info");
 
     // create a 2nd datanode
     DatanodeDescriptor dn2 = createDatanodeDescriptor(5010);
@@ -113,9 +113,9 @@ public class TestProvidedStorageMap {
 
     DatanodeStorageInfo dns2Provided = providedMap.getStorage(
         dn2, dn2ProvidedStorage);
-    assertTrue("The provided storages should be equal",
-        dns2Provided == providedMapStorage);
-    assertTrue("The DatanodeDescriptor should contain the provided storage",
-        dn2.getStorageInfo(providedStorageID) == providedMapStorage);
+    assertTrue(dns2Provided == providedMapStorage,
+        "The provided storages should be equal");
+    assertTrue(dn2.getStorageInfo(providedStorageID) == providedMapStorage,
+        "The DatanodeDescriptor should contain the provided storage");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRBWBlockInvalidation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRBWBlockInvalidation.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -45,7 +45,8 @@ import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.hdfs.server.namenode.ha.TestDNFencing.RandomDeleterPolicy;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.function.Supplier;
 
@@ -69,7 +70,8 @@ public class TestRBWBlockInvalidation {
    * datanode, namenode should ask to invalidate that corrupted block and
    * schedule replication for one more replica for that under replicated block.
    */
-  @Test(timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testBlockInvalidationWhenRBWReplicaMissedInDN()
       throws IOException, InterruptedException {
     // This test cannot pass on Windows due to file locking enforcement.  It will
@@ -112,8 +114,8 @@ public class TestRBWBlockInvalidation {
         }
         Thread.sleep(100);
       }
-      assertEquals("There should be less than 2 replicas in the "
-          + "liveReplicasMap", 1, liveReplicas);
+      assertEquals(1, liveReplicas,
+          "There should be less than 2 replicas in the " + "liveReplicasMap");
       
       while (true) {
         if ((liveReplicas =
@@ -124,7 +126,7 @@ public class TestRBWBlockInvalidation {
         }
         Thread.sleep(100);
       }
-      assertEquals("There should be two live replicas", 2, liveReplicas);
+      assertEquals(2, liveReplicas, "There should be two live replicas");
 
       while (true) {
         Thread.sleep(100);
@@ -146,7 +148,8 @@ public class TestRBWBlockInvalidation {
    * were RWR replicas with out-of-date genstamps, the NN could accidentally
    * delete good replicas instead of the bad replicas.
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testRWRInvalidation() throws Exception {
     Configuration conf = new HdfsConfiguration();
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.hdfs.util.RwLockMode;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -96,7 +96,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
   private static final HdfsConfiguration conf = new HdfsConfiguration();
   private DistributedFileSystem fs;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_INTERVAL_SECONDS_KEY, 1);
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_CONSIDERLOAD_KEY,
@@ -104,7 +104,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
     conf.setInt(DFSConfigKeys.DFS_NAMENODE_DECOMMISSION_INTERVAL_KEY, 1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -179,8 +179,8 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       DatanodeStorageInfo storage = it.next();
       rackSet.add(storage.getDatanodeDescriptor().getNetworkLocation());
     }
-    Assert.assertEquals("rackSet size is wrong: " + rackSet, dataBlocks - 1,
-        rackSet.size());
+    Assertions.assertEquals(dataBlocks - 1, rackSet.size(),
+        "rackSet size is wrong: " + rackSet);
 
     // restart the stopped datanode
     cluster.restartDataNode(lastHost);
@@ -189,8 +189,8 @@ public class TestReconstructStripedBlocksWithRackAwareness {
     // make sure we have 6 racks again
     NetworkTopology topology = bm.getDatanodeManager().getNetworkTopology();
     LOG.info("topology is: {}", topology);
-    Assert.assertEquals(hosts.length, topology.getNumOfLeaves());
-    Assert.assertEquals(dataBlocks, topology.getNumOfRacks());
+    Assertions.assertEquals(hosts.length, topology.getNumOfLeaves());
+    Assertions.assertEquals(dataBlocks, topology.getNumOfRacks());
 
     // pause all the heartbeats
     for (DataNode dn : cluster.getDataNodes()) {
@@ -212,8 +212,8 @@ public class TestReconstructStripedBlocksWithRackAwareness {
         DatanodeStorageInfo storage = it.next();
         if (storage != null) {
           DatanodeDescriptor dn = storage.getDatanodeDescriptor();
-          Assert.assertEquals("Block to be erasure coded is wrong for datanode:"
-              + dn, 0, dn.getNumberOfBlocksToBeErasureCoded());
+          Assertions.assertEquals(0, dn.getNumberOfBlocksToBeErasureCoded(),
+              "Block to be erasure coded is wrong for datanode:" + dn);
           if (dn.getNumberOfBlocksToBeReplicated() == 1) {
             scheduled = true;
           }
@@ -224,7 +224,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       }
       Thread.sleep(1000);
     }
-    Assert.assertTrue(scheduled);
+    Assertions.assertTrue(scheduled);
   }
 
   @Test
@@ -271,7 +271,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
     LocatedBlocks blks = fs.getClient().getLocatedBlocks(file.toString(), 0);
     LocatedStripedBlock block = (LocatedStripedBlock) blks.getLastLocatedBlock();
     for (DatanodeInfo dn : block.getLocations()) {
-      Assert.assertFalse(dn.getHostName().equals("host1"));
+      Assertions.assertFalse(dn.getHostName().equals("host1"));
     }
   }
 
@@ -322,11 +322,11 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       recovered = bm.countNodes(blockInfo).liveReplicas() >=
           dataBlocks + parityBlocks;
     }
-    Assert.assertTrue(recovered);
+    Assertions.assertTrue(recovered);
 
     // mark h9 as decommissioning
     DataNode datanode9 = getDataNode(hostNames[hostNames.length - 3]);
-    Assert.assertNotNull(datanode9);
+    Assertions.assertNotNull(datanode9);
     final DatanodeDescriptor dn9 = dm.getDatanode(datanode9.getDatanodeId());
     dn9.startDecommission();
 
@@ -339,7 +339,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
 
     // start decommissioning h9
     boolean satisfied = bm.isPlacementPolicySatisfied(blockInfo);
-    Assert.assertFalse(satisfied);
+    Assertions.assertFalse(satisfied);
     final DatanodeAdminManager decomManager =
         (DatanodeAdminManager) Whitebox.getInternalState(
             dm, "datanodeAdminManager");
@@ -358,7 +358,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       Thread.sleep(1000);
       decommissioned = dn9.isDecommissioned();
     }
-    Assert.assertTrue(decommissioned);
-    Assert.assertTrue(bm.isPlacementPolicySatisfied(blockInfo));
+    Assertions.assertTrue(decommissioned);
+    Assertions.assertTrue(bm.isPlacementPolicySatisfied(blockInfo));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReconstructStripedBlocksWithRackAwareness.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -49,6 +48,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestReconstructStripedBlocksWithRackAwareness {
   public static final Logger LOG = LoggerFactory.getLogger(
@@ -179,7 +183,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       DatanodeStorageInfo storage = it.next();
       rackSet.add(storage.getDatanodeDescriptor().getNetworkLocation());
     }
-    Assertions.assertEquals(dataBlocks - 1, rackSet.size(),
+    assertEquals(dataBlocks - 1, rackSet.size(),
         "rackSet size is wrong: " + rackSet);
 
     // restart the stopped datanode
@@ -189,8 +193,8 @@ public class TestReconstructStripedBlocksWithRackAwareness {
     // make sure we have 6 racks again
     NetworkTopology topology = bm.getDatanodeManager().getNetworkTopology();
     LOG.info("topology is: {}", topology);
-    Assertions.assertEquals(hosts.length, topology.getNumOfLeaves());
-    Assertions.assertEquals(dataBlocks, topology.getNumOfRacks());
+    assertEquals(hosts.length, topology.getNumOfLeaves());
+    assertEquals(dataBlocks, topology.getNumOfRacks());
 
     // pause all the heartbeats
     for (DataNode dn : cluster.getDataNodes()) {
@@ -212,7 +216,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
         DatanodeStorageInfo storage = it.next();
         if (storage != null) {
           DatanodeDescriptor dn = storage.getDatanodeDescriptor();
-          Assertions.assertEquals(0, dn.getNumberOfBlocksToBeErasureCoded(),
+          assertEquals(0, dn.getNumberOfBlocksToBeErasureCoded(),
               "Block to be erasure coded is wrong for datanode:" + dn);
           if (dn.getNumberOfBlocksToBeReplicated() == 1) {
             scheduled = true;
@@ -224,7 +228,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       }
       Thread.sleep(1000);
     }
-    Assertions.assertTrue(scheduled);
+    assertTrue(scheduled);
   }
 
   @Test
@@ -271,7 +275,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
     LocatedBlocks blks = fs.getClient().getLocatedBlocks(file.toString(), 0);
     LocatedStripedBlock block = (LocatedStripedBlock) blks.getLastLocatedBlock();
     for (DatanodeInfo dn : block.getLocations()) {
-      Assertions.assertFalse(dn.getHostName().equals("host1"));
+      assertFalse(dn.getHostName().equals("host1"));
     }
   }
 
@@ -322,11 +326,11 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       recovered = bm.countNodes(blockInfo).liveReplicas() >=
           dataBlocks + parityBlocks;
     }
-    Assertions.assertTrue(recovered);
+    assertTrue(recovered);
 
     // mark h9 as decommissioning
     DataNode datanode9 = getDataNode(hostNames[hostNames.length - 3]);
-    Assertions.assertNotNull(datanode9);
+    assertNotNull(datanode9);
     final DatanodeDescriptor dn9 = dm.getDatanode(datanode9.getDatanodeId());
     dn9.startDecommission();
 
@@ -339,7 +343,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
 
     // start decommissioning h9
     boolean satisfied = bm.isPlacementPolicySatisfied(blockInfo);
-    Assertions.assertFalse(satisfied);
+    assertFalse(satisfied);
     final DatanodeAdminManager decomManager =
         (DatanodeAdminManager) Whitebox.getInternalState(
             dm, "datanodeAdminManager");
@@ -358,7 +362,7 @@ public class TestReconstructStripedBlocksWithRackAwareness {
       Thread.sleep(1000);
       decommissioned = dn9.isDecommissioned();
     }
-    Assertions.assertTrue(decommissioned);
-    Assertions.assertTrue(bm.isPlacementPolicySatisfied(blockInfo));
+    assertTrue(decommissioned);
+    assertTrue(bm.isPlacementPolicySatisfied(blockInfo));
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRedundancyMonitor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestRedundancyMonitor.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdfs.TestBlockStoragePolicy;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.test.GenericTestUtils.DelayAnswer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Set;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
@@ -18,12 +18,13 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_REDUNDANCY_CONSIDERLOADBYSTORAGETYPE_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -73,13 +74,13 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestReplicationPolicy extends BaseReplicationPolicyTest {
 
   private static final String filename = "/dummyfile.txt";
@@ -87,14 +88,11 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
   private static final long staleInterval =
       DFSConfigKeys.DFS_NAMENODE_STALE_DATANODE_INTERVAL_DEFAULT;
   private static AtomicLong mockINodeId = new AtomicLong(0);
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   public TestReplicationPolicy(String blockPlacementPolicyClassName) {
     this.blockPlacementPolicy = blockPlacementPolicyClassName;
   }
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         { BlockPlacementPolicyDefault.class.getName() },
@@ -844,7 +842,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
    * Test for the high priority blocks are processed before the low priority
    * blocks.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReplicationWithPriority() throws Exception {
     int DFS_NAMENODE_REPLICATION_INTERVAL = 1000;
     int HIGH_PRIORITY = 0;
@@ -875,8 +874,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
 
       // Check replication completed successfully. Need not wait till it process
       // all the 100 normal blocks.
-      assertFalse("Not able to clear the element from high priority list",
-          neededReconstruction.iterator(HIGH_PRIORITY).hasNext());
+      assertFalse(neededReconstruction.iterator(HIGH_PRIORITY).hasNext(),
+          "Not able to clear the element from high priority list");
     } finally {
       cluster.shutdown();
     }
@@ -946,11 +945,11 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
       List<List<BlockInfo>> chosenBlocks, int... expectedSizes) {
     int i = 0;
     for(; i < chosenBlocks.size(); i++) {
-      assertEquals("Not returned the expected number for i=" + i,
-          expectedSizes[i], chosenBlocks.get(i).size());
+      assertEquals(expectedSizes[i], chosenBlocks.get(i).size(),
+          "Not returned the expected number for i=" + i);
     }
     for(; i < expectedSizes.length; i++) {
-      assertEquals("Expected size is non-zero for i=" + i, 0, expectedSizes[i]);
+      assertEquals(0, expectedSizes[i], "Expected size is non-zero for i=" + i);
     }
   }
   
@@ -1294,8 +1293,9 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     
     conf.set(DFSConfigKeys.
         DFS_NAMENODE_INVALIDATE_WORK_PCT_PER_ITERATION, "0.0f");
-    exception.expect(IllegalArgumentException.class);
-    blocksInvalidateWorkPct = DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    });
   }
   
   /**
@@ -1312,8 +1312,9 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     
     conf.set(DFSConfigKeys.
         DFS_NAMENODE_INVALIDATE_WORK_PCT_PER_ITERATION, "-0.5f");
-    exception.expect(IllegalArgumentException.class);
-    blocksInvalidateWorkPct = DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    });
   }
   
   /**
@@ -1330,8 +1331,9 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     
     conf.set(DFSConfigKeys.
         DFS_NAMENODE_INVALIDATE_WORK_PCT_PER_ITERATION, "1.5f");
-    exception.expect(IllegalArgumentException.class);
-    blocksInvalidateWorkPct = DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DFSUtil.getInvalidateWorkPctPerIteration(conf);
+    });
   }
 
   /**
@@ -1353,11 +1355,13 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     
     conf.set(DFSConfigKeys.
         DFS_NAMENODE_REPLICATION_WORK_MULTIPLIER_PER_ITERATION,"-1");
-    exception.expect(IllegalArgumentException.class);
-    blocksReplWorkMultiplier = DFSUtil.getReplWorkMultiplier(conf);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DFSUtil.getReplWorkMultiplier(conf);
+    });
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateDoesNotCauseSkippedReplication() {
     LowRedundancyBlocks lowRedundancyBlocks = new LowRedundancyBlocks();
 
@@ -1401,7 +1405,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     assertTheChosenBlocks(chosenBlocks, 0, 0, 1, 0, 0);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAddStoredBlockDoesNotCauseSkippedReplication()
       throws IOException {
     FSNamesystem mockNS = mock(FSNamesystem.class);
@@ -1456,7 +1461,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     assertTheChosenBlocks(chosenBlocks, 1, 0, 0, 0, 0);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void
       testConvertLastBlockToUnderConstructionDoesNotCauseSkippedReplication()
           throws IOException {
@@ -1530,7 +1536,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     assertTheChosenBlocks(chosenBlocks, 1, 0, 0, 0, 0);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testupdateNeededReplicationsDoesNotCauseSkippedReplication()
       throws IOException {
     Namesystem mockNS = mock(Namesystem.class);
@@ -1591,8 +1598,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
     targets = chooseTarget(5, dataNodes[2], null, favouredNodes);
     assertEquals(targets.length, 5);
     for (int i = 0; i < targets.length; i++) {
-      assertTrue("Target should be a part of Expected Targets",
-          expectedTargets.contains(targets[i].getDatanodeDescriptor()));
+      assertTrue(expectedTargets.contains(targets[i].getDatanodeDescriptor()),
+          "Target should be a part of Expected Targets");
     }
   }
 
@@ -1611,8 +1618,8 @@ public class TestReplicationPolicy extends BaseReplicationPolicyTest {
           favouredNodes);
       assertEquals(targets.length, 2);
       for (int i = 0; i < targets.length; i++) {
-        assertTrue("Target should be a part of Expected Targets",
-            expectedTargets.contains(targets[i].getDatanodeDescriptor()));
+        assertTrue(expectedTargets.contains(targets[i].getDatanodeDescriptor()),
+            "Target should be a part of Expected Targets");
       }
     } finally {
       ((BlockPlacementPolicyDefault) replicator).setPreferLocalNode(true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyConsiderLoad.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,11 +32,12 @@ import org.apache.hadoop.hdfs.TestBlockStoragePolicy;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestReplicationPolicyConsiderLoad
     extends BaseReplicationPolicyTest {
 
@@ -44,7 +45,6 @@ public class TestReplicationPolicyConsiderLoad
     this.blockPlacementPolicy = blockPlacementPolicy;
   }
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         { BlockPlacementPolicyDefault.class.getName() },
@@ -94,8 +94,8 @@ public class TestReplicationPolicyConsiderLoad
       // value in the above heartbeats
       final int load = 2 + 4 + 4;
       
-      assertEquals((double)load/6, dnManager.getFSClusterStats()
-        .getInServiceXceiverAverage(), EPSILON);
+      assertEquals((double) load / 6, dnManager.getFSClusterStats().getInServiceXceiverAverage(),
+          EPSILON);
       
       // Decommission DNs so BlockPlacementPolicyDefault.isGoodTarget()
       // returns false
@@ -104,8 +104,8 @@ public class TestReplicationPolicyConsiderLoad
         dnManager.getDatanodeAdminManager().startDecommission(d);
         d.setDecommissioned();
       }
-      assertEquals((double)load/3, dnManager.getFSClusterStats()
-        .getInServiceXceiverAverage(), EPSILON);
+      assertEquals((double) load / 3, dnManager.getFSClusterStats().getInServiceXceiverAverage(),
+          EPSILON);
 
       DatanodeDescriptor writerDn = dataNodes[0];
 
@@ -175,9 +175,9 @@ public class TestReplicationPolicyConsiderLoad
               new ArrayList<DatanodeStorageInfo>(), false, null,
               1024, TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
       for(DatanodeStorageInfo info : targets) {
-        assertTrue("The node "+info.getDatanodeDescriptor().getName()+
-                " has higher load and should not have been picked!",
-            info.getDatanodeDescriptor().getXceiverCount() <= (load/6)*1.2);
+        assertTrue(info.getDatanodeDescriptor().getXceiverCount() <= (load / 6) * 1.2,
+            "The node " + info.getDatanodeDescriptor().getName()
+                + " has higher load and should not have been picked!");
       }
     } finally {
       namenode.getNamesystem().writeUnlock(RwLockMode.BM, "testConsiderLoadFactor");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdfs.server.protocol.OutlierMetrics;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,6 +38,7 @@ import java.util.Set;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PEER_STATS_ENABLED_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MethodSource("data")
@@ -154,7 +154,7 @@ public class TestReplicationPolicyExcludeSlowNodes
 
       // mock slow nodes
       SlowPeerTracker tracker = dnManager.getSlowPeerTracker();
-      Assertions.assertNotNull(tracker);
+      assertNotNull(tracker);
 
       OutlierMetrics outlierMetrics = new OutlierMetrics(0.0, 0.0, 0.0, 5.0);
       tracker.addReport(dataNodes[0].getInfoAddr(), dataNodes[3].getInfoAddr(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyExcludeSlowNodes.java
@@ -26,21 +26,23 @@ import org.apache.hadoop.hdfs.server.protocol.OutlierMetrics;
 import org.apache.hadoop.hdfs.util.RwLockMode;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_PEER_STATS_ENABLED_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
+@MethodSource("data")
+@ParameterizedClass
 public class TestReplicationPolicyExcludeSlowNodes
     extends BaseReplicationPolicyTest {
 
@@ -48,7 +50,6 @@ public class TestReplicationPolicyExcludeSlowNodes
     this.blockPlacementPolicy = blockPlacementPolicy;
   }
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {BlockPlacementPolicyDefault.class.getName()},
@@ -153,7 +154,7 @@ public class TestReplicationPolicyExcludeSlowNodes
 
       // mock slow nodes
       SlowPeerTracker tracker = dnManager.getSlowPeerTracker();
-      Assert.assertNotNull(tracker);
+      Assertions.assertNotNull(tracker);
 
       OutlierMetrics outlierMetrics = new OutlierMetrics(0.0, 0.0, 0.0, 5.0);
       tracker.addReport(dataNodes[0].getInfoAddr(), dataNodes[3].getInfoAddr(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyRatioConsiderLoadWithStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyRatioConsiderLoadWithStorage.java
@@ -24,14 +24,14 @@ import org.apache.hadoop.hdfs.TestBlockStoragePolicy;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verify that chooseTarget can exclude nodes with high volume average load.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithNodeGroup.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithNodeGroup.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_USE_DFS_NETWORK_TOPOLOGY_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,8 +42,7 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.NetworkTopologyWithNodeGroup;
 import org.apache.hadoop.net.Node;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTest {
   public TestReplicationPolicyWithNodeGroup() {
@@ -895,10 +894,10 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     favouredNodes.add(dataNodes[3]);
     favouredNodes.add(dataNodes[0]);
     targets = chooseTarget(2, dataNodes[7], null, favouredNodes);
-    assertTrue("1st Replica is incorrect",
-      expectedTargets.contains(targets[0].getDatanodeDescriptor()));
-    assertTrue("2nd Replica is incorrect",
-      expectedTargets.contains(targets[1].getDatanodeDescriptor()));
+    assertTrue(expectedTargets.contains(targets[0].getDatanodeDescriptor()),
+        "1st Replica is incorrect");
+    assertTrue(expectedTargets.contains(targets[1].getDatanodeDescriptor()),
+        "2nd Replica is incorrect");
   }
 
   /**
@@ -928,8 +927,8 @@ public class TestReplicationPolicyWithNodeGroup extends BaseReplicationPolicyTes
     favouredNodes.add(dataNodes[2]);
     targets = chooseTarget(3, dataNodes[3], null, favouredNodes);
     for (int i = 0; i < targets.length; i++) {
-      assertTrue("Target should be a part of Expected Targets",
-          expectedTargets.contains(targets[i].getDatanodeDescriptor()));
+      assertTrue(expectedTargets.contains(targets[i].getDatanodeDescriptor()),
+          "Target should be a part of Expected Targets");
     }
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithUpgradeDomain.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicyWithUpgradeDomain.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +40,7 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.net.Node;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 public class TestReplicationPolicyWithUpgradeDomain
     extends BaseReplicationPolicyTest {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSlowDiskTracker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSlowDiskTracker.java
@@ -18,11 +18,9 @@
 
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +32,7 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys
 import static org.apache.hadoop.hdfs.DFSConfigKeys
     .DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
@@ -48,10 +47,9 @@ import org.apache.hadoop.util.FakeTimer;
 import java.util.function.Supplier;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,16 +61,12 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link SlowDiskTracker}.
+ * Set a timeout for every test case.
  */
+@Timeout(300)
 public class TestSlowDiskTracker {
   public static final Logger LOG = LoggerFactory.getLogger(
       TestSlowDiskTracker.class);
-
-  /**
-   * Set a timeout for every test case.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   private static Configuration conf;
   private SlowDiskTracker tracker;
@@ -89,7 +83,8 @@ public class TestSlowDiskTracker {
     conf.setTimeDuration(DFS_DATANODE_OUTLIERS_REPORT_INTERVAL_KEY,
         OUTLIERS_REPORT_INTERVAL, TimeUnit.MILLISECONDS);
   }
-  @Before
+
+  @BeforeEach
   public void setup() {
     timer = new FakeTimer();
     tracker = new SlowDiskTracker(conf, timer);
@@ -136,7 +131,7 @@ public class TestSlowDiskTracker {
       Map<String, DiskLatency> slowDisksReport = getSlowDisksReportForTesting(
           slowDiskTracker);
 
-      assertThat(slowDisksReport.size(), is(4));
+      assertThat(slowDisksReport.size()).isEqualTo(4);
       assertTrue(Math.abs(slowDisksReport.get(dn1ID + ":disk1")
           .getLatency(DiskOp.WRITE) - 1.3) < 0.0000001);
       assertTrue(Math.abs(slowDisksReport.get(dn1ID + ":disk2")
@@ -152,7 +147,7 @@ public class TestSlowDiskTracker {
       ArrayList<DiskLatency> jsonReport = getAndDeserializeJson(
           slowDiskTracker.getSlowDiskReportAsJsonString());
 
-      assertThat(jsonReport.size(), is(4));
+      assertThat(jsonReport.size()).isEqualTo(4);
       assertTrue(isDiskInReports(jsonReport, dn1ID, "disk1", DiskOp.WRITE, 1.3));
       assertTrue(isDiskInReports(jsonReport, dn1ID, "disk2", DiskOp.READ, 1.6));
       assertTrue(isDiskInReports(jsonReport, dn1ID, "disk2", DiskOp.WRITE, 1.1));
@@ -193,7 +188,7 @@ public class TestSlowDiskTracker {
 
     Map<String, DiskLatency> reports = getSlowDisksReportForTesting(tracker);
 
-    assertThat(reports.size(), is(3));
+    assertThat(reports.size()).isEqualTo(3);
     assertTrue(Math.abs(reports.get("dn1:disk1")
         .getLatency(DiskOp.METADATA) - 1.1) < 0.0000001);
     assertTrue(Math.abs(reports.get("dn1:disk1")
@@ -229,7 +224,7 @@ public class TestSlowDiskTracker {
 
     Map<String, DiskLatency> reports = getSlowDisksReportForTesting(tracker);
 
-    assertThat(reports.size(), is(3));
+    assertThat(reports.size()).isEqualTo(3);
     assertTrue(Math.abs(reports.get("dn1:disk1")
         .getLatency(DiskOp.METADATA) - 1.1) < 0.0000001);
     assertTrue(Math.abs(reports.get("dn1:disk1")
@@ -252,7 +247,7 @@ public class TestSlowDiskTracker {
 
     reports = getSlowDisksReportForTesting(tracker);
 
-    assertThat(reports.size(), is(0));
+    assertThat(reports.size()).isEqualTo(0);
   }
 
   /**
@@ -280,7 +275,7 @@ public class TestSlowDiskTracker {
 
     Map<String, DiskLatency> reports = getSlowDisksReportForTesting(tracker);
 
-    assertThat(reports.size(), is(1));
+    assertThat(reports.size()).isEqualTo(1);
     assertTrue(Math.abs(reports.get("dn2:disk2")
         .getLatency(DiskOp.WRITE) - 1.1) < 0.0000001);
   }
@@ -307,7 +302,7 @@ public class TestSlowDiskTracker {
 
     Map<String, DiskLatency> reports = getSlowDisksReportForTesting(tracker);
 
-    assertThat(reports.size(), is(1));
+    assertThat(reports.size()).isEqualTo(1);
     assertTrue(reports.get("dn1:disk1").getLatency(DiskOp.METADATA) == null);
     assertTrue(Math.abs(reports.get("dn1:disk1")
         .getLatency(DiskOp.READ) - 1.4) < 0.0000001);
@@ -337,7 +332,7 @@ public class TestSlowDiskTracker {
         tracker.getSlowDiskReportAsJsonString());
 
     // And ensure its contents are what we expect.
-    assertThat(jsonReport.size(), is(4));
+    assertThat(jsonReport.size()).isEqualTo(4);
     assertTrue(isDiskInReports(jsonReport, "dn1", "disk1", DiskOp.METADATA,
         1.1));
     assertTrue(isDiskInReports(jsonReport, "dn1", "disk1", DiskOp.READ, 1.8));
@@ -378,7 +373,7 @@ public class TestSlowDiskTracker {
         tracker.getSlowDiskReportAsJsonString());
 
     // Ensure that only the top 5 highest latencies are in the report.
-    assertThat(jsonReport.size(), is(5));
+    assertThat(jsonReport.size()).isEqualTo(5);
     assertTrue(isDiskInReports(jsonReport, "dn3", "disk2", DiskOp.READ, 1.7));
     assertTrue(isDiskInReports(jsonReport, "dn3", "disk1", DiskOp.WRITE, 1.6));
     assertTrue(isDiskInReports(jsonReport, "dn2", "disk2", DiskOp.READ, 1.5));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedBlock.java
@@ -27,15 +27,16 @@ import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests the sorting of located blocks based on
@@ -62,7 +63,8 @@ public class TestSortLocatedBlock {
    * or
    * (d4 -> d3 -> d1 -> d2 -> d0).
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testWithStaleDatanodes() throws IOException {
     long blockID = Long.MAX_VALUE;
     int totalDns = 5;
@@ -115,8 +117,7 @@ public class TestSortLocatedBlock {
     assertEquals(locs[1].getIpAddr(), locations[2].getIpAddr());
     // decommissioned
     assertEquals(true,
-        decommissionedNodes.contains(locations[3])
-        && decommissionedNodes.contains(locations[4]));
+        decommissionedNodes.contains(locations[3]) && decommissionedNodes.contains(locations[4]));
   }
 
   /**
@@ -130,7 +131,8 @@ public class TestSortLocatedBlock {
    * avoidStaleDataNodesForRead=true && avoidSlowDataNodesForRead=true
    * d6 -> d5 -> d4 -> d3 -> d2 -> d1 -> d0
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAviodStaleAndSlowDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(true, true);
     DatanodeInfo[] locs = mockDatanodes(dm);
@@ -176,7 +178,8 @@ public class TestSortLocatedBlock {
    * avoidStaleDataNodesForRead=true && avoidSlowDataNodesForRead=false
    * (d6 <-> d5) -> (d4 <-> d3) -> d2 -> d1 -> d0
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAviodStaleDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(true, false);
     DatanodeInfo[] locs = mockDatanodes(dm);
@@ -224,7 +227,8 @@ public class TestSortLocatedBlock {
    * avoidStaleDataNodesForRead=false && avoidSlowDataNodesForRead=true
    * (d6 -> d4) -> (d5 <-> d3) -> d2 -> d1 -> d0
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAviodSlowDatanodes() throws IOException {
     DatanodeManager dm = mockDatanodeManager(false, true);
     DatanodeInfo[] locs = mockDatanodes(dm);
@@ -272,7 +276,8 @@ public class TestSortLocatedBlock {
    * avoidStaleDataNodesForRead=false && avoidSlowDataNodesForRead=false
    * (d6 <-> d5 <-> d4 <-> d3) -> d2 -> d1 -> d0
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testWithServiceComparator() throws IOException {
     DatanodeManager dm = mockDatanodeManager(false, false);
     DatanodeInfo[] locs = mockDatanodes(dm);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
@@ -38,9 +38,9 @@ import java.util.Iterator;
 
 
 public class TestUnderReplicatedBlocks {
-    @Test
-    @Timeout(value = 120)
-    public void testSetRepIncWithUnderReplicatedBlocks() throws Exception {
+  @Test
+  @Timeout(value = 120)
+  public void testSetRepIncWithUnderReplicatedBlocks() throws Exception {
     Configuration conf = new HdfsConfiguration();
     final short REPLICATION_FACTOR = 2;
     final String FILE_NAME = "/testFile";
@@ -80,13 +80,13 @@ public class TestUnderReplicatedBlocks {
       // increment this file's replication factor
       FsShell shell = new FsShell(conf);
       assertEquals(0, shell.run(
-          new String[] { "-setrep", "-w", Integer.toString(1 + REPLICATION_FACTOR), FILE_NAME }));
+          new String[]{"-setrep", "-w", Integer.toString(1 + REPLICATION_FACTOR), FILE_NAME}));
       BlockManagerTestUtil.updateState(bm);
       DFSTestUtil.verifyClientStats(conf, cluster);
     } finally {
       cluster.shutdown();
     }
-    
+
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestUnderReplicatedBlocks.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -31,14 +31,16 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Iterator;
 
 
 public class TestUnderReplicatedBlocks {
-  @Test(timeout=120000) // 1 min timeout
-  public void testSetRepIncWithUnderReplicatedBlocks() throws Exception {
+    @Test
+    @Timeout(value = 120)
+    public void testSetRepIncWithUnderReplicatedBlocks() throws Exception {
     Configuration conf = new HdfsConfiguration();
     final short REPLICATION_FACTOR = 2;
     final String FILE_NAME = "/testFile";
@@ -77,9 +79,8 @@ public class TestUnderReplicatedBlocks {
 
       // increment this file's replication factor
       FsShell shell = new FsShell(conf);
-      assertEquals(0, shell.run(new String[] {
-          "-setrep", "-w", Integer.toString(1 + REPLICATION_FACTOR),
-          FILE_NAME }));
+      assertEquals(0, shell.run(
+          new String[] { "-setrep", "-w", Integer.toString(1 + REPLICATION_FACTOR), FILE_NAME }));
       BlockManagerTestUtil.updateState(bm);
       DFSTestUtil.verifyClientStats(conf, cluster);
     } finally {
@@ -105,7 +106,8 @@ public class TestUnderReplicatedBlocks {
    *    exceed the limit.
    * @throws Exception
    */
-  @Test(timeout=60000) // 1 min timeout
+  @Test
+  @Timeout(value = 60)
   public void testNumberOfBlocksToBeReplicated() throws Exception {
     Configuration conf = new HdfsConfiguration();
 
@@ -152,16 +154,15 @@ public class TestUnderReplicatedBlocks {
       DFSTestUtil.verifyClientStats(conf, cluster);
 
       bm.computeDatanodeWork();
-      assertTrue("The number of replication work pending before targets are " +
-              "determined should be non-negative.",
-          (Integer)Whitebox.getInternalState(secondDn,
-              "pendingReplicationWithoutTargets") >= 0);
+      assertTrue((Integer) Whitebox.getInternalState(secondDn,
+              "pendingReplicationWithoutTargets") >= 0,
+          "The number of replication work pending before targets are "
+              + "determined should be non-negative.");
 
       BlockManagerTestUtil.updateState(bm);
-      assertTrue("The number of blocks to be replicated should be less than "
-          + "or equal to " + bm.getReplicationStreamsHardLimit(),
-          secondDn.getNumberOfBlocksToBeReplicated()
-          <= bm.getReplicationStreamsHardLimit());
+      assertTrue(secondDn.getNumberOfBlocksToBeReplicated() <= bm.getReplicationStreamsHardLimit(),
+          "The number of blocks to be replicated should be less than " + "or equal to "
+              + bm.getReplicationStreamsHardLimit());
       DFSTestUtil.verifyClientStats(conf, cluster);
     } finally {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestInMemoryLevelDBAliasMapClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestInMemoryLevelDBAliasMapClient.java
@@ -29,18 +29,16 @@ import org.apache.hadoop.hdfs.server.common.FileRegion;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Lists;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_SERVICE_RPC_BIND_HOST_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,10 +63,7 @@ public class TestInMemoryLevelDBAliasMapClient {
   private Configuration conf;
   private final static String BPID = "BPID-0";
 
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new Configuration();
     int port = 9876;
@@ -87,7 +82,7 @@ public class TestInMemoryLevelDBAliasMapClient {
     inMemoryLevelDBAliasMapClient = new InMemoryLevelDBAliasMapClient();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     levelDBAliasMapServer.close();
     inMemoryLevelDBAliasMapClient.close();
@@ -146,7 +141,7 @@ public class TestInMemoryLevelDBAliasMapClient {
     }
 
     assertArrayEquals(
-        new FileRegion[] {new FileRegion(block1, providedStorageLocation1),
+        new FileRegion[]{new FileRegion(block1, providedStorageLocation1),
             new FileRegion(block2, providedStorageLocation2)},
         actualFileRegions.toArray());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestLevelDBFileRegionAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestLevelDBFileRegionAliasMap.java
@@ -21,14 +21,14 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.server.common.FileRegion;
 import org.apache.hadoop.hdfs.server.common.blockaliasmap.BlockAliasMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Tests for the {@link LevelDBFileRegionAliasMap}.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestLevelDbMockAliasMapClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestLevelDbMockAliasMapClient.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.hdfs.server.aliasmap.InMemoryLevelDBAliasMapServer;
 import org.apache.hadoop.hdfs.server.common.FileRegion;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.iq80.leveldb.DBException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -50,7 +50,7 @@ public class TestLevelDbMockAliasMapClient {
   private InMemoryAliasMap aliasMapMock;
   private final String bpid = "BPID-0";
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     aliasMapMock = mock(InMemoryAliasMap.class);
     when(aliasMapMock.getBlockPoolId()).thenReturn(bpid);
@@ -72,7 +72,7 @@ public class TestLevelDbMockAliasMapClient {
     inMemoryLevelDBAliasMapClient.setConf(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     levelDBAliasMapServer.close();
     inMemoryLevelDBAliasMapClient.close();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestTextBlockAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestTextBlockAliasMap.java
@@ -32,10 +32,10 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.server.common.blockaliasmap.impl.TextFileRegionAliasMap.fileNameFromBlockPoolID;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test for the text based block format for provided block maps.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestTextBlockAliasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/blockaliasmap/impl/TestTextBlockAliasMap.java
@@ -35,7 +35,11 @@ import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.server.common.blockaliasmap.impl.TextFileRegionAliasMap.fileNameFromBlockPoolID;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for the text based block format for provided block maps.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeMetrics.java
@@ -19,15 +19,16 @@ package org.apache.hadoop.hdfs.server.datanode;
 
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -46,13 +47,12 @@ import org.apache.hadoop.hdfs.server.datanode.fsdataset.FsVolumeSpi;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.test.MetricsAsserts;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for DataNodeVolumeMetrics.
  */
+@Timeout(300)
 public class TestDataNodeVolumeMetrics {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDataNodeVolumeMetrics.class);
@@ -60,9 +60,6 @@ public class TestDataNodeVolumeMetrics {
   private static final int BLOCK_SIZE = 1024;
   private static final short REPL = 1;
   private static final int NUM_DATANODES = 1;
-
-  @Rule
-  public Timeout timeout = new Timeout(300000);
 
   @Test
   public void testVolumeMetrics() throws Exception {
@@ -105,7 +102,7 @@ public class TestDataNodeVolumeMetrics {
       }
 
       ArrayList<DataNode> dns = cluster.getDataNodes();
-      assertTrue("DN1 should be up", dns.get(0).isDatanodeUp());
+      assertTrue(dns.get(0).isDatanodeUp(), "DN1 should be up");
       final File dn1Vol2 = cluster.getInstanceStorageDir(0, 1);
 
       DataNodeTestUtils.injectDataDirFailure(dn1Vol2);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
@@ -37,8 +37,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_WEB_AUTHENTICATION_KERBER
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DATA_TRANSFER_PROTECTION_KEY;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,8 +105,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +137,7 @@ public class TestMover {
 
   static Mover newMover(Configuration conf) throws IOException {
     final Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-    Assert.assertEquals(1, namenodes.size());
+    Assertions.assertEquals(1, namenodes.size());
     Map<URI, List<Path>> nnMap = Maps.newHashMap();
     for (URI nn : namenodes) {
       nnMap.put(nn, null);
@@ -178,8 +179,8 @@ public class TestMover {
 
       final List<StorageType> storageTypes = new ArrayList<StorageType>(
           Arrays.asList(StorageType.DEFAULT, StorageType.DEFAULT));
-      Assert.assertTrue(processor.scheduleMoveReplica(db, ml, storageTypes));
-      Assert.assertFalse(processor.scheduleMoveReplica(db, ml, storageTypes));
+      Assertions.assertTrue(processor.scheduleMoveReplica(db, ml, storageTypes));
+      Assertions.assertFalse(processor.scheduleMoveReplica(db, ml, storageTypes));
     } finally {
       cluster.shutdown();
     }
@@ -219,13 +220,13 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assert.assertTrue(StorageType.DISK == storageType);
+        Assertions.assertTrue(StorageType.DISK == storageType);
       }
       // move to ARCHIVE
       dfs.setStoragePolicy(dir, "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", dir.toString()});
-      Assert.assertEquals("Movement to ARCHIVE should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, sameNode ? 3 : 1);
@@ -283,14 +284,14 @@ public class TestMover {
     LocatedBlock lb = dfs1.getClient().getLocatedBlocks(file, 0).get(0);
     StorageType[] storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assert.assertTrue(StorageType.DISK == storageType);
+      Assertions.assertTrue(StorageType.DISK == storageType);
     }
 
     //verify before movement
     lb = dfs2.getClient().getLocatedBlocks(file, 0).get(0);
     storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assert.assertTrue(StorageType.ARCHIVE == storageType);
+      Assertions.assertTrue(StorageType.ARCHIVE == storageType);
     }
   }
 
@@ -320,7 +321,8 @@ public class TestMover {
     }, 100, 3000);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWithFederateClusterWithinSameNode() throws
       Exception {
     final Configuration conf = new HdfsConfiguration();
@@ -351,15 +353,13 @@ public class TestMover {
       dfs1.setStoragePolicy(dir, "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString()});
-      Assert.assertEquals("Movement to ARCHIVE should be successful", 0, rc);
-
+      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       //move to DISK
       dfs2.setStoragePolicy(dir, "HOT");
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn2 + dir.toString()});
-      Assert.assertEquals("Movement to DISK should be successful", 0, rc);
-
+      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
@@ -370,7 +370,8 @@ public class TestMover {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWithFederatedCluster() throws Exception{
 
     final Configuration conf = new HdfsConfiguration();
@@ -403,7 +404,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString(), nn2 + dir.toString()});
 
-      Assert.assertEquals("Movement to DISK should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
 
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
       waitForLocatedBlockWithDiskStorageType(dfs2, file, 3);
@@ -414,7 +415,8 @@ public class TestMover {
 
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWithFederatedHACluster() throws Exception{
 
     final Configuration conf = new HdfsConfiguration();
@@ -457,7 +459,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString(), nn2 + dir.toString()});
 
-      Assert.assertEquals("Movement to DISK should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
 
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
       waitForLocatedBlockWithDiskStorageType(dfs2, file, 3);
@@ -517,9 +519,9 @@ public class TestMover {
   }
 
   private void checkMovePaths(List<Path> actual, Path... expected) {
-    Assert.assertEquals(expected.length, actual.size());
+    Assertions.assertEquals(expected.length, actual.size());
     for (Path p : expected) {
-      Assert.assertTrue(actual.contains(p));
+      Assertions.assertTrue(actual.contains(p));
     }
   }
 
@@ -538,24 +540,24 @@ public class TestMover {
       final Configuration conf = cluster.getConfiguration(0);
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo", "bar");
-        Assert.fail("Expected exception for illegal path bar");
+        Assertions.fail("Expected exception for illegal path bar");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains("bar is not absolute", e);
       }
 
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf);
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assert.assertEquals(1, namenodes.size());
-      Assert.assertEquals(1, movePaths.size());
+      Assertions.assertEquals(1, namenodes.size());
+      Assertions.assertEquals(1, movePaths.size());
       URI nn = namenodes.iterator().next();
-      Assert.assertTrue(movePaths.containsKey(nn));
-      Assert.assertNull(movePaths.get(nn));
+      Assertions.assertTrue(movePaths.containsKey(nn));
+      Assertions.assertNull(movePaths.get(nn));
 
       movePaths = Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo", "/bar");
       namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assert.assertEquals(1, movePaths.size());
+      Assertions.assertEquals(1, movePaths.size());
       nn = namenodes.iterator().next();
-      Assert.assertTrue(movePaths.containsKey(nn));
+      Assertions.assertTrue(movePaths.containsKey(nn));
       checkMovePaths(movePaths.get(nn), new Path("/foo"), new Path("/bar"));
     } finally {
       cluster.shutdown();
@@ -576,11 +578,11 @@ public class TestMover {
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", "/foo", "/bar");
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assert.assertEquals(1, namenodes.size());
-      Assert.assertEquals(1, movePaths.size());
+      Assertions.assertEquals(1, namenodes.size());
+      Assertions.assertEquals(1, movePaths.size());
       URI nn = namenodes.iterator().next();
-      Assert.assertEquals(new URI("hdfs://MyCluster"), nn);
-      Assert.assertTrue(movePaths.containsKey(nn));
+      Assertions.assertEquals(new URI("hdfs://MyCluster"), nn);
+      Assertions.assertTrue(movePaths.containsKey(nn));
       checkMovePaths(movePaths.get(nn), new Path("/foo"), new Path("/bar"));
     } finally {
       cluster.shutdown();
@@ -602,11 +604,11 @@ public class TestMover {
     DFSTestUtil.setFederatedConfiguration(cluster, conf);
     try {
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assert.assertEquals(3, namenodes.size());
+      Assertions.assertEquals(3, namenodes.size());
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo");
-        Assert.fail("Expect exception for missing authority information");
+        Assertions.fail("Expect exception for missing authority information");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains(
             "does not contain scheme and authority", e);
@@ -614,7 +616,7 @@ public class TestMover {
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "hdfs:///foo");
-        Assert.fail("Expect exception for missing authority information");
+        Assertions.fail("Expect exception for missing authority information");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains(
             "does not contain scheme and authority", e);
@@ -622,7 +624,7 @@ public class TestMover {
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "wrong-hdfs://ns1/foo");
-        Assert.fail("Expect exception for wrong scheme");
+        Assertions.fail("Expect exception for wrong scheme");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains("Cannot resolve the path", e);
       }
@@ -632,7 +634,7 @@ public class TestMover {
       URI nn2 = iter.next();
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", nn1 + "/foo", nn1 + "/bar", nn2 + "/foo/bar");
-      Assert.assertEquals(2, movePaths.size());
+      Assertions.assertEquals(2, movePaths.size());
       checkMovePaths(movePaths.get(nn1), new Path("/foo"), new Path("/bar"));
       checkMovePaths(movePaths.get(nn2), new Path("/foo/bar"));
     } finally {
@@ -655,7 +657,7 @@ public class TestMover {
     DFSTestUtil.setFederatedHAConfiguration(cluster, conf);
     try {
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assert.assertEquals(3, namenodes.size());
+      Assertions.assertEquals(3, namenodes.size());
 
       Iterator<URI> iter = namenodes.iterator();
       URI nn1 = iter.next();
@@ -663,7 +665,7 @@ public class TestMover {
       URI nn3 = iter.next();
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", nn1 + "/foo", nn1 + "/bar", nn2 + "/foo/bar", nn3 + "/foobar");
-      Assert.assertEquals(3, movePaths.size());
+      Assertions.assertEquals(3, movePaths.size());
       checkMovePaths(movePaths.get(nn1), new Path("/foo"), new Path("/bar"));
       checkMovePaths(movePaths.get(nn2), new Path("/foo/bar"));
       checkMovePaths(movePaths.get(nn3), new Path("/foobar"));
@@ -672,7 +674,8 @@ public class TestMover {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testTwoReplicaSameStorageTypeShouldNotSelect() throws Exception {
     // HDFS-8147
     final Configuration conf = new HdfsConfiguration();
@@ -696,13 +699,13 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assert.assertTrue(StorageType.DISK == storageType);
+        Assertions.assertTrue(StorageType.DISK == storageType);
       }
       // move to ARCHIVE
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", file.toString() });
-      Assert.assertEquals("Movement to ARCHIVE should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, 2);
@@ -711,7 +714,8 @@ public class TestMover {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoveWhenStoragePolicyNotSatisfying() throws Exception {
     // HDFS-8147
     final Configuration conf = new HdfsConfiguration();
@@ -736,13 +740,14 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", file.toString() });
       int exitcode = ExitStatus.NO_MOVE_BLOCK.getExitCode();
-      Assert.assertEquals("Exit code should be " + exitcode, exitcode, rc);
+      Assertions.assertEquals(exitcode, rc, "Exit code should be " + exitcode);
     } finally {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoveWhenStoragePolicySatisfierIsRunning() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     conf.set(DFSConfigKeys.DFS_STORAGE_POLICY_SATISFIER_MODE_KEY,
@@ -769,7 +774,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
       int exitcode = ExitStatus.IO_EXCEPTION.getExitCode();
-      Assert.assertEquals("Exit code should be " + exitcode, exitcode, rc);
+      Assertions.assertEquals(exitcode, rc, "Exit code should be " + exitcode);
     } finally {
       cluster.shutdown();
     }
@@ -803,14 +808,15 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assert.assertEquals("Movement should fail after some retry",
-          ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc);
+      Assertions.assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
+          "Movement should fail after some retry");
     } finally {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerMaxIterationTimeNotAffectMover() throws Exception {
     long blockSize = 10*1024*1024;
     final Configuration conf = new HdfsConfiguration();
@@ -849,8 +855,8 @@ public class TestMover {
       fs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file});
-      Assert.assertEquals("Retcode expected to be ExitStatus.SUCCESS (0).",
-          ExitStatus.SUCCESS.getExitCode(), rc);
+      Assertions.assertEquals(ExitStatus.SUCCESS.getExitCode(), rc,
+          "Retcode expected to be ExitStatus.SUCCESS (0).");
     } finally {
       cluster.shutdown();
     }
@@ -875,7 +881,8 @@ public class TestMover {
         StoragePolicySatisfierMode.NONE.toString());
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoverWithStripedFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConfWithStripe(conf);
@@ -934,7 +941,7 @@ public class TestMover {
           client.getBlockLocations(fooFile, 0, fileLen);
       for(LocatedBlock lb : locatedBlocks.getLocatedBlocks()){
         for( StorageType type : lb.getStorageTypes()){
-          Assert.assertEquals(StorageType.DISK, type);
+          Assertions.assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,
@@ -963,7 +970,7 @@ public class TestMover {
       // run Mover
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", barDir });
-      Assert.assertEquals("Movement to ARCHIVE should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Verify storage types and locations.
       // Wait until Namenode confirms ARCHIVE storage type for all blocks of
@@ -1003,7 +1010,7 @@ public class TestMover {
       locatedBlocks = client.getBlockLocations(fooFile, 0, fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assert.assertEquals(StorageType.ARCHIVE, type);
+          Assertions.assertEquals(StorageType.ARCHIVE, type);
         }
       }
     }finally{
@@ -1011,7 +1018,8 @@ public class TestMover {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoverWithStripedFileMaintenance() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConfWithStripe(conf);
@@ -1070,7 +1078,7 @@ public class TestMover {
       for(LocatedBlock lb : locatedBlocks.getLocatedBlocks()){
         location = lb.getLocations()[8];
         for(StorageType type : lb.getStorageTypes()){
-          Assert.assertEquals(StorageType.SSD, type);
+          Assertions.assertEquals(StorageType.SSD, type);
         }
       }
 
@@ -1120,7 +1128,7 @@ public class TestMover {
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[]{"-p", barDir});
 
-      Assert.assertEquals("Movement to HOT should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to HOT should be successful");
     } finally {
       cluster.shutdown();
     }
@@ -1194,7 +1202,7 @@ public class TestMover {
     String username = "mover";
     File baseDir = GenericTestUtils.getTestDir(TestMover.class.getSimpleName());
     FileUtil.fullyDelete(baseDir);
-    Assert.assertTrue(baseDir.mkdirs());
+    Assertions.assertTrue(baseDir.mkdirs());
 
     Properties kdcConf = MiniKdc.createConf();
     MiniKdc kdc = new MiniKdc(kdcConf, baseDir);
@@ -1204,8 +1212,8 @@ public class TestMover {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
     KerberosName.resetDefaultRealm();
-    Assert.assertTrue("Expected configuration to enable security",
-        UserGroupInformation.isSecurityEnabled());
+    Assertions.assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Expected configuration to enable security");
 
     keytabFile = new File(baseDir, username + ".keytab");
     String keytab = keytabFile.getAbsolutePath();
@@ -1249,7 +1257,8 @@ public class TestMover {
    * Reusing testMovementWithLocalityOption
    * here for basic functionality testing.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoverWithKeytabs() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     try {
@@ -1263,7 +1272,7 @@ public class TestMover {
           // verify that mover runs Ok.
           testMovementWithLocalityOption(conf, true);
           // verify that UGI was logged in using keytab.
-          Assert.assertTrue(UserGroupInformation.isLoginKeytabBased());
+          Assertions.assertTrue(UserGroupInformation.isLoginKeytabBased());
           return null;
         }
       });
@@ -1277,7 +1286,8 @@ public class TestMover {
   /**
    * Test to verify that mover can't move pinned blocks.
    */
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testMoverWithPinnedBlocks() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1308,7 +1318,7 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assert.assertTrue(StorageType.DISK == storageType);
+        Assertions.assertTrue(StorageType.DISK == storageType);
       }
 
       // Adding one SSD based data node to the cluster.
@@ -1328,7 +1338,7 @@ public class TestMover {
           new String[] {"-p", dir.toString()});
 
       int exitcode = ExitStatus.NO_MOVE_BLOCK.getExitCode();
-      Assert.assertEquals("Movement should fail", exitcode, rc);
+      Assertions.assertEquals(exitcode, rc, "Movement should fail");
 
     } finally {
       cluster.shutdown();
@@ -1339,7 +1349,8 @@ public class TestMover {
    * Test to verify that mover should work well with pinned blocks as well as
    * failed blocks. Mover should continue retrying the failed blocks only.
    */
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testMoverFailedRetryWithPinnedBlocks() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1367,8 +1378,7 @@ public class TestMover {
 
       // Delete block file so, block move will fail with FileNotFoundException
       LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file1, 0);
-      Assert.assertEquals("Wrong block count", 2,
-          locatedBlocks.locatedBlockCount());
+      Assertions.assertEquals(2, locatedBlocks.locatedBlockCount(), "Wrong block count");
       LocatedBlock lb = locatedBlocks.get(0);
       cluster.corruptBlockOnDataNodesByDeletingBlockFile(lb.getBlock());
 
@@ -1376,14 +1386,15 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(parenDir), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", parenDir.toString()});
-      Assert.assertEquals("Movement should fail after some retry",
-          ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc);
+      Assertions.assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
+          "Movement should fail after some retry");
     } finally {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoverWhenStoragePolicyUnset() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1403,29 +1414,30 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assert.assertEquals("Movement to ARCHIVE should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, 1);
 
       // verify before unset policy
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
-      Assert.assertTrue(StorageType.ARCHIVE == (lb.getStorageTypes())[0]);
+      Assertions.assertTrue(StorageType.ARCHIVE == (lb.getStorageTypes())[0]);
 
       // unset storage policy
       dfs.unsetStoragePolicy(new Path(file));
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assert.assertEquals("Movement to DISK should be successful", 0, rc);
+      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
 
       lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
-      Assert.assertTrue(StorageType.DISK == (lb.getStorageTypes())[0]);
+      Assertions.assertTrue(StorageType.DISK == (lb.getStorageTypes())[0]);
     } finally {
       cluster.shutdown();
     }
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testMoverMetrics() throws Exception {
     long blockSize = 10*1024*1024;
     final Configuration conf = new HdfsConfiguration();
@@ -1501,8 +1513,8 @@ public class TestMover {
 
     // Mock FsDatasetSpi#getPinning to show that the block is pinned.
     LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file, 0);
-    Assert.assertEquals("Wrong block count", 2,
-        locatedBlocks.locatedBlockCount());
+    Assertions.assertEquals(2, locatedBlocks.locatedBlockCount(),
+        "Wrong block count");
     LocatedBlock lb = locatedBlocks.get(0);
     DatanodeInfo datanodeInfo = lb.getLocations()[0];
     for (DataNode dn : cluster.getDataNodes()) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestMover.java
@@ -38,7 +38,11 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DATA_TRANSF
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,7 +109,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -137,7 +140,7 @@ public class TestMover {
 
   static Mover newMover(Configuration conf) throws IOException {
     final Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-    Assertions.assertEquals(1, namenodes.size());
+    assertEquals(1, namenodes.size());
     Map<URI, List<Path>> nnMap = Maps.newHashMap();
     for (URI nn : namenodes) {
       nnMap.put(nn, null);
@@ -179,8 +182,8 @@ public class TestMover {
 
       final List<StorageType> storageTypes = new ArrayList<StorageType>(
           Arrays.asList(StorageType.DEFAULT, StorageType.DEFAULT));
-      Assertions.assertTrue(processor.scheduleMoveReplica(db, ml, storageTypes));
-      Assertions.assertFalse(processor.scheduleMoveReplica(db, ml, storageTypes));
+      assertTrue(processor.scheduleMoveReplica(db, ml, storageTypes));
+      assertFalse(processor.scheduleMoveReplica(db, ml, storageTypes));
     } finally {
       cluster.shutdown();
     }
@@ -220,13 +223,13 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assertions.assertTrue(StorageType.DISK == storageType);
+        assertTrue(StorageType.DISK == storageType);
       }
       // move to ARCHIVE
       dfs.setStoragePolicy(dir, "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", dir.toString()});
-      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
+      assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, sameNode ? 3 : 1);
@@ -284,14 +287,14 @@ public class TestMover {
     LocatedBlock lb = dfs1.getClient().getLocatedBlocks(file, 0).get(0);
     StorageType[] storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assertions.assertTrue(StorageType.DISK == storageType);
+      assertTrue(StorageType.DISK == storageType);
     }
 
     //verify before movement
     lb = dfs2.getClient().getLocatedBlocks(file, 0).get(0);
     storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assertions.assertTrue(StorageType.ARCHIVE == storageType);
+      assertTrue(StorageType.ARCHIVE == storageType);
     }
   }
 
@@ -353,13 +356,13 @@ public class TestMover {
       dfs1.setStoragePolicy(dir, "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString()});
-      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
+      assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       //move to DISK
       dfs2.setStoragePolicy(dir, "HOT");
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn2 + dir.toString()});
-      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
+      assertEquals(0, rc, "Movement to DISK should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
@@ -404,7 +407,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString(), nn2 + dir.toString()});
 
-      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
+      assertEquals(0, rc, "Movement to DISK should be successful");
 
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
       waitForLocatedBlockWithDiskStorageType(dfs2, file, 3);
@@ -459,7 +462,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", nn1 + dir.toString(), nn2 + dir.toString()});
 
-      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
+      assertEquals(0, rc, "Movement to DISK should be successful");
 
       waitForLocatedBlockWithArchiveStorageType(dfs1, file, 3);
       waitForLocatedBlockWithDiskStorageType(dfs2, file, 3);
@@ -519,9 +522,9 @@ public class TestMover {
   }
 
   private void checkMovePaths(List<Path> actual, Path... expected) {
-    Assertions.assertEquals(expected.length, actual.size());
+    assertEquals(expected.length, actual.size());
     for (Path p : expected) {
-      Assertions.assertTrue(actual.contains(p));
+      assertTrue(actual.contains(p));
     }
   }
 
@@ -540,24 +543,24 @@ public class TestMover {
       final Configuration conf = cluster.getConfiguration(0);
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo", "bar");
-        Assertions.fail("Expected exception for illegal path bar");
+        fail("Expected exception for illegal path bar");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains("bar is not absolute", e);
       }
 
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf);
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assertions.assertEquals(1, namenodes.size());
-      Assertions.assertEquals(1, movePaths.size());
+      assertEquals(1, namenodes.size());
+      assertEquals(1, movePaths.size());
       URI nn = namenodes.iterator().next();
-      Assertions.assertTrue(movePaths.containsKey(nn));
-      Assertions.assertNull(movePaths.get(nn));
+      assertTrue(movePaths.containsKey(nn));
+      assertNull(movePaths.get(nn));
 
       movePaths = Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo", "/bar");
       namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assertions.assertEquals(1, movePaths.size());
+      assertEquals(1, movePaths.size());
       nn = namenodes.iterator().next();
-      Assertions.assertTrue(movePaths.containsKey(nn));
+      assertTrue(movePaths.containsKey(nn));
       checkMovePaths(movePaths.get(nn), new Path("/foo"), new Path("/bar"));
     } finally {
       cluster.shutdown();
@@ -578,11 +581,11 @@ public class TestMover {
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", "/foo", "/bar");
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assertions.assertEquals(1, namenodes.size());
-      Assertions.assertEquals(1, movePaths.size());
+      assertEquals(1, namenodes.size());
+      assertEquals(1, movePaths.size());
       URI nn = namenodes.iterator().next();
-      Assertions.assertEquals(new URI("hdfs://MyCluster"), nn);
-      Assertions.assertTrue(movePaths.containsKey(nn));
+      assertEquals(new URI("hdfs://MyCluster"), nn);
+      assertTrue(movePaths.containsKey(nn));
       checkMovePaths(movePaths.get(nn), new Path("/foo"), new Path("/bar"));
     } finally {
       cluster.shutdown();
@@ -604,11 +607,11 @@ public class TestMover {
     DFSTestUtil.setFederatedConfiguration(cluster, conf);
     try {
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assertions.assertEquals(3, namenodes.size());
+      assertEquals(3, namenodes.size());
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "/foo");
-        Assertions.fail("Expect exception for missing authority information");
+        fail("Expect exception for missing authority information");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains(
             "does not contain scheme and authority", e);
@@ -616,7 +619,7 @@ public class TestMover {
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "hdfs:///foo");
-        Assertions.fail("Expect exception for missing authority information");
+        fail("Expect exception for missing authority information");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains(
             "does not contain scheme and authority", e);
@@ -624,7 +627,7 @@ public class TestMover {
 
       try {
         Mover.Cli.getNameNodePathsToMove(conf, "-p", "wrong-hdfs://ns1/foo");
-        Assertions.fail("Expect exception for wrong scheme");
+        fail("Expect exception for wrong scheme");
       } catch (IllegalArgumentException e) {
         GenericTestUtils.assertExceptionContains("Cannot resolve the path", e);
       }
@@ -634,7 +637,7 @@ public class TestMover {
       URI nn2 = iter.next();
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", nn1 + "/foo", nn1 + "/bar", nn2 + "/foo/bar");
-      Assertions.assertEquals(2, movePaths.size());
+      assertEquals(2, movePaths.size());
       checkMovePaths(movePaths.get(nn1), new Path("/foo"), new Path("/bar"));
       checkMovePaths(movePaths.get(nn2), new Path("/foo/bar"));
     } finally {
@@ -657,7 +660,7 @@ public class TestMover {
     DFSTestUtil.setFederatedHAConfiguration(cluster, conf);
     try {
       Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
-      Assertions.assertEquals(3, namenodes.size());
+      assertEquals(3, namenodes.size());
 
       Iterator<URI> iter = namenodes.iterator();
       URI nn1 = iter.next();
@@ -665,7 +668,7 @@ public class TestMover {
       URI nn3 = iter.next();
       Map<URI, List<Path>> movePaths = Mover.Cli.getNameNodePathsToMove(conf,
           "-p", nn1 + "/foo", nn1 + "/bar", nn2 + "/foo/bar", nn3 + "/foobar");
-      Assertions.assertEquals(3, movePaths.size());
+      assertEquals(3, movePaths.size());
       checkMovePaths(movePaths.get(nn1), new Path("/foo"), new Path("/bar"));
       checkMovePaths(movePaths.get(nn2), new Path("/foo/bar"));
       checkMovePaths(movePaths.get(nn3), new Path("/foobar"));
@@ -699,13 +702,13 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assertions.assertTrue(StorageType.DISK == storageType);
+        assertTrue(StorageType.DISK == storageType);
       }
       // move to ARCHIVE
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", file.toString() });
-      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
+      assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, 2);
@@ -740,7 +743,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", file.toString() });
       int exitcode = ExitStatus.NO_MOVE_BLOCK.getExitCode();
-      Assertions.assertEquals(exitcode, rc, "Exit code should be " + exitcode);
+      assertEquals(exitcode, rc, "Exit code should be " + exitcode);
     } finally {
       cluster.shutdown();
     }
@@ -774,7 +777,7 @@ public class TestMover {
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
       int exitcode = ExitStatus.IO_EXCEPTION.getExitCode();
-      Assertions.assertEquals(exitcode, rc, "Exit code should be " + exitcode);
+      assertEquals(exitcode, rc, "Exit code should be " + exitcode);
     } finally {
       cluster.shutdown();
     }
@@ -808,7 +811,7 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assertions.assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
+      assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
           "Movement should fail after some retry");
     } finally {
       cluster.shutdown();
@@ -855,7 +858,7 @@ public class TestMover {
       fs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file});
-      Assertions.assertEquals(ExitStatus.SUCCESS.getExitCode(), rc,
+      assertEquals(ExitStatus.SUCCESS.getExitCode(), rc,
           "Retcode expected to be ExitStatus.SUCCESS (0).");
     } finally {
       cluster.shutdown();
@@ -941,7 +944,7 @@ public class TestMover {
           client.getBlockLocations(fooFile, 0, fileLen);
       for(LocatedBlock lb : locatedBlocks.getLocatedBlocks()){
         for( StorageType type : lb.getStorageTypes()){
-          Assertions.assertEquals(StorageType.DISK, type);
+          assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,
@@ -970,7 +973,7 @@ public class TestMover {
       // run Mover
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] { "-p", barDir });
-      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
+      assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Verify storage types and locations.
       // Wait until Namenode confirms ARCHIVE storage type for all blocks of
@@ -1010,7 +1013,7 @@ public class TestMover {
       locatedBlocks = client.getBlockLocations(fooFile, 0, fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assertions.assertEquals(StorageType.ARCHIVE, type);
+          assertEquals(StorageType.ARCHIVE, type);
         }
       }
     }finally{
@@ -1078,7 +1081,7 @@ public class TestMover {
       for(LocatedBlock lb : locatedBlocks.getLocatedBlocks()){
         location = lb.getLocations()[8];
         for(StorageType type : lb.getStorageTypes()){
-          Assertions.assertEquals(StorageType.SSD, type);
+          assertEquals(StorageType.SSD, type);
         }
       }
 
@@ -1128,7 +1131,7 @@ public class TestMover {
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[]{"-p", barDir});
 
-      Assertions.assertEquals(0, rc, "Movement to HOT should be successful");
+      assertEquals(0, rc, "Movement to HOT should be successful");
     } finally {
       cluster.shutdown();
     }
@@ -1202,7 +1205,7 @@ public class TestMover {
     String username = "mover";
     File baseDir = GenericTestUtils.getTestDir(TestMover.class.getSimpleName());
     FileUtil.fullyDelete(baseDir);
-    Assertions.assertTrue(baseDir.mkdirs());
+    assertTrue(baseDir.mkdirs());
 
     Properties kdcConf = MiniKdc.createConf();
     MiniKdc kdc = new MiniKdc(kdcConf, baseDir);
@@ -1212,7 +1215,7 @@ public class TestMover {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
     KerberosName.resetDefaultRealm();
-    Assertions.assertTrue(UserGroupInformation.isSecurityEnabled(),
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
         "Expected configuration to enable security");
 
     keytabFile = new File(baseDir, username + ".keytab");
@@ -1272,7 +1275,7 @@ public class TestMover {
           // verify that mover runs Ok.
           testMovementWithLocalityOption(conf, true);
           // verify that UGI was logged in using keytab.
-          Assertions.assertTrue(UserGroupInformation.isLoginKeytabBased());
+          assertTrue(UserGroupInformation.isLoginKeytabBased());
           return null;
         }
       });
@@ -1318,7 +1321,7 @@ public class TestMover {
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
       StorageType[] storageTypes = lb.getStorageTypes();
       for (StorageType storageType : storageTypes) {
-        Assertions.assertTrue(StorageType.DISK == storageType);
+        assertTrue(StorageType.DISK == storageType);
       }
 
       // Adding one SSD based data node to the cluster.
@@ -1338,7 +1341,7 @@ public class TestMover {
           new String[] {"-p", dir.toString()});
 
       int exitcode = ExitStatus.NO_MOVE_BLOCK.getExitCode();
-      Assertions.assertEquals(exitcode, rc, "Movement should fail");
+      assertEquals(exitcode, rc, "Movement should fail");
 
     } finally {
       cluster.shutdown();
@@ -1378,7 +1381,7 @@ public class TestMover {
 
       // Delete block file so, block move will fail with FileNotFoundException
       LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file1, 0);
-      Assertions.assertEquals(2, locatedBlocks.locatedBlockCount(), "Wrong block count");
+      assertEquals(2, locatedBlocks.locatedBlockCount(), "Wrong block count");
       LocatedBlock lb = locatedBlocks.get(0);
       cluster.corruptBlockOnDataNodesByDeletingBlockFile(lb.getBlock());
 
@@ -1386,7 +1389,7 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(parenDir), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", parenDir.toString()});
-      Assertions.assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
+      assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), rc,
           "Movement should fail after some retry");
     } finally {
       cluster.shutdown();
@@ -1414,23 +1417,23 @@ public class TestMover {
       dfs.setStoragePolicy(new Path(file), "COLD");
       int rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assertions.assertEquals(0, rc, "Movement to ARCHIVE should be successful");
+      assertEquals(0, rc, "Movement to ARCHIVE should be successful");
 
       // Wait till namenode notified about the block location details
       waitForLocatedBlockWithArchiveStorageType(dfs, file, 1);
 
       // verify before unset policy
       LocatedBlock lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
-      Assertions.assertTrue(StorageType.ARCHIVE == (lb.getStorageTypes())[0]);
+      assertTrue(StorageType.ARCHIVE == (lb.getStorageTypes())[0]);
 
       // unset storage policy
       dfs.unsetStoragePolicy(new Path(file));
       rc = ToolRunner.run(conf, new Mover.Cli(),
           new String[] {"-p", file.toString()});
-      Assertions.assertEquals(0, rc, "Movement to DISK should be successful");
+      assertEquals(0, rc, "Movement to DISK should be successful");
 
       lb = dfs.getClient().getLocatedBlocks(file, 0).get(0);
-      Assertions.assertTrue(StorageType.DISK == (lb.getStorageTypes())[0]);
+      assertTrue(StorageType.DISK == (lb.getStorageTypes())[0]);
     } finally {
       cluster.shutdown();
     }
@@ -1513,7 +1516,7 @@ public class TestMover {
 
     // Mock FsDatasetSpi#getPinning to show that the block is pinned.
     LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file, 0);
-    Assertions.assertEquals(2, locatedBlocks.locatedBlockCount(),
+    assertEquals(2, locatedBlocks.locatedBlockCount(),
         "Wrong block count");
     LocatedBlock lb = locatedBlocks.get(0);
     DatanodeInfo datanodeInfo = lb.getLocations()[0];

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
@@ -62,11 +62,14 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotTestHelper;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the data migration tool (for Archival Storage)
@@ -275,7 +278,7 @@ public class TestStorageMover {
         nnMap.put(nn, null);
       }
       int result = Mover.run(nnMap, conf);
-      Assertions.assertEquals(expectedExitCode.getExitCode(), result);
+      assertEquals(expectedExitCode.getExitCode(), result);
     }
 
     private void verifyNamespace() throws Exception {
@@ -309,7 +312,7 @@ public class TestStorageMover {
           return;
         }
       }
-      Assertions.fail("File " + file + " not found.");
+      fail("File " + file + " not found.");
     }
 
     private void verifyFile(final Path parent, final HdfsFileStatus status,
@@ -318,14 +321,14 @@ public class TestStorageMover {
       byte policyId = fileStatus.getStoragePolicy();
       BlockStoragePolicy policy = policies.getPolicy(policyId);
       if (expectedPolicyId != null) {
-        Assertions.assertEquals((byte) expectedPolicyId, policy.getId());
+        assertEquals((byte) expectedPolicyId, policy.getId());
       }
       final List<StorageType> types = policy.chooseStorageTypes(
           status.getReplication());
       for(LocatedBlock lb : fileStatus.getLocatedBlocks().getLocatedBlocks()) {
         final Mover.StorageTypeDiff diff = new Mover.StorageTypeDiff(types,
             lb.getStorageTypes());
-        Assertions.assertTrue(diff.removeOverlap(true),
+        assertTrue(diff.removeOverlap(true),
             fileStatus.getFullName(parent.toString())
                 + " with policy " + policy + " has non-empty overlap: " + diff
                 + ", the corresponding block is " + lb.getBlock().getLocalBlock());
@@ -348,7 +351,7 @@ public class TestStorageMover {
         throws IOException {
       final List<LocatedBlock> lbs = dfs.getClient().getLocatedBlocks(
           file.toString(), 0).getLocatedBlocks();
-      Assertions.assertEquals(1, lbs.size());
+      assertEquals(1, lbs.size());
 
       LocatedBlock lb = lbs.get(0);
       StringBuilder types = new StringBuilder(); 
@@ -360,13 +363,13 @@ public class TestStorageMover {
         } else if (t == StorageType.ARCHIVE) {
           r.archive++;
         } else {
-          Assertions.fail("Unexpected storage type " + t);
+          fail("Unexpected storage type " + t);
         }
       }
 
       if (expected != null) {
         final String s = "file = " + file + "\n  types = [" + types + "]";
-        Assertions.assertEquals(expected, r, s);
+        assertEquals(expected, r, s);
       }
       return r;
     }
@@ -520,7 +523,7 @@ public class TestStorageMover {
       Map<URI, List<Path>> map = Mover.Cli.getNameNodePathsToMove(test.conf,
           "-p", "/foo/bar", "/foo2");
       int result = Mover.run(map, test.conf);
-      Assertions.assertEquals(ExitStatus.SUCCESS.getExitCode(), result);
+      assertEquals(ExitStatus.SUCCESS.getExitCode(), result);
 
       Thread.sleep(5000);
       test.verify(true);
@@ -563,8 +566,8 @@ public class TestStorageMover {
           barFile.toString(), BLOCK_SIZE);
       LOG.info("Locations: " + lbs);
       List<LocatedBlock> blks = lbs.getLocatedBlocks();
-      Assertions.assertEquals(1, blks.size());
-      Assertions.assertEquals(1, blks.get(0).getLocations().length);
+      assertEquals(1, blks.size());
+      assertEquals(1, blks.get(0).getLocations().length);
 
       banner("finish the migration, continue writing");
       // make sure the writing can continue
@@ -576,8 +579,8 @@ public class TestStorageMover {
           barFile.toString(), BLOCK_SIZE);
       LOG.info("Locations: " + lbs);
       blks = lbs.getLocatedBlocks();
-      Assertions.assertEquals(1, blks.size());
-      Assertions.assertEquals(1, blks.get(0).getLocations().length);
+      assertEquals(1, blks.size());
+      assertEquals(1, blks.get(0).getLocations().length);
 
       banner("finish writing, starting reading");
       // check the content of /foo/bar
@@ -586,7 +589,7 @@ public class TestStorageMover {
       // read from offset 1024
       in.readFully(BLOCK_SIZE, buf, 0, buf.length);
       IOUtils.cleanupWithLogger(LOG, in);
-      Assertions.assertEquals("hello, world!", new String(buf));
+      assertEquals("hello, world!", new String(buf));
     } finally {
       test.shutdownCluster();
     }
@@ -740,7 +743,7 @@ public class TestStorageMover {
         // since no more ARCHIVE space.
         final Path file0 = new Path(pathPolicyMap.cold, "file0");
         final Replication r = test.getReplication(file0);
-        Assertions.assertEquals(0, r.disk);
+        assertEquals(0, r.disk);
 
         final short newReplication = (short) 5;
         test.dfs.setReplication(file0, newReplication);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/mover/TestStorageMover.java
@@ -62,8 +62,8 @@ import org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotTestHelper;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
@@ -275,7 +275,7 @@ public class TestStorageMover {
         nnMap.put(nn, null);
       }
       int result = Mover.run(nnMap, conf);
-      Assert.assertEquals(expectedExitCode.getExitCode(), result);
+      Assertions.assertEquals(expectedExitCode.getExitCode(), result);
     }
 
     private void verifyNamespace() throws Exception {
@@ -309,7 +309,7 @@ public class TestStorageMover {
           return;
         }
       }
-      Assert.fail("File " + file + " not found.");
+      Assertions.fail("File " + file + " not found.");
     }
 
     private void verifyFile(final Path parent, final HdfsFileStatus status,
@@ -318,17 +318,17 @@ public class TestStorageMover {
       byte policyId = fileStatus.getStoragePolicy();
       BlockStoragePolicy policy = policies.getPolicy(policyId);
       if (expectedPolicyId != null) {
-        Assert.assertEquals((byte)expectedPolicyId, policy.getId());
+        Assertions.assertEquals((byte) expectedPolicyId, policy.getId());
       }
       final List<StorageType> types = policy.chooseStorageTypes(
           status.getReplication());
       for(LocatedBlock lb : fileStatus.getLocatedBlocks().getLocatedBlocks()) {
         final Mover.StorageTypeDiff diff = new Mover.StorageTypeDiff(types,
             lb.getStorageTypes());
-        Assert.assertTrue(fileStatus.getFullName(parent.toString())
-            + " with policy " + policy + " has non-empty overlap: " + diff
-            + ", the corresponding block is " + lb.getBlock().getLocalBlock(),
-            diff.removeOverlap(true));
+        Assertions.assertTrue(diff.removeOverlap(true),
+            fileStatus.getFullName(parent.toString())
+                + " with policy " + policy + " has non-empty overlap: " + diff
+                + ", the corresponding block is " + lb.getBlock().getLocalBlock());
       }
     }
 
@@ -348,7 +348,7 @@ public class TestStorageMover {
         throws IOException {
       final List<LocatedBlock> lbs = dfs.getClient().getLocatedBlocks(
           file.toString(), 0).getLocatedBlocks();
-      Assert.assertEquals(1, lbs.size());
+      Assertions.assertEquals(1, lbs.size());
 
       LocatedBlock lb = lbs.get(0);
       StringBuilder types = new StringBuilder(); 
@@ -360,13 +360,13 @@ public class TestStorageMover {
         } else if (t == StorageType.ARCHIVE) {
           r.archive++;
         } else {
-          Assert.fail("Unexpected storage type " + t);
+          Assertions.fail("Unexpected storage type " + t);
         }
       }
 
       if (expected != null) {
         final String s = "file = " + file + "\n  types = [" + types + "]";
-        Assert.assertEquals(s, expected, r);
+        Assertions.assertEquals(expected, r, s);
       }
       return r;
     }
@@ -520,7 +520,7 @@ public class TestStorageMover {
       Map<URI, List<Path>> map = Mover.Cli.getNameNodePathsToMove(test.conf,
           "-p", "/foo/bar", "/foo2");
       int result = Mover.run(map, test.conf);
-      Assert.assertEquals(ExitStatus.SUCCESS.getExitCode(), result);
+      Assertions.assertEquals(ExitStatus.SUCCESS.getExitCode(), result);
 
       Thread.sleep(5000);
       test.verify(true);
@@ -563,8 +563,8 @@ public class TestStorageMover {
           barFile.toString(), BLOCK_SIZE);
       LOG.info("Locations: " + lbs);
       List<LocatedBlock> blks = lbs.getLocatedBlocks();
-      Assert.assertEquals(1, blks.size());
-      Assert.assertEquals(1, blks.get(0).getLocations().length);
+      Assertions.assertEquals(1, blks.size());
+      Assertions.assertEquals(1, blks.get(0).getLocations().length);
 
       banner("finish the migration, continue writing");
       // make sure the writing can continue
@@ -576,8 +576,8 @@ public class TestStorageMover {
           barFile.toString(), BLOCK_SIZE);
       LOG.info("Locations: " + lbs);
       blks = lbs.getLocatedBlocks();
-      Assert.assertEquals(1, blks.size());
-      Assert.assertEquals(1, blks.get(0).getLocations().length);
+      Assertions.assertEquals(1, blks.size());
+      Assertions.assertEquals(1, blks.get(0).getLocations().length);
 
       banner("finish writing, starting reading");
       // check the content of /foo/bar
@@ -586,7 +586,7 @@ public class TestStorageMover {
       // read from offset 1024
       in.readFully(BLOCK_SIZE, buf, 0, buf.length);
       IOUtils.cleanupWithLogger(LOG, in);
-      Assert.assertEquals("hello, world!", new String(buf));
+      Assertions.assertEquals("hello, world!", new String(buf));
     } finally {
       test.shutdownCluster();
     }
@@ -740,7 +740,7 @@ public class TestStorageMover {
         // since no more ARCHIVE space.
         final Path file0 = new Path(pathPolicyMap.cold, "file0");
         final Replication r = test.getReplication(file0);
-        Assert.assertEquals(0, r.disk);
+        Assertions.assertEquals(0, r.disk);
 
         final short newReplication = (short) 5;
         test.dfs.setReplication(file0, newReplication);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestBlockStorageMovementAttemptedItems.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestBlockStorageMovementAttemptedItems.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdfs.server.namenode.sps;
 
 import static org.apache.hadoop.util.Time.monotonicNow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,9 +35,10 @@ import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.server.namenode.sps.StoragePolicySatisfier.StorageTypeNodePair;
 import org.apache.hadoop.hdfs.server.sps.ExternalSPSContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 /**
@@ -50,7 +51,7 @@ public class TestBlockStorageMovementAttemptedItems {
   private BlockStorageMovementNeeded unsatisfiedStorageMovementFiles;
   private final int selfRetryTimeout = 500;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration config = new HdfsConfiguration();
     Context ctxt = Mockito.mock(ExternalSPSContext.class);
@@ -64,7 +65,7 @@ public class TestBlockStorageMovementAttemptedItems {
         unsatisfiedStorageMovementFiles, ctxt);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (bsmAttemptedItems != null) {
       bsmAttemptedItems.stop();
@@ -96,7 +97,8 @@ public class TestBlockStorageMovementAttemptedItems {
   /**
    * Verify that moved blocks reporting should queued up the block info.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAddReportedMoveAttemptFinishedBlocks() throws Exception {
     Long item = new Long(1234);
     Block block = new Block(item);
@@ -108,14 +110,15 @@ public class TestBlockStorageMovementAttemptedItems {
     bsmAttemptedItems.add(0L, 0L, 0L, blocksMap, 0);
     bsmAttemptedItems.notifyReportedBlock(dnInfo, StorageType.ARCHIVE,
         block);
-    assertEquals("Failed to receive result!", 1,
-        bsmAttemptedItems.getMovementFinishedBlocksCount());
+    assertEquals(1, bsmAttemptedItems.getMovementFinishedBlocksCount(),
+        "Failed to receive result!");
   }
 
   /**
    * Verify empty moved blocks reporting queue.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNoBlockMovementAttemptFinishedReportAdded() throws Exception {
     Long item = new Long(1234);
     Block block = new Block(item);
@@ -125,10 +128,9 @@ public class TestBlockStorageMovementAttemptedItems {
     Map<Block, Set<StorageTypeNodePair>> blocksMap = new HashMap<>();
     blocksMap.put(block, locs);
     bsmAttemptedItems.add(0L, 0L, 0L, blocksMap, 0);
-    assertEquals("Shouldn't receive result", 0,
-        bsmAttemptedItems.getMovementFinishedBlocksCount());
-    assertEquals("Item doesn't exist in the attempted list", 1,
-        bsmAttemptedItems.getAttemptedItemsCount());
+    assertEquals(0, bsmAttemptedItems.getMovementFinishedBlocksCount(), "Shouldn't receive result");
+    assertEquals(1, bsmAttemptedItems.getAttemptedItemsCount(),
+        "Item doesn't exist in the attempted list");
   }
 
   /**
@@ -137,7 +139,8 @@ public class TestBlockStorageMovementAttemptedItems {
    * is #blockStorageMovementReportedItemsCheck() and then
    * #blocksStorageMovementUnReportedItemsCheck().
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testPartialBlockMovementShouldBeRetried1() throws Exception {
     Long item = new Long(1234);
     Block block1 = new Block(item);
@@ -155,10 +158,9 @@ public class TestBlockStorageMovementAttemptedItems {
 
     // start block movement report monitor thread
     bsmAttemptedItems.start();
-    assertTrue("Failed to add to the retry list",
-        checkItemMovedForRetry(trackID, 5000));
-    assertEquals("Failed to remove from the attempted list", 0,
-        bsmAttemptedItems.getAttemptedItemsCount());
+    assertTrue(checkItemMovedForRetry(trackID, 5000), "Failed to add to the retry list");
+    assertEquals(0, bsmAttemptedItems.getAttemptedItemsCount(),
+        "Failed to remove from the attempted list");
   }
 
   /**
@@ -166,7 +168,8 @@ public class TestBlockStorageMovementAttemptedItems {
    * #blocksStorageMovementUnReportedItemsCheck() and then
    * #blockStorageMovementReportedItemsCheck().
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testPartialBlockMovementShouldBeRetried2() throws Exception {
     Long item = new Long(1234);
     Block block = new Block(item);
@@ -185,17 +188,18 @@ public class TestBlockStorageMovementAttemptedItems {
     bsmAttemptedItems.blocksStorageMovementUnReportedItemsCheck();
     bsmAttemptedItems.blockStorageMovementReportedItemsCheck();
 
-    assertTrue("Failed to add to the retry list",
-        checkItemMovedForRetry(trackID, 5000));
-    assertEquals("Failed to remove from the attempted list", 0,
-        bsmAttemptedItems.getAttemptedItemsCount());
+    assertTrue(checkItemMovedForRetry(trackID, 5000),
+        "Failed to add to the retry list");
+    assertEquals(0, bsmAttemptedItems.getAttemptedItemsCount(),
+        "Failed to remove from the attempted list");
   }
 
   /**
    * Partial block movement with only BlocksStorageMoveAttemptFinished report
    * and storageMovementAttemptedItems list is empty.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testPartialBlockMovementWithEmptyAttemptedQueue()
       throws Exception {
     Long item = new Long(1234);
@@ -210,10 +214,9 @@ public class TestBlockStorageMovementAttemptedItems {
     bsmAttemptedItems.notifyReportedBlock(dnInfo, StorageType.ARCHIVE,
         block);
     assertFalse(
-        "Should not add in queue again if it is not there in"
-            + " storageMovementAttemptedItems",
-        checkItemMovedForRetry(trackID, 5000));
-    assertEquals("Failed to remove from the attempted list", 1,
-        bsmAttemptedItems.getAttemptedItemsCount());
+        checkItemMovedForRetry(trackID, 5000),
+        "Should not add in queue again if it is not there in" + " storageMovementAttemptedItems");
+    assertEquals(1, bsmAttemptedItems.getAttemptedItemsCount(),
+        "Failed to remove from the attempted list");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.hdfs.server.balancer.NameNodeConnector;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.sps.ExternalSPSContext;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -54,6 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests that StoragePolicySatisfier daemon is able to check the striped blocks
@@ -167,7 +168,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assertions.assertEquals(StorageType.DISK, type);
+          assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,
@@ -278,7 +279,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assertions.assertEquals(StorageType.DISK, type);
+          assertEquals(StorageType.DISK, type);
         }
       }
       Thread.sleep(5000);
@@ -484,7 +485,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assertions.assertEquals(StorageType.DISK, type);
+          assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/sps/TestStoragePolicySatisfierWithStripedFile.java
@@ -46,9 +46,10 @@ import org.apache.hadoop.hdfs.server.balancer.NameNodeConnector;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.sps.ExternalSPSContext;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
   /**
    * Initialize erasure coding policy.
    */
-  @Before
+  @BeforeEach
   public void init(){
     ecPolicy = getEcPolicy();
     dataBlocks = ecPolicy.getNumDataUnits();
@@ -105,7 +106,8 @@ public class TestStoragePolicySatisfierWithStripedFile {
    * Tests to verify that all the striped blocks(data + parity blocks) are
    * moving to satisfy the storage policy.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoverWithFullStripe() throws Exception {
     // start 11 datanodes
     int numOfDatanodes = 11;
@@ -165,7 +167,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assert.assertEquals(StorageType.DISK, type);
+          Assertions.assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,
@@ -215,7 +217,8 @@ public class TestStoragePolicySatisfierWithStripedFile {
    * while choosing the target node for A, it shouldn't choose C. For C, it
    * should do local block movement as it has ARCHIVE storage type.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenOnlyFewTargetNodesAreAvailableToSatisfyStoragePolicy()
       throws Exception {
     // start 10 datanodes
@@ -275,7 +278,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assert.assertEquals(StorageType.DISK, type);
+          Assertions.assertEquals(StorageType.DISK, type);
         }
       }
       Thread.sleep(5000);
@@ -324,7 +327,8 @@ public class TestStoragePolicySatisfierWithStripedFile {
    * 5. Start remaining 5 datanode.
    * 6. All replica  should be moved in proper storage based on policy.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSWhenFileHasLowRedundancyBlocks() throws Exception {
     // start 9 datanodes
     int numOfDatanodes = 9;
@@ -420,7 +424,8 @@ public class TestStoragePolicySatisfierWithStripedFile {
    *
    * SPS won't schedule any block movement for this path.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenNoTargetDatanodeToSatisfyStoragePolicy()
       throws Exception {
     // start 10 datanodes
@@ -479,7 +484,7 @@ public class TestStoragePolicySatisfierWithStripedFile {
           fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assert.assertEquals(StorageType.DISK, type);
+          Assertions.assertEquals(StorageType.DISK, type);
         }
       }
       StripedFileTestUtil.verifyLocatedStripedBlocks(locatedBlocks,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
@@ -37,9 +37,9 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_STORAGE_POLICY_SATISFIER_
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_WEB_AUTHENTICATION_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DATA_TRANSFER_PROTECTION_KEY;
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -96,11 +96,12 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.ExitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public class TestExternalStoragePolicySatisfier {
     }
   };
 
-  @Before
+  @BeforeEach
   public void setUp() {
     config = new HdfsConfiguration();
     config.set(DFSConfigKeys.DFS_STORAGE_POLICY_SATISFIER_MODE_KEY,
@@ -157,7 +158,7 @@ public class TestExternalStoragePolicySatisfier {
         StoragePolicySatisfierMode.EXTERNAL.toString());
   }
 
-  @After
+  @AfterEach
   public void destroy() throws Exception {
     if (kdc != null) {
       kdc.stop();
@@ -296,7 +297,7 @@ public class TestExternalStoragePolicySatisfier {
     baseDir = GenericTestUtils
         .getTestDir(TestExternalStoragePolicySatisfier.class.getSimpleName());
     FileUtil.fullyDelete(baseDir);
-    Assert.assertTrue(baseDir.mkdirs());
+    Assertions.assertTrue(baseDir.mkdirs());
 
     Properties kdcConf = MiniKdc.createConf();
     kdc = new MiniKdc(kdcConf, baseDir);
@@ -306,8 +307,8 @@ public class TestExternalStoragePolicySatisfier {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
     KerberosName.resetDefaultRealm();
-    Assert.assertTrue("Expected configuration to enable security",
-        UserGroupInformation.isSecurityEnabled());
+    Assertions.assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Expected configuration to enable security");
 
     keytabFile = new File(baseDir, username + ".keytab");
     String keytab = keytabFile.getAbsolutePath();
@@ -352,7 +353,8 @@ public class TestExternalStoragePolicySatisfier {
    * Test SPS runs fine when logging in with a keytab in kerberized env. Reusing
    * testWhenStoragePolicySetToALLSSD here for basic functionality testing.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWithKeytabs() throws Exception {
     try {
       initSecureConf(getConf());
@@ -365,7 +367,7 @@ public class TestExternalStoragePolicySatisfier {
           // verify that sps runs Ok.
           testWhenStoragePolicySetToALLSSD();
           // verify that UGI was logged in using keytab.
-          Assert.assertTrue(UserGroupInformation.isLoginKeytabBased());
+          Assertions.assertTrue(UserGroupInformation.isLoginKeytabBased());
           return null;
         }
       });
@@ -382,7 +384,8 @@ public class TestExternalStoragePolicySatisfier {
    *
    * @throws Exception
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testOutstandingQueueLimitExceeds() throws Exception {
     try {
       getConf().setInt(DFS_SPS_MAX_OUTSTANDING_PATHS_KEY, 3);
@@ -406,7 +409,7 @@ public class TestExternalStoragePolicySatisfier {
       writeContent(fileExceeds);
       try {
         fs.satisfyStoragePolicy(new Path(fileExceeds));
-        Assert.fail("Should throw exception as it exceeds "
+        Assertions.fail("Should throw exception as it exceeds "
             + "outstanding SPS call Q limit");
       } catch (IOException ioe) {
         GenericTestUtils.assertExceptionContains(
@@ -422,7 +425,8 @@ public class TestExternalStoragePolicySatisfier {
    * is not being hold by a Mover. This can be the case when Mover exits
    * ungracefully without deleting the ID file from HDFS.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenMoverExitsWithoutDeleteMoverIDFile()
       throws IOException {
     try {
@@ -432,8 +436,7 @@ public class TestExternalStoragePolicySatisfier {
           HdfsServerConstants.MOVER_ID_PATH, 0, (short) 1, 0);
       restartNamenode();
       boolean running = externalCtxt.isRunning();
-      Assert.assertTrue("SPS should be running as "
-          + "no Mover really running", running);
+      Assertions.assertTrue(running, "SPS should be running as " + "no Mover really running");
     } finally {
       shutdownCluster();
     }
@@ -471,7 +474,8 @@ public class TestExternalStoragePolicySatisfier {
   }
 
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenStoragePolicySetToCOLD()
       throws Exception {
 
@@ -483,7 +487,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testInfiniteStartWhenAnotherSPSRunning()
       throws Exception {
 
@@ -507,7 +512,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenStoragePolicySetToCOLDWithException()
       throws Exception {
 
@@ -539,7 +545,8 @@ public class TestExternalStoragePolicySatisfier {
         dfs);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenStoragePolicySetToALLNVDIMM()
           throws Exception {
     try {
@@ -566,7 +573,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenStoragePolicySetToALLSSD()
       throws Exception {
     try {
@@ -593,7 +601,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenStoragePolicySetToONESSD()
       throws Exception {
     try {
@@ -624,7 +633,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests to verify that the block storage movement report will be propagated
    * to Namenode via datanode heartbeat.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBlksStorageMovementAttemptFinishedReport() throws Exception {
     try {
       createCluster();
@@ -656,7 +666,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests to verify that multiple files are giving to satisfy storage policy
    * and should work well altogether.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMultipleFilesForSatisfyStoragePolicy() throws Exception {
     try {
       createCluster();
@@ -703,7 +714,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests to verify hdfsAdmin.satisfyStoragePolicy works well for file.
    * @throws Exception
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSatisfyFileWithHdfsAdmin() throws Exception {
     try {
       createCluster();
@@ -734,7 +746,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests to verify hdfsAdmin.satisfyStoragePolicy works well for dir.
    * @throws Exception
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSatisfyDirWithHdfsAdmin() throws Exception {
     try {
       createCluster();
@@ -781,7 +794,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests to verify hdfsAdmin.satisfyStoragePolicy exceptions.
    * @throws Exception
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSatisfyWithExceptions() throws Exception {
     try {
       createCluster();
@@ -794,7 +808,7 @@ public class TestExternalStoragePolicySatisfier {
 
       try {
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
-        Assert.fail(String.format(
+        Assertions.fail(String.format(
             "Should failed to satisfy storage policy "
                 + "for %s since %s is set to false.",
             FILE, DFS_STORAGE_POLICY_ENABLED_KEY));
@@ -811,7 +825,7 @@ public class TestExternalStoragePolicySatisfier {
       hdfsAdmin = new HdfsAdmin(FileSystem.getDefaultUri(config), config);
       try {
         hdfsAdmin.satisfyStoragePolicy(new Path(nonExistingFile));
-        Assert.fail("Should throw FileNotFoundException for " +
+        Assertions.fail("Should throw FileNotFoundException for " +
             nonExistingFile);
       } catch (FileNotFoundException e) {
 
@@ -821,7 +835,7 @@ public class TestExternalStoragePolicySatisfier {
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
       } catch (Exception e) {
-        Assert.fail(String.format("Allow to invoke mutlipe times "
+        Assertions.fail(String.format("Allow to invoke mutlipe times "
             + "#satisfyStoragePolicy() api for a path %s , internally just "
             + "skipping addtion to satisfy movement queue.", FILE));
       }
@@ -844,7 +858,8 @@ public class TestExternalStoragePolicySatisfier {
    * SPS will schedule block movement to the coordinator node with the details,
    * blk_1[move A(DISK) -> D(ARCHIVE)], blk_2[move A(DISK) -> D(ARCHIVE)].
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenOnlyFewTargetDatanodeAreAvailableToSatisfyStoragePolicy()
       throws Exception {
     try {
@@ -887,7 +902,8 @@ public class TestExternalStoragePolicySatisfier {
    *
    * SPS won't schedule any block movement for this path.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenNoTargetDatanodeToSatisfyStoragePolicy()
       throws Exception {
     try {
@@ -921,7 +937,8 @@ public class TestExternalStoragePolicySatisfier {
    * Test to verify that satisfy worker can't move blocks. If the given block is
    * pinned it shouldn't be considered for retries.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testMoveWithBlockPinning() throws Exception {
     try{
       config.setBoolean(DFSConfigKeys.DFS_DATANODE_BLOCK_PINNING_ENABLED, true);
@@ -979,7 +996,8 @@ public class TestExternalStoragePolicySatisfier {
    * blk_1[move A(DISK) -> A(ARCHIVE), move E(DISK) -> E(ARCHIVE)],
    * blk_2[move A(DISK) -> A(ARCHIVE), move E(DISK) -> E(ARCHIVE)].
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testWhenOnlyFewSourceNodesHaveMatchingTargetNodes()
       throws Exception {
     try {
@@ -1020,7 +1038,8 @@ public class TestExternalStoragePolicySatisfier {
    * storagepolicy set to ONE_SSD and request satisfyStoragePolicy, then block
    * should move to DN2[SSD] successfully.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBlockMoveInSameDatanodeWithONESSD() throws Exception {
     StorageType[][] diskTypes =
         new StorageType[][]{{StorageType.DISK, StorageType.ARCHIVE},
@@ -1054,7 +1073,8 @@ public class TestExternalStoragePolicySatisfier {
    * satisfyStoragePolicy, then block should move to DN1[ARCHIVE] and
    * DN2[ARCHIVE] successfully.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBlockMoveInSameAndRemoteDatanodesWithWARM() throws Exception {
     StorageType[][] diskTypes =
         new StorageType[][]{{StorageType.DISK, StorageType.ARCHIVE},
@@ -1087,7 +1107,8 @@ public class TestExternalStoragePolicySatisfier {
    * If replica with expected storage type already exist in source DN then that
    * DN should be skipped.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSWhenReplicaWithExpectedStorageAlreadyAvailableInSource()
       throws Exception {
     StorageType[][] diskTypes = new StorageType[][] {
@@ -1131,7 +1152,8 @@ public class TestExternalStoragePolicySatisfier {
    * Tests that movements should not be assigned when there is no space in
    * target DN.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testChooseInSameDatanodeWithONESSDShouldNotChooseIfNoSpace()
       throws Exception {
     StorageType[][] diskTypes =
@@ -1197,7 +1219,8 @@ public class TestExternalStoragePolicySatisfier {
    *
    * @throws Exception
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSShouldNotLeakXattrIfSatisfyStoragePolicyCallOnECFiles()
       throws Exception {
     StorageType[][] diskTypes =
@@ -1252,7 +1275,7 @@ public class TestExternalStoragePolicySatisfier {
           client.getBlockLocations(testFile, 0, fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assert.assertEquals(StorageType.DISK, type);
+          Assertions.assertEquals(StorageType.DISK, type);
         }
       }
 
@@ -1270,7 +1293,8 @@ public class TestExternalStoragePolicySatisfier {
    * 2. Call satisfyStoragePolicy for empty file.
    * 3. SPS should skip this file and xattr should not be added for empty file.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSWhenFileLengthIsZero() throws Exception {
     try {
       hdfsCluster = startCluster(config, allDiskTypes, NUM_OF_DATANODES,
@@ -1283,12 +1307,12 @@ public class TestExternalStoragePolicySatisfier {
           .getEditLog();
       long lastWrittenTxId = editlog.getLastWrittenTxId();
       fs.satisfyStoragePolicy(filePath);
-      Assert.assertEquals("Xattr should not be added for the file",
-          lastWrittenTxId, editlog.getLastWrittenTxId());
+      Assertions.assertEquals(lastWrittenTxId, editlog.getLastWrittenTxId(),
+          "Xattr should not be added for the file");
       INode inode = hdfsCluster.getNameNode().getNamesystem().getFSDirectory()
           .getINode(filePath.toString());
-      Assert.assertTrue("XAttrFeature should be null for file",
-          inode.getXAttrFeature() == null);
+      Assertions.assertTrue(inode.getXAttrFeature() == null,
+          "XAttrFeature should be null for file");
     } finally {
       shutdownCluster();
     }
@@ -1305,7 +1329,8 @@ public class TestExternalStoragePolicySatisfier {
    * 6. Third Datanode replica also should be moved in proper
    * sorage based on policy.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSWhenFileHasLowRedundancyBlocks() throws Exception {
     try {
       config.set(DFSConfigKeys
@@ -1351,7 +1376,8 @@ public class TestExternalStoragePolicySatisfier {
    * 4. Set policy and call satisfyStoragePolicy for file.
    * 5. Block should be moved successfully.
    */
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testSPSWhenFileHasExcessRedundancyBlocks() throws Exception {
     try {
       config.set(DFSConfigKeys
@@ -1378,8 +1404,8 @@ public class TestExternalStoragePolicySatisfier {
       fs.satisfyStoragePolicy(filePath);
       DFSTestUtil.waitExpectedStorageType(filePath.toString(),
           StorageType.ARCHIVE, 3, 60000, hdfsCluster.getFileSystem());
-      assertFalse("Log output does not contain expected log message: ",
-          logs.getOutput().contains("some of the blocks are low redundant"));
+      assertFalse(logs.getOutput().contains("some of the blocks are low redundant"),
+          "Log output does not contain expected log message: ");
     } finally {
       shutdownCluster();
     }
@@ -1388,7 +1414,8 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * Test SPS for empty directory, xAttr should be removed.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSForEmptyDirectory() throws IOException, TimeoutException,
       InterruptedException {
     try {
@@ -1410,7 +1437,8 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * Test SPS for not exist directory.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSForNonExistDirectory() throws Exception {
     try {
       hdfsCluster = startCluster(config, allDiskTypes, NUM_OF_DATANODES,
@@ -1432,7 +1460,8 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * Test SPS for directory tree which doesn't have files.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSWithDirectoryTreeWithoutFile() throws Exception {
     try {
       hdfsCluster = startCluster(config, allDiskTypes, NUM_OF_DATANODES,
@@ -1466,7 +1495,8 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * Test SPS that satisfy the files and then delete the files before start SPS.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSPSSatisfyAndThenDeleteFileBeforeStartSPS() throws Exception {
     try {
       createCluster();
@@ -1505,7 +1535,8 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * Test SPS for directory which has multilevel directories.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMultipleLevelDirectoryForSatisfyStoragePolicy()
       throws Exception {
     try {
@@ -1544,7 +1575,8 @@ public class TestExternalStoragePolicySatisfier {
    * 6. Call SPS for 11-20 files to trigger move block tasks to new DNs
    * 7. Wait for the under replica and SPS tasks completion
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testMoveBlocksWithUnderReplicatedBlocks() throws Exception {
     try {
       config.setInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, 3);
@@ -1606,7 +1638,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testExternalSPSMetrics()
       throws Exception {
 
@@ -1704,20 +1737,19 @@ public class TestExternalStoragePolicySatisfier {
         DEFAULT_BLOCK_SIZE, (short) 3, 0, false, favoredNodes);
 
     LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file1, 0);
-    Assert.assertEquals("Wrong block count", 1,
-        locatedBlocks.locatedBlockCount());
+    Assertions.assertEquals(1, locatedBlocks.locatedBlockCount(), "Wrong block count");
 
     // verify storage type before movement
     LocatedBlock lb = locatedBlocks.get(0);
     StorageType[] storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assert.assertTrue(StorageType.DISK == storageType);
+      Assertions.assertTrue(StorageType.DISK == storageType);
     }
 
     // Mock FsDatasetSpi#getPinning to show that the block is pinned.
     DatanodeInfo[] locations = lb.getLocations();
-    Assert.assertEquals(3, locations.length);
-    Assert.assertTrue(favoredNodesCount < locations.length);
+    Assertions.assertEquals(3, locations.length);
+    Assertions.assertTrue(favoredNodesCount < locations.length);
     for(DatanodeInfo dnInfo: locations){
       LOG.info("Simulate block pinning in datanode {}",
           locations[favoredNodesCount]);
@@ -1822,7 +1854,8 @@ public class TestExternalStoragePolicySatisfier {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testExternalSPSMetricsExposedToJMX() throws Exception {
     try {
       createCluster();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
@@ -39,6 +39,7 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_DATA_TRANSF
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.XATTR_SATISFY_STORAGE_POLICY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
@@ -97,7 +98,6 @@ import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
@@ -297,7 +297,7 @@ public class TestExternalStoragePolicySatisfier {
     baseDir = GenericTestUtils
         .getTestDir(TestExternalStoragePolicySatisfier.class.getSimpleName());
     FileUtil.fullyDelete(baseDir);
-    Assertions.assertTrue(baseDir.mkdirs());
+    assertTrue(baseDir.mkdirs());
 
     Properties kdcConf = MiniKdc.createConf();
     kdc = new MiniKdc(kdcConf, baseDir);
@@ -307,7 +307,7 @@ public class TestExternalStoragePolicySatisfier {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
     KerberosName.resetDefaultRealm();
-    Assertions.assertTrue(UserGroupInformation.isSecurityEnabled(),
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
         "Expected configuration to enable security");
 
     keytabFile = new File(baseDir, username + ".keytab");
@@ -367,7 +367,7 @@ public class TestExternalStoragePolicySatisfier {
           // verify that sps runs Ok.
           testWhenStoragePolicySetToALLSSD();
           // verify that UGI was logged in using keytab.
-          Assertions.assertTrue(UserGroupInformation.isLoginKeytabBased());
+          assertTrue(UserGroupInformation.isLoginKeytabBased());
           return null;
         }
       });
@@ -409,7 +409,7 @@ public class TestExternalStoragePolicySatisfier {
       writeContent(fileExceeds);
       try {
         fs.satisfyStoragePolicy(new Path(fileExceeds));
-        Assertions.fail("Should throw exception as it exceeds "
+        fail("Should throw exception as it exceeds "
             + "outstanding SPS call Q limit");
       } catch (IOException ioe) {
         GenericTestUtils.assertExceptionContains(
@@ -436,7 +436,7 @@ public class TestExternalStoragePolicySatisfier {
           HdfsServerConstants.MOVER_ID_PATH, 0, (short) 1, 0);
       restartNamenode();
       boolean running = externalCtxt.isRunning();
-      Assertions.assertTrue(running, "SPS should be running as " + "no Mover really running");
+      assertTrue(running, "SPS should be running as " + "no Mover really running");
     } finally {
       shutdownCluster();
     }
@@ -808,7 +808,7 @@ public class TestExternalStoragePolicySatisfier {
 
       try {
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
-        Assertions.fail(String.format(
+        fail(String.format(
             "Should failed to satisfy storage policy "
                 + "for %s since %s is set to false.",
             FILE, DFS_STORAGE_POLICY_ENABLED_KEY));
@@ -825,7 +825,7 @@ public class TestExternalStoragePolicySatisfier {
       hdfsAdmin = new HdfsAdmin(FileSystem.getDefaultUri(config), config);
       try {
         hdfsAdmin.satisfyStoragePolicy(new Path(nonExistingFile));
-        Assertions.fail("Should throw FileNotFoundException for " +
+        fail("Should throw FileNotFoundException for " +
             nonExistingFile);
       } catch (FileNotFoundException e) {
 
@@ -835,7 +835,7 @@ public class TestExternalStoragePolicySatisfier {
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
         hdfsAdmin.satisfyStoragePolicy(new Path(FILE));
       } catch (Exception e) {
-        Assertions.fail(String.format("Allow to invoke mutlipe times "
+        fail(String.format("Allow to invoke mutlipe times "
             + "#satisfyStoragePolicy() api for a path %s , internally just "
             + "skipping addtion to satisfy movement queue.", FILE));
       }
@@ -1275,7 +1275,7 @@ public class TestExternalStoragePolicySatisfier {
           client.getBlockLocations(testFile, 0, fileLen);
       for (LocatedBlock lb : locatedBlocks.getLocatedBlocks()) {
         for (StorageType type : lb.getStorageTypes()) {
-          Assertions.assertEquals(StorageType.DISK, type);
+          assertEquals(StorageType.DISK, type);
         }
       }
 
@@ -1307,11 +1307,11 @@ public class TestExternalStoragePolicySatisfier {
           .getEditLog();
       long lastWrittenTxId = editlog.getLastWrittenTxId();
       fs.satisfyStoragePolicy(filePath);
-      Assertions.assertEquals(lastWrittenTxId, editlog.getLastWrittenTxId(),
+      assertEquals(lastWrittenTxId, editlog.getLastWrittenTxId(),
           "Xattr should not be added for the file");
       INode inode = hdfsCluster.getNameNode().getNamesystem().getFSDirectory()
           .getINode(filePath.toString());
-      Assertions.assertTrue(inode.getXAttrFeature() == null,
+      assertTrue(inode.getXAttrFeature() == null,
           "XAttrFeature should be null for file");
     } finally {
       shutdownCluster();
@@ -1737,19 +1737,19 @@ public class TestExternalStoragePolicySatisfier {
         DEFAULT_BLOCK_SIZE, (short) 3, 0, false, favoredNodes);
 
     LocatedBlocks locatedBlocks = dfs.getClient().getLocatedBlocks(file1, 0);
-    Assertions.assertEquals(1, locatedBlocks.locatedBlockCount(), "Wrong block count");
+    assertEquals(1, locatedBlocks.locatedBlockCount(), "Wrong block count");
 
     // verify storage type before movement
     LocatedBlock lb = locatedBlocks.get(0);
     StorageType[] storageTypes = lb.getStorageTypes();
     for (StorageType storageType : storageTypes) {
-      Assertions.assertTrue(StorageType.DISK == storageType);
+      assertTrue(StorageType.DISK == storageType);
     }
 
     // Mock FsDatasetSpi#getPinning to show that the block is pinned.
     DatanodeInfo[] locations = lb.getLocations();
-    Assertions.assertEquals(3, locations.length);
-    Assertions.assertTrue(favoredNodesCount < locations.length);
+    assertEquals(3, locations.length);
+    assertTrue(favoredNodesCount < locations.length);
     for(DatanodeInfo dnInfo: locations){
       LOG.info("Simulate block pinning in datanode {}",
           locations[favoredNodesCount]);


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part16.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

