### PR TITLE
HADOOP-19594. Bump Maven 3.9.11

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -279,8 +279,7 @@ Maven build goals:
    OWASP's dependency-check plugin will scan the third party dependencies
    of this project for known CVEs (security vulnerabilities against them).
    It will produce a report in target/dependency-check-report.html. To
-   invoke, run 'mvn dependency-check:aggregate'. Note that this plugin
-   requires maven 3.1.1 or greater.
+   invoke, run 'mvn dependency-check:aggregate'.
 
  PMDK library build options:
 
@@ -529,7 +528,7 @@ Requirements:
 
 * Windows 10
 * JDK 1.8
-* Maven 3.0 or later (maven.apache.org)
+* Maven 3.3 or later (maven.apache.org)
 * Boost 1.86.0 (boost.org)
 * Protocol Buffers 3.21.12 (https://github.com/protocolbuffers/protobuf/tags)
 * CMake 3.19 or newer (cmake.org)

--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -121,12 +121,14 @@ pipeline {
             }
 
             steps {
-                withCredentials(getGithubCreds()) {
-                        sh '''#!/usr/bin/env bash
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                    withCredentials(getGithubCreds()) {
+                            sh '''#!/usr/bin/env bash
 
-                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                        "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
-                        '''
+                            chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                            "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
+                            '''
+                    }
                 }
             }
 
@@ -167,12 +169,14 @@ pipeline {
             }
 
             steps {
-                withCredentials(getGithubCreds()) {
-                    sh '''#!/usr/bin/env bash
+                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                    withCredentials(getGithubCreds()) {
+                        sh '''#!/usr/bin/env bash
 
-                    chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
-                    "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
-                    '''
+                        chmod u+x "${SOURCEDIR}/dev-support/jenkins.sh"
+                        "${SOURCEDIR}/dev-support/jenkins.sh" run_ci
+                        '''
+                    }
                 }
             }
 

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -61,7 +61,8 @@ ENV PYTHONIOENCODING=utf-8
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
@@ -88,6 +89,7 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION true
 # Install packages
 ####
 RUN pkg-resolver/install-common-pkgs.sh
+RUN pkg-resolver/install-maven.sh ubuntu:focal
 RUN pkg-resolver/install-spotbugs.sh ubuntu:focal
 RUN pkg-resolver/install-boost.sh ubuntu:focal
 RUN pkg-resolver/install-protobuf.sh ubuntu:focal

--- a/dev-support/docker/Dockerfile_aarch64
+++ b/dev-support/docker/Dockerfile_aarch64
@@ -62,7 +62,8 @@ ENV PYTHONIOENCODING=utf-8
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-arm64
 
@@ -92,6 +93,7 @@ ENV QT_QPA_PLATFORM offscreen
 # Install packages
 ####
 RUN pkg-resolver/install-common-pkgs.sh
+RUN pkg-resolver/install-maven.sh ubuntu:focal::arch64
 RUN pkg-resolver/install-spotbugs.sh ubuntu:focal::arch64
 RUN pkg-resolver/install-boost.sh ubuntu:focal::arch64
 RUN pkg-resolver/install-protobuf.sh ubuntu:focal::arch64

--- a/dev-support/docker/Dockerfile_debian_11
+++ b/dev-support/docker/Dockerfile_debian_11
@@ -54,7 +54,8 @@ RUN apt-get -q update \
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME=/usr
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
@@ -80,6 +81,7 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION=true
 ####
 # Install packages
 ####
+RUN pkg-resolver/install-maven.sh debian:11
 RUN pkg-resolver/install-cmake.sh debian:11
 RUN pkg-resolver/install-spotbugs.sh debian:11
 RUN pkg-resolver/install-boost.sh debian:11

--- a/dev-support/docker/Dockerfile_ubuntu_24
+++ b/dev-support/docker/Dockerfile_ubuntu_24
@@ -61,7 +61,8 @@ ENV PYTHONIOENCODING=utf-8
 ######
 # Set env vars required to build Hadoop
 ######
-ENV MAVEN_HOME /usr
+ENV MAVEN_HOME=/opt/maven
+ENV PATH="${PATH}:${MAVEN_HOME}/bin"
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
@@ -87,6 +88,7 @@ ENV HADOOP_SKIP_YETUS_VERIFICATION true
 ####
 # Install packages
 ####
+RUN pkg-resolver/install-maven.sh ubuntu:noble
 RUN pkg-resolver/install-spotbugs.sh ubuntu:noble
 RUN pkg-resolver/install-boost.sh ubuntu:noble
 RUN pkg-resolver/install-protobuf.sh ubuntu:noble

--- a/dev-support/docker/Dockerfile_windows_10
+++ b/dev-support/docker/Dockerfile_windows_10
@@ -62,8 +62,8 @@ RUN powershell Invoke-WebRequest -URI https://cdn.azul.com/zulu/bin/zulu8.62.0.1
 RUN powershell Expand-Archive -Path $Env:TEMP\zulu8.62.0.19-ca-jdk8.0.332-win_x64.zip -DestinationPath "C:\Java"
 
 # Install Apache Maven.
-RUN powershell Invoke-WebRequest -URI https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip -OutFile $Env:TEMP\apache-maven-3.8.8-bin.zip
-RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.8.8-bin.zip -DestinationPath "C:\Maven"
+RUN powershell Invoke-WebRequest -URI https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -OutFile $Env:TEMP\apache-maven-3.9.11-bin.zip
+RUN powershell Expand-Archive -Path $Env:TEMP\apache-maven-3.9.11-bin.zip -DestinationPath "C:\Maven"
 
 # Install CMake 3.19.0.
 RUN powershell Invoke-WebRequest -URI https://cmake.org/files/v3.19/cmake-3.19.0-win64-x64.zip -OutFile $Env:TEMP\cmake-3.19.0-win64-x64.zip
@@ -141,7 +141,7 @@ ENV MAVEN_OPTS '-Xmx2048M -Xss128M'
 ENV IS_WINDOWS 1
 RUN setx PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 RUN setx PATH "%PATH%;%JAVA_HOME%\bin"
-RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.8.8\bin"
+RUN setx PATH "%PATH%;C:\Maven\apache-maven-3.9.11\bin"
 RUN setx PATH "%PATH%;C:\CMake\cmake-3.19.0-win64-x64\bin"
 RUN setx PATH "%PATH%;C:\ZStd"
 RUN setx PATH "%PATH%;C:\Program Files\Git\usr\bin"

--- a/dev-support/docker/pkg-resolver/install-maven.sh
+++ b/dev-support/docker/pkg-resolver/install-maven.sh
@@ -27,22 +27,22 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-default_version="3.6.3"
+default_version="3.9.11"
 version_to_install=$default_version
 if [ -n "$2" ]; then
   version_to_install="$2"
 fi
 
-if [ "$version_to_install" != "3.6.3" ]; then
+if [ "$version_to_install" != "3.9.11" ]; then
   echo "WARN: Don't know how to install version $version_to_install, installing the default version $default_version instead"
   version_to_install=$default_version
 fi
 
-if [ "$version_to_install" == "3.6.3" ]; then
+if [ "$version_to_install" == "3.9.11" ]; then
   mkdir -p /opt/maven /tmp/maven &&
-    curl -L -s -S https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz \
-      -o /tmp/maven/apache-maven-3.6.3-bin.tar.gz &&
-    tar xzf /tmp/maven/apache-maven-3.6.3-bin.tar.gz --strip-components 1 -C /opt/maven
+    curl -L -s -S https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.tar.gz \
+      -o /tmp/maven/apache-maven-3.9.11-bin.tar.gz &&
+    tar xzf /tmp/maven/apache-maven-3.9.11-bin.tar.gz --strip-components 1 -C /opt/maven
 else
   echo "ERROR: Don't know how to install version $version_to_install"
   exit 1

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -254,12 +254,6 @@
     "ubuntu:focal::arch64": "make",
     "rockylinux:8": "make"
   },
-  "maven": {
-    "debian:11": "maven",
-    "ubuntu:focal": "maven",
-    "ubuntu:noble": "maven",
-    "ubuntu:focal::arch64": "maven"
-  },
   "java": {
     "debian:11": [
       "openjdk-11-jdk",

--- a/hadoop-common-project/hadoop-auth/src/site/markdown/BuildingIt.md
+++ b/hadoop-common-project/hadoop-auth/src/site/markdown/BuildingIt.md
@@ -18,8 +18,8 @@ Hadoop Auth, Java HTTP SPNEGO - Building It
 Requirements
 ------------
 
-* Java 7+
-* Maven 3+
+* JDK 1.8
+* Maven 3.3 or later
 * Kerberos KDC (for running Kerberos test cases)
 
 Building

--- a/pom.xml
+++ b/pom.xml
@@ -617,8 +617,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
              dependencies of this project for known CVEs (security
              vulnerabilities against them). It will produce a report
              in target/dependency-check-report.html. To invoke, run
-             'mvn dependency-check:aggregate'. Note that this plugin
-             requires maven 3.1.1 or greater.
+             'mvn dependency-check:aggregate'.
         -->
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Maven prior 3.8 is EOL, bump Maven from 3.6.3 to the latest 3.9.11

- https://maven.apache.org/docs/3.9.10/release-notes.html
- https://maven.apache.org/docs/3.9.11/release-notes.html

> Maven 3.9.10 now has a far better support if you want to run your builds on Java 24.

This PR also unifies the Maven version in all Dockerfiles.

### How was this patch tested?

CI

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

