### PR TITLE
HADOOP-19659. (Follow-up) Install missing procps for Debian 11 docker image

### DIFF
--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -203,6 +203,9 @@
       "libprotoc-dev"
     ]
   },
+  "procps": {
+    "debian:11": "procps"
+  },
   "sasl": {
     "debian:11": "libsasl2-dev",
     "ubuntu:focal": "libsasl2-dev",


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Fix the issue that `kill` command is not found

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree
[ERROR] Tests run: 5, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.950 s <<< FAILURE! -- in org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree
[ERROR] org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree.testProcessTree -- Time elapsed: 7.534 s <<< ERROR!
java.io.IOException: Cannot run program "kill": error=2, No such file or directory
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at org.apache.hadoop.util.Shell.runCommand(Shell.java:1000)
	at org.apache.hadoop.util.Shell.run(Shell.java:959)
	at org.apache.hadoop.util.Shell$ShellCommandExecutor.execute(Shell.java:1284)
	at org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree.sendSignal(TestProcfsBasedProcessTree.java:857)
	at org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree.destroyProcessTree(TestProcfsBasedProcessTree.java:257)
	at org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree.testProcessTree(TestProcfsBasedProcessTree.java:196)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:340)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:271)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
	... 10 more

```

### How was this patch tested?

```
./start-build-env.sh debian_11
```

```
$ mvn clean install -DskipShade -DskipTests -Pnative
$ mvn -pl :hadoop-yarn-common test -Dtest=hadoop.yarn.util.TestProcfsBasedProcessTree
...
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.064 s -- in org.apache.hadoop.yarn.util.TestProcfsBasedProcessTree
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.306 s
[INFO] Finished at: 2025-09-05T10:14:12Z
[INFO] ------------------------------------------------------------------------
```


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

