### PR TITLE
Add Retries for InputStream exceptions on Analytics Stream

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -216,7 +216,7 @@
     <aws-java-sdk.version>1.12.720</aws-java-sdk.version>
     <aws-java-sdk-v2.version>2.29.52</aws-java-sdk-v2.version>
     <amazon-s3-encryption-client-java.version>3.1.1</amazon-s3-encryption-client-java.version>
-    <amazon-s3-analyticsaccelerator-s3.version>1.2.1</amazon-s3-analyticsaccelerator-s3.version>
+    <amazon-s3-analyticsaccelerator-s3.version>1.3.0</amazon-s3-analyticsaccelerator-s3.version>
     <aws.eventstream.version>1.0.1</aws.eventstream.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AnalyticsStreamRetryPolicy.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/AnalyticsStreamRetryPolicy.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.HttpChannelEOFException;
+import org.apache.hadoop.fs.s3a.S3ARetryPolicy;
+import org.apache.hadoop.net.ConnectTimeoutException;
+import software.amazon.s3.analyticsaccelerator.util.retry.DefaultRetryStrategyImpl;
+import software.amazon.s3.analyticsaccelerator.util.retry.RetryPolicy;
+import software.amazon.s3.analyticsaccelerator.util.retry.RetryStrategy;
+
+import java.io.EOFException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+import static org.apache.hadoop.fs.s3a.Constants.RETRY_LIMIT;
+import static org.apache.hadoop.fs.s3a.Constants.RETRY_LIMIT_DEFAULT;
+
+public class AnalyticsStreamRetryPolicy extends S3ARetryPolicy {
+
+  private final RetryStrategy strategy;
+
+  /**
+   * Instantiate.
+   *
+   * @param conf configuration to read.
+   */
+  public AnalyticsStreamRetryPolicy(Configuration conf) {
+    super(conf);
+    int limit = conf.getInt(RETRY_LIMIT, RETRY_LIMIT_DEFAULT);
+
+    RetryPolicy connectivityFailure = connectivityFailure(limit);
+    this.strategy = new DefaultRetryStrategyImpl(connectivityFailure);
+  }
+
+  public RetryStrategy getAnalyticsRetryStrategy() {
+    return this.strategy;
+  }
+
+  private RetryPolicy connectivityFailure(int limit) {
+    List<Class<? extends Throwable>> retryableExceptions = ImmutableList.of(
+        HttpChannelEOFException.class,
+        ConnectTimeoutException.class,
+        ConnectException.class,
+        EOFException.class,
+        SocketException.class,
+        SocketTimeoutException.class
+    );
+
+    return RetryPolicy.builder().handle(retryableExceptions).withMaxRetries(limit).build();
+  }
+
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AInputPolicy;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
+import software.amazon.s3.analyticsaccelerator.util.retry.RetryStrategy;
 import org.apache.hadoop.fs.FileRange;
 import org.apache.hadoop.fs.VectoredReadUtils;
 
@@ -64,11 +65,12 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   public static final Logger LOG = LoggerFactory.getLogger(AnalyticsStream.class);
 
   public AnalyticsStream(final ObjectReadParameters parameters,
-      final S3SeekableInputStreamFactory s3SeekableInputStreamFactory) throws IOException {
+                         final S3SeekableInputStreamFactory s3SeekableInputStreamFactory,
+                         final RetryStrategy retryStrategy) throws IOException {
     super(InputStreamType.Analytics, parameters);
     S3ObjectAttributes s3Attributes = parameters.getObjectAttributes();
     this.inputStream = s3SeekableInputStreamFactory.createStream(S3URI.of(s3Attributes.getBucket(),
-        s3Attributes.getKey()), buildOpenStreamInformation(parameters));
+        s3Attributes.getKey()), buildOpenStreamInformation(parameters, retryStrategy));
     getS3AStreamStatistics().streamOpened(InputStreamType.Analytics);
   }
 
@@ -241,7 +243,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
     this.close();
   }
 
-  private OpenStreamInformation buildOpenStreamInformation(ObjectReadParameters parameters) {
+  private OpenStreamInformation buildOpenStreamInformation(ObjectReadParameters parameters,
+                                                           RetryStrategy retries) {
     OpenStreamInformation.OpenStreamInformationBuilder openStreamInformationBuilder =
         OpenStreamInformation.builder()
             .inputPolicy(mapS3AInputPolicyToAAL(parameters.getContext()
@@ -251,6 +254,10 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()
           .contentLength(parameters.getObjectAttributes().getLen())
           .etag(parameters.getObjectAttributes().getETag()).build());
+    }
+
+    if(retries != null) {
+      openStreamInformationBuilder.retryStrategy(retries);
     }
 
     return openStreamInformationBuilder.build();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.s3a.impl.streams;
 
 import java.io.IOException;
 
+import org.apache.hadoop.fs.s3a.impl.AnalyticsStreamRetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
@@ -47,6 +48,7 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
 
   private S3SeekableInputStreamConfiguration seekableInputStreamConfiguration;
   private LazyAutoCloseableReference<S3SeekableInputStreamFactory>  s3SeekableInputStreamFactory;
+  private AnalyticsStreamRetryPolicy retryPolicy;
   private boolean requireCrt;
 
   public AnalyticsStreamFactory() {
@@ -61,6 +63,7 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
     this.seekableInputStreamConfiguration =
                 S3SeekableInputStreamConfiguration.fromConfiguration(configuration);
     this.requireCrt = false;
+    this.retryPolicy = new AnalyticsStreamRetryPolicy(conf);
   }
 
   @Override
@@ -74,7 +77,7 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
   public ObjectInputStream readObject(final ObjectReadParameters parameters) throws IOException {
     return new AnalyticsStream(
                 parameters,
-                getOrCreateS3SeekableInputStreamFactory());
+                getOrCreateS3SeekableInputStreamFactory(), retryPolicy.getAnalyticsRetryStrategy());
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestAnalyticsInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestAnalyticsInputStreamRetry.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import org.apache.hadoop.fs.s3a.impl.streams.AnalyticsStreamFactory;
+import org.apache.hadoop.fs.s3a.impl.streams.FactoryBindingParameters;
+import org.apache.hadoop.fs.s3a.impl.streams.ObjectInputStreamFactory;
+import org.apache.hadoop.service.CompositeService;
+import org.junit.jupiter.api.BeforeEach;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.fs.s3a.Constants.FS_S3A;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+public class TestAnalyticsInputStreamRetry extends TestS3AInputStreamRetry {
+
+  protected S3AsyncClient s3Async;
+  private FlakyS3StoreImpl s3Store;
+
+  @BeforeEach
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    conf = createConfiguration();
+    fs = new S3AFileSystem();
+    URI uri = URI.create(FS_S3A + "://" + BUCKET);
+    // unset S3CSE property from config to avoid pathIOE.
+    conf.unset(Constants.S3_ENCRYPTION_ALGORITHM);
+    conf.set(Constants.INPUT_STREAM_TYPE, Constants.INPUT_STREAM_TYPE_ANALYTICS);
+    fs.initialize(uri, conf);
+    s3Async = fs.getS3AInternals().getStore().getOrCreateAsyncClient();
+    s3Store = new FlakyS3StoreImpl();
+
+  }
+
+  @Override
+  protected ObjectInputStreamFactory getFactory() throws IOException {
+    return s3Store.getFactory();
+  }
+
+
+  private class FlakyS3StoreImpl extends CompositeService {
+    ObjectInputStreamFactory factory;
+
+    public FlakyS3StoreImpl() throws Exception {
+      super("FlakyS3Store");
+      this.factory = new AnalyticsStreamFactory();
+      addService(factory);
+      super.serviceInit(conf);
+      factory.bind(new FactoryBindingParameters(new FlakyCallbacks()));
+    }
+
+    public ObjectInputStreamFactory getFactory() {
+      return factory;
+    }
+
+  }
+  /**
+   * Callbacks from {@link ObjectInputStreamFactory} instances.
+   * Will throw connection exception twice on client.getObject() and succeed third time.
+   */
+  private class FlakyCallbacks implements ObjectInputStreamFactory.StreamFactoryCallbacks {
+    AtomicInteger attempts = new AtomicInteger(0);
+    AtomicInteger fail = new AtomicInteger(2);
+    ConnectException exception = new ConnectException("Mock Connection Exception");
+    @Override
+    public S3AsyncClient getOrCreateAsyncClient(final boolean requireCRT) throws IOException {
+      S3AsyncClientWrapper flakyClient = spy(new S3AsyncClientWrapper(s3Async));
+      doAnswer(
+          invocation ->
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    try {
+                      InputStream flakyInputStream =
+                          mockedInputStream(GetObjectResponse.builder().build(),
+                              attempts.incrementAndGet() < fail.get(),
+                              exception);
+
+                      return new ResponseInputStream<>(
+                          GetObjectResponse.builder().build(), flakyInputStream);
+                    } catch (Throwable e) {
+                      throw new RuntimeException(e);
+                    }
+                  }))
+          .when(flakyClient)
+          .getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class));
+      return flakyClient;
+    }
+
+    @Override
+    public void incrementFactoryStatistic(Statistic statistic) {
+    }
+  }
+  /** Wrapper for S3 Async client, used to mock input stream
+   * returned by the S3 Async client.
+   */
+  public static class S3AsyncClientWrapper implements S3AsyncClient {
+
+    private final S3AsyncClient delegate;
+
+    public S3AsyncClientWrapper(S3AsyncClient delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String serviceName() {
+      return delegate.serviceName();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public <ReturnT> CompletableFuture<ReturnT> getObject(
+        GetObjectRequest getObjectRequest,
+        AsyncResponseTransformer<GetObjectResponse, ReturnT> asyncResponseTransformer) {
+      return delegate.getObject(getObjectRequest, asyncResponseTransformer);
+    }
+
+    @Override
+    public CompletableFuture<HeadObjectResponse> headObject(HeadObjectRequest headObjectRequest) {
+      return delegate.headObject(headObjectRequest);
+    }
+
+    @Override
+    public CompletableFuture<PutObjectResponse> putObject(
+        PutObjectRequest putObjectRequest, AsyncRequestBody requestBody) {
+      return delegate.putObject(putObjectRequest, requestBody);
+    }
+
+    @Override
+    public CompletableFuture<CreateBucketResponse> createBucket(
+        CreateBucketRequest createBucketRequest) {
+      return delegate.createBucket(createBucketRequest);
+    }
+
+    @Override
+    public S3ServiceClientConfiguration serviceClientConfiguration() {
+      return delegate.serviceClientConfiguration();
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AInputStreamRetry.java
@@ -25,7 +25,9 @@ import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-
+import org.apache.hadoop.fs.s3a.impl.streams.ObjectInputStream;
+import org.apache.hadoop.fs.s3a.impl.streams.ObjectInputStreamFactory;
+import org.apache.hadoop.fs.s3a.impl.streams.StreamIntegration;
 import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -68,6 +70,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
    * Test input stream content: charAt(x) == hex value of x.
    */
   private static final String INPUT = "012345678ABCDEF";
+  private static ObjectInputStreamFactory factory = null;
 
   /**
    * Status code to raise by default.
@@ -76,7 +79,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
 
   @Test
   public void testInputStreamReadRetryForException() throws IOException {
-    S3AInputStream s3AInputStream = getMockedS3AInputStream(failingInputStreamCallbacks(
+    ObjectInputStream s3AInputStream = getMockedInputStream(failingInputStreamCallbacks(
         awsServiceException(STATUS)));
     assertEquals(INPUT.charAt(0), s3AInputStream.read(),
         "'0' from the test input stream should be the first " +
@@ -89,7 +92,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   @Test
   public void testInputStreamReadLengthRetryForException() throws IOException {
     byte[] result = new byte[INPUT.length()];
-    S3AInputStream s3AInputStream = getMockedS3AInputStream(
+    ObjectInputStream s3AInputStream = getMockedInputStream(
         failingInputStreamCallbacks(awsServiceException(STATUS)));
     s3AInputStream.read(result, 0, INPUT.length());
 
@@ -101,7 +104,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   @Test
   public void testInputStreamReadFullyRetryForException() throws IOException {
     byte[] result = new byte[INPUT.length()];
-    S3AInputStream s3AInputStream = getMockedS3AInputStream(failingInputStreamCallbacks(
+    ObjectInputStream s3AInputStream = getMockedInputStream(failingInputStreamCallbacks(
         awsServiceException(STATUS)));
     s3AInputStream.readFully(0, result);
 
@@ -118,7 +121,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   public void testReadMultipleSeeksNoHttpResponse() throws Throwable {
     final RuntimeException ex = sdkClientException(new NoHttpResponseException("no response"));
     // fail on even reads
-    S3AInputStream stream = getMockedS3AInputStream(
+    ObjectInputStream stream = getMockedInputStream(
         maybeFailInGetCallback(ex, (index) -> (index % 2 == 0)));
     // 10 reads with repeated failures.
     for (int i = 0; i < 10; i++) {
@@ -136,7 +139,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
   public void testReadMultipleSeeksStreamClosed() throws Throwable {
     final RuntimeException ex = sdkClientException(new NoHttpResponseException("no response"));
     // fail on even reads
-    S3AInputStream stream = getMockedS3AInputStream(
+    ObjectInputStream stream = getMockedInputStream(
         maybeFailInGetCallback(ex, (index) -> (index % 2 == 0)));
     // 10 reads with repeated failures.
     for (int i = 0; i < 10; i++) {
@@ -167,8 +170,8 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
    * @param streamCallback callback to use on GET calls
    * @return a stream.
    */
-  private S3AInputStream getMockedS3AInputStream(
-      ObjectInputStreamCallbacks streamCallback) {
+  private ObjectInputStream getMockedInputStream(
+      ObjectInputStreamCallbacks streamCallback) throws IOException {
     Path path = new Path("test-path");
     String eTag = "test-etag";
     String versionId = "test-version-id";
@@ -198,8 +201,15 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
         .withStreamStatistics(
             s3AReadOpContext.getS3AStatisticsContext().newInputStreamStatistics())
         .withBoundedThreadPool(null);
+    ObjectInputStreamFactory factory = getFactory();
+    return factory.readObject(parameters);
+  }
 
-    return new S3AInputStream(parameters);
+  protected ObjectInputStreamFactory getFactory() throws IOException {
+    if (factory == null) {
+      factory = StreamIntegration.factoryFromConfig(conf);
+    }
+    return factory;
   }
 
   /**
@@ -240,7 +250,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
 
   /**
    * Create mocked InputStreamCallbacks which returns a mocked S3Object and fails
-   * when the the predicate indicates that it should.
+   * when the predicate indicates that it should.
    * The stream response itself does not fail.
    * @param ex exception to raise on failure
    * @return mocked object.
@@ -339,7 +349,7 @@ public class TestS3AInputStreamRetry extends AbstractS3AMockTest {
    * @param ioe exception to raise
    * @return mocked object.
    */
-  private ResponseInputStream<GetObjectResponse> mockedInputStream(
+  protected ResponseInputStream<GetObjectResponse> mockedInputStream(
       GetObjectResponse objectResponse,
       boolean triggerFailure,
       final IOException ioe) {


### PR DESCRIPTION
### Description of PR
This PR enables Analytics Stream to retry connection failures on stream from S3 to AAL up to `fs.s3a.retry.limit` times. 
Note on idempotancy:  As AAL maintains an internal state of stream, it handles re-opening stream from the blocks that are not filled yet on its own. This PR adds that logic to PhysicalIO: https://github.com/awslabs/analytics-accelerator-s3/pull/340

### How was this patch tested?
Added new tests with FlakyAsynClient that throws exception twice and succeeds at the third call. 

### For code changes:
There is no Jira item for this task. 

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [N/A ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

