### PR TITLE
WIP. Provide hadoop dev contianer Dockerfile for riscv64

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -37,7 +37,7 @@ On Linux / Mac:
         Note:
           CPU arch emulation may have significant performance overhead.
           To enable cross-platform container support, run this command first:
-          $ docker run --rm --privileged tonistiigi/binfmt --install amd64,arm64
+          $ docker run --rm --privileged tonistiigi/binfmt --install amd64,arm64,riscv64
           To run an x86_64 container on arm machine, use this command:
           $ CPU_ARCH=x86_64 ./start-build-env.sh ubuntu_24
 

--- a/dev-support/docker/Dockerfile_ubuntu_24_riscv64
+++ b/dev-support/docker/Dockerfile_ubuntu_24_riscv64
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for installing the necessary dependencies for building Hadoop.
+# See BUILDING.txt.
+
+FROM ubuntu:noble
+
+WORKDIR /root
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+#####
+# Disable suggests/recommends
+#####
+RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
+RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_TERSE=true
+
+######
+# Platform package dependency resolver
+######
+COPY pkg-resolver pkg-resolver
+RUN chmod a+x pkg-resolver/*.sh pkg-resolver/*.py \
+    && chmod a+r pkg-resolver/*.json
+
+######
+# Install packages from apt
+######
+# hadolint ignore=DL3008,SC2046
+RUN apt-get -q update \
+    && apt-get -q install -y --no-install-recommends wget apt-transport-https gpg gpg-agent gawk ca-certificates \
+    && apt-get -q install -y --no-install-recommends python3 pylint python3-dateutil \
+    && apt-get -q install -y --no-install-recommends $(pkg-resolver/resolve.py ubuntu:noble::riscv64) \
+    && apt-get clean \
+    && update-java-alternatives -s java-1.17.0-openjdk-riscv64 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV PYTHONIOENCODING=utf-8
+
+######
+# Set env vars required to build Hadoop
+######
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
+# JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-riscv64
+
+#######
+# Set env vars for SpotBugs 4.2.2
+#######
+ENV SPOTBUGS_HOME=/opt/spotbugs
+
+#######
+# Set env vars for Google Protobuf 3.25.5
+#######
+ENV PROTOBUF_HOME=/opt/protobuf
+ENV PATH="${PATH}:/opt/protobuf/bin"
+
+###
+# Avoid out of memory errors in builds
+###
+ENV MAVEN_OPTS="-Xms256m -Xmx3072m"
+
+# Skip gpg verification when downloading Yetus via yetus-wrapper
+ENV HADOOP_SKIP_YETUS_VERIFICATION=true
+
+####
+# Install packages
+####
+RUN pkg-resolver/install-maven.sh ubuntu:noble::riscv64
+RUN pkg-resolver/install-spotbugs.sh ubuntu:noble::riscv64
+RUN pkg-resolver/install-boost.sh ubuntu:noble::riscv64
+RUN pkg-resolver/install-protobuf.sh ubuntu:noble::riscv64
+RUN pkg-resolver/install-hadolint.sh ubuntu:noble::riscv64
+
+###
+# Everything past this point is either not needed for testing or breaks Yetus.
+# So tell Yetus not to read the rest of the file:
+# YETUS CUT HERE
+###
+
+# Add a welcome message and environment checks.
+COPY hadoop_env_checks.sh /root/hadoop_env_checks.sh
+RUN chmod 755 /root/hadoop_env_checks.sh
+# hadolint ignore=SC2016
+RUN echo '${HOME}/hadoop_env_checks.sh' >> /root/.bashrc

--- a/dev-support/docker/hadoop_env_checks.sh
+++ b/dev-support/docker/hadoop_env_checks.sh
@@ -110,8 +110,31 @@ End-of-message
 
 # -------------------------------------------------------
 
+function showTips {
+    CPU_ARCH=$(uname -m)
+    if [[ "$CPU_ARCH" == "riscv64" ]]; then
+        cat <<End-of-message
+
+You must install 'com.google.protobuf:protoc:exe:linux-riscv64:3.25.5'
+into maven local repository (~/.m2) manually on riscv64 platform.
+
+  mvn install:install-file \\
+    -DgroupId=com.google.protobuf \\
+    -DartifactId=protoc \\
+    -Dversion=3.25.5 \\
+    -Dclassifier=linux-riscv64 \\
+    -Dpackaging=exe \\
+    -Dfile=${PROTOBUF_HOME}/bin/protoc
+
+End-of-message
+    fi
+}
+
+# -------------------------------------------------------
+
 showWelcome
 warnIfLowMemory
 failIfUserIsRoot
+showTips
 
 # -------------------------------------------------------

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -7,6 +7,7 @@
     "ubuntu:focal::arch64": "ant",
     "ubuntu:noble": "ant",
     "ubuntu:noble::arch64": "ant",
+    "ubuntu:noble::riscv64": "ant",
     "rockylinux:8": "ant"
   },
   "apt-utils": {
@@ -16,6 +17,7 @@
     "ubuntu:focal": "apt-utils",
     "ubuntu:noble": "apt-utils",
     "ubuntu:noble::arch64": "apt-utils",
+    "ubuntu:noble::riscv64": "apt-utils",
     "ubuntu:focal::arch64": "apt-utils"
   },
   "automake": {
@@ -25,6 +27,7 @@
     "ubuntu:focal": "automake",
     "ubuntu:noble": "automake",
     "ubuntu:noble::arch64": "automake",
+    "ubuntu:noble::riscv64": "automake",
     "ubuntu:focal::arch64": "automake",
     "rockylinux:8": "automake"
   },
@@ -35,6 +38,7 @@
     "ubuntu:focal": "bats",
     "ubuntu:noble": "bats",
     "ubuntu:noble::arch64": "bats",
+    "ubuntu:noble::riscv64": "bats",
     "ubuntu:focal::arch64": "bats",
     "rockylinux:8": "bats"
   },
@@ -45,6 +49,7 @@
     "ubuntu:focal": "build-essential",
     "ubuntu:noble": "build-essential",
     "ubuntu:noble::arch64": "build-essential",
+    "ubuntu:noble::riscv64": "build-essential",
     "ubuntu:focal::arch64": "build-essential"
   },
   "bzip2": {
@@ -72,6 +77,10 @@
       "bzip2",
       "libbz2-dev"
     ],
+    "ubuntu:noble::riscv64": [
+      "bzip2",
+      "libbz2-dev"
+    ],
     "ubuntu:focal::arch64": [
       "bzip2",
       "libbz2-dev"
@@ -88,6 +97,7 @@
     "ubuntu:focal": "clang",
     "ubuntu:noble": "clang",
     "ubuntu:noble::arch64": "clang",
+    "ubuntu:noble::riscv64": "clang",
     "ubuntu:focal::arch64": "clang",
     "rockylinux:8": "clang"
   },
@@ -98,6 +108,7 @@
     "ubuntu:focal": "cmake",
     "ubuntu:noble": "cmake",
     "ubuntu:noble::arch64": "cmake",
+    "ubuntu:noble::riscv64": "cmake",
     "ubuntu:focal::arch64": "cmake"
   },
   "curl": {
@@ -125,6 +136,10 @@
       "curl",
       "libcurl4-openssl-dev"
     ],
+    "ubuntu:noble::riscv64": [
+      "curl",
+      "libcurl4-openssl-dev"
+    ],
     "ubuntu:focal::arch64": [
       "curl",
       "libcurl4-openssl-dev"
@@ -141,6 +156,7 @@
     "ubuntu:focal": "doxygen",
     "ubuntu:noble": "doxygen",
     "ubuntu:noble::arch64": "doxygen",
+    "ubuntu:noble::riscv64": "doxygen",
     "ubuntu:focal::arch64": "doxygen"
   },
   "dnf": {
@@ -168,6 +184,10 @@
       "libfuse-dev"
     ],
     "ubuntu:noble::arch64": [
+      "fuse",
+      "libfuse-dev"
+    ],
+    "ubuntu:noble::riscv64": [
       "fuse",
       "libfuse-dev"
     ],
@@ -208,6 +228,10 @@
       "gcc",
       "g++"
     ],
+    "ubuntu:noble::riscv64": [
+      "gcc",
+      "g++"
+    ],
     "ubuntu:focal::arch64": [
       "gcc",
       "g++"
@@ -220,6 +244,7 @@
     "ubuntu:focal": "git",
     "ubuntu:noble": "git",
     "ubuntu:noble::arch64": "git",
+    "ubuntu:noble::riscv64": "git",
     "ubuntu:focal::arch64": "git",
     "rockylinux:8": "git"
   },
@@ -230,6 +255,7 @@
     "ubuntu:focal": "gnupg-agent",
     "ubuntu:noble": "gnupg-agent",
     "ubuntu:noble::arch64": "gnupg-agent",
+    "ubuntu:noble::riscv64": "gnupg-agent",
     "ubuntu:focal::arch64": "gnupg-agent"
   },
   "hugo": {
@@ -239,6 +265,7 @@
     "ubuntu:focal": "hugo",
     "ubuntu:noble": "hugo",
     "ubuntu:noble::arch64": "hugo",
+    "ubuntu:noble::riscv64": "hugo",
     "ubuntu:focal::arch64": "hugo"
   },
   "libbcprov-java": {
@@ -248,6 +275,7 @@
     "ubuntu:focal": "libbcprov-java",
     "ubuntu:noble": "libbcprov-java",
     "ubuntu:noble::arch64": "libbcprov-java",
+    "ubuntu:noble::riscv64": "libbcprov-java",
     "ubuntu:focal::arch64": "libbcprov-java"
   },
   "libtool": {
@@ -257,6 +285,7 @@
     "ubuntu:focal": "libtool",
     "ubuntu:noble": "libtool",
     "ubuntu:noble::arch64": "libtool",
+    "ubuntu:noble::riscv64": "libtool",
     "ubuntu:focal::arch64": "libtool",
     "rockylinux:8": "libtool"
   },
@@ -267,6 +296,7 @@
     "ubuntu:focal": "libssl-dev",
     "ubuntu:noble": "libssl-dev",
     "ubuntu:noble::arch64": "libssl-dev",
+    "ubuntu:noble::riscv64": "libssl-dev",
     "ubuntu:focal::arch64": "libssl-dev",
     "rockylinux:8": "openssl-devel"
   },
@@ -301,6 +331,10 @@
       "libprotobuf-dev",
       "libprotoc-dev"
     ],
+    "ubuntu:noble::riscv64": [
+      "libprotobuf-dev",
+      "libprotoc-dev"
+    ],
     "ubuntu:focal::arch64": [
       "libprotobuf-dev",
       "libprotoc-dev"
@@ -318,6 +352,7 @@
     "ubuntu:focal": "libsasl2-dev",
     "ubuntu:noble": "libsasl2-dev",
     "ubuntu:noble::arch64": "libsasl2-dev",
+    "ubuntu:noble::riscv64": "libsasl2-dev",
     "ubuntu:focal::arch64": "libsasl2-dev",
     "rockylinux:8": "cyrus-sasl-devel"
   },
@@ -328,6 +363,7 @@
     "ubuntu:focal": "libsnappy-dev",
     "ubuntu:noble": "libsnappy-dev",
     "ubuntu:noble::arch64": "libsnappy-dev",
+    "ubuntu:noble::riscv64": "libsnappy-dev",
     "ubuntu:focal::arch64": "libsnappy-dev"
   },
   "zlib": {
@@ -355,6 +391,10 @@
       "libzstd-dev",
       "zlib1g-dev"
     ],
+    "ubuntu:noble::riscv64": [
+      "libzstd-dev",
+      "zlib1g-dev"
+    ],
     "ubuntu:focal::arch64": [
       "libzstd-dev",
       "zlib1g-dev"
@@ -371,6 +411,7 @@
     "ubuntu:focal": "locales",
     "ubuntu:noble": "locales",
     "ubuntu:noble::arch64": "locales",
+    "ubuntu:noble::riscv64": "locales",
     "ubuntu:focal::arch64": "locales"
   },
   "libtirpc-devel": {
@@ -378,7 +419,8 @@
     "debian:13": "libtirpc-dev",
     "rockylinux:8": "libtirpc-devel",
     "ubuntu:noble": "libtirpc-dev",
-    "ubuntu:noble::arch64": "libtirpc-dev"
+    "ubuntu:noble::arch64": "libtirpc-dev",
+    "ubuntu:noble::riscv64": "libtirpc-dev"
   },
   "make": {
     "debian:11": "make",
@@ -387,6 +429,7 @@
     "ubuntu:focal": "make",
     "ubuntu:noble": "make",
     "ubuntu:noble::arch64": "make",
+    "ubuntu:noble::riscv64": "make",
     "ubuntu:focal::arch64": "make",
     "rockylinux:8": "make"
   },
@@ -426,6 +469,11 @@
       "openjdk-17-jdk",
       "openjdk-21-jdk"
     ],
+    "ubuntu:noble::riscv64": [
+      "openjdk-17-jdk",
+      "openjdk-21-jdk",
+      "openjdk-25-jdk"
+    ],
     "ubuntu:focal::arch64": [
       "temurin-25-jdk",
       "openjdk-8-jdk",
@@ -441,6 +489,7 @@
     "ubuntu:focal": "pinentry-curses",
     "ubuntu:noble": "pinentry-curses",
     "ubuntu:noble::arch64": "pinentry-curses",
+    "ubuntu:noble::riscv64": "pinentry-curses",
     "ubuntu:focal::arch64": "pinentry-curses",
     "rockylinux:8": "pinentry-curses"
   },
@@ -451,6 +500,7 @@
     "ubuntu:focal": "pkg-config",
     "ubuntu:noble": "pkg-config",
     "ubuntu:noble::arch64": "pkg-config",
+    "ubuntu:noble::riscv64": "pkg-config",
     "ubuntu:focal::arch64": "pkg-config",
     "rockylinux:8": "pkg-config"
   },
@@ -497,6 +547,13 @@
       "python3-setuptools",
       "python3-wheel"
     ],
+    "ubuntu:noble::riscv64": [
+      "python3",
+      "python3-pip",
+      "python3-pkg-resources",
+      "python3-setuptools",
+      "python3-wheel"
+    ],
     "ubuntu:focal::arch64": [
       "python2.7",
       "python3",
@@ -519,6 +576,7 @@
     "ubuntu:focal": "rsync",
     "ubuntu:noble": "rsync",
     "ubuntu:noble::arch64": "rsync",
+    "ubuntu:noble::riscv64": "rsync",
     "ubuntu:focal::arch64": "rsync",
     "rockylinux:8": "rsync"
   },
@@ -529,6 +587,7 @@
     "ubuntu:focal": "shellcheck",
     "ubuntu:noble": "shellcheck",
     "ubuntu:noble::arch64": "shellcheck",
+    "ubuntu:noble::riscv64": "shellcheck",
     "ubuntu:focal::arch64": "shellcheck"
   },
   "shasum": {
@@ -539,6 +598,7 @@
     "ubuntu:focal": "software-properties-common",
     "ubuntu:noble": "software-properties-common",
     "ubuntu:noble::arch64": "software-properties-common",
+    "ubuntu:noble::riscv64": "software-properties-common",
     "ubuntu:focal::arch64": "software-properties-common"
   },
   "sudo": {
@@ -548,6 +608,7 @@
     "ubuntu:focal": "sudo",
     "ubuntu:noble": "sudo",
     "ubuntu:noble::arch64": "sudo",
+    "ubuntu:noble::riscv64": "sudo",
     "ubuntu:focal::arch64": "sudo",
     "rockylinux:8": "sudo"
   },
@@ -568,6 +629,7 @@
     "ubuntu:focal": "yasm",
     "ubuntu:noble": "yasm",
     "ubuntu:noble::arch64": "yasm",
+    "ubuntu:noble::riscv64": "yasm",
     "ubuntu:focal::arch64": "yasm"
   }
 }

--- a/dev-support/docker/pkg-resolver/platforms.json
+++ b/dev-support/docker/pkg-resolver/platforms.json
@@ -3,6 +3,7 @@
   "ubuntu:focal::arch64",
   "ubuntu:noble",
   "ubuntu:noble::arch64",
+  "ubuntu:noble::riscv64",
   "rockylinux:8",
   "debian:11",
   "debian:12",

--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -1152,13 +1152,13 @@
         </plugins>
       </build>
     </profile>
-    <!-- profile to use already generated protobuf code using 2.5.0 for aarch64-->
+    <!-- profile to use already generated protobuf code using 2.5.0 -->
+    <!-- for non-x86_64 platforms, e.g., aarch64, riscv64. -->
     <profile>
-      <id>aarch64</id>
+      <id>non-x86_64</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
         <os>
-          <arch>aarch64</arch>
+          <arch>!x86_64</arch>
         </os>
       </activation>
       <build>
@@ -1200,9 +1200,8 @@
     <profile>
       <id>x86_64</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
         <os>
-          <arch>!aarch64</arch>
+          <arch>x86_64</arch>
         </os>
       </activation>
       <build>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -193,7 +193,7 @@
     <trimStackTrace>false</trimStackTrace>
 
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
+    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-jar-plugin.version>2.5</maven-jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>
     <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
@@ -358,6 +359,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven-install-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -42,6 +42,9 @@ if [[ "$CPU_ARCH" == "x86_64" || "$CPU_ARCH" == "amd64" ]]; then
 elif [[ "$CPU_ARCH" == "aarch64" || "$CPU_ARCH" == "arm64" ]]; then
   DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}_aarch64"
   DOCKER_PLATFORM_ARGS=("--platform" "linux/arm64")
+elif [[ "$CPU_ARCH" == "riscv64" ]]; then
+  DOCKER_FILE="${DOCKER_DIR}/Dockerfile${OS_PLATFORM_SUFFIX}_riscv64"
+  DOCKER_PLATFORM_ARGS=("--platform" "linux/riscv64")
 fi
 
 if [ ! -e "${DOCKER_FILE}" ] ; then


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

I saw that some contributors have started adding riscv64 support. Currently, Hadoop neither has riscv64 CI pipeline nor a dev container, the reviewers are not easy to verify the patch on x86_64 or aarch64 platforms.

This PR proposes to leverage Docker's cross-platform capability to allow running standard dev containers on x86_64 or aarch64 platforms.

### How was this patch tested?

I'm using a MacBook Pro with an M1 Max chip.

```
$ uname -a
Darwin H27212-MAC-01.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:30:29 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6000 arm64
$ docker --version
Docker version 28.3.3, build 980b856
```

Launch Hadoop dev container
```
$ docker run --rm --privileged tonistiigi/binfmt --install riscv64
$ CPU_ARCH=riscv64 ./start-build-env.sh ubuntu_24
...
 => => naming to docker.io/library/hadoop-build_ubuntu_24-501                                                                                                                                                    0.0s

 _   _           _                    ______
| | | |         | |                   |  _  \
| |_| | __ _  __| | ___   ___  _ __   | | | |_____   __
|  _  |/ _` |/ _` |/ _ \ / _ \| '_ \  | | | / _ \ \ / /
| | | | (_| | (_| | (_) | (_) | |_) | | |/ /  __/\ V /
\_| |_/\__,_|\__,_|\___/ \___/| .__/  |___/ \___| \_(_)
                              | |
                              |_|

This is the standard Hadoop Developer build environment.
This has all the right tools installed required to build
Hadoop from source.


You must install 'com.google.protobuf:protoc:exe:linux-riscv64:3.25.5'
into maven local repository (~/.m2) manually on riscv64 platform.

  mvn install:install-file \
    -DgroupId=com.google.protobuf \
    -DartifactId=protoc \
    -Dversion=3.25.5 \
    -Dclassifier=linux-riscv64 \
    -Dpackaging=exe \
    -Dfile=/opt/protobuf/bin/protoc

chengpan@65fadd843df5:~/hadoop$
```

Successfully building hadoop common modules, there are some issues that need to be fixed independently
```
$ mvn clean install -DskipTests -Pnative -pl :hadoop-common -am
```
### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

