### PR TITLE
HDFS-12431. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs Part17.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancer.java
@@ -43,14 +43,14 @@ import java.lang.reflect.Field;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicyWithNodeGroup;
 import org.apache.hadoop.net.NetworkTopologyWithNodeGroup;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 
 import static org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset.CONFIG_PROPERTY_NONDFSUSED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -79,8 +79,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.HadoopIllegalArgumentException;
@@ -128,8 +127,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.Tool;
 import org.slf4j.event.Level;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -162,14 +162,14 @@ public class TestBalancer {
   private AtomicLong startGetBlocksTime;
   private AtomicLong endGetBlocksTime;
 
-  @Before
+  @BeforeEach
   public void setup() {
     numGetBlocksCalls = new AtomicInteger(0);
     startGetBlocksTime = new AtomicLong(Long.MAX_VALUE);
     endGetBlocksTime = new AtomicLong(Long.MIN_VALUE);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -242,8 +242,8 @@ public class TestBalancer {
         UserGroupInformation.AuthenticationMethod.KERBEROS, conf);
     UserGroupInformation.setConfiguration(conf);
     KerberosName.resetDefaultRealm();
-    assertTrue("Expected configuration to enable security",
-        UserGroupInformation.isSecurityEnabled());
+    assertTrue(UserGroupInformation.isSecurityEnabled(),
+        "Expected configuration to enable security");
 
     keytabFile = new File(baseDir, username + ".keytab");
     String keytab = keytabFile.getAbsolutePath();
@@ -282,7 +282,7 @@ public class TestBalancer {
     initConf(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void destroy() throws Exception {
     if (kdc != null) {
       kdc.stop();
@@ -543,7 +543,7 @@ public class TestBalancer {
           break;
         }
       }
-      assertEquals(expectedExcludedNodes,actualExcludedNodeCount);
+      assertEquals(expectedExcludedNodes, actualExcludedNodeCount);
     } while (!balanced);
   }
 
@@ -1044,7 +1044,7 @@ public class TestBalancer {
     tool.setConf(conf);
     final int r = tool.run(args.toArray(new String[0])); // start rebalancing
 
-    assertEquals("Tools should exit 0 on success", 0, r);
+    assertEquals(0, r, "Tools should exit 0 on success");
     waitForHeartBeat(totalDfsUsedSpace, totalCapacity, client, cluster);
     LOG.info("Rebalancing with default ctor.");
     long totalUsedSpace = totalDfsUsedSpace + totalNonDfsUsedSpace;
@@ -1077,7 +1077,8 @@ public class TestBalancer {
     oneNodeTest(conf, false);
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testUnknownDatanodeSimple() throws Exception {
     Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1147,7 +1148,8 @@ public class TestBalancer {
    * Test parse method in Balancer#Cli class with threshold value out of
    * boundaries.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliParseWithThresholdOutOfBoundaries() {
     String parameters[] = new String[] { "-threshold", "0" };
     String reason = "IllegalArgumentException is expected when threshold value"
@@ -1169,7 +1171,8 @@ public class TestBalancer {
 
   /** Test a cluster with even distribution,
    * then a new empty node is added to the cluster*/
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancer0() throws Exception {
     testBalancer0Internal(new HdfsConfiguration());
   }
@@ -1181,7 +1184,8 @@ public class TestBalancer {
   }
 
   /** Test unevenly distributed cluster */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancer1() throws Exception {
     testBalancer1Internal(new HdfsConfiguration());
   }
@@ -1194,21 +1198,25 @@ public class TestBalancer {
         new String[]{RACK0, RACK1});
   }
 
-  @Test(expected=HadoopIllegalArgumentException.class)
+  @Test
   public void testBalancerWithZeroThreadsForMove() throws Exception {
-    Configuration conf = new HdfsConfiguration();
-    conf.setInt(DFSConfigKeys.DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, 0);
-    testBalancer1Internal (conf);
+    assertThrows(HadoopIllegalArgumentException.class, () -> {
+      Configuration conf = new HdfsConfiguration();
+      conf.setInt(DFSConfigKeys.DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, 0);
+      testBalancer1Internal(conf);
+    });
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithNonZeroThreadsForMove() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_DATANODE_BALANCE_MAX_NUM_CONCURRENT_MOVES_KEY, 8);
     testBalancer1Internal(conf);
   }
 
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancer2() throws Exception {
     testBalancer2Internal(new HdfsConfiguration());
   }
@@ -1221,7 +1229,8 @@ public class TestBalancer {
 
   /** Test a cluster with even distribution,
    * then a new node with nonDfsUsed is added to the cluster. */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancer3() throws Exception {
     Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1266,7 +1275,8 @@ public class TestBalancer {
   /**
    * Test parse method in Balancer#Cli class with wrong number of params
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliParseWithWrongParams() {
     String parameters[] = new String[] { "-threshold" };
     String reason =
@@ -1448,14 +1458,15 @@ public class TestBalancer {
       Object hotBlockTimeInterval = field1.get(dispatcher);
       assertEquals(1000, (long)hotBlockTimeInterval);
     } catch (Exception e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 
   /**
    * Verify balancer exits 0 on success.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testExitZeroOnSuccess() throws Exception {
     final Configuration conf = new HdfsConfiguration();
 
@@ -1469,7 +1480,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithExcludeList() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1487,7 +1499,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithExcludeListWithPorts() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1500,7 +1513,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithExcludeList() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1519,7 +1533,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithExcludeListWithPorts() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1532,7 +1547,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list in a file
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithExcludeListInAFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1550,7 +1566,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the exclude list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithExcludeListWithPortsInAFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1563,7 +1580,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithIncludeList() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1580,7 +1598,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithIncludeListWithPorts() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1593,7 +1612,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithIncludeList() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1610,7 +1630,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithIncludeListWithPorts() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1623,7 +1644,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithIncludeListInAFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1640,7 +1662,8 @@ public class TestBalancer {
    * then three nodes are added to the cluster,
    * runs balancer with two of the nodes in the include list
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithIncludeListWithPortsInAFile() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1651,7 +1674,8 @@ public class TestBalancer {
   /**
    * Test a cluster with BlockPlacementPolicyWithNodeGroup
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerCliWithBlockPlacementPolicyWithNodeGroup() throws Exception {
     Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1667,7 +1691,8 @@ public class TestBalancer {
   /**
    * Check that the balancer exits when there is an unfinalized upgrade.
    */
-  @Test(timeout=300000)
+  @Test
+  @Timeout(value = 300)
   public void testBalancerDuringUpgrade() throws Exception {
     final int SEED = 0xFADED;
     Configuration conf = new HdfsConfiguration();
@@ -1737,7 +1762,8 @@ public class TestBalancer {
    * Case-2: When running second balancer 'balancer.id' file exists but the
    * lease doesn't exists. Now, the second balancer should run successfully.
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testManyBalancerSimultaneously() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -1778,25 +1804,25 @@ public class TestBalancer {
         .create(Balancer.BALANCER_ID_PATH, false);
     out.writeBytes(InetAddress.getLocalHost().getHostName());
     out.hflush();
-    assertTrue("'balancer.id' file doesn't exist!",
-        fs.exists(Balancer.BALANCER_ID_PATH));
+    assertTrue(fs.exists(Balancer.BALANCER_ID_PATH),
+        "'balancer.id' file doesn't exist!");
 
     // start second balancer
     final String[] args = { "-policy", "datanode" };
     final Tool tool = new Cli();
     tool.setConf(conf);
     int exitCode = tool.run(args); // start balancing
-    assertEquals("Exit status code mismatches",
-        ExitStatus.IO_EXCEPTION.getExitCode(), exitCode);
+    assertEquals(ExitStatus.IO_EXCEPTION.getExitCode(),
+        exitCode, "Exit status code mismatches");
 
     // Case2: Release lease so that another balancer would be able to
     // perform balancing.
     out.close();
-    assertTrue("'balancer.id' file doesn't exist!",
-        fs.exists(Balancer.BALANCER_ID_PATH));
+    assertTrue(fs.exists(Balancer.BALANCER_ID_PATH),
+        "'balancer.id' file doesn't exist!");
     exitCode = tool.run(args); // start balancing
-    assertEquals("Exit status code mismatches",
-        ExitStatus.SUCCESS.getExitCode(), exitCode);
+    assertEquals(ExitStatus.SUCCESS.getExitCode(), exitCode,
+        "Exit status code mismatches");
   }
 
   public void integrationTestWithStripedFile(Configuration conf) throws Exception {
@@ -1804,7 +1830,8 @@ public class TestBalancer {
     doTestBalancerWithStripedFile(conf);
   }
 
-  @Test(timeout = 200000)
+  @Test
+  @Timeout(value = 200)
   public void testBalancerWithStripedFile() throws Exception {
     Configuration conf = new Configuration();
     initConfWithStripe(conf);
@@ -1960,7 +1987,7 @@ public class TestBalancer {
           cluster.triggerHeartbeats();
           datanodeInfos = client.getDatanodeReport(DatanodeReportType.ALL);
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         long blocksAfterBalancer = 0;
         for (DatanodeInfo dn : datanodeInfos) {
@@ -2006,7 +2033,8 @@ public class TestBalancer {
    * Test Balancer runs fine when logging in with a keytab in kerberized env.
    * Reusing testUnknownDatanode here for basic functionality testing.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBalancerWithKeytabs() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     try {
@@ -2075,15 +2103,15 @@ public class TestBalancer {
         // also includes the time it took to perform the block move ops in the
         // first iteration
         new PortNumberBasedNodes(1, 0, 0), false, false, true, 0.5, null);
-    assertTrue("Number of getBlocks should be not less than " +
-        getBlocksMaxQps, numGetBlocksCalls.get() >= getBlocksMaxQps);
+    assertTrue(numGetBlocksCalls.get() >= getBlocksMaxQps,
+        "Number of getBlocks should be not less than " + getBlocksMaxQps);
     long durationMs = 1 + endGetBlocksTime.get() - startGetBlocksTime.get();
     int durationSec = (int) Math.ceil(durationMs / 1000.0);
     LOG.info("Balancer executed {} getBlocks in {} msec (round up to {} sec)",
         numGetBlocksCalls.get(), durationMs, durationSec);
     long getBlockCallsPerSecond = numGetBlocksCalls.get() / durationSec;
-    assertTrue("Expected balancer getBlocks calls per second <= " +
-        getBlocksMaxQps, getBlockCallsPerSecond <= getBlocksMaxQps);
+    assertTrue(getBlockCallsPerSecond <= getBlocksMaxQps,
+        "Expected balancer getBlocks calls per second <= " + getBlocksMaxQps);
   }
 
   /**
@@ -2091,7 +2119,8 @@ public class TestBalancer {
    * One of three added nodes is excluded in the target nodes list.
    * Balancer should only move blocks to the two included nodes.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerExcludeTargetNodesNoMoveBlock() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -2117,7 +2146,8 @@ public class TestBalancer {
    * Two of three added nodes are included in the target nodes list.
    * Balancer should only move blocks to the included nodes.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerIncludeTargetNodesNoMoveBlock() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -2144,7 +2174,8 @@ public class TestBalancer {
    * Three of three added nodes are included in the target nodes list.
    * Balancer should exit with success code.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerIncludeTargetNodesSuccess() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -2166,7 +2197,8 @@ public class TestBalancer {
    * Test balancer with included source nodes.
    * Since newly added nodes are the only included source nodes no balancing will occur.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerIncludeSourceNodesNoMoveBlock() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -2194,7 +2226,8 @@ public class TestBalancer {
    * Since newly added nodes will not be selected as a source,
    * all nodes will be included in balancing.
    */
-  @Test(timeout=100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerExcludeSourceNodes() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerHttpServer.java
@@ -22,9 +22,9 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
@@ -35,7 +35,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBalancerHttpServer {
   private static final String BASEDIR =
@@ -45,7 +45,7 @@ public class TestBalancerHttpServer {
   private static Configuration conf;
   private static URLConnectionFactory connectionFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new Configuration();
     conf.set(DFSConfigKeys.DFS_HTTP_POLICY_KEY, HttpConfig.Policy.HTTP_ONLY.name());
@@ -60,7 +60,7 @@ public class TestBalancerHttpServer {
     connectionFactory = URLConnectionFactory.newDefaultURLConnectionFactory(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     FileUtil.fullyDelete(new File(BASEDIR));
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerLongRunningTasks.java
@@ -50,8 +50,9 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -77,8 +78,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HEARTBEAT_RECHECK_INTERVAL_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_LAZY_PERSIST_FILE_SCRUB_INTERVAL_SEC;
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Some long running Balancer tasks.
@@ -101,7 +102,7 @@ public class TestBalancerLongRunningTasks {
   private final static Path FILE_PATH = new Path(FILE_NAME);
   private MiniDFSCluster cluster;
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -159,7 +160,8 @@ public class TestBalancerLongRunningTasks {
    * Replica in (DN0,SSD) should not be moved to (DN1,SSD).
    * Otherwise DN1 has 2 replicas.
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testTwoReplicaShouldNotInSameDN() throws Exception {
     final Configuration conf = new HdfsConfiguration();
 
@@ -218,7 +220,8 @@ public class TestBalancerLongRunningTasks {
    * One DN has two files on RAM_DISK, other DN has no files on RAM_DISK.
    * Then verify that the balancer does not migrate files on RAM_DISK across DN.
    */
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testBalancerWithRamDisk() throws Exception {
     final int seed = 0xFADED;
     final short replicationFactor = 1;
@@ -285,7 +288,8 @@ public class TestBalancerLongRunningTasks {
   /**
    * Balancer should not move blocks with size < minBlockSize.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testMinBlockSizeAndSourceNodes() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -405,7 +409,8 @@ public class TestBalancerLongRunningTasks {
    *
    * @throws Exception
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testUpgradeDomainPolicyAfterBalance() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -425,7 +430,8 @@ public class TestBalancerLongRunningTasks {
    *
    * @throws Exception
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testRackPolicyAfterBalance() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -505,7 +511,8 @@ public class TestBalancerLongRunningTasks {
    *
    * @throws Exception
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testBalancerWithPinnedBlocks() throws Exception {
     // This test assumes stick-bit based block pin mechanism available only
     // in Linux/Unix. It can be unblocked on Windows when HDFS-7759 is ready to
@@ -559,7 +566,8 @@ public class TestBalancerLongRunningTasks {
     assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), r);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerWithSortTopNodes() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -666,16 +674,17 @@ public class TestBalancerLongRunningTasks {
     // Hence, overall total blocks moved by HDFS balancer would be either of these 2 options:
     // a) 2 blocks of total size (100B + 100B)
     // b) 3 blocks of total size (50B + 100B + 100B)
-    assertTrue("BalancerResult is not as expected. " + balancerResult,
-        (balancerResult.getBytesAlreadyMoved() == 200
+    assertTrue((balancerResult.getBytesAlreadyMoved() == 200
             && balancerResult.getBlocksMoved() == 2)
             || (balancerResult.getBytesAlreadyMoved() == 250
-            && balancerResult.getBlocksMoved() == 3));
+            && balancerResult.getBlocksMoved() == 3),
+        "BalancerResult is not as expected. " + balancerResult);
     // 100% and 95% used nodes will be balanced, so top used will be 900
     assertEquals(900, maxUsage);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerWithLimitOverUtilizedNum() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     // Init the config (block size to 100)
@@ -762,12 +771,14 @@ public class TestBalancerLongRunningTasks {
       }
       // The maxUsage value is 950, only 100% of the nodes will be balanced
       assertEquals(950, maxUsage);
-      assertTrue("BalancerResult is not as expected. " + balancerResult,
-          (balancerResult.getBytesAlreadyMoved() == 100 && balancerResult.getBlocksMoved() == 1));
+      assertTrue(
+          (balancerResult.getBytesAlreadyMoved() == 100 && balancerResult.getBlocksMoved() == 1),
+          "BalancerResult is not as expected. " + balancerResult);
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerMetricsDuplicate() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     // Init the config (block size to 100)
@@ -824,7 +835,8 @@ public class TestBalancerLongRunningTasks {
     }
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100)
   public void testMaxIterationTime() throws Exception {
     final Configuration conf = new HdfsConfiguration();
     initConf(conf);
@@ -881,8 +893,8 @@ public class TestBalancerLongRunningTasks {
           // (highly unlikely) and then a block is moved unexpectedly,
           // IN_PROGRESS will be reported. This is highly unlikely unexpected
           // case. See HDFS-15989.
-          assertEquals("We expect ExitStatus.NO_MOVE_PROGRESS to be reported.",
-              ExitStatus.NO_MOVE_PROGRESS, r.getExitStatus());
+          assertEquals(ExitStatus.NO_MOVE_PROGRESS, r.getExitStatus(),
+              "We expect ExitStatus.NO_MOVE_PROGRESS to be reported.");
           assertEquals(0, r.getBlocksMoved());
         }
       } finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerRPCDelay.java
@@ -18,29 +18,27 @@
 package org.apache.hadoop.hdfs.server.balancer;
 
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * The Balancer ensures that it disperses RPCs to the NameNode
  * in order to avoid NN's RPC queue saturation.
  */
+@Timeout(100)
 public class TestBalancerRPCDelay {
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(100);
 
   private TestBalancer testBalancer;
 
-  @Before
+  @BeforeEach
   public void setup() {
     testBalancer = new TestBalancer();
     testBalancer.setup();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (testBalancer != null) {
       testBalancer.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerService.java
@@ -35,7 +35,8 @@ import org.apache.hadoop.test.MetricsAsserts;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.VersionInfo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.lang.management.ManagementFactory;
 import java.util.concurrent.TimeUnit;
@@ -43,9 +44,9 @@ import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test balancer run as a service.
@@ -124,7 +125,8 @@ public class TestBalancerService {
    * should balance succeed but not exit, then make the cluster imbalanced and
    * wait for balancer to balance it again
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerServiceBalanceTwice() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setTimeDuration(DFSConfigKeys.DFS_BALANCER_SERVICE_INTERVAL_KEY, 5,
@@ -174,7 +176,8 @@ public class TestBalancerService {
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testBalancerServiceOnError() throws Exception {
     Configuration conf = new HdfsConfiguration();
     // retry for every 5 seconds
@@ -217,7 +220,8 @@ public class TestBalancerService {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerServiceMetrics() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setTimeDuration(DFSConfigKeys.DFS_BALANCER_SERVICE_INTERVAL_KEY, 5, TimeUnit.SECONDS);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithEncryptedTransfer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithEncryptedTransfer.java
@@ -20,30 +20,34 @@ package org.apache.hadoop.hdfs.server.balancer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestBalancerWithEncryptedTransfer {
   
   private final Configuration conf = new HdfsConfiguration();
   
-  @Before
+  @BeforeEach
   public void setUpConf() {
     conf.setBoolean(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_KEY, true);
     conf.setBoolean(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, true);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testEncryptedBalancer0() throws Exception {
     new TestBalancer().testBalancer0Internal(conf);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testEncryptedBalancer1() throws Exception {
     new TestBalancer().testBalancer1Internal(conf);
   }
   
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testEncryptedBalancer2() throws Exception {
     new TestBalancer().testBalancer2Internal(conf);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithHANameNodes.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdfs.server.balancer;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -57,7 +57,8 @@ import org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -104,7 +105,8 @@ public class TestBalancerWithHANameNodes {
    * it to be 30% full (with a single file replicated identically to all
    * datanodes); It then adds one new empty node and starts balancing.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerWithHANameNodes() throws Exception {
     Configuration conf = new HdfsConfiguration();
     TestBalancer.initConf(conf);
@@ -178,7 +180,8 @@ public class TestBalancerWithHANameNodes {
   /**
    * Test Balancer request Standby NameNode when enable this feature.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerRequestSBNWithHA() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setBoolean(DFS_NAMENODE_GETBLOCKS_CHECK_OPERATION_KEY, false);
@@ -223,7 +226,8 @@ public class TestBalancerWithHANameNodes {
   /**
    * Test Balancer with ObserverNodes.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testBalancerWithObserver() throws Exception {
     testBalancerWithObserver(false);
   }
@@ -231,7 +235,8 @@ public class TestBalancerWithHANameNodes {
   /**
    * Test Balancer with ObserverNodes when one has failed.
    */
-  @Test(timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testBalancerWithObserverWithFailedNode() throws Exception {
     testBalancerWithObserver(true);
   }
@@ -291,7 +296,8 @@ public class TestBalancerWithHANameNodes {
    * from the active and standby NameNodes,
    * the results should be the same.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetLiveDatanodeStorageReport() throws Exception {
     Configuration conf = new HdfsConfiguration();
     TestBalancer.initConf(conf);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
@@ -51,8 +51,11 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeStorageReport;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.slf4j.event.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test balancer with multiple NameNodes
@@ -65,7 +68,7 @@ public class TestBalancerWithMultipleNameNodes {
   }
 
   
-  private static final long CAPACITY = 500L;
+  private static final long CAPACITY = 5000L;
   private static final String RACK0 = "/rack0";
   private static final String RACK1 = "/rack1";
   private static final String RACK2 = "/rack2";
@@ -184,7 +187,7 @@ public class TestBalancerWithMultipleNameNodes {
     // start rebalancing
     final Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(s.conf);
     final int r = Balancer.run(namenodes, s.parameters, s.conf);
-    Assert.assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
+    assertEquals(ExitStatus.SUCCESS.getExitCode(), r);
 
     LOG.info("BALANCER 2");
     wait(s, totalUsed, totalCapacity);
@@ -201,7 +204,7 @@ public class TestBalancerWithMultipleNameNodes {
       for(int n = 0; n < s.clients.length; n++) {
         final DatanodeInfo[] datanodes = s.clients[n].getDatanodeReport(
             DatanodeReportType.ALL);
-        Assert.assertEquals(datanodes.length, used.length);
+        assertEquals(datanodes.length, used.length);
 
         for(int d = 0; d < datanodes.length; d++) {
           if (n == 0) {
@@ -213,8 +216,8 @@ public class TestBalancerWithMultipleNameNodes {
                   + ", getCapacity()=" + datanodes[d].getCapacity());
             }
           } else {
-            Assert.assertEquals(used[d], datanodes[d].getDfsUsed());
-            Assert.assertEquals(cap[d], datanodes[d].getCapacity());
+            assertEquals(used[d], datanodes[d].getDfsUsed());
+            assertEquals(cap[d], datanodes[d].getCapacity());
           }
           bpUsed[n][d] = datanodes[d].getBlockPoolUsed();
         }
@@ -266,7 +269,7 @@ public class TestBalancerWithMultipleNameNodes {
     // cluster is balanced, verify that only selected blockpools were touched
     Map<Integer, DatanodeStorageReport[]> postBalancerPoolUsages =
         getStorageReports(s);
-    Assert.assertEquals(preBalancerPoolUsages.size(),
+    assertEquals(preBalancerPoolUsages.size(),
         postBalancerPoolUsages.size());
     for (Map.Entry<Integer, DatanodeStorageReport[]> entry
         : preBalancerPoolUsages.entrySet()) {
@@ -284,15 +287,14 @@ public class TestBalancerWithMultipleNameNodes {
    */
   private static void compareTotalPoolUsage(DatanodeStorageReport[] preReports,
       DatanodeStorageReport[] postReports) {
-    Assert.assertNotNull(preReports);
-    Assert.assertNotNull(postReports);
-    Assert.assertEquals(preReports.length, postReports.length);
+    assertNotNull(preReports);
+    assertNotNull(postReports);
+    assertEquals(preReports.length, postReports.length);
     for (DatanodeStorageReport preReport : preReports) {
       String dnUuid = preReport.getDatanodeInfo().getDatanodeUuid();
-      for(DatanodeStorageReport postReport : postReports) {
-        if(postReport.getDatanodeInfo().getDatanodeUuid().equals(dnUuid)) {
-          Assert.assertEquals(getTotalPoolUsage(preReport),
-              getTotalPoolUsage(postReport));
+      for (DatanodeStorageReport postReport : postReports) {
+        if (postReport.getDatanodeInfo().getDatanodeUuid().equals(dnUuid)) {
+          assertEquals(getTotalPoolUsage(preReport), getTotalPoolUsage(postReport));
           LOG.info("Comparision of datanode pool usage pre/post balancer run. "
               + "PrePoolUsage: " + getTotalPoolUsage(preReport)
               + ", PostPoolUsage: " + getTotalPoolUsage(postReport));
@@ -490,7 +492,7 @@ public class TestBalancerWithMultipleNameNodes {
     final long[] capacities = new long[nDataNodes];
     Arrays.fill(capacities, CAPACITY);
     LOG.info("nNameNodes=" + nNameNodes + ", nDataNodes=" + nDataNodes);
-    Assert.assertEquals(nDataNodes, racks.length);
+    assertEquals(nDataNodes, racks.length);
 
     LOG.info("RUN_TEST -1: start a cluster with nNameNodes=" + nNameNodes
         + ", nDataNodes=" + nDataNodes);
@@ -595,14 +597,16 @@ public class TestBalancerWithMultipleNameNodes {
   }
 
   /** Even distribution with 2 Namenodes, 4 Datanodes and 2 new Datanodes. */
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testTwoFourTwo() throws Exception {
     final Configuration conf = createConf();
     runTest(2, new String[]{RACK0, RACK0, RACK1, RACK1},
         new String[]{RACK2, RACK2}, conf, 2, null);
   }
 
-  @Test(timeout=600000)
+  @Test
+  @Timeout(value = 600)
   public void testBalancingBlockpoolsWithBlockPoolPolicy() throws Exception {
     final Configuration conf = createConf();
     BalancerParameters balancerParameters = new BalancerParameters.Builder()
@@ -612,7 +616,8 @@ public class TestBalancerWithMultipleNameNodes {
         balancerParameters);
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void test1OutOf2BlockpoolsWithBlockPoolPolicy()
       throws
       Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithNodeGroup.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithNodeGroup.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.balancer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.net.URI;
@@ -52,7 +52,8 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementStatus;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.NetworkTopologyWithNodeGroup;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests if a balancer schedules tasks correctly.
@@ -195,8 +196,8 @@ public class TestBalancerWithNodeGroup {
     // start rebalancing
     Collection<URI> namenodes = DFSUtil.getInternalNsRpcUris(conf);
     final int r = Balancer.run(namenodes, BalancerParameters.DEFAULT, conf);
-    assertEquals("Balancer did not exit with NO_MOVE_PROGRESS",
-        ExitStatus.NO_MOVE_PROGRESS.getExitCode(), r);
+    assertEquals(ExitStatus.NO_MOVE_PROGRESS.getExitCode(), r,
+        "Balancer did not exit with NO_MOVE_PROGRESS");
     waitForHeartBeat(totalUsedSpace, totalCapacity);
     LOG.info("Rebalancing with default factor.");
   }
@@ -218,8 +219,8 @@ public class TestBalancerWithNodeGroup {
     NetworkTopology topology =
         cluster.getNamesystem().getBlockManager().getDatanodeManager().
             getNetworkTopology();
-    assertTrue("must be an instance of NetworkTopologyWithNodeGroup",
-        topology instanceof NetworkTopologyWithNodeGroup);
+    assertTrue(topology instanceof NetworkTopologyWithNodeGroup,
+        "must be an instance of NetworkTopologyWithNodeGroup");
   }
 
   private void verifyProperBlockPlacement(String file,
@@ -228,13 +229,13 @@ public class TestBalancerWithNodeGroup {
         cluster.getNamesystem().getBlockManager().getBlockPlacementPolicy();
     List<LocatedBlock> locatedBlocks = client.
         getBlockLocations(file, 0, length).getLocatedBlocks();
-    assertFalse("No blocks found for file " + file, locatedBlocks.isEmpty());
+    assertFalse(locatedBlocks.isEmpty(), "No blocks found for file " + file);
     for (LocatedBlock locatedBlock : locatedBlocks) {
       BlockPlacementStatus status = placementPolicy.verifyBlockPlacement(
           locatedBlock.getLocations(), numOfReplicas);
-      assertTrue("Block placement policy was not satisfied for block " +
-          locatedBlock.getBlock().getBlockId(),
-          status.isPlacementPolicySatisfied());
+      assertTrue(status.isPlacementPolicySatisfied(),
+          "Block placement policy was not satisfied for block "
+              + locatedBlock.getBlock().getBlockId());
     }
   }
 
@@ -242,7 +243,8 @@ public class TestBalancerWithNodeGroup {
    * Create a cluster with even distribution, and a new empty node is added to
    * the cluster, then test rack locality for balancer policy. 
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerWithRackLocality() throws Exception {
     Configuration conf = createConf();
     long[] capacities = new long[]{CAPACITY, CAPACITY};
@@ -303,7 +305,8 @@ public class TestBalancerWithNodeGroup {
    * Create a cluster with even distribution, and a new empty node is added to
    * the cluster, then test node-group locality for balancer policy.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerWithNodeGroup() throws Exception {
     Configuration conf = createConf();
     long[] capacities = new long[]{CAPACITY, CAPACITY, CAPACITY, CAPACITY};
@@ -363,7 +366,8 @@ public class TestBalancerWithNodeGroup {
    * to n0 or n1 as balancer policy with node group. Thus, we expect the balancer
    * to end in 5 iterations without move block process.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testBalancerEndInNoMoveProgress() throws Exception {
     Configuration conf = createConf();
     long[] capacities = new long[]{CAPACITY, CAPACITY, CAPACITY, CAPACITY};

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestKeyManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestKeyManager.java
@@ -25,22 +25,20 @@ import org.apache.hadoop.hdfs.security.token.block.DataEncryptionKey;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocol;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.FakeTimer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Test KeyManager class.
  */
+@Timeout(120)
 public class TestKeyManager {
-  @Rule
-  public Timeout globalTimeout = new Timeout(120000);
 
   @Test
   public void testNewDataEncryptionKey() throws Exception {
@@ -70,8 +68,8 @@ public class TestKeyManager {
         "timer", fakeTimer);
     final DataEncryptionKey dek = keyManager.newDataEncryptionKey();
     final long remainingTime = dek.expiryDate - fakeTimer.now();
-    assertEquals("KeyManager dataEncryptionKey should expire in 2 seconds",
-        keyUpdateInterval, remainingTime);
+    assertEquals(keyUpdateInterval, remainingTime,
+        "KeyManager dataEncryptionKey should expire in 2 seconds");
     // advance the timer to expire the block key and data encryption key
     fakeTimer.advance(keyUpdateInterval + 1);
 
@@ -79,9 +77,9 @@ public class TestKeyManager {
     // regenerate a valid data encryption key using the current block key.
     final DataEncryptionKey dekAfterExpiration =
         keyManager.newDataEncryptionKey();
-    assertNotEquals("KeyManager should generate a new data encryption key",
-        dek, dekAfterExpiration);
-    assertTrue("KeyManager has an expired DataEncryptionKey!",
-        dekAfterExpiration.expiryDate > fakeTimer.now());
+    assertNotEquals(dek, dekAfterExpiration,
+        "KeyManager should generate a new data encryption key");
+    assertTrue(dekAfterExpiration.expiryDate > fakeTimer.now(),
+        "KeyManager has an expired DataEncryptionKey!");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestAvailableSpaceRackFaultTolerantBPP.java
@@ -29,10 +29,9 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.Node;
 import org.apache.hadoop.test.PathUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,8 +39,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests AvailableSpaceRackFaultTolerant block placement policy.
@@ -61,7 +61,7 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
   private static BlockPlacementPolicy placementPolicy;
   private static NetworkTopology cluster;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCluster() throws Exception {
     conf = new HdfsConfiguration();
     conf.setFloat(
@@ -140,7 +140,7 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
    */
   @Test
   public void testPolicyReplacement() {
-    Assert.assertTrue(
+    assertTrue(
         (placementPolicy instanceof
             AvailableSpaceRackFaultTolerantBlockPlacementPolicy));
   }
@@ -160,7 +160,7 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
                   new ArrayList<DatanodeStorageInfo>(), false, null, BLOCK_SIZE,
                   TestBlockStoragePolicy.DEFAULT_STORAGE_POLICY, null);
 
-      Assert.assertTrue(targets.length == REPLICA);
+      assertTrue(targets.length == REPLICA);
       for (int j = 0; j < REPLICA; j++) {
         total++;
         if (targets[j].getDatanodeDescriptor().getRemainingPercent() > 60) {
@@ -168,10 +168,10 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
         }
       }
     }
-    Assert.assertTrue(total == REPLICA * CHOOSE_TIMES);
+    assertTrue(total == REPLICA * CHOOSE_TIMES);
     double possibility = 1.0 * moreRemainingNode / total;
-    Assert.assertTrue(possibility > 0.52);
-    Assert.assertTrue(possibility < 0.55);
+    assertTrue(possibility > 0.52);
+    assertTrue(possibility < 0.55);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
             .chooseDataNode("~", allNodes);
       }
     } catch (NullPointerException npe) {
-      Assert.fail("NPE should not be thrown");
+      fail("NPE should not be thrown");
     }
   }
 
@@ -253,7 +253,7 @@ public class TestAvailableSpaceRackFaultTolerantBPP {
             tolerateDataNodes[0]) == 1);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardownCluster() {
     if (namenode != null) {
       namenode.stop();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfoStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockInfoStriped.java
@@ -30,12 +30,10 @@ import org.apache.hadoop.hdfs.tools.DFSck;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -45,15 +43,20 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test {@link BlockInfoStriped}.
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass(name="{index}: {0}")
+@MethodSource("policies")
+@Timeout(300)
 public class TestBlockInfoStriped {
   private static final long BASE_ID = -1600;
   private final Block baseBlock = new Block(BASE_ID);
@@ -68,7 +71,6 @@ public class TestBlockInfoStriped {
     info = new BlockInfoStriped(baseBlock, testECPolicy);
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<Object[]> policies() {
     return StripedFileTestUtil.getECPolicies();
   }
@@ -80,9 +82,6 @@ public class TestBlockInfoStriped {
     }
     return blocks;
   }
-
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
 
   /**
    * Test adding storage and reported block.
@@ -97,38 +96,38 @@ public class TestBlockInfoStriped {
     int i = 0;
     for (; i < storageInfos.length; i += 2) {
       info.addStorage(storageInfos[i], blocks[i]);
-      Assert.assertEquals(i/2 + 1, info.numNodes());
+      assertEquals(i / 2 + 1, info.numNodes());
     }
     i /= 2;
     for (int j = 1; j < storageInfos.length; j += 2) {
-      Assert.assertTrue(info.addStorage(storageInfos[j], blocks[j]));
-      Assert.assertEquals(i + (j+1)/2, info.numNodes());
+      assertTrue(info.addStorage(storageInfos[j], blocks[j]));
+      assertEquals(i + (j + 1) / 2, info.numNodes());
     }
 
     // check
     byte[] indices = (byte[]) Whitebox.getInternalState(info, "indices");
-    Assert.assertEquals(totalBlocks, info.getCapacity());
-    Assert.assertEquals(totalBlocks, indices.length);
+    assertEquals(totalBlocks, info.getCapacity());
+    assertEquals(totalBlocks, indices.length);
     i = 0;
     for (DatanodeStorageInfo storage : storageInfos) {
       int index = info.findStorageInfo(storage);
-      Assert.assertEquals(i++, index);
-      Assert.assertEquals(index, indices[index]);
+      assertEquals(i++, index);
+      assertEquals(index, indices[index]);
     }
 
     // the same block is reported from the same storage twice
     i = 0;
     for (DatanodeStorageInfo storage : storageInfos) {
-      Assert.assertTrue(info.addStorage(storage, blocks[i++]));
+      assertTrue(info.addStorage(storage, blocks[i++]));
     }
-    Assert.assertEquals(totalBlocks, info.getCapacity());
-    Assert.assertEquals(totalBlocks, info.numNodes());
-    Assert.assertEquals(totalBlocks, indices.length);
+    assertEquals(totalBlocks, info.getCapacity());
+    assertEquals(totalBlocks, info.numNodes());
+    assertEquals(totalBlocks, indices.length);
     i = 0;
     for (DatanodeStorageInfo storage : storageInfos) {
       int index = info.findStorageInfo(storage);
-      Assert.assertEquals(i++, index);
-      Assert.assertEquals(index, indices[index]);
+      assertEquals(i++, index);
+      assertEquals(index, indices[index]);
     }
 
     // the same block is reported from another storage
@@ -137,15 +136,15 @@ public class TestBlockInfoStriped {
     // only add the second half of info2
     for (i = totalBlocks; i < storageInfos2.length; i++) {
       info.addStorage(storageInfos2[i], blocks[i % totalBlocks]);
-      Assert.assertEquals(i + 1, info.getCapacity());
-      Assert.assertEquals(i + 1, info.numNodes());
+      assertEquals(i + 1, info.getCapacity());
+      assertEquals(i + 1, info.numNodes());
       indices = (byte[]) Whitebox.getInternalState(info, "indices");
-      Assert.assertEquals(i + 1, indices.length);
+      assertEquals(i + 1, indices.length);
     }
     for (i = totalBlocks; i < storageInfos2.length; i++) {
       int index = info.findStorageInfo(storageInfos2[i]);
-      Assert.assertEquals(i++, index);
-      Assert.assertEquals(index - totalBlocks, indices[index]);
+      assertEquals(i++, index);
+      assertEquals(index - totalBlocks, indices[index]);
     }
   }
 
@@ -164,17 +163,17 @@ public class TestBlockInfoStriped {
     info.removeStorage(storages[2]);
 
     // check
-    Assert.assertEquals(totalBlocks, info.getCapacity());
-    Assert.assertEquals(totalBlocks - 2, info.numNodes());
+    assertEquals(totalBlocks, info.getCapacity());
+    assertEquals(totalBlocks - 2, info.numNodes());
     byte[] indices = (byte[]) Whitebox.getInternalState(info, "indices");
     for (int i = 0; i < storages.length; i++) {
       int index = info.findStorageInfo(storages[i]);
       if (i != 0 && i != 2) {
-        Assert.assertEquals(i, index);
-        Assert.assertEquals(index, indices[index]);
+        assertEquals(i, index);
+        assertEquals(index, indices[index]);
       } else {
-        Assert.assertEquals(-1, index);
-        Assert.assertEquals(-1, indices[i]);
+        assertEquals(-1, index);
+        assertEquals(-1, indices[i]);
       }
     }
 
@@ -185,17 +184,17 @@ public class TestBlockInfoStriped {
       info.addStorage(storages2[i], blocks[i % totalBlocks]);
     }
     // now we should have 8 storages
-    Assert.assertEquals(totalBlocks * 2 - 2, info.numNodes());
-    Assert.assertEquals(totalBlocks * 2 - 2, info.getCapacity());
+    assertEquals(totalBlocks * 2 - 2, info.numNodes());
+    assertEquals(totalBlocks * 2 - 2, info.getCapacity());
     indices = (byte[]) Whitebox.getInternalState(info, "indices");
-    Assert.assertEquals(totalBlocks * 2 - 2, indices.length);
+    assertEquals(totalBlocks * 2 - 2, indices.length);
     int j = totalBlocks;
     for (int i = totalBlocks; i < storages2.length; i++) {
       int index = info.findStorageInfo(storages2[i]);
       if (i == totalBlocks || i == totalBlocks + 2) {
-        Assert.assertEquals(i - totalBlocks, index);
+        assertEquals(i - totalBlocks, index);
       } else {
-        Assert.assertEquals(j++, index);
+        assertEquals(j++, index);
       }
     }
 
@@ -204,22 +203,22 @@ public class TestBlockInfoStriped {
       info.removeStorage(storages2[i + totalBlocks]);
     }
     // now we should have 3 storages
-    Assert.assertEquals(totalBlocks - 2, info.numNodes());
-    Assert.assertEquals(totalBlocks * 2 - 2, info.getCapacity());
+    assertEquals(totalBlocks - 2, info.numNodes());
+    assertEquals(totalBlocks * 2 - 2, info.getCapacity());
     indices = (byte[]) Whitebox.getInternalState(info, "indices");
-    Assert.assertEquals(totalBlocks * 2 - 2, indices.length);
+    assertEquals(totalBlocks * 2 - 2, indices.length);
     for (int i = 0; i < totalBlocks; i++) {
       if (i == 0 || i == 2) {
         int index = info.findStorageInfo(storages2[i + totalBlocks]);
-        Assert.assertEquals(-1, index);
+        assertEquals(-1, index);
       } else {
         int index = info.findStorageInfo(storages[i]);
-        Assert.assertEquals(i, index);
+        assertEquals(i, index);
       }
     }
     for (int i = totalBlocks; i < totalBlocks * 2 - 2; i++) {
-      Assert.assertEquals(-1, indices[i]);
-      Assert.assertNull(info.getDatanode(i));
+      assertEquals(-1, indices[i]);
+      assertNull(info.getDatanode(i));
     }
   }
 
@@ -251,8 +250,8 @@ public class TestBlockInfoStriped {
       bInfo.removeStorage(dnStorageInfo[1]);
       ByteArrayOutputStream bStream = new ByteArrayOutputStream();
       PrintStream out = new PrintStream(bStream, true);
-      assertEquals(0, ToolRunner.run(new DFSck(conf, out), new String[] {
-          new Path("/ecDir/ecFile").toString(), "-blockId", id }));
+      assertEquals(0, ToolRunner.run(new DFSck(conf, out),
+          new String[]{new Path("/ecDir/ecFile").toString(), "-blockId", id}));
       assertFalse(out.toString().contains("null"));
     }
   }
@@ -279,20 +278,24 @@ public class TestBlockInfoStriped {
     assertArrayEquals(byteBuffer.array(), byteStream.toByteArray());
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testAddStorageWithReplicatedBlock() {
-    DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
-        "storageID", "127.0.0.1");
-    BlockInfo replica = new BlockInfoContiguous(new Block(1000L), (short) 3);
-    info.addStorage(storage, replica);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
+          "storageID", "127.0.0.1");
+      BlockInfo replica = new BlockInfoContiguous(new Block(1000L), (short) 3);
+      info.addStorage(storage, replica);
+    });
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test
   public void testAddStorageWithDifferentBlockGroup() {
-    DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
-        "storageID", "127.0.0.1");
-    BlockInfo diffGroup = new BlockInfoStriped(new Block(BASE_ID + 100),
-        testECPolicy);
-    info.addStorage(storage, diffGroup);
+    assertThrows(IllegalArgumentException.class, () -> {
+      DatanodeStorageInfo storage = DFSTestUtil.createDatanodeStorageInfo(
+          "storageID", "127.0.0.1");
+      BlockInfo diffGroup = new BlockInfoStriped(new Block(BASE_ID + 100),
+          testECPolicy);
+      info.addStorage(storage, diffGroup);
+    });
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockStatsMXBean.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockStatsMXBean.java
@@ -18,11 +18,11 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,24 +45,21 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.eclipse.jetty.util.ajax.JSON;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Class for testing {@link BlockStatsMXBean} implementation
  */
+@Timeout(300)
 public class TestBlockStatsMXBean {
 
   private MiniDFSCluster cluster;
 
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     HdfsConfiguration conf = new HdfsConfiguration();
     conf.setTimeDuration(DFSConfigKeys.DFS_DATANODE_DISK_CHECK_MIN_GAP_KEY,
@@ -84,7 +81,7 @@ public class TestBlockStatsMXBean {
     cluster.waitActive();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -219,8 +216,8 @@ public class TestBlockStatsMXBean {
     Thread.sleep(6000);
     storageTypeStatsMap = cluster.getNamesystem().getBlockManager()
         .getStorageTypeStats();
-    assertFalse("StorageTypeStatsMap should not contain DISK Storage type",
-        storageTypeStatsMap.containsKey(StorageType.DISK));
+    assertFalse(storageTypeStatsMap.containsKey(StorageType.DISK),
+        "StorageTypeStatsMap should not contain DISK Storage type");
     DataNodeTestUtils.restoreDataDirFromFailure(dn1ArcVol1);
     DataNodeTestUtils.restoreDataDirFromFailure(dn2ArcVol1);
     DataNodeTestUtils.restoreDataDirFromFailure(dn3ArcVol1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -64,8 +64,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.ServerSocketUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 public class TestBlockTokenWithDFS {
@@ -105,7 +104,7 @@ public class TestBlockTokenWithDFS {
     } catch (IOException e) {
       return false;
     }
-    assertEquals("Cannot read file.", toRead.length, totalRead);
+    assertEquals(toRead.length, totalRead, "Cannot read file.");
     return checkFile(toRead, expected);
   }
 
@@ -113,8 +112,8 @@ public class TestBlockTokenWithDFS {
   private boolean checkFile2(FSDataInputStream in, byte[] expected) {
     byte[] toRead = new byte[expected.length];
     try {
-      assertEquals("Cannot read file", toRead.length, in.read(0, toRead, 0,
-          toRead.length));
+      assertEquals(toRead.length, in.read(0, toRead, 0,
+          toRead.length), "Cannot read file");
     } catch (IOException e) {
       return false;
     }
@@ -198,14 +197,14 @@ public class TestBlockTokenWithDFS {
       }
     }
     if (shouldSucceed) {
-      Assert.assertNotNull("OP_READ_BLOCK: access token is invalid, "
-            + "when it is expected to be valid", blockReader);
+      assertNotNull(blockReader,
+          "OP_READ_BLOCK: access token is invalid, " + "when it is expected to be valid");
     } else {
-      Assert.assertNotNull("OP_READ_BLOCK: access token is valid, "
-          + "when it is expected to be invalid", ioe);
-      Assert.assertTrue(
-          "OP_READ_BLOCK failed due to reasons other than access token: ",
-          ioe instanceof InvalidBlockTokenException);
+      assertNotNull(ioe,
+          "OP_READ_BLOCK: access token is valid, " + "when it is expected to be invalid");
+      assertTrue(
+          ioe instanceof InvalidBlockTokenException,
+          "OP_READ_BLOCK failed due to reasons other than access token: ");
     }
   }
 
@@ -575,10 +574,26 @@ public class TestBlockTokenWithDFS {
     cluster.shutdownNameNode(0);
 
     // verify blockSeekTo() fails (cached tokens become invalid)
-    in1.seek(0);
-    assertFalse(checkFile1(in1,expected));
+    if (isStriped) {
+      try {
+        in1.seek(0);
+        assertFalse(checkFile1(in1, expected));
+      } catch (Exception ignored) {
+      }
+    } else {
+      in1.seek(0);
+      assertFalse(checkFile1(in1, expected));
+    }
+
     // verify fetchBlockByteRange() fails (cached tokens become invalid)
-    assertFalse(checkFile2(in3,expected));
+    if (isStriped) {
+      try {
+        assertFalse(checkFile2(in3, expected));
+      } catch (Exception ignored) {
+      }
+    } else {
+      assertFalse(checkFile2(in3, expected));
+    }
 
     // restart the namenode to allow DFSClient to re-fetch tokens
     cluster.restartNameNode(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFSStriped.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFSStriped.java
@@ -27,12 +27,12 @@ import org.apache.hadoop.hdfs.protocol.LocatedStripedBlock;
 import org.apache.hadoop.hdfs.server.balancer.TestBalancer;
 import org.apache.hadoop.hdfs.util.StripedBlockUtil;
 import org.apache.hadoop.net.ServerSocketUtil;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
+@Timeout(300)
 public class TestBlockTokenWithDFSStriped extends TestBlockTokenWithDFS {
   private final ErasureCodingPolicy ecPolicy =
       StripedFileTestUtil.getDefaultECPolicy();
@@ -48,9 +48,6 @@ public class TestBlockTokenWithDFSStriped extends TestBlockTokenWithDFS {
     BLOCK_SIZE = cellSize * stripesPerBlock;
     FILE_SIZE =  BLOCK_SIZE * dataBlocks * 3;
   }
-
-  @Rule
-  public Timeout globalTimeout = new Timeout(300000);
 
   private Configuration getConf() {
     Configuration conf = super.getConf(numDNs);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithShortCircuitRead.java
@@ -42,8 +42,7 @@ import org.apache.hadoop.net.unix.DomainSocket;
 import org.apache.hadoop.net.unix.TemporarySocketDirectory;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.io.File;
@@ -57,8 +56,8 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BLOCK_SIZE_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DOMAIN_SOCKET_PATH_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestBlockTokenWithShortCircuitRead {
 
@@ -78,7 +77,7 @@ public class TestBlockTokenWithShortCircuitRead {
       toRead.length - totalRead)) > 0) {
       totalRead += nRead;
     }
-    assertEquals("Cannot read file.", toRead.length, totalRead);
+    assertEquals(toRead.length, totalRead, "Cannot read file.");
   }
 
   @Test
@@ -128,8 +127,8 @@ public class TestBlockTokenWithShortCircuitRead {
         @Override
         public void visit(HashMap<DatanodeInfo, PerDatanodeVisitorInfo> info) {
           // The ClientShmManager starts off empty
-          Assert.assertEquals(0, info.size());
-        }
+              assertEquals(0, info.size());
+          }
       });
 
       // create file to read
@@ -184,11 +183,11 @@ public class TestBlockTokenWithShortCircuitRead {
     cache.getDfsClientShmManager().visit(new Visitor() {
       @Override
       public void visit(HashMap<DatanodeInfo, PerDatanodeVisitorInfo> info) {
-        Assert.assertEquals(1, info.size());
+        assertEquals(1, info.size());
         PerDatanodeVisitorInfo vinfo = info.get(datanode);
-        Assert.assertFalse(vinfo.disabled);
-        Assert.assertEquals(0, vinfo.full.size());
-        Assert.assertEquals(1, vinfo.notFull.size());
+        assertFalse(vinfo.disabled);
+        assertEquals(0, vinfo.full.size());
+        assertEquals(1, vinfo.notFull.size());
 
         int slotCnt = 0;
         DfsClientShm shm = vinfo.notFull.values().iterator().next();
@@ -196,7 +195,7 @@ public class TestBlockTokenWithShortCircuitRead {
           iter.next();
           slotCnt++;
         }
-        Assert.assertEquals(expectedSlotCnt, slotCnt);
+        assertEquals(expectedSlotCnt, slotCnt);
       }
     });
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCachedBlocksList.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCachedBlocksList.java
@@ -27,14 +27,18 @@ import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor.CachedBlocksList;
 import org.apache.hadoop.hdfs.server.namenode.CachedBlock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCachedBlocksList {
   public static final Logger LOG =
       LoggerFactory.getLogger(TestCachedBlocksList.class);
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testSingleList() {
     DatanodeDescriptor dn = new DatanodeDescriptor(
       new DatanodeID("127.0.0.1", "localhost", "abcd", 5000, 5001, 5002, 5003));
@@ -44,51 +48,50 @@ public class TestCachedBlocksList {
           new CachedBlock(2L, (short)1, true),
       };
     // check that lists are empty
-    Assert.assertTrue("expected pending cached list to start off empty.", 
-        !dn.getPendingCached().iterator().hasNext());
-    Assert.assertTrue("expected cached list to start off empty.", 
-        !dn.getCached().iterator().hasNext());
-    Assert.assertTrue("expected pending uncached list to start off empty.", 
-        !dn.getPendingUncached().iterator().hasNext());
+    assertTrue(!dn.getPendingCached().iterator().hasNext(),
+        "expected pending cached list to start off empty.");
+    assertTrue(!dn.getCached().iterator().hasNext(),
+        "expected cached list to start off empty.");
+    assertTrue(!dn.getPendingUncached().iterator().hasNext(),
+        "expected pending uncached list to start off empty.");
     // add a block to the back
-    Assert.assertTrue(dn.getCached().add(blocks[0]));
-    Assert.assertTrue("expected pending cached list to still be empty.", 
-        !dn.getPendingCached().iterator().hasNext());
-    Assert.assertEquals("failed to insert blocks[0]", blocks[0],
-        dn.getCached().iterator().next());
-    Assert.assertTrue("expected pending uncached list to still be empty.", 
-        !dn.getPendingUncached().iterator().hasNext());
+    assertTrue(dn.getCached().add(blocks[0]));
+    assertTrue(!dn.getPendingCached().iterator().hasNext(),
+        "expected pending cached list to still be empty.");
+    assertEquals(blocks[0], dn.getCached().iterator().next(),
+        "failed to insert blocks[0]");
+    assertTrue(!dn.getPendingUncached().iterator().hasNext(),
+        "expected pending uncached list to still be empty.");
     // add another block to the back
-    Assert.assertTrue(dn.getCached().add(blocks[1]));
+    assertTrue(dn.getCached().add(blocks[1]));
     Iterator<CachedBlock> iter = dn.getCached().iterator();
-    Assert.assertEquals(blocks[0], iter.next());
-    Assert.assertEquals(blocks[1], iter.next());
-    Assert.assertTrue(!iter.hasNext());
+    assertEquals(blocks[0], iter.next());
+    assertEquals(blocks[1], iter.next());
+    assertTrue(!iter.hasNext());
     // add a block to the front
-    Assert.assertTrue(dn.getCached().addFirst(blocks[2]));
+    assertTrue(dn.getCached().addFirst(blocks[2]));
     iter = dn.getCached().iterator();
-    Assert.assertEquals(blocks[2], iter.next());
-    Assert.assertEquals(blocks[0], iter.next());
-    Assert.assertEquals(blocks[1], iter.next());
-    Assert.assertTrue(!iter.hasNext());
+    assertEquals(blocks[2], iter.next());
+    assertEquals(blocks[0], iter.next());
+    assertEquals(blocks[1], iter.next());
+    assertTrue(!iter.hasNext());
     // remove a block from the middle
-    Assert.assertTrue(dn.getCached().remove(blocks[0]));
+    assertTrue(dn.getCached().remove(blocks[0]));
     iter = dn.getCached().iterator();
-    Assert.assertEquals(blocks[2], iter.next());
-    Assert.assertEquals(blocks[1], iter.next());
-    Assert.assertTrue(!iter.hasNext());
+    assertEquals(blocks[2], iter.next());
+    assertEquals(blocks[1], iter.next());
+    assertTrue(!iter.hasNext());
     // remove all blocks
     dn.getCached().clear();
-    Assert.assertTrue("expected cached list to be empty after clear.", 
-        !dn.getPendingCached().iterator().hasNext());
+    assertTrue(!dn.getPendingCached().iterator().hasNext(),
+        "expected cached list to be empty after clear.");
   }
 
   private void testAddElementsToList(CachedBlocksList list,
       CachedBlock[] blocks) {
-    Assert.assertTrue("expected list to start off empty.", 
-        !list.iterator().hasNext());
+    assertTrue(!list.iterator().hasNext(), "expected list to start off empty.");
     for (CachedBlock block : blocks) {
-      Assert.assertTrue(list.add(block));
+      assertTrue(list.add(block));
     }
   }
 
@@ -96,7 +99,7 @@ public class TestCachedBlocksList {
       CachedBlocksList list, CachedBlock[] blocks) {
     int i = 0;
     for (Iterator<CachedBlock> iter = list.iterator(); iter.hasNext(); ) {
-      Assert.assertEquals(blocks[i], iter.next());
+      assertEquals(blocks[i], iter.next());
       i++;
     }
     if (r.nextBoolean()) {
@@ -111,17 +114,18 @@ public class TestCachedBlocksList {
       for (int removed = 0; removed < remainingBlocks.length; ) {
         int toRemove = r.nextInt(remainingBlocks.length);
         if (remainingBlocks[toRemove] != null) {
-          Assert.assertTrue(list.remove(remainingBlocks[toRemove]));
+          assertTrue(list.remove(remainingBlocks[toRemove]));
           remainingBlocks[toRemove] = null;
           removed++;
         }
       }
     }
-    Assert.assertTrue("expected list to be empty after everything " +
-        "was removed.", !list.iterator().hasNext());
+    assertTrue(!list.iterator().hasNext(),
+        "expected list to be empty after everything " + "was removed.");
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testMultipleLists() {
     DatanodeDescriptor[] datanodes = new DatanodeDescriptor[] {
       new DatanodeDescriptor(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptReplicaInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptReplicaInfo.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdfs.StripedFileTestUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.BlockType;
 import org.apache.hadoop.hdfs.server.blockmanagement.CorruptReplicasMap.Reason;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 
@@ -83,13 +83,12 @@ public class TestCorruptReplicaInfo {
       long expectedReplicaCount, long expectedStripedBlockCount) {
     long totalExpectedCorruptBlocks = expectedReplicaCount +
         expectedStripedBlockCount;
-    assertEquals("Unexpected total corrupt blocks count!",
-        totalExpectedCorruptBlocks, corruptReplicasMap.size());
-    assertEquals("Unexpected replica blocks count!",
-        expectedReplicaCount, corruptReplicasMap.getCorruptBlocks());
-    assertEquals("Unexpected striped blocks count!",
-        expectedStripedBlockCount,
-        corruptReplicasMap.getCorruptECBlockGroups());
+    assertEquals(totalExpectedCorruptBlocks, corruptReplicasMap.size(),
+        "Unexpected total corrupt blocks count!");
+    assertEquals(expectedReplicaCount, corruptReplicasMap.getCorruptBlocks(),
+        "Unexpected replica blocks count!");
+    assertEquals(expectedStripedBlockCount, corruptReplicasMap.getCorruptECBlockGroups(),
+        "Unexpected striped blocks count!");
   }
   
   @Test
@@ -102,20 +101,20 @@ public class TestCorruptReplicaInfo {
     assertTrue(!bim.isLegacyBlock(new Block(-1)));
 
     // Make sure initial values are returned correctly
-    assertEquals("Total number of corrupt blocks must initially be 0!",
-        0, crm.size());
-    assertEquals("Number of corrupt replicas must initially be 0!",
-        0, crm.getCorruptBlocks());
-    assertEquals("Number of corrupt striped block groups must initially be 0!",
-        0, crm.getCorruptECBlockGroups());
-    assertNull("Param n cannot be less than 0",
-        crm.getCorruptBlockIdsForTesting(bim, BlockType.CONTIGUOUS, -1, null));
-    assertNull("Param n cannot be greater than 100",
-        crm.getCorruptBlockIdsForTesting(bim, BlockType.CONTIGUOUS, 101, null));
+    assertEquals(0, crm.size(),
+        "Total number of corrupt blocks must initially be 0!");
+    assertEquals(0, crm.getCorruptBlocks(),
+        "Number of corrupt replicas must initially be 0!");
+    assertEquals(0, crm.getCorruptECBlockGroups(),
+        "Number of corrupt striped block groups must initially be 0!");
+    assertNull(crm.getCorruptBlockIdsForTesting(bim, BlockType.CONTIGUOUS, -1, null),
+        "Param n cannot be less than 0");
+    assertNull(crm.getCorruptBlockIdsForTesting(bim, BlockType.CONTIGUOUS, 101, null),
+        "Param n cannot be greater than 100");
     long[] l = crm.getCorruptBlockIdsForTesting(
         bim, BlockType.CONTIGUOUS, 0, null);
-    assertNotNull("n = 0 must return non-null", l);
-    assertEquals("n = 0 must return an empty list", 0, l.length);
+    assertNotNull(l, "n = 0 must return non-null");
+    assertEquals(0, l.length, "n = 0 must return an empty list");
 
     // Create a list of block ids. A list is used to allow easy
     // validation of the output of getCorruptReplicaBlockIds.
@@ -165,25 +164,25 @@ public class TestCorruptReplicaInfo {
       addToCorruptReplicasMap(crm, getStripedBlock(blockId), dn1);
     }
 
-    assertEquals("Number of corrupt blocks not returning correctly",
-        2 * blockCount, crm.size());
-    assertTrue("First five corrupt replica blocks ids are not right!",
-        Arrays.equals(Arrays.copyOfRange(replicaIds, 0, 5),
+    assertEquals(2 * blockCount, crm.size(),
+        "Number of corrupt blocks not returning correctly");
+    assertTrue(Arrays.equals(Arrays.copyOfRange(replicaIds, 0, 5),
             crm.getCorruptBlockIdsForTesting(
-                bim, BlockType.CONTIGUOUS, 5, null)));
-    assertTrue("First five corrupt striped blocks ids are not right!",
-        Arrays.equals(Arrays.copyOfRange(stripedIds, 0, 5),
+                bim, BlockType.CONTIGUOUS, 5, null)),
+        "First five corrupt replica blocks ids are not right!");
+    assertTrue(Arrays.equals(Arrays.copyOfRange(stripedIds, 0, 5),
             crm.getCorruptBlockIdsForTesting(
-                bim, BlockType.STRIPED, 5, null)));
+                bim, BlockType.STRIPED, 5, null)),
+        "First five corrupt striped blocks ids are not right!");
 
-    assertTrue("10 replica blocks after 7 not returned correctly!",
-        Arrays.equals(Arrays.copyOfRange(replicaIds, 7, 17),
+    assertTrue(Arrays.equals(Arrays.copyOfRange(replicaIds, 7, 17),
             crm.getCorruptBlockIdsForTesting(
-                bim, BlockType.CONTIGUOUS, 10, 7L)));
-    assertTrue("10 striped blocks after 7 not returned correctly!",
-        Arrays.equals(Arrays.copyOfRange(stripedIds, 7, 17),
+                bim, BlockType.CONTIGUOUS, 10, 7L)),
+        "10 replica blocks after 7 not returned correctly!");
+    assertTrue(Arrays.equals(Arrays.copyOfRange(stripedIds, 7, 17),
             crm.getCorruptBlockIdsForTesting(bim, BlockType.STRIPED,
-                10, getStripedBlock(7).getBlockId())));
+                10, getStripedBlock(7).getBlockId())),
+        "10 striped blocks after 7 not returned correctly!");
   }
   
   private static void addToCorruptReplicasMap(CorruptReplicasMap crm,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptionWithFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestCorruptionWithFailover.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_CORRUPT_BLOCK_DELETE_IMMEDIATELY_ENABLED;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestErasureCodingCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestErasureCodingCorruption.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_CORRUPT_BLOCK_DELETE_IMMEDIATELY_ENABLED;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHeartbeatHandling.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHeartbeatHandling.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs.server.blockmanagement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 
@@ -43,22 +43,16 @@ import org.apache.hadoop.hdfs.server.protocol.DatanodeProtocol;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeStorage;
 import org.apache.hadoop.hdfs.util.RwLockMode;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 /**
  * Test if FSNamesystem handles heartbeat right
+ * Set a timeout for every test case.
  */
+@Timeout(300)
 public class TestHeartbeatHandling {
-
-
-  /**
-   * Set a timeout for every test case.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   /**
    * Test if

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHostFileManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestHostFileManager.java
@@ -23,13 +23,15 @@ import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class TestHostFileManager {
@@ -44,57 +46,57 @@ public class TestHostFileManager {
     // address + port combo.
     s.add(entry("127.0.0.1:12345"));
     s.add(entry("localhost:12345"));
-    Assert.assertEquals(1, s.size());
+    assertEquals(1, s.size());
     s.add(entry("127.0.0.1:12345"));
-    Assert.assertEquals(1, s.size());
+    assertEquals(1, s.size());
 
     // The following entries should not be de-duped.
     s.add(entry("127.0.0.1:12346"));
-    Assert.assertEquals(2, s.size());
+    assertEquals(2, s.size());
     s.add(entry("127.0.0.1"));
-    Assert.assertEquals(3, s.size());
+    assertEquals(3, s.size());
     s.add(entry("127.0.0.10"));
-    Assert.assertEquals(4, s.size());
+    assertEquals(4, s.size());
   }
 
   @Test
   public void testRelation() {
     HostSet s = new HostSet();
     s.add(entry("127.0.0.1:123"));
-    Assert.assertTrue(s.match(entry("127.0.0.1:123")));
-    Assert.assertFalse(s.match(entry("127.0.0.1:12")));
-    Assert.assertFalse(s.match(entry("127.0.0.1")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.1:12")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1:123")));
-    Assert.assertFalse(s.match(entry("127.0.0.2")));
-    Assert.assertFalse(s.match(entry("127.0.0.2:123")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.2")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.2:123")));
+    assertTrue(s.match(entry("127.0.0.1:123")));
+    assertFalse(s.match(entry("127.0.0.1:12")));
+    assertFalse(s.match(entry("127.0.0.1")));
+    assertFalse(s.matchedBy(entry("127.0.0.1:12")));
+    assertTrue(s.matchedBy(entry("127.0.0.1")));
+    assertTrue(s.matchedBy(entry("127.0.0.1:123")));
+    assertFalse(s.match(entry("127.0.0.2")));
+    assertFalse(s.match(entry("127.0.0.2:123")));
+    assertFalse(s.matchedBy(entry("127.0.0.2")));
+    assertFalse(s.matchedBy(entry("127.0.0.2:123")));
 
     s.add(entry("127.0.0.1"));
-    Assert.assertTrue(s.match(entry("127.0.0.1:123")));
-    Assert.assertTrue(s.match(entry("127.0.0.1:12")));
-    Assert.assertTrue(s.match(entry("127.0.0.1")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.1:12")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1:123")));
-    Assert.assertFalse(s.match(entry("127.0.0.2")));
-    Assert.assertFalse(s.match(entry("127.0.0.2:123")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.2")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.2:123")));
+    assertTrue(s.match(entry("127.0.0.1:123")));
+    assertTrue(s.match(entry("127.0.0.1:12")));
+    assertTrue(s.match(entry("127.0.0.1")));
+    assertFalse(s.matchedBy(entry("127.0.0.1:12")));
+    assertTrue(s.matchedBy(entry("127.0.0.1")));
+    assertTrue(s.matchedBy(entry("127.0.0.1:123")));
+    assertFalse(s.match(entry("127.0.0.2")));
+    assertFalse(s.match(entry("127.0.0.2:123")));
+    assertFalse(s.matchedBy(entry("127.0.0.2")));
+    assertFalse(s.matchedBy(entry("127.0.0.2:123")));
 
     s.add(entry("127.0.0.2:123"));
-    Assert.assertTrue(s.match(entry("127.0.0.1:123")));
-    Assert.assertTrue(s.match(entry("127.0.0.1:12")));
-    Assert.assertTrue(s.match(entry("127.0.0.1")));
-    Assert.assertFalse(s.matchedBy(entry("127.0.0.1:12")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.1:123")));
-    Assert.assertFalse(s.match(entry("127.0.0.2")));
-    Assert.assertTrue(s.match(entry("127.0.0.2:123")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.2")));
-    Assert.assertTrue(s.matchedBy(entry("127.0.0.2:123")));
+    assertTrue(s.match(entry("127.0.0.1:123")));
+    assertTrue(s.match(entry("127.0.0.1:12")));
+    assertTrue(s.match(entry("127.0.0.1")));
+    assertFalse(s.matchedBy(entry("127.0.0.1:12")));
+    assertTrue(s.matchedBy(entry("127.0.0.1")));
+    assertTrue(s.matchedBy(entry("127.0.0.1:123")));
+    assertFalse(s.match(entry("127.0.0.2")));
+    assertTrue(s.match(entry("127.0.0.2:123")));
+    assertTrue(s.matchedBy(entry("127.0.0.2")));
+    assertTrue(s.matchedBy(entry("127.0.0.2:123")));
   }
 
   @Test
@@ -115,8 +117,8 @@ public class TestHostFileManager {
     excludedNodes.add(entry("127.0.0.1:12346"));
     excludedNodes.add(entry("127.0.30.1:12346"));
 
-    Assert.assertEquals(2, includedNodes.size());
-    Assert.assertEquals(2, excludedNodes.size());
+    assertEquals(2, includedNodes.size());
+    assertEquals(2, excludedNodes.size());
 
     hm.refresh(includedNodes, excludedNodes);
 
@@ -127,30 +129,30 @@ public class TestHostFileManager {
 
     // After the de-duplication, there should be only one DN from the included
     // nodes declared as dead.
-    Assert.assertEquals(2, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.ALL).size());
-    Assert.assertEquals(2, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(2,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.ALL).size());
+    assertEquals(2,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
     dnMap.put("uuid-foo", new DatanodeDescriptor(new DatanodeID("127.0.0.1",
             "localhost", "uuid-foo", 12345, 1020, 1021, 1022)));
-    Assert.assertEquals(1, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(1,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
     dnMap.put("uuid-bar", new DatanodeDescriptor(new DatanodeID("127.0.0.2",
             "127.0.0.2", "uuid-bar", 12345, 1020, 1021, 1022)));
-    Assert.assertEquals(0, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(0,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
     DatanodeDescriptor spam = new DatanodeDescriptor(new DatanodeID("127.0.0" +
             ".3", "127.0.0.3", "uuid-spam", 12345, 1020, 1021, 1022));
     DFSTestUtil.setDatanodeDead(spam);
     includedNodes.add(entry("127.0.0.3:12345"));
     dnMap.put("uuid-spam", spam);
-    Assert.assertEquals(1, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(1,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
     dnMap.remove("uuid-spam");
-    Assert.assertEquals(1, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(1,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
     excludedNodes.add(entry("127.0.0.3"));
-    Assert.assertEquals(1, dm.getDatanodeListForReport(HdfsConstants
-            .DatanodeReportType.DEAD).size());
+    assertEquals(1,
+        dm.getDatanodeListForReport(HdfsConstants.DatanodeReportType.DEAD).size());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestLowRedundancyBlockQueues.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestLowRedundancyBlockQueues.java
@@ -26,19 +26,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdfs.StripedFileTestUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test {@link LowRedundancyBlocks}.
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{index}: {0}")
+@MethodSource("policies")
 public class TestLowRedundancyBlockQueues {
 
   private final ErasureCodingPolicy ecPolicy;
@@ -48,7 +49,6 @@ public class TestLowRedundancyBlockQueues {
     ecPolicy = policy;
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<Object[]> policies() {
     return StripedFileTestUtil.getECPolicies();
   }
@@ -76,33 +76,27 @@ public class TestLowRedundancyBlockQueues {
       int corruptReplicationOneCount, int lowRedundancyStripedCount,
       int corruptStripedCount, int highestPriorityReplicatedBlockCount,
       int highestPriorityECBlockCount, int badlyDistributedBlockCount) {
-    assertEquals("Low redundancy replica count incorrect!",
-        lowRedundancyReplicaCount, queues.getLowRedundancyBlocks());
-    assertEquals("Corrupt replica count incorrect!",
-        corruptReplicaCount, queues.getCorruptBlocks());
-    assertEquals("Corrupt replica one count incorrect!",
-        corruptReplicationOneCount,
-        queues.getCorruptReplicationOneBlocks());
-    assertEquals("Low redundancy striped blocks count incorrect!",
-        lowRedundancyStripedCount, queues.getLowRedundancyECBlockGroups());
-    assertEquals("Corrupt striped blocks count incorrect!",
-        corruptStripedCount, queues.getCorruptECBlockGroups());
-    assertEquals("Low Redundancy count incorrect!",
-        lowRedundancyReplicaCount + lowRedundancyStripedCount,
-        queues.getLowRedundancyBlockCount());
-    assertEquals("LowRedundancyBlocks queue size incorrect!",
-        (lowRedundancyReplicaCount + corruptReplicaCount +
-        lowRedundancyStripedCount + corruptStripedCount), queues.size());
-    assertEquals("Badly Distributed Blocks queue size incorrect!",
-        badlyDistributedBlockCount, queues.getBadlyDistributedBlocks());
-    assertEquals("Highest priority replicated low redundancy " +
-            "blocks count is incorrect!",
-        highestPriorityReplicatedBlockCount,
-        queues.getHighestPriorityReplicatedBlockCount());
-    assertEquals("Highest priority erasure coded low redundancy " +
-            "blocks count is incorrect!",
-        highestPriorityECBlockCount,
-        queues.getHighestPriorityECBlockCount());
+    assertEquals(lowRedundancyReplicaCount, queues.getLowRedundancyBlocks(),
+        "Low redundancy replica count incorrect!");
+    assertEquals(corruptReplicaCount, queues.getCorruptBlocks(),
+        "Corrupt replica count incorrect!");
+    assertEquals(corruptReplicationOneCount, queues.getCorruptReplicationOneBlocks(),
+        "Corrupt replica one count incorrect!");
+    assertEquals(lowRedundancyStripedCount, queues.getLowRedundancyECBlockGroups(),
+        "Low redundancy striped blocks count incorrect!");
+    assertEquals(corruptStripedCount, queues.getCorruptECBlockGroups(),
+        "Corrupt striped blocks count incorrect!");
+    assertEquals(lowRedundancyReplicaCount + lowRedundancyStripedCount,
+        queues.getLowRedundancyBlockCount(), "Low Redundancy count incorrect!");
+    assertEquals((lowRedundancyReplicaCount + corruptReplicaCount + lowRedundancyStripedCount
+        + corruptStripedCount), queues.size(), "LowRedundancyBlocks queue size incorrect!");
+    assertEquals(badlyDistributedBlockCount, queues.getBadlyDistributedBlocks(),
+        "Badly Distributed Blocks queue size incorrect!");
+    assertEquals(highestPriorityReplicatedBlockCount,
+        queues.getHighestPriorityReplicatedBlockCount(),
+        "Highest priority replicated low redundancy " + "blocks count is incorrect!");
+    assertEquals(highestPriorityECBlockCount, queues.getHighestPriorityECBlockCount(),
+        "Highest priority erasure coded low redundancy " + "blocks count is incorrect!");
   }
 
   /**
@@ -198,13 +192,13 @@ public class TestLowRedundancyBlockQueues {
     // Now try to add a block that is corrupt
     assertAdded(queues, block_corrupt, 0, 0, 3);
     assertInLevel(queues, block_corrupt,
-                  LowRedundancyBlocks.QUEUE_WITH_CORRUPT_BLOCKS);
+        LowRedundancyBlocks.QUEUE_WITH_CORRUPT_BLOCKS);
     verifyBlockStats(queues, 2, 1, 0, 0, 0, 1, 0, 0);
 
     // Insert a very insufficiently redundancy block
     assertAdded(queues, block_very_low_redundancy, 4, 0, 25);
     assertInLevel(queues, block_very_low_redundancy,
-                  LowRedundancyBlocks.QUEUE_VERY_LOW_REDUNDANCY);
+        LowRedundancyBlocks.QUEUE_VERY_LOW_REDUNDANCY);
     verifyBlockStats(queues, 3, 1, 0, 0, 0, 1, 0, 0);
 
     // Insert a corrupt block with replication factor 1
@@ -302,11 +296,10 @@ public class TestLowRedundancyBlockQueues {
                            int curReplicas,
                            int decommissionedReplicas,
                            int expectedReplicas) {
-    assertTrue("Failed to add " + block,
-               queues.add(block,
-                          curReplicas, 0,
-                          decommissionedReplicas,
-                          expectedReplicas));
+    assertTrue(queues.add(block,
+        curReplicas, 0,
+        decommissionedReplicas,
+        expectedReplicas), "Failed to add " + block);
   }
 
   /**
@@ -339,7 +332,7 @@ public class TestLowRedundancyBlockQueues {
     neededReconstruction.add(block, 2, 0, 1, 3);
     neededReconstruction.add(block, 0, 0, 0, 3);
     neededReconstruction.remove(block, LowRedundancyBlocks.LEVEL);
-    assertFalse("Should not contain the block.",
-        neededReconstruction.contains(block));
+    assertFalse(neededReconstruction.contains(block),
+        "Should not contain the block.");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingInvalidateBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestPendingInvalidateBlock.java
@@ -32,15 +32,17 @@ import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
 
 import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test if we can correctly delay the deletion of blocks.
@@ -57,7 +59,7 @@ public class TestPendingInvalidateBlock {
   private MiniDFSCluster cluster;
   private DistributedFileSystem dfs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCKSIZE);
@@ -75,7 +77,7 @@ public class TestPendingInvalidateBlock {
     dfs = cluster.getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -102,23 +104,23 @@ public class TestPendingInvalidateBlock {
     dfs.delete(foo, true);
 
     waitForNumPendingDeletionBlocks(REPLICATION);
-    Assert.assertEquals(0, cluster.getNamesystem().getBlocksTotal());
-    Assert.assertEquals(REPLICATION, cluster.getNamesystem()
+    assertEquals(0, cluster.getNamesystem().getBlocksTotal());
+    assertEquals(REPLICATION, cluster.getNamesystem()
         .getPendingDeletionBlocks());
-    Assert.assertEquals(REPLICATION,
+    assertEquals(REPLICATION,
         dfs.getPendingDeletionBlocksCount());
     Mockito.doReturn(0L).when(mockIb).getInvalidationDelay();
 
     waitForNumPendingDeletionBlocks(0);
-    Assert.assertEquals(0, cluster.getNamesystem().getBlocksTotal());
-    Assert.assertEquals(0, cluster.getNamesystem().getPendingDeletionBlocks());
-    Assert.assertEquals(0, dfs.getPendingDeletionBlocksCount());
+    assertEquals(0, cluster.getNamesystem().getBlocksTotal());
+    assertEquals(0, cluster.getNamesystem().getPendingDeletionBlocks());
+    assertEquals(0, dfs.getPendingDeletionBlocksCount());
     long nnStarted = cluster.getNamesystem().getNNStartedTimeInMillis();
     long blockDeletionStartTime = cluster.getNamesystem()
         .getBlockDeletionStartTime();
-    Assert.assertTrue(String.format(
+    assertTrue(blockDeletionStartTime > nnStarted, String.format(
         "Expect blockDeletionStartTime = %d > nnStarted = %d.",
-        blockDeletionStartTime, nnStarted), blockDeletionStartTime > nnStarted);
+        blockDeletionStartTime, nnStarted));
 
     // test client protocol compatibility
     Method method = DFSClient.class.
@@ -130,8 +132,8 @@ public class TestPendingInvalidateBlock {
     // get an out of index value
     long invalidState = (Long) method.invoke(dfs.getClient(),
         ClientProtocol.STATS_ARRAY_LENGTH);
-    Assert.assertEquals(0, validState);
-    Assert.assertEquals(-1, invalidState);
+    assertEquals(0, validState);
+    assertEquals(-1, invalidState);
   }
 
   /**
@@ -170,7 +172,7 @@ public class TestPendingInvalidateBlock {
     Whitebox.setInternalState(cluster.getNamesystem().getBlockManager(),
         "invalidateBlocks", mockIb);
 
-    Assert.assertEquals(0L, cluster.getNamesystem().getPendingDeletionBlocks());
+    assertEquals(0L, cluster.getNamesystem().getPendingDeletionBlocks());
     // restart DataNodes
     for (int i = 0; i < REPLICATION; i++) {
       cluster.restartDataNode(dnprops[i]);
@@ -182,13 +184,13 @@ public class TestPendingInvalidateBlock {
     }
     Thread.sleep(2000);
     // make sure we have received block reports by checking the total block #
-    Assert.assertEquals(3, cluster.getNamesystem().getBlocksTotal());
-    Assert.assertEquals(4, cluster.getNamesystem().getPendingDeletionBlocks());
+    assertEquals(3, cluster.getNamesystem().getBlocksTotal());
+    assertEquals(4, cluster.getNamesystem().getPendingDeletionBlocks());
 
     cluster.restartNameNode(true);
     waitForNumPendingDeletionBlocks(0);
-    Assert.assertEquals(3, cluster.getNamesystem().getBlocksTotal());
-    Assert.assertEquals(0, cluster.getNamesystem().getPendingDeletionBlocks());
+    assertEquals(3, cluster.getNamesystem().getBlocksTotal());
+    assertEquals(0, cluster.getNamesystem().getPendingDeletionBlocks());
   }
 
   private long waitForReplication() throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSequentialBlockGroupId.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSequentialBlockGroupId.java
@@ -19,11 +19,10 @@ package org.apache.hadoop.hdfs.server.blockmanagement;
 
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BLOCK_GROUP_INDEX_MASK;
 import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.MAX_BLOCKS_IN_GROUP;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,10 +42,10 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.Whitebox;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -76,7 +75,7 @@ public class TestSequentialBlockGroupId {
   private SequentialBlockGroupIdGenerator blockGrpIdGenerator;
   private Path ecDir = new Path("/ecDir");
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration conf = new HdfsConfiguration();
     conf.setInt(DFSConfigKeys.DFS_REPLICATION_KEY, 1);
@@ -94,7 +93,7 @@ public class TestSequentialBlockGroupId {
         StripedFileTestUtil.getDefaultECPolicy().getName());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -105,7 +104,8 @@ public class TestSequentialBlockGroupId {
   /**
    * Test that blockGroup IDs are generating unique value.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testBlockGroupIdGeneration() throws IOException {
     long blockGroupIdInitialValue = blockGrpIdGenerator.getCurrentValue();
 
@@ -114,7 +114,9 @@ public class TestSequentialBlockGroupId {
     DFSTestUtil.createFile(fs, path, cellSize, fileLen, blockSize, REPLICATION,
         SEED);
     List<LocatedBlock> blocks = DFSTestUtil.getAllBlocks(fs, path);
-    assertThat("Wrong BlockGrps", blocks.size(), is(blockGrpCount));
+    assertThat(blocks.size())
+        .as("Wrong BlockGrps")
+        .isEqualTo(blockGrpCount);
 
     // initialising the block group generator for verifying the block id
     blockGrpIdGenerator.setCurrentValue(blockGroupIdInitialValue);
@@ -126,20 +128,23 @@ public class TestSequentialBlockGroupId {
       long nextBlockExpectedId = blockGrpIdGenerator.getCurrentValue();
       long nextBlockGrpId = blocks.get(i).getBlock().getBlockId();
       LOG.info("BlockGrp" + i + " id is " + nextBlockGrpId);
-      assertThat("BlockGrpId mismatches!", nextBlockGrpId,
-          is(nextBlockExpectedId));
+      assertThat(nextBlockGrpId)
+          .as("BlockGrpId mismatches!")
+          .isEqualTo(nextBlockExpectedId);
     }
 
     // verify that the blockGroupId resets on #clear call.
     cluster.getNamesystem().getBlockManager().clear();
-    assertThat("BlockGrpId mismatches!", blockGrpIdGenerator.getCurrentValue(),
-        is(Long.MIN_VALUE));
+    assertThat(blockGrpIdGenerator.getCurrentValue())
+        .as("BlockGrpId mismatches!")
+        .isEqualTo(Long.MIN_VALUE);
   }
 
   /**
    * Test that collisions in the blockGroup ID space are handled gracefully.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testTriggerBlockGroupIdCollision() throws IOException {
     long blockGroupIdInitialValue = blockGrpIdGenerator.getCurrentValue();
 
@@ -149,7 +154,9 @@ public class TestSequentialBlockGroupId {
     DFSTestUtil.createFile(fs, path1, cellSize, fileLen, blockSize,
         REPLICATION, SEED);
     List<LocatedBlock> blocks1 = DFSTestUtil.getAllBlocks(fs, path1);
-    assertThat("Wrong BlockGrps", blocks1.size(), is(blockGrpCount));
+    assertThat(blocks1.size())
+        .as("Wrong BlockGrps")
+        .isEqualTo(blockGrpCount);
 
     // Rewind the block ID counter in the name system object. This will result
     // in block ID collisions when we try to allocate new blocks.
@@ -160,14 +167,18 @@ public class TestSequentialBlockGroupId {
     DFSTestUtil.createFile(fs, path2, cellSize, fileLen, blockSize,
         REPLICATION, SEED);
     List<LocatedBlock> blocks2 = DFSTestUtil.getAllBlocks(fs, path2);
-    assertThat("Wrong BlockGrps", blocks2.size(), is(blockGrpCount));
+    assertThat(blocks2.size())
+        .as("Wrong BlockGrps")
+        .isEqualTo(blockGrpCount);
 
     // Make sure that file1 and file2 block IDs are different
     for (LocatedBlock locBlock1 : blocks1) {
       long blockId1 = locBlock1.getBlock().getBlockId();
       for (LocatedBlock locBlock2 : blocks2) {
         long blockId2 = locBlock2.getBlock().getBlockId();
-        assertThat("BlockGrpId mismatches!", blockId1, is(not(blockId2)));
+        assertThat(blockId1)
+            .as("BlockGrpId mismatches!")
+            .isNotEqualTo(blockId2);
       }
     }
   }
@@ -176,7 +187,8 @@ public class TestSequentialBlockGroupId {
    * Test that collisions in the blockGroup ID when the id is occupied by legacy
    * block.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testTriggerBlockGroupIdCollisionWithLegacyBlockId()
       throws Exception {
     long blockGroupIdInitialValue = blockGrpIdGenerator.getCurrentValue();
@@ -208,9 +220,9 @@ public class TestSequentialBlockGroupId {
     DFSTestUtil.createFile(fs, path1, 1024, REPLICATION, SEED);
 
     List<LocatedBlock> contiguousBlocks = DFSTestUtil.getAllBlocks(fs, path1);
-    assertThat(contiguousBlocks.size(), is(1));
-    Assert.assertEquals("Unexpected BlockId!", curBlockGroupIdValue,
-        contiguousBlocks.get(0).getBlock().getBlockId());
+    assertThat(contiguousBlocks.size()).isEqualTo(1);
+    assertEquals(curBlockGroupIdValue, contiguousBlocks.get(0).getBlock().getBlockId(),
+        "Unexpected BlockId!");
 
     // Reset back to the initial value to trigger collision
     blockGrpIdGenerator.setCurrentValue(blockGroupIdInitialValue);
@@ -219,14 +231,18 @@ public class TestSequentialBlockGroupId {
     DFSTestUtil.createFile(fs, path2, cellSize, fileLen, blockSize,
         REPLICATION, SEED);
     List<LocatedBlock> blocks2 = DFSTestUtil.getAllBlocks(fs, path2);
-    assertThat("Wrong BlockGrps", blocks2.size(), is(blockGrpCount));
+    assertThat(blocks2.size())
+        .as("Wrong BlockGrps")
+        .isEqualTo(blockGrpCount);
 
     // Make sure that file1 and file2 block IDs are different
     for (LocatedBlock locBlock1 : contiguousBlocks) {
       long blockId1 = locBlock1.getBlock().getBlockId();
       for (LocatedBlock locBlock2 : blocks2) {
         long blockId2 = locBlock2.getBlock().getBlockId();
-        assertThat("BlockGrpId mismatches!", blockId1, is(not(blockId2)));
+        assertThat(blockId1)
+            .as("BlockGrpId mismatches!")
+            .isNotEqualTo(blockId2);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSequentialBlockId.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSequentialBlockId.java
@@ -32,11 +32,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the sequential block ID generation mechanism and block ID
@@ -79,7 +78,7 @@ public class TestSequentialBlockId {
       for (int i = 1; i < blocks.size(); ++i) {
         long nextBlockId = blocks.get(i).getBlock().getBlockId();
         LOG.info("Block" + i + " id is " + nextBlockId);
-        assertThat(nextBlockId, is(nextBlockExpectedId));
+        assertThat(nextBlockId).isEqualTo(nextBlockExpectedId);
         ++nextBlockExpectedId;
       }
     } finally {
@@ -127,11 +126,11 @@ public class TestSequentialBlockId {
           fs, path2, IO_SIZE, BLOCK_SIZE * blockCount,
           BLOCK_SIZE, REPLICATION, SEED);
       List<LocatedBlock> blocks2 = DFSTestUtil.getAllBlocks(fs, path2);
-      assertThat(blocks2.size(), is(blockCount));
+      assertThat(blocks2.size()).isEqualTo(blockCount);
 
       // Make sure that file2 block IDs start immediately after file1
-      assertThat(blocks2.get(0).getBlock().getBlockId(),
-                 is(blocks1.get(9).getBlock().getBlockId() + 1));
+      assertThat(blocks2.get(0).getBlock().getBlockId())
+          .isEqualTo(blocks1.get(9).getBlock().getBlockId() + 1);
 
     } finally {
       cluster.shutdown();
@@ -166,8 +165,8 @@ public class TestSequentialBlockId {
     // Make sure that isLegacyBlock() can correctly detect
     // legacy and new blocks.
     when(bid.isLegacyBlock(any(Block.class))).thenCallRealMethod();
-    assertThat(bid.isLegacyBlock(legacyBlock), is(true));
-    assertThat(bid.isLegacyBlock(newBlock), is(false));
+    assertThat(bid.isLegacyBlock(legacyBlock)).isEqualTo(true);
+    assertThat(bid.isLegacyBlock(newBlock)).isEqualTo(false);
   }
 
   /**
@@ -192,7 +191,7 @@ public class TestSequentialBlockId {
     // Make sure that the generation stamp is set correctly for both
     // kinds of blocks.
     when(bid.nextGenerationStamp(anyBoolean())).thenCallRealMethod();
-    assertThat(bid.nextGenerationStamp(true), is(nextLegacyGenerationStamp));
-    assertThat(bid.nextGenerationStamp(false), is(nextGenerationStamp));
+    assertThat(bid.nextGenerationStamp(true)).isEqualTo(nextLegacyGenerationStamp);
+    assertThat(bid.nextGenerationStamp(false)).isEqualTo(nextGenerationStamp);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSlowPeerTracker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSlowPeerTracker.java
@@ -25,33 +25,27 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.server.protocol.OutlierMetrics;
 import org.apache.hadoop.util.FakeTimer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Set;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link SlowPeerTracker}.
+ * Set a timeout for every test case.
  */
+@Timeout(300)
 public class TestSlowPeerTracker {
   private static final Logger LOG = LoggerFactory.getLogger(TestSlowPeerTracker.class);
-
-  /**
-   * Set a timeout for every test case.
-   */
-  @Rule
-  public Timeout testTimeout = new Timeout(300_000);
 
   private Configuration conf;
   private SlowPeerTracker tracker;
@@ -60,7 +54,7 @@ public class TestSlowPeerTracker {
   private static final ObjectReader READER =
       new ObjectMapper().readerFor(new TypeReference<Set<SlowPeerJsonReport>>() {});
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new HdfsConfiguration();
     timer = new FakeTimer();
@@ -83,10 +77,10 @@ public class TestSlowPeerTracker {
     tracker.addReport("node3", "node1", new OutlierMetrics(0.0, 0.0, 0.0, 2.1));
     tracker.addReport("node3", "node2", new OutlierMetrics(0.0, 0.0, 0.0, 1.22));
 
-    assertThat(tracker.getReportsForAllDataNodes().size(), is(2));
-    assertThat(tracker.getReportsForNode("node2").size(), is(1));
-    assertThat(tracker.getReportsForNode("node3").size(), is(2));
-    assertThat(tracker.getReportsForNode("node1").size(), is(0));
+    assertThat(tracker.getReportsForAllDataNodes().size()).isEqualTo(2);
+    assertThat(tracker.getReportsForNode("node2").size()).isEqualTo(1);
+    assertThat(tracker.getReportsForNode("node3").size()).isEqualTo(2);
+    assertThat(tracker.getReportsForNode("node1").size()).isEqualTo(0);
   }
 
   /**
@@ -100,7 +94,7 @@ public class TestSlowPeerTracker {
 
     // No reports should expire after 1ms.
     timer.advance(1);
-    assertThat(tracker.getReportsForAllDataNodes().size(), is(3));
+    assertThat(tracker.getReportsForAllDataNodes().size()).isEqualTo(3);
 
     // All reports should expire after REPORT_VALIDITY_MS.
     timer.advance(reportValidityMs);
@@ -120,8 +114,8 @@ public class TestSlowPeerTracker {
     tracker.addReport("node3", "node2", new OutlierMetrics(0.0, 0.0, 0.0, 1.222));
     timer.advance(reportValidityMs);
     tracker.addReport("node3", "node4", new OutlierMetrics(0.0, 0.0, 0.0, 1.20));
-    assertThat(tracker.getReportsForAllDataNodes().size(), is(1));
-    assertThat(tracker.getReportsForNode("node3").size(), is(1));
+    assertThat(tracker.getReportsForAllDataNodes().size()).isEqualTo(1);
+    assertThat(tracker.getReportsForNode("node3").size()).isEqualTo(1);
     assertEquals(1, tracker.getReportsForNode("node3").stream()
         .filter(e -> e.getReportingNode().equals("node4")).count());
   }
@@ -134,13 +128,13 @@ public class TestSlowPeerTracker {
     OutlierMetrics outlierMetrics1 = new OutlierMetrics(0.0, 0.0, 0.0, 2.1);
     tracker.addReport("node2", "node1", outlierMetrics1);
     timer.advance(reportValidityMs); // Expire the report.
-    assertThat(tracker.getReportsForAllDataNodes().size(), is(0));
+    assertThat(tracker.getReportsForAllDataNodes().size()).isEqualTo(0);
 
     // This should replace the expired report with a newer valid one.
     OutlierMetrics outlierMetrics2 = new OutlierMetrics(0.0, 0.0, 0.0, 0.001);
     tracker.addReport("node2", "node1", outlierMetrics2);
-    assertThat(tracker.getReportsForAllDataNodes().size(), is(1));
-    assertThat(tracker.getReportsForNode("node2").size(), is(1));
+    assertThat(tracker.getReportsForAllDataNodes().size()).isEqualTo(1);
+    assertThat(tracker.getReportsForNode("node2").size()).isEqualTo(1);
   }
 
   @Test
@@ -157,7 +151,7 @@ public class TestSlowPeerTracker {
     final Set<SlowPeerJsonReport> reports = getAndDeserializeJson();
 
     // And ensure its contents are what we expect.
-    assertThat(reports.size(), is(3));
+    assertThat(reports.size()).isEqualTo(3);
     assertTrue(isNodeInReports(reports, "node1"));
     assertTrue(isNodeInReports(reports, "node2"));
     assertTrue(isNodeInReports(reports, "node4"));
@@ -192,29 +186,39 @@ public class TestSlowPeerTracker {
     assertTrue(isNodeInReports(reports, "node5"));
     assertTrue(isNodeInReports(reports, "node6"));
 
-    assertEquals(1, reports.stream().filter(
-        e -> e.getSlowNode().equals("node1") && e.getSlowPeerLatencyWithReportingNodes().size() == 2
-            && e.getSlowPeerLatencyWithReportingNodes().first().getReportedLatency().equals(1.634)
-            && e.getSlowPeerLatencyWithReportingNodes().last().getReportedLatency().equals(2.3566))
+    assertEquals(1,
+        reports.stream().filter(e -> e.getSlowNode().equals("node1")
+                && e.getSlowPeerLatencyWithReportingNodes().size() == 2
+                && e.getSlowPeerLatencyWithReportingNodes().first()
+                .getReportedLatency().equals(1.634)
+                && e.getSlowPeerLatencyWithReportingNodes().last()
+                .getReportedLatency().equals(2.3566))
+            .count());
+
+    assertEquals(1,
+        reports.stream().filter(e -> e.getSlowNode().equals("node2")
+                && e.getSlowPeerLatencyWithReportingNodes().size() == 2
+                && e.getSlowPeerLatencyWithReportingNodes().first()
+                .getReportedLatency().equals(3.869)
+                && e.getSlowPeerLatencyWithReportingNodes().last()
+                .getReportedLatency().equals(4.1356))
+            .count());
+
+    assertEquals(1, reports.stream().filter(e -> e.getSlowNode().equals("node3")
+            && e.getSlowPeerLatencyWithReportingNodes().size() == 2
+            && e.getSlowPeerLatencyWithReportingNodes().first()
+            .getReportedLatency().equals(1.73057)
+            && e.getSlowPeerLatencyWithReportingNodes().last()
+            .getReportedLatency().equals(2.4956730))
         .count());
 
-    assertEquals(1, reports.stream().filter(
-        e -> e.getSlowNode().equals("node2") && e.getSlowPeerLatencyWithReportingNodes().size() == 2
-            && e.getSlowPeerLatencyWithReportingNodes().first().getReportedLatency().equals(3.869)
-            && e.getSlowPeerLatencyWithReportingNodes().last().getReportedLatency().equals(4.1356))
+    assertEquals(1, reports.stream().filter(e -> e.getSlowNode().equals("node6")
+            && e.getSlowPeerLatencyWithReportingNodes().size() == 2
+            && e.getSlowPeerLatencyWithReportingNodes().first()
+            .getReportedLatency().equals(1.29475656)
+            && e.getSlowPeerLatencyWithReportingNodes().last()
+            .getReportedLatency().equals(2.37464))
         .count());
-
-    assertEquals(1, reports.stream().filter(
-        e -> e.getSlowNode().equals("node3") && e.getSlowPeerLatencyWithReportingNodes().size() == 2
-            && e.getSlowPeerLatencyWithReportingNodes().first().getReportedLatency().equals(1.73057)
-            && e.getSlowPeerLatencyWithReportingNodes().last().getReportedLatency()
-            .equals(2.4956730)).count());
-
-    assertEquals(1, reports.stream().filter(
-        e -> e.getSlowNode().equals("node6") && e.getSlowPeerLatencyWithReportingNodes().size() == 2
-            && e.getSlowPeerLatencyWithReportingNodes().first().getReportedLatency()
-            .equals(1.29475656) && e.getSlowPeerLatencyWithReportingNodes().last()
-            .getReportedLatency().equals(2.37464)).count());
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedStripedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestSortLocatedStripedBlock.java
@@ -38,12 +38,15 @@ import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests the sorting of located striped blocks based on
@@ -63,7 +66,7 @@ public class TestSortLocatedStripedBlock {
   static DatanodeManager dm;
   static final long STALE_INTERVAL = 30 * 1000 * 60;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     dm = mockDatanodeManager();
   }
@@ -89,7 +92,8 @@ public class TestSortLocatedStripedBlock {
    *
    * Note: after sorting block indices will not be in ascending order.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWithMultipleDecommnDatanodes() {
     LOG.info("Starting test testSortWithMultipleDecommnDatanodes");
     int lbsCount = 2; // two located block groups
@@ -142,7 +146,8 @@ public class TestSortLocatedStripedBlock {
    *
    * Note: after sorting block indices will not be in ascending order.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testTwoDatanodesWithSameBlockIndexAreDecommn() {
     LOG.info("Starting test testTwoDatanodesWithSameBlockIndexAreDecommn");
     int lbsCount = 2; // two located block groups
@@ -197,7 +202,8 @@ public class TestSortLocatedStripedBlock {
    *
    * Note: after sorting block indices will not be in ascending order.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testSmallerThanOneStripeWithMultpleDecommnNodes()
       throws Exception {
     LOG.info("Starting test testSmallerThanOneStripeWithDecommn");
@@ -257,7 +263,8 @@ public class TestSortLocatedStripedBlock {
    *
    * Note: after sorting block indices will not be in ascending order.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testTargetDecommnDatanodeDoesntExists() {
     LOG.info("Starting test testTargetDecommnDatanodeDoesntExists");
     int lbsCount = 2; // two located block groups
@@ -321,7 +328,8 @@ public class TestSortLocatedStripedBlock {
    *
    * Note: after sorting block indices will not be in ascending order.
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testWithMultipleInServiceAndDecommnDatanodes() {
     LOG.info("Starting test testWithMultipleInServiceAndDecommnDatanodes");
     int lbsCount = 2; // two located block groups
@@ -366,12 +374,11 @@ public class TestSortLocatedStripedBlock {
     for (LocatedBlock lb : lbs) {
       byte[] blockIndices = ((LocatedStripedBlock) lb).getBlockIndices();
       // after sorting stale block index will be placed after normal nodes.
-      Assert.assertEquals("Failed to move stale node to bottom!", 1,
-          blockIndices[9]);
+      assertEquals(1, blockIndices[9], "Failed to move stale node to bottom!");
       DatanodeInfo[] locations = lb.getLocations();
       // After sorting stale node d13 will be placed after normal nodes
-      Assert.assertEquals("Failed to move stale dn after normal one!",
-          staleDns.remove(0), locations[9]);
+      assertEquals(staleDns.remove(0), locations[9],
+          "Failed to move stale dn after normal one!");
     }
   }
 
@@ -392,17 +399,17 @@ public class TestSortLocatedStripedBlock {
         LOG.info("Block Locations size={}, locs={}, j=", nodes.length,
             dnInfo.toString(), j);
         if (j < blkGrpWidth) {
-          Assert.assertEquals("Node shouldn't be decommissioned",
-              AdminStates.NORMAL, dnInfo.getAdminState());
+          assertEquals(AdminStates.NORMAL, dnInfo.getAdminState(),
+              "Node shouldn't be decommissioned");
         } else {
           // check against decommissioned list
-          Assert.assertTrue(
+          assertTrue(
+              decommissionedNodeList.contains(dnInfo.getXferAddr()),
               "For block " + blk.getBlock() + " decommissioned node " + dnInfo
                   + " is not last node in list: " + j + "th index of "
-                  + nodes.length,
-              decommissionedNodeList.contains(dnInfo.getXferAddr()));
-          Assert.assertEquals("Node should be decommissioned",
-              AdminStates.DECOMMISSIONED, dnInfo.getAdminState());
+                  + nodes.length);
+          assertEquals(AdminStates.DECOMMISSIONED, dnInfo.getAdminState(),
+              "Node should be decommissioned");
         }
       }
     }
@@ -552,10 +559,10 @@ public class TestSortLocatedStripedBlock {
           locToTokenList.get(i);
       DatanodeInfo[] di = lb.getLocations();
       for (int j = 0; j < di.length; j++) {
-        Assert.assertEquals("Block index value mismatches after sorting",
-            (byte) locToIndex.get(di[j]), stripedBlk.getBlockIndices()[j]);
-        Assert.assertEquals("Block token value mismatches after sorting",
-            locToToken.get(di[j]), stripedBlk.getBlockTokens()[j]);
+        assertEquals((byte) locToIndex.get(di[j]), stripedBlk.getBlockIndices()[j],
+            "Block index value mismatches after sorting");
+        assertEquals(locToToken.get(di[j]), stripedBlk.getBlockTokens()[j],
+            "Block token value mismatches after sorting");
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestStorageBlockPoolUsageStdDev.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestStorageBlockPoolUsageStdDev.java
@@ -30,14 +30,15 @@ import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.protocol.StorageReport;
 import org.eclipse.jetty.util.ajax.JSON;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestStorageBlockPoolUsageStdDev {
   private final static int NUM_DATANODES = 5;
@@ -48,7 +49,7 @@ public class TestStorageBlockPoolUsageStdDev {
   private MiniDFSCluster cluster;
   private FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new HdfsConfiguration();
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
@@ -137,23 +138,23 @@ public class TestStorageBlockPoolUsageStdDev {
     // When multiple values are operated on in different order,
     // the results may be inconsistent, so we only take two decimal
     // points to assert.
-    Assert.assertEquals(
+    assertEquals(
         Util.getBlockPoolUsedPercentStdDev(storageReportsDn0),
         (double) info.get(dn0.getDisplayName()).get("blockPoolUsedPercentStdDev"),
         0.01d);
-    Assert.assertEquals(
+    assertEquals(
         Util.getBlockPoolUsedPercentStdDev(storageReportsDn1),
         (double) info.get(dn1.getDisplayName()).get("blockPoolUsedPercentStdDev"),
         0.01d);
-    Assert.assertEquals(
+    assertEquals(
         Util.getBlockPoolUsedPercentStdDev(storageReportsDn2),
         (double) info.get(dn2.getDisplayName()).get("blockPoolUsedPercentStdDev"),
         0.01d);
-    Assert.assertEquals(
+    assertEquals(
         Util.getBlockPoolUsedPercentStdDev(storageReportsDn3),
         (double) info.get(dn3.getDisplayName()).get("blockPoolUsedPercentStdDev"),
         0.01d);
-    Assert.assertEquals(
+    assertEquals(
         Util.getBlockPoolUsedPercentStdDev(storageReportsDn4),
         (double) info.get(dn4.getDisplayName()).get("blockPoolUsedPercentStdDev"),
         0.01d);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestGetUriFromString.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestGetUriFromString.java
@@ -17,15 +17,15 @@
  */
 package org.apache.hadoop.hdfs.server.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URI;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This is a unit test, which tests {@link Util#stringAsURI(String)}
@@ -68,10 +68,10 @@ public class TestGetUriFromString {
     URI u = null;
     u = Util.stringAsURI(ABSOLUTE_PATH_WINDOWS);
     assertNotNull(
-        "Uri should not be null for Windows path" + ABSOLUTE_PATH_WINDOWS, u);
+        u, "Uri should not be null for Windows path" + ABSOLUTE_PATH_WINDOWS);
     assertEquals(URI_FILE_SCHEMA, u.getScheme());
     u = Util.stringAsURI(ABSOLUTE_PATH_UNIX);
-    assertNotNull("Uri should not be null for Unix path" + ABSOLUTE_PATH_UNIX, u);
+    assertNotNull(u, "Uri should not be null for Unix path" + ABSOLUTE_PATH_UNIX);
     assertEquals(URI_FILE_SCHEMA, u.getScheme());
   }
 
@@ -84,14 +84,14 @@ public class TestGetUriFromString {
     LOG.info("Testing correct Unix URI: " + URI_UNIX);
     URI u = Util.stringAsURI(URI_UNIX);
     LOG.info("Uri: " + u);    
-    assertNotNull("Uri should not be null at this point", u);
+    assertNotNull(u, "Uri should not be null at this point");
     assertEquals(URI_FILE_SCHEMA, u.getScheme());
     assertEquals(URI_PATH_UNIX, u.getPath());
 
     LOG.info("Testing correct windows URI: " + URI_WINDOWS);
     u = Util.stringAsURI(URI_WINDOWS);
     LOG.info("Uri: " + u);
-    assertNotNull("Uri should not be null at this point", u);
+    assertNotNull(u, "Uri should not be null at this point");
     assertEquals(URI_FILE_SCHEMA, u.getScheme());
     assertEquals(URI_PATH_WINDOWS.replace("%20", " "), u.getPath());
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestHostRestrictingAuthorizationFilter.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdfs.server.common;
 
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestJspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestJspHelper.java
@@ -39,9 +39,8 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.ServletContext;
@@ -49,7 +48,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,7 +62,7 @@ public class TestJspHelper {
   private final Configuration conf = new HdfsConfiguration();
 
   // allow user with TGT to run tests
-  @BeforeClass
+  @BeforeAll
   public static void setupKerb() {
     System.setProperty("java.security.krb5.kdc", "");
     System.setProperty("java.security.krb5.realm", "NONE");
@@ -142,7 +145,7 @@ public class TestJspHelper {
     UserGroupInformation ugi = JspHelper.getUGI(context, request, conf);
     Token<? extends TokenIdentifier> tokenInUgi = ugi.getTokens().iterator()
         .next();
-    Assert.assertEquals(expected, tokenInUgi.getService().toString());
+    assertEquals(expected, tokenInUgi.getService().toString());
   }
 
   @Test
@@ -168,9 +171,9 @@ public class TestJspHelper {
     when(request.getParameter(JspHelper.DELEGATION_PARAMETER_NAME)).thenReturn(
         tokenString);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
 
     // token with auth-ed user
@@ -178,9 +181,9 @@ public class TestJspHelper {
     when(request.getParameter(JspHelper.DELEGATION_PARAMETER_NAME)).thenReturn(
         tokenString);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);    
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
     
     // completely different user, token trumps auth
@@ -188,9 +191,9 @@ public class TestJspHelper {
     when(request.getParameter(JspHelper.DELEGATION_PARAMETER_NAME)).thenReturn(
         tokenString);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);    
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
     
     // expected case
@@ -198,9 +201,9 @@ public class TestJspHelper {
     when(request.getParameter(JspHelper.DELEGATION_PARAMETER_NAME)).thenReturn(
         tokenString);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);    
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
 
     // if present token, ignore doas parameter
@@ -209,9 +212,9 @@ public class TestJspHelper {
         tokenString);
 
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
 
     // if present token, ignore user.name parameter
@@ -220,9 +223,9 @@ public class TestJspHelper {
         tokenString);
 
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
 
     // if present token, ignore user.name and doas parameter
@@ -231,9 +234,9 @@ public class TestJspHelper {
         tokenString);
 
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromToken(ugi);
 
   }
@@ -253,41 +256,39 @@ public class TestJspHelper {
     request = getMockRequest(null, null, null);
     try {
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad request allowed");
+      fail("bad request allowed");
     } catch (IOException ioe) {
-      Assert.assertEquals(
-          "Security enabled but user not authenticated by filter",
+      assertEquals("Security enabled but user not authenticated by filter",
           ioe.getMessage());
     }
     request = getMockRequest(null, realUser, null);
     try {
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad request allowed");
+      fail("bad request allowed");
     } catch (IOException ioe) {
-      Assert.assertEquals(
-          "Security enabled but user not authenticated by filter",
+      assertEquals("Security enabled but user not authenticated by filter",
           ioe.getMessage());
     }
     
     // ugi for remote user
     request = getMockRequest(realUser, null, null);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getShortUserName(), realUser);
+    assertNull(ugi.getRealUser());
+    assertEquals(ugi.getShortUserName(), realUser);
     checkUgiFromAuth(ugi);
     
     // ugi for remote user = real user
     request = getMockRequest(realUser, realUser, null);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getShortUserName(), realUser);
+    assertNull(ugi.getRealUser());
+    assertEquals(ugi.getShortUserName(), realUser);
     checkUgiFromAuth(ugi);
     
     // if there is remote user via SPNEGO, ignore user.name param
     request = getMockRequest(realUser, user, null);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getShortUserName(), realUser);
+    assertNull(ugi.getRealUser());
+    assertEquals(ugi.getShortUserName(), realUser);
     checkUgiFromAuth(ugi);
   }
   
@@ -312,44 +313,42 @@ public class TestJspHelper {
     request = getMockRequest(null, null, user);
     try {
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad request allowed");
+      fail("bad request allowed");
     } catch (IOException ioe) {
-      Assert.assertEquals(
-          "Security enabled but user not authenticated by filter",
+      assertEquals("Security enabled but user not authenticated by filter",
           ioe.getMessage());
     }
     request = getMockRequest(null, realUser, user);
     try {
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad request allowed");
+      fail("bad request allowed");
     } catch (IOException ioe) {
-      Assert.assertEquals(
-          "Security enabled but user not authenticated by filter",
+      assertEquals("Security enabled but user not authenticated by filter",
           ioe.getMessage());
     }
     
     // proxy ugi for user via remote user
     request = getMockRequest(realUser, null, user);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromAuth(ugi);
     
     // proxy ugi for user vi a remote user = real user
     request = getMockRequest(realUser, realUser, user);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromAuth(ugi);
 
     // if there is remote user via SPNEGO, ignore user.name, doas param
     request = getMockRequest(realUser, user, user);
     ugi = JspHelper.getUGI(context, request, conf);
-    Assert.assertNotNull(ugi.getRealUser());
-    Assert.assertEquals(ugi.getRealUser().getShortUserName(), realUser);
-    Assert.assertEquals(ugi.getShortUserName(), user);
+    assertNotNull(ugi.getRealUser());
+    assertEquals(ugi.getRealUser().getShortUserName(), realUser);
+    assertEquals(ugi.getShortUserName(), user);
     checkUgiFromAuth(ugi);
 
 
@@ -358,20 +357,18 @@ public class TestJspHelper {
     try {
       request = getMockRequest(user, null, realUser);
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad proxy request allowed");
+      fail("bad proxy request allowed");
     } catch (AuthorizationException ae) {
-      Assert.assertEquals(
-          "User: " + user + " is not allowed to impersonate " + realUser,
-           ae.getMessage());
+      assertEquals("User: " + user + " is not allowed to impersonate " + realUser,
+          ae.getMessage());
     }
     try {
       request = getMockRequest(user, user, realUser);
       JspHelper.getUGI(context, request, conf);
-      Assert.fail("bad proxy request allowed");
+      fail("bad proxy request allowed");
     } catch (AuthorizationException ae) {
-      Assert.assertEquals(
-          "User: " + user + " is not allowed to impersonate " + realUser,
-           ae.getMessage());
+      assertEquals("User: " + user + " is not allowed to impersonate " + realUser,
+          ae.getMessage());
     }
   }
 
@@ -420,25 +417,21 @@ public class TestJspHelper {
   
   private void checkUgiFromAuth(UserGroupInformation ugi) {
     if (ugi.getRealUser() != null) {
-      Assert.assertEquals(AuthenticationMethod.PROXY,
-                          ugi.getAuthenticationMethod());
-      Assert.assertEquals(AuthenticationMethod.KERBEROS_SSL,
-                          ugi.getRealUser().getAuthenticationMethod());
+      assertEquals(AuthenticationMethod.PROXY, ugi.getAuthenticationMethod());
+      assertEquals(AuthenticationMethod.KERBEROS_SSL,
+          ugi.getRealUser().getAuthenticationMethod());
     } else {
-      Assert.assertEquals(AuthenticationMethod.KERBEROS_SSL,
-                          ugi.getAuthenticationMethod()); 
+      assertEquals(AuthenticationMethod.KERBEROS_SSL, ugi.getAuthenticationMethod());
     }
   }
   
   private void checkUgiFromToken(UserGroupInformation ugi) {
     if (ugi.getRealUser() != null) {
-      Assert.assertEquals(AuthenticationMethod.PROXY,
-                          ugi.getAuthenticationMethod());
-      Assert.assertEquals(AuthenticationMethod.TOKEN,
-                          ugi.getRealUser().getAuthenticationMethod());
+      assertEquals(AuthenticationMethod.PROXY, ugi.getAuthenticationMethod());
+      assertEquals(AuthenticationMethod.TOKEN,
+          ugi.getRealUser().getAuthenticationMethod());
     } else {
-      Assert.assertEquals(AuthenticationMethod.TOKEN,
-                          ugi.getAuthenticationMethod());
+      assertEquals(AuthenticationMethod.TOKEN, ugi.getAuthenticationMethod());
     }
   }
 
@@ -453,7 +446,7 @@ public class TestJspHelper {
         in.reset(out.getData(), out.getLength());
         HdfsServerConstants.ReplicaState result = HdfsServerConstants.ReplicaState
             .read(in);
-        assertTrue("testReadWrite error !!!", repState == result);
+        assertTrue(repState == result, "testReadWrite error !!!");
         out.reset();
         in.reset();
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/web/TestDatanodeHttpServer.java
@@ -35,15 +35,16 @@ import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(value = Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ParameterizedClass
+@MethodSource("policy")
 public class TestDatanodeHttpServer {
   private static final String BASEDIR = GenericTestUtils
       .getTempPath(TestDatanodeHttpServer.class.getSimpleName());
@@ -52,7 +53,6 @@ public class TestDatanodeHttpServer {
   private static Configuration conf;
   private static URLConnectionFactory connectionFactory;
 
-  @Parameters
   public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] {{HttpConfig.Policy.HTTP_ONLY},
         {HttpConfig.Policy.HTTPS_ONLY}, {HttpConfig.Policy.HTTP_AND_HTTPS}};
@@ -66,7 +66,7 @@ public class TestDatanodeHttpServer {
     this.policy = policy;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
@@ -83,7 +83,7 @@ public class TestDatanodeHttpServer {
         KeyStoreTestUtil.getServerSSLConfigFileName());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     FileUtil.fullyDelete(new File(BASEDIR));
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
@@ -100,14 +100,14 @@ public class TestDatanodeHttpServer {
       server = new DatanodeHttpServer(conf, null, null);
       server.start();
 
-      Assert.assertTrue(implies(policy.isHttpEnabled(),
+      assertTrue(implies(policy.isHttpEnabled(),
           canAccess("http", server.getHttpAddress())));
-      Assert.assertTrue(implies(!policy.isHttpEnabled(),
+      assertTrue(implies(!policy.isHttpEnabled(),
           server.getHttpAddress() == null));
 
-      Assert.assertTrue(implies(policy.isHttpsEnabled(),
+      assertTrue(implies(policy.isHttpsEnabled(),
           canAccess("https", server.getHttpsAddress())));
-      Assert.assertTrue(implies(!policy.isHttpsEnabled(),
+      assertTrue(implies(!policy.isHttpsEnabled(),
           server.getHttpsAddress() == null));
 
     } finally {
@@ -125,7 +125,7 @@ public class TestDatanodeHttpServer {
       URL url = new URL(scheme + "://" + NetUtils.getHostPortString(addr));
       URLConnection conn = connectionFactory.openConnection(url);
       conn.connect();
-      Assert.assertTrue(conn instanceof java.net.HttpURLConnection);
+      assertTrue(conn instanceof java.net.HttpURLConnection);
       java.net.HttpURLConnection httpConn = (java.net.HttpURLConnection) conn;
       if (httpConn.getResponseCode() != 200) {
         return false;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/DiskBalancerTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/DiskBalancerTestUtil.java
@@ -44,8 +44,8 @@ import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestConnectors.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestConnectors.java
@@ -23,12 +23,13 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.diskbalancer.connectors.ClusterConnector;
 import org.apache.hadoop.hdfs.server.diskbalancer.connectors.ConnectorFactory;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerCluster;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Class that tests connectors.
@@ -39,14 +40,14 @@ public class TestConnectors {
   private final int volumeCount = 2; // default volumes in MiniDFSCluster.
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new HdfsConfiguration();
     cluster = new MiniDFSCluster.Builder(conf)
         .numDataNodes(numDatanodes).build();
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -61,10 +62,10 @@ public class TestConnectors {
     DiskBalancerCluster diskBalancerCluster =
         new DiskBalancerCluster(nameNodeConnector);
     diskBalancerCluster.readClusterInfo();
-    Assert.assertEquals("Expected number of Datanodes not found.",
-        numDatanodes, diskBalancerCluster.getNodes().size());
-    Assert.assertEquals("Expected number of volumes not found.",
-        volumeCount, diskBalancerCluster.getNodes().get(0).getVolumeCount());
+    assertEquals(numDatanodes, diskBalancerCluster.getNodes().size(),
+        "Expected number of Datanodes not found.");
+    assertEquals(volumeCount, diskBalancerCluster.getNodes().get(0).getVolumeCount(),
+        "Expected number of volumes not found.");
   }
 
   @Test
@@ -78,8 +79,7 @@ public class TestConnectors {
     String diskBalancerJson = diskBalancerCluster.toJson();
     DiskBalancerCluster serializedCluster =
         DiskBalancerCluster.parseJson(diskBalancerJson);
-    Assert.assertEquals("Parsed cluster is not equal to persisted info.",
-        diskBalancerCluster.getNodes().size(),
-        serializedCluster.getNodes().size());
+    assertEquals(diskBalancerCluster.getNodes().size(),
+        serializedCluster.getNodes().size(), "Parsed cluster is not equal to persisted info.");
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDataModels.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDataModels.java
@@ -21,14 +21,18 @@ import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerCluster;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerDataNode;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolume;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolumeSet;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests DiskBalancer Data models.
@@ -38,14 +42,14 @@ public class TestDataModels {
   public void testCreateRandomVolume() throws Exception {
     DiskBalancerTestUtil util = new DiskBalancerTestUtil();
     DiskBalancerVolume vol = util.createRandomVolume(StorageType.DISK);
-    Assert.assertNotNull(vol.getUuid());
-    Assert.assertNotNull(vol.getPath());
-    Assert.assertNotNull(vol.getStorageType());
-    Assert.assertFalse(vol.isFailed());
-    Assert.assertFalse(vol.isTransient());
-    Assert.assertTrue(vol.getCapacity() > 0);
-    Assert.assertTrue((vol.getCapacity() - vol.getReserved()) > 0);
-    Assert.assertTrue((vol.getReserved() + vol.getUsed()) < vol.getCapacity());
+    assertNotNull(vol.getUuid());
+    assertNotNull(vol.getPath());
+    assertNotNull(vol.getStorageType());
+    assertFalse(vol.isFailed());
+    assertFalse(vol.isTransient());
+    assertTrue(vol.getCapacity() > 0);
+    assertTrue((vol.getCapacity() - vol.getReserved()) > 0);
+    assertTrue((vol.getReserved() + vol.getUsed()) < vol.getCapacity());
   }
 
   @Test
@@ -53,9 +57,8 @@ public class TestDataModels {
     DiskBalancerTestUtil util = new DiskBalancerTestUtil();
     DiskBalancerVolumeSet vSet =
         util.createRandomVolumeSet(StorageType.SSD, 10);
-    Assert.assertEquals(10, vSet.getVolumeCount());
-    Assert.assertEquals(StorageType.SSD.toString(),
-        vSet.getVolumes().get(0).getStorageType());
+    assertEquals(10, vSet.getVolumeCount());
+    assertEquals(StorageType.SSD.toString(), vSet.getVolumes().get(0).getStorageType());
 
   }
 
@@ -64,7 +67,7 @@ public class TestDataModels {
     DiskBalancerTestUtil util = new DiskBalancerTestUtil();
     DiskBalancerDataNode node = util.createRandomDataNode(
         new StorageType[]{StorageType.DISK, StorageType.RAM_DISK}, 10);
-    Assert.assertNotNull(node.getNodeDataDensity());
+    assertNotNull(node.getNodeDataDensity());
   }
 
   @Test
@@ -86,11 +89,11 @@ public class TestDataModels {
 
     for (int x = 0; x < queueSize; x++) {
 
-      Assert.assertEquals(reverseList.get(x).getCapacity(),
+      assertEquals(reverseList.get(x).getCapacity(),
           highList.get(x).getCapacity());
-      Assert.assertEquals(reverseList.get(x).getReserved(),
+      assertEquals(reverseList.get(x).getReserved(),
           highList.get(x).getReserved());
-      Assert.assertEquals(reverseList.get(x).getUsed(),
+      assertEquals(reverseList.get(x).getUsed(),
           highList.get(x).getUsed());
     }
   }
@@ -117,7 +120,7 @@ public class TestDataModels {
     node.addVolume(v2);
 
     for (DiskBalancerVolumeSet vsets : node.getVolumeSets().values()) {
-      Assert.assertFalse(vsets.isBalancingNeeded(10.0f));
+      assertFalse(vsets.isBalancingNeeded(10.0f));
     }
   }
 
@@ -143,7 +146,7 @@ public class TestDataModels {
     node.addVolume(v2);
 
     for (DiskBalancerVolumeSet vsets : node.getVolumeSets().values()) {
-      Assert.assertFalse(vsets.isBalancingNeeded(10.0f));
+      assertFalse(vsets.isBalancingNeeded(10.0f));
     }
   }
 
@@ -170,7 +173,7 @@ public class TestDataModels {
     node.addVolume(v2);
 
     for (DiskBalancerVolumeSet vsets : node.getVolumeSets().values()) {
-      Assert.assertFalse(vsets.isBalancingNeeded(10.0f));
+      assertFalse(vsets.isBalancingNeeded(10.0f));
     }
   }
 
@@ -194,7 +197,7 @@ public class TestDataModels {
     node.addVolume(v2);
 
     for (DiskBalancerVolumeSet vsets : node.getVolumeSets().values()) {
-      Assert.assertTrue(vsets.isBalancingNeeded(10.0f));
+      assertTrue(vsets.isBalancingNeeded(10.0f));
     }
   }
 
@@ -206,7 +209,7 @@ public class TestDataModels {
     DiskBalancerVolume parsedVolume =
         DiskBalancerVolume.parseJson(originalString);
     String parsedString = parsedVolume.toJson();
-    Assert.assertEquals(originalString, parsedString);
+    assertEquals(originalString, parsedString);
   }
 
   @Test
@@ -220,9 +223,8 @@ public class TestDataModels {
 
     DiskBalancerCluster newCluster =
         DiskBalancerCluster.parseJson(cluster.toJson());
-    Assert.assertEquals(cluster.getNodes(), newCluster.getNodes());
-    Assert
-        .assertEquals(cluster.getNodes().size(), newCluster.getNodes().size());
+    assertEquals(cluster.getNodes(), newCluster.getNodes());
+    assertEquals(cluster.getNodes().size(), newCluster.getNodes().size());
   }
 
   @Test
@@ -233,11 +235,11 @@ public class TestDataModels {
     DiskBalancerVolume v1 = util.createRandomVolume(StorageType.DISK);
     v1.setCapacity(DiskBalancerTestUtil.GB);
     v1.setUsed(2 * DiskBalancerTestUtil.GB);
-    Assert.assertEquals(v1.getUsed(),v1.getCapacity());
+    assertEquals(v1.getUsed(), v1.getCapacity());
     // If usage is less than capacity, usage should be set to the real usage
     DiskBalancerVolume v2 = util.createRandomVolume(StorageType.DISK);
     v2.setCapacity(2*DiskBalancerTestUtil.GB);
     v2.setUsed(DiskBalancerTestUtil.GB);
-    Assert.assertEquals(v1.getUsed(),DiskBalancerTestUtil.GB);
+    assertEquals(v1.getUsed(), DiskBalancerTestUtil.GB);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancer.java
@@ -48,8 +48,7 @@ import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerDataNode
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.NodePlan;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -65,13 +64,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DATANODE_DATA_DIR_KEY;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test Disk Balancer.
@@ -101,10 +100,8 @@ public class TestDiskBalancer {
       DiskBalancerDataNode dbDnNode =
           diskBalancerCluster.getNodeByUUID(dnNode.getDatanodeUuid());
       assertEquals(dnNode.getDatanodeUuid(), dbDnNode.getDataNodeUUID());
-      assertEquals(dnNode.getDatanodeId().getIpAddr(),
-          dbDnNode.getDataNodeIP());
-      assertEquals(dnNode.getDatanodeId().getHostName(),
-          dbDnNode.getDataNodeName());
+      assertEquals(dnNode.getDatanodeId().getIpAddr(), dbDnNode.getDataNodeIP());
+      assertEquals(dnNode.getDatanodeId().getHostName(), dbDnNode.getDataNodeName());
       try (FsDatasetSpi.FsVolumeReferences ref = dnNode.getFSDataset()
           .getFsVolumeReferences()) {
         assertEquals(ref.size(), dbDnNode.getVolumeCount());
@@ -275,9 +272,9 @@ public class TestDiskBalancer {
       // Expect return sleep delay in Milliseconds. sleep value = bytesCopied /
       // (1024*1024*bandwidth in MB/milli) - timeUsed;
       long val = diskBalancerMover.computeDelay(20 * 1024 * 1024, 1200, item);
-      Assert.assertEquals(val, (long) 800);
+      assertEquals(val, (long) 800);
     } catch (Exception e) {
-      Assert.fail("Unexpected exception: " + e);
+      fail("Unexpected exception: " + e);
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -335,8 +332,9 @@ public class TestDiskBalancer {
       dataMover.verifyAllVolumesHaveData(false);
     } finally {
       String logOut = logCapturer.getOutput();
-      Assert.assertTrue("Wrong log: " + logOut, logOut.contains(
-          "NextBlock call returned null. No valid block to copy."));
+      assertTrue(
+          logOut.contains("NextBlock call returned null. No valid block to copy."),
+          "Wrong log: " + logOut);
       cluster.shutdown();
     }
   }
@@ -423,7 +421,7 @@ public class TestDiskBalancer {
       dataMover.verifyAllVolumesHaveData(true);
       dataMover.verifyTolerance(plan, 0, sourceDiskIndex, 10);
     } catch (Exception e) {
-      Assert.fail("Unexpected exception: " + e);
+      fail("Unexpected exception: " + e);
     } finally {
       if (cluster != null) {
         cluster.shutdown();
@@ -725,15 +723,14 @@ public class TestDiskBalancer {
             LOG.info("Waiting for work plan creation!");
             createWorkPlanLatch.await();
             LOG.info("Work plan created. Removing disk!");
-            assertThat(
-                "DN did not update its own config", node.
-                reconfigurePropertyImpl(DFS_DATANODE_DATA_DIR_KEY, newDirs),
-                is(node.getConf().get(DFS_DATANODE_DATA_DIR_KEY)));
+            assertThat(node.reconfigurePropertyImpl(DFS_DATANODE_DATA_DIR_KEY, newDirs))
+                .as("DN did not update its own config")
+                .isEqualTo(node.getConf().get(DFS_DATANODE_DATA_DIR_KEY));
             Thread.sleep(1000);
             LOG.info("Removed disk!");
             removeDiskLatch.countDown();
           } catch (ReconfigurationException | InterruptedException e) {
-            Assert.fail("Unexpected error while reconfiguring: " + e);
+            fail("Unexpected error while reconfiguring: " + e);
           }
         }
       };
@@ -757,8 +754,8 @@ public class TestDiskBalancer {
         }
       }, 1000, 100000);
 
-      assertTrue("Disk balancer operation hit max errors!", errorCount.get() <=
-          DFSConfigKeys.DFS_DISK_BALANCER_MAX_DISK_ERRORS_DEFAULT);
+      assertTrue(errorCount.get() <= DFSConfigKeys.DFS_DISK_BALANCER_MAX_DISK_ERRORS_DEFAULT,
+          "Disk balancer operation hit max errors!");
       createWorkPlanLatch.await();
       removeDiskLatch.await();
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancerRPC.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancerRPC.java
@@ -37,12 +37,9 @@ import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerCluster;
 import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerDataNode;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.GreedyPlanner;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.NodePlan;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,20 +48,22 @@ import java.util.Random;
 import static org.apache.hadoop.hdfs.server.datanode.DiskBalancerWorkStatus.Result.NO_PLAN;
 import static org.apache.hadoop.hdfs.server.datanode.DiskBalancerWorkStatus.Result.PLAN_DONE;
 import static org.apache.hadoop.hdfs.server.datanode.DiskBalancerWorkStatus.Result.PLAN_UNDER_PROGRESS;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test DiskBalancer RPC.
  */
 public class TestDiskBalancerRPC {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private static final String PLAN_FILE = "/system/current.plan.json";
   private MiniDFSCluster cluster;
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new HdfsConfiguration();
     conf.setBoolean(DFSConfigKeys.DFS_DISK_BALANCER_ENABLED, true);
@@ -72,7 +71,7 @@ public class TestDiskBalancerRPC {
     cluster.waitActive();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -100,10 +99,13 @@ public class TestDiskBalancerRPC {
     planHash = String.valueOf(hashArray);
     int planVersion = rpcTestHelper.getPlanVersion();
     NodePlan plan = rpcTestHelper.getPlan();
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.INVALID_PLAN_HASH));
-    dataNode.submitDiskBalancerPlan(planHash, planVersion, PLAN_FILE,
-        plan.toJson(), false);
+
+    final String planHashVariant = planHash;
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.submitDiskBalancerPlan(planHashVariant, planVersion, PLAN_FILE,
+          plan.toJson(), false);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.INVALID_PLAN_HASH);
   }
 
   @Test
@@ -114,10 +116,13 @@ public class TestDiskBalancerRPC {
     int planVersion = rpcTestHelper.getPlanVersion();
     planVersion++;
     NodePlan plan = rpcTestHelper.getPlan();
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.INVALID_PLAN_VERSION));
-    dataNode.submitDiskBalancerPlan(planHash, planVersion, PLAN_FILE,
-        plan.toJson(), false);
+
+    final int planVersionVariant = planVersion;
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.submitDiskBalancerPlan(planHash, planVersionVariant, PLAN_FILE,
+          plan.toJson(), false);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.INVALID_PLAN_VERSION);
   }
 
   @Test
@@ -127,10 +132,11 @@ public class TestDiskBalancerRPC {
     String planHash = rpcTestHelper.getPlanHash();
     int planVersion = rpcTestHelper.getPlanVersion();
     NodePlan plan = rpcTestHelper.getPlan();
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.INVALID_PLAN));
-    dataNode.submitDiskBalancerPlan(planHash, planVersion, "", "",
-        false);
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.submitDiskBalancerPlan(planHash, planVersion, "", "",
+          false);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.INVALID_PLAN);
   }
 
   @Test
@@ -154,9 +160,12 @@ public class TestDiskBalancerRPC {
     hashArray[0]++;
     planHash = String.valueOf(hashArray);
     NodePlan plan = rpcTestHelper.getPlan();
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.NO_SUCH_PLAN));
-    dataNode.cancelDiskBalancePlan(planHash);
+
+    final String planHashVariant = planHash;
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.cancelDiskBalancePlan(planHashVariant);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.NO_SUCH_PLAN);
   }
 
   @Test
@@ -165,9 +174,11 @@ public class TestDiskBalancerRPC {
     DataNode dataNode = rpcTestHelper.getDataNode();
     String planHash = "";
     NodePlan plan = rpcTestHelper.getPlan();
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.NO_SUCH_PLAN));
-    dataNode.cancelDiskBalancePlan(planHash);
+
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.cancelDiskBalancePlan(planHash);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.NO_SUCH_PLAN);
   }
 
   @Test
@@ -176,14 +187,14 @@ public class TestDiskBalancerRPC {
     DataNode dataNode = cluster.getDataNodes().get(dnIndex);
     String volumeNameJson = dataNode.getDiskBalancerSetting(
         DiskBalancerConstants.DISKBALANCER_VOLUME_NAME);
-    Assert.assertNotNull(volumeNameJson);
+    assertNotNull(volumeNameJson);
     ObjectMapper mapper = new ObjectMapper();
 
     @SuppressWarnings("unchecked")
     Map<String, String> volumemap =
         mapper.readValue(volumeNameJson, HashMap.class);
 
-    Assert.assertEquals(2, volumemap.size());
+    assertEquals(2, volumemap.size());
   }
 
   @Test
@@ -191,9 +202,11 @@ public class TestDiskBalancerRPC {
     final int dnIndex = 0;
     final String invalidSetting = "invalidSetting";
     DataNode dataNode = cluster.getDataNodes().get(dnIndex);
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(Result.UNKNOWN_KEY));
-    dataNode.getDiskBalancerSetting(invalidSetting);
+
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      dataNode.getDiskBalancerSetting(invalidSetting);
+    });
+    assertThat(ex.getResult()).isEqualTo(Result.UNKNOWN_KEY);
   }
 
   @Test
@@ -209,7 +222,7 @@ public class TestDiskBalancerRPC {
     String bandwidthString = dataNode.getDiskBalancerSetting(
         DiskBalancerConstants.DISKBALANCER_BANDWIDTH);
     long value = Long.decode(bandwidthString);
-    Assert.assertEquals(10L, value);
+    assertEquals(10L, value);
   }
 
   @Test
@@ -223,7 +236,7 @@ public class TestDiskBalancerRPC {
     dataNode.submitDiskBalancerPlan(planHash, planVersion, PLAN_FILE,
         plan.toJson(), false);
     DiskBalancerWorkStatus status = dataNode.queryDiskBalancerPlan();
-    Assert.assertTrue(status.getResult() == PLAN_UNDER_PROGRESS ||
+    assertTrue(status.getResult() == PLAN_UNDER_PROGRESS ||
         status.getResult() == PLAN_DONE);
   }
 
@@ -233,7 +246,7 @@ public class TestDiskBalancerRPC {
     DataNode dataNode = rpcTestHelper.getDataNode();
 
     DiskBalancerWorkStatus status = dataNode.queryDiskBalancerPlan();
-    Assert.assertTrue(status.getResult() == NO_PLAN);
+    assertTrue(status.getResult() == NO_PLAN);
   }
 
   @Test
@@ -307,7 +320,7 @@ public class TestDiskBalancerRPC {
       DiskBalancerCluster diskBalancerCluster =
           new DiskBalancerCluster(nameNodeConnector);
       diskBalancerCluster.readClusterInfo();
-      Assert.assertEquals(cluster.getDataNodes().size(),
+      assertEquals(cluster.getDataNodes().size(),
           diskBalancerCluster.getNodes().size());
       diskBalancerCluster.setNodesToProcess(diskBalancerCluster.getNodes());
       dataNode = cluster.getDataNodes().get(dnIndex);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancerWithMockMover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestDiskBalancerWithMockMover.java
@@ -43,11 +43,9 @@ import org.apache.hadoop.hdfs.server.diskbalancer.planner.NodePlan;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.Step;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
@@ -55,9 +53,11 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdfs.server.datanode.DiskBalancerWorkStatus.Result.NO_PLAN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests diskbalancer with a mock mover.
@@ -65,9 +65,6 @@ import static org.junit.Assert.assertTrue;
 public class TestDiskBalancerWithMockMover {
   static final Logger LOG =
       LoggerFactory.getLogger(TestDiskBalancerWithMockMover.class);
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private static final String PLAN_FILE = "/system/current.plan.json";
   private MiniDFSCluster cluster;
@@ -94,11 +91,11 @@ public class TestDiskBalancerWithMockMover {
         .setMover(blockMover)
         .build();
 
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.DISK_BALANCER_NOT_ENABLED));
-
-    balancer.queryWorkStatus();
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      balancer.queryWorkStatus();
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.DISK_BALANCER_NOT_ENABLED);
   }
 
   /**
@@ -149,13 +146,15 @@ public class TestDiskBalancerWithMockMover {
     // ask block mover to get stuck in copy block
     mockMoverHelper.getBlockMover().setSleep();
     executeSubmitPlan(plan, balancer);
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.PLAN_ALREADY_IN_PROGRESS));
-    executeSubmitPlan(plan, balancer);
 
-    // Not needed but this is the cleanup step.
-    mockMoverHelper.getBlockMover().clearSleep();
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      executeSubmitPlan(plan, balancer);
+
+      // Not needed but this is the cleanup step.
+      mockMoverHelper.getBlockMover().clearSleep();
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.PLAN_ALREADY_IN_PROGRESS);
   }
 
   @Test
@@ -189,10 +188,12 @@ public class TestDiskBalancerWithMockMover {
     DiskBalancer balancer = mockMoverHelper.getBalancer();
 
     plan.setTimeStamp(Time.now() - (32 * millisecondInAnHour));
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.OLD_PLAN_SUBMITTED));
-    executeSubmitPlan(plan, balancer);
+
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      executeSubmitPlan(plan, balancer);
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.OLD_PLAN_SUBMITTED);
   }
 
   @Test
@@ -201,12 +202,12 @@ public class TestDiskBalancerWithMockMover {
     NodePlan plan = mockMoverHelper.getPlan();
     DiskBalancer balancer = mockMoverHelper.getBalancer();
 
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.INVALID_PLAN_VERSION));
-
-    // Plan version is invalid -- there is no version 0.
-    executeSubmitPlan(plan, balancer, 0);
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      // Plan version is invalid -- there is no version 0.
+      executeSubmitPlan(plan, balancer, 0);
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.INVALID_PLAN_VERSION);
   }
 
   @Test
@@ -217,11 +218,11 @@ public class TestDiskBalancerWithMockMover {
     String planJson = plan.toJson();
     String planID = DigestUtils.sha1Hex(planJson);
 
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.INVALID_PLAN));
-
-    balancer.submitPlan(planID, 1, "no-plan-file.json", null, false);
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      balancer.submitPlan(planID, 1, "no-plan-file.json", null, false);
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.INVALID_PLAN);
   }
 
   @Test
@@ -236,11 +237,13 @@ public class TestDiskBalancerWithMockMover {
     char repChar = planID.charAt(0);
     repChar++;
 
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.INVALID_PLAN_HASH));
-    balancer.submitPlan(planID.replace(planID.charAt(0), repChar),
-        1, PLAN_FILE, planJson, false);
+    final char repCharVariant = repChar;
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      balancer.submitPlan(planID.replace(planID.charAt(0), repCharVariant),
+          1, PLAN_FILE, planJson, false);
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.INVALID_PLAN_HASH);
 
   }
 
@@ -266,28 +269,27 @@ public class TestDiskBalancerWithMockMover {
     balancer.cancelPlan(planID);
 
     DiskBalancerWorkStatus status = balancer.queryWorkStatus();
-    assertEquals(DiskBalancerWorkStatus.Result.PLAN_CANCELLED,
-        status.getResult());
-
+    assertEquals(DiskBalancerWorkStatus.Result.PLAN_CANCELLED, status.getResult());
 
     executeSubmitPlan(plan, balancer);
 
     // Send a Wrong cancellation request.
     char first = planID.charAt(0);
     first++;
-    thrown.expect(DiskBalancerException.class);
-    thrown.expect(new DiskBalancerResultVerifier(DiskBalancerException
-        .Result.NO_SUCH_PLAN));
-    balancer.cancelPlan(planID.replace(planID.charAt(0), first));
 
-    // Now cancel the real one
-    balancer.cancelPlan(planID);
-    mockMoverHelper.getBlockMover().clearSleep(); // unblock mover.
+    final char firstVariant = first;
+    DiskBalancerException ex = assertThrows(DiskBalancerException.class, () -> {
+      balancer.cancelPlan(planID.replace(planID.charAt(0), firstVariant));
 
-    status = balancer.queryWorkStatus();
-    assertEquals(DiskBalancerWorkStatus.Result.PLAN_CANCELLED,
-        status.getResult());
+      // Now cancel the real one
+      balancer.cancelPlan(planID);
+      mockMoverHelper.getBlockMover().clearSleep(); // unblock mover.
 
+      final DiskBalancerWorkStatus statusVariant = balancer.queryWorkStatus();
+      assertEquals(DiskBalancerWorkStatus.Result.PLAN_CANCELLED, statusVariant.getResult());
+    });
+    assertThat(ex.getResult()).isEqualTo(DiskBalancerException
+        .Result.NO_SUCH_PLAN);
   }
 
 
@@ -318,7 +320,7 @@ public class TestDiskBalancerWithMockMover {
   }
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration conf = new HdfsConfiguration();
     final int numStoragesPerDn = 2;
@@ -339,7 +341,7 @@ public class TestDiskBalancerWithMockMover {
     references.close();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestPlanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/TestPlanner.java
@@ -27,8 +27,7 @@ import org.apache.hadoop.hdfs.server.diskbalancer.datamodel.DiskBalancerVolumeSe
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.GreedyPlanner;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.NodePlan;
 import org.apache.hadoop.hdfs.server.diskbalancer.planner.Step;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,9 +35,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Planner.
@@ -55,7 +54,7 @@ public class TestPlanner {
         null);
     DiskBalancerCluster cluster = new DiskBalancerCluster(jsonConnector);
     cluster.readClusterInfo();
-    Assert.assertEquals(3, cluster.getNodes().size());
+    assertEquals(3, cluster.getNodes().size());
     cluster.setNodesToProcess(cluster.getNodes());
     DiskBalancerDataNode node = cluster.getNodes().get(0);
     GreedyPlanner planner = new GreedyPlanner(10.0f, node);
@@ -72,10 +71,10 @@ public class TestPlanner {
         null);
     DiskBalancerCluster cluster = new DiskBalancerCluster(jsonConnector);
     cluster.readClusterInfo();
-    Assert.assertEquals(3, cluster.getNodes().size());
+    assertEquals(3, cluster.getNodes().size());
     cluster.setNodesToProcess(cluster.getNodes());
     List<NodePlan> plan = cluster.computePlan(10.0f);
-    Assert.assertNotNull(plan);
+    assertNotNull(plan);
   }
 
   private DiskBalancerVolume createVolume(String path, int capacityInGB,
@@ -115,7 +114,7 @@ public class TestPlanner {
     node.addVolume(volume30);
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(10.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeName(),
@@ -142,7 +141,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(5.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeUUID(),
@@ -183,7 +182,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(5.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeUUID(),
@@ -219,7 +218,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(10.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeName(),
@@ -250,7 +249,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(10.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeName(),
@@ -289,7 +288,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(10.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeName(),
@@ -348,7 +347,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner newPlanner = new GreedyPlanner(01.0f, node);
     NodePlan newPlan = new NodePlan(node.getDataNodeName(), node
@@ -387,7 +386,7 @@ public class TestPlanner {
   @Test
   public void testLoadsCorrectClusterConnector() throws Exception {
     ClusterConnector connector = ConnectorFactory.getCluster(getClass()
-            .getResource("/diskBalancer/data-cluster-3node-3disk.json").toURI()
+        .getResource("/diskBalancer/data-cluster-3node-3disk.json").toURI()
         , null);
     assertEquals(connector.getClass().toString(),
         "class org.apache.hadoop.hdfs.server.diskbalancer.connectors." +
@@ -422,11 +421,11 @@ public class TestPlanner {
         newPlan);
 
     // Assuming that our random disks at least generated one step
-    assertTrue("No Steps Generated from random disks, very unlikely",
-        newPlan.getVolumeSetPlans().size() > 0);
+    assertTrue(newPlan.getVolumeSetPlans().size() > 0,
+        "No Steps Generated from random disks, very unlikely");
 
-    assertTrue("Steps Generated less than disk count - false",
-        newPlan.getVolumeSetPlans().size() < diskCount);
+    assertTrue(newPlan.getVolumeSetPlans().size() < diskCount,
+        "Steps Generated less than disk count - false");
     LOG.info("Number of steps are : %d%n", newPlan.getVolumeSetPlans().size());
 
   }
@@ -501,7 +500,7 @@ public class TestPlanner {
 
     nullConnector.addNode(node);
     cluster.readClusterInfo();
-    Assert.assertEquals(1, cluster.getNodes().size());
+    assertEquals(1, cluster.getNodes().size());
 
     GreedyPlanner planner = new GreedyPlanner(1.0f, node);
     NodePlan plan = new NodePlan(node.getDataNodeName(),

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/diskbalancer/command/TestDiskBalancerCommand.java
@@ -28,12 +28,10 @@ import static org.apache.hadoop.hdfs.tools.DiskBalancerCLI.PLAN;
 import static org.apache.hadoop.hdfs.tools.DiskBalancerCLI.QUERY;
 import static org.apache.hadoop.hdfs.tools.DiskBalancerCLI.REPORT;
 import static org.apache.hadoop.hdfs.tools.DiskBalancerCLI.SKIPDATECHECK;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -66,19 +64,16 @@ import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests various CLI commands of DiskBalancer.
  */
 public class TestDiskBalancerCommand {
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
   private MiniDFSCluster cluster;
   private URI clusterJson;
   private Configuration conf = new HdfsConfiguration();
@@ -88,7 +83,7 @@ public class TestDiskBalancerCommand {
   private final static long CAPCACITY = 300 * 1024;
   private final static long[] CAPACITIES = new long[] {CAPCACITY, CAPCACITY};
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf.setBoolean(DFSConfigKeys.DFS_DISK_BALANCER_ENABLED, true);
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(3)
@@ -99,7 +94,7 @@ public class TestDiskBalancerCommand {
         "/diskBalancer/data-cluster-64node-3disk.json").toURI();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       // Just make sure we can shutdown datanodes.
@@ -114,7 +109,8 @@ public class TestDiskBalancerCommand {
    * Tests if it's allowed to submit and execute plan when Datanode is in status
    * other than REGULAR.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testSubmitPlanInNonRegularStatus() throws Exception {
     final int numDatanodes = 1;
     MiniDFSCluster miniCluster = null;
@@ -141,11 +137,9 @@ public class TestDiskBalancerCommand {
             planFileFullName);
         runCommand(cmdLine, hdfsConf, miniCluster);
       } catch(RemoteException e) {
-        assertThat(e.getClassName(), containsString("DiskBalancerException"));
-        assertThat(e.toString(),
-            is(allOf(
-                containsString("Datanode is in special state"),
-                containsString("Disk balancing not permitted."))));
+        assertThat(e.getClassName()).contains("DiskBalancerException");
+        assertThat(e.toString()).contains("Datanode is in special state")
+            .contains("Disk balancing not permitted.");
       }
     } finally {
       if (miniCluster != null) {
@@ -158,7 +152,8 @@ public class TestDiskBalancerCommand {
    * Tests running multiple commands under on setup. This mainly covers
    * {@link org.apache.hadoop.hdfs.server.diskbalancer.command.Command#close}
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testRunMultipleCommandsUnderOneSetup() throws Exception {
 
     final int numDatanodes = 1;
@@ -192,7 +187,8 @@ public class TestDiskBalancerCommand {
 
 
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDiskBalancerExecuteOptionPlanValidityWithException() throws
       Exception {
     final int numDatanodes = 1;
@@ -234,7 +230,8 @@ public class TestDiskBalancerCommand {
     }
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDiskBalancerExecutePlanValidityWithOutUnitException()
       throws
       Exception {
@@ -277,7 +274,8 @@ public class TestDiskBalancerCommand {
     }
   }
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDiskBalancerForceExecute() throws
       Exception {
     final int numDatanodes = 1;
@@ -317,7 +315,8 @@ public class TestDiskBalancerCommand {
   }
 
 
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600)
   public void testDiskBalancerExecuteOptionPlanValidity() throws Exception {
     final int numDatanodes = 1;
 
@@ -373,11 +372,9 @@ public class TestDiskBalancerCommand {
     final String planFileName = dn.getDatanodeUuid();
 
     /* verify plan command */
-    assertEquals(
-        "There must be two lines: the 1st is writing plan to...,"
-            + " the 2nd is actual full path of plan file.",
-        2, outputs.size());
-    assertThat(outputs.get(1), containsString(planFileName));
+    assertEquals(2, outputs.size(), "There must be two lines: the 1st is writing plan to...,"
+        + " the 2nd is actual full path of plan file.");
+    assertThat(outputs.get(1)).contains(planFileName);
 
     /* get full path of plan file*/
     final String planFileFullName = outputs.get(1);
@@ -385,73 +382,79 @@ public class TestDiskBalancerCommand {
   }
 
   /* test exception on invalid arguments */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testExceptionOnInvalidArguments() throws Exception {
     final String cmdLine = "hdfs diskbalancer random1 -report random2 random3";
-    thrown.expect(HadoopIllegalArgumentException.class);
-    thrown.expectMessage(
-        "Invalid or extra Arguments: [random1, random2, random3]");
-    runCommand(cmdLine);
+    HadoopIllegalArgumentException ex = assertThrows(HadoopIllegalArgumentException.class, () -> {
+      runCommand(cmdLine);
+    });
+    assertTrue(ex.getMessage().contains(
+        "Invalid or extra Arguments: [random1, random2, random3]"));
   }
 
   /* test basic report */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportSimple() throws Exception {
     final String cmdLine = "hdfs diskbalancer -report";
     final List<String> outputs = runCommand(cmdLine);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
+        outputs.get(0)).
+        contains("Processing report command");
     assertThat(
-        outputs.get(1),
-        is(allOf(containsString("No top limit specified"),
-            containsString("using default top value"), containsString("100"))));
+        outputs.get(1))
+        .contains("No top limit specified")
+        .contains("using default top value")
+        .contains("100");
     assertThat(
-        outputs.get(2),
-        is(allOf(
-            containsString("Reporting top"),
-            containsString("64"),
-            containsString(
-                "DataNode(s) benefiting from running DiskBalancer"))));
+        outputs.get(2))
+        .contains("Reporting top")
+        .contains("64")
+        .contains("DataNode(s) benefiting from running DiskBalancer");
     assertThat(
-        outputs.get(32),
-        is(allOf(containsString("30/64 null[null:0]"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"),
-            containsString("9 volumes with node data density 1.97"))));
+        outputs.get(32))
+        .contains("30/64 null[null:0]")
+        .contains("a87654a9-54c7-4693-8dd9-c9c7021dc340")
+        .contains("9 volumes with node data density 1.97");
 
   }
 
   /* test basic report with negative top limit */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportWithNegativeTopLimit()
       throws Exception {
     final String cmdLine = "hdfs diskbalancer -report -top -32";
-    thrown.expect(java.lang.IllegalArgumentException.class);
-    thrown.expectMessage("Top limit input should be a positive numeric value");
-    runCommand(cmdLine);
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+      runCommand(cmdLine);
+    });
+    assertTrue(ex.getMessage().contains("Top limit input should be a positive numeric value"));
   }
   /* test less than 64 DataNode(s) as total, e.g., -report -top 32 */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportLessThanTotal() throws Exception {
     final String cmdLine = "hdfs diskbalancer -report -top 32";
     final List<String> outputs = runCommand(cmdLine);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
+        outputs.get(0))
+        .contains("Processing report command");
     assertThat(
-        outputs.get(1),
-        is(allOf(
-            containsString("Reporting top"),
-            containsString("32"),
-            containsString(
-                "DataNode(s) benefiting from running DiskBalancer"))));
-    assertThat(
-        outputs.get(31),
-        is(allOf(containsString("30/32 null[null:0]"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"),
-            containsString("9 volumes with node data density 1.97"))));
+        outputs.get(1))
+        .contains(
+            "Reporting top",
+            "32",
+            "DataNode(s) benefiting from running DiskBalancer"
+        );
+    assertThat(outputs.get(31))
+        .contains(
+            "30/32 null[null:0]",
+            "a87654a9-54c7-4693-8dd9-c9c7021dc340",
+            "9 volumes with node data density 1.97"
+        );
   }
 
   /**
@@ -459,7 +462,8 @@ public class TestDiskBalancerCommand {
    * with a generic option 'fs'.
    * @throws Exception
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportWithGenericOptionFS() throws Exception {
     final String topReportArg = "5";
     final String reportArgs = String.format("-%s file:%s -%s -%s %s",
@@ -468,65 +472,68 @@ public class TestDiskBalancerCommand {
     final String cmdLine = String.format("%s", reportArgs);
     final List<String> outputs = runCommand(cmdLine);
 
-    assertThat(outputs.get(0), containsString("Processing report command"));
-    assertThat(outputs.get(1),
-        is(allOf(containsString("Reporting top"), containsString(topReportArg),
-            containsString(
-                "DataNode(s) benefiting from running DiskBalancer"))));
+    assertThat(outputs.get(0)).contains("Processing report command");
+    assertThat(outputs.get(1))
+        .contains(
+            "Reporting top",
+            topReportArg,
+            "DataNode(s) benefiting from running DiskBalancer");
   }
 
   /* test more than 64 DataNode(s) as total, e.g., -report -top 128 */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportMoreThanTotal() throws Exception {
     final String cmdLine = "hdfs diskbalancer -report -top 128";
     final List<String> outputs = runCommand(cmdLine);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
-    assertThat(
-        outputs.get(1),
-        is(allOf(
-            containsString("Reporting top"),
-            containsString("64"),
-            containsString(
-                "DataNode(s) benefiting from running DiskBalancer"))));
-    assertThat(
-        outputs.get(31),
-        is(allOf(containsString("30/64 null[null:0]"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"),
-            containsString("9 volumes with node data density 1.97"))));
-
+        outputs.get(0)).contains("Processing report command");
+    assertThat(outputs.get(1))
+        .contains(
+            "Reporting top",
+            "64",
+            "DataNode(s) benefiting from running DiskBalancer"
+        );
+    assertThat(outputs.get(31))
+        .contains(
+            "30/64 null[null:0]",
+            "a87654a9-54c7-4693-8dd9-c9c7021dc340",
+            "9 volumes with node data density 1.97"
+        );
   }
 
   /* test invalid top limit, e.g., -report -top xx */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportInvalidTopLimit() throws Exception {
     final String cmdLine = "hdfs diskbalancer -report -top xx";
     final List<String> outputs = runCommand(cmdLine);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
-    assertThat(
-        outputs.get(1),
-        is(allOf(containsString("Top limit input is not numeric"),
-            containsString("using default top value"), containsString("100"))));
-    assertThat(
-        outputs.get(2),
-        is(allOf(
-            containsString("Reporting top"),
-            containsString("64"),
-            containsString(
-                "DataNode(s) benefiting from running DiskBalancer"))));
-    assertThat(
-        outputs.get(32),
-        is(allOf(containsString("30/64 null[null:0]"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"),
-            containsString("9 volumes with node data density 1.97"))));
+        outputs.get(0)).contains("Processing report command");
+    assertThat(outputs.get(1))
+        .contains(
+            "Top limit input is not numeric",
+            "using default top value",
+            "100"
+        );
+    assertThat(outputs.get(2))
+        .contains(
+            "Reporting top",
+            "64",
+            "DataNode(s) benefiting from running DiskBalancer"
+        );
+    assertThat(outputs.get(32))
+        .contains(
+            "30/64 null[null:0]",
+            "a87654a9-54c7-4693-8dd9-c9c7021dc340",
+            "9 volumes with node data density 1.97"
+        );
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportNode() throws Exception {
     final String cmdLine =
         "hdfs diskbalancer -report -node " +
@@ -534,74 +541,85 @@ public class TestDiskBalancerCommand {
     final List<String> outputs = runCommand(cmdLine);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
-    assertThat(
-        outputs.get(1),
-        is(allOf(containsString("Reporting volume information for DataNode"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"))));
-    assertThat(
-        outputs.get(2),
-        is(allOf(containsString("null[null:0]"),
-            containsString("a87654a9-54c7-4693-8dd9-c9c7021dc340"),
-            containsString("9 volumes with node data density 1.97"))));
-    assertThat(
-        outputs.get(3),
-        is(allOf(containsString("DISK"),
-            containsString("/tmp/disk/KmHefYNURo"),
-            containsString("0.20 used: 39160240782/200000000000"),
-            containsString("0.80 free: 160839759218/200000000000"))));
-    assertThat(
-        outputs.get(4),
-        is(allOf(containsString("DISK"),
-            containsString("/tmp/disk/Mxfcfmb24Y"),
-            containsString("0.92 used: 733099315216/800000000000"),
-            containsString("0.08 free: 66900684784/800000000000"))));
-    assertThat(
-        outputs.get(5),
-        is(allOf(containsString("DISK"),
-            containsString("/tmp/disk/xx3j3ph3zd"),
-            containsString("0.72 used: 289544224916/400000000000"),
-            containsString("0.28 free: 110455775084/400000000000"))));
-    assertThat(
-        outputs.get(6),
-        is(allOf(containsString("RAM_DISK"),
-            containsString("/tmp/disk/BoBlQFxhfw"),
-            containsString("0.60 used: 477590453390/800000000000"),
-            containsString("0.40 free: 322409546610/800000000000"))));
-    assertThat(
-        outputs.get(7),
-        is(allOf(containsString("RAM_DISK"),
-            containsString("/tmp/disk/DtmAygEU6f"),
-            containsString("0.34 used: 134602910470/400000000000"),
-            containsString("0.66 free: 265397089530/400000000000"))));
-    assertThat(
-        outputs.get(8),
-        is(allOf(containsString("RAM_DISK"),
-            containsString("/tmp/disk/MXRyYsCz3U"),
-            containsString("0.55 used: 438102096853/800000000000"),
-            containsString("0.45 free: 361897903147/800000000000"))));
-    assertThat(
-        outputs.get(9),
-        is(allOf(containsString("SSD"),
-            containsString("/tmp/disk/BGe09Y77dI"),
-            containsString("0.89 used: 890446265501/1000000000000"),
-            containsString("0.11 free: 109553734499/1000000000000"))));
-    assertThat(
-        outputs.get(10),
-        is(allOf(containsString("SSD"),
-            containsString("/tmp/disk/JX3H8iHggM"),
-            containsString("0.31 used: 2782614512957/9000000000000"),
-            containsString("0.69 free: 6217385487043/9000000000000"))));
-    assertThat(
-        outputs.get(11),
-        is(allOf(containsString("SSD"),
-            containsString("/tmp/disk/uLOYmVZfWV"),
-            containsString("0.75 used: 1509592146007/2000000000000"),
-            containsString("0.25 free: 490407853993/2000000000000"))));
+        outputs.get(0)).contains("Processing report command");
+    assertThat(outputs.get(1))
+        .contains(
+            "Reporting volume information for DataNode",
+            "a87654a9-54c7-4693-8dd9-c9c7021dc340"
+        );
+    assertThat(outputs.get(2))
+        .contains(
+            "null[null:0]",
+            "a87654a9-54c7-4693-8dd9-c9c7021dc340",
+            "9 volumes with node data density 1.97"
+        );
+    assertThat(outputs.get(3))
+        .contains(
+            "DISK",
+            "/tmp/disk/KmHefYNURo",
+            "0.20 used: 39160240782/200000000000",
+            "0.80 free: 160839759218/200000000000"
+        );
+    assertThat(outputs.get(4))
+        .contains(
+            "DISK",
+            "/tmp/disk/Mxfcfmb24Y",
+            "0.92 used: 733099315216/800000000000",
+            "0.08 free: 66900684784/800000000000"
+        );
+    assertThat(outputs.get(5))
+        .contains(
+            "DISK",
+            "/tmp/disk/xx3j3ph3zd",
+            "0.72 used: 289544224916/400000000000",
+            "0.28 free: 110455775084/400000000000"
+        );
+    assertThat(outputs.get(6))
+        .contains(
+            "RAM_DISK",
+            "/tmp/disk/BoBlQFxhfw",
+            "0.60 used: 477590453390/800000000000",
+            "0.40 free: 322409546610/800000000000"
+        );
+    assertThat(outputs.get(7))
+        .contains(
+            "RAM_DISK",
+            "/tmp/disk/DtmAygEU6f",
+            "0.34 used: 134602910470/400000000000",
+            "0.66 free: 265397089530/400000000000"
+        );
+    assertThat(outputs.get(8))
+        .contains(
+            "RAM_DISK",
+            "/tmp/disk/MXRyYsCz3U",
+            "0.55 used: 438102096853/800000000000",
+            "0.45 free: 361897903147/800000000000"
+        );
+    assertThat(outputs.get(9))
+        .contains(
+            "SSD",
+            "/tmp/disk/BGe09Y77dI",
+            "0.89 used: 890446265501/1000000000000",
+            "0.11 free: 109553734499/1000000000000"
+        );
+    assertThat(outputs.get(10))
+        .contains(
+            "SSD",
+            "/tmp/disk/JX3H8iHggM",
+            "0.31 used: 2782614512957/9000000000000",
+            "0.69 free: 6217385487043/9000000000000"
+        );
+    assertThat(outputs.get(11))
+        .contains(
+            "SSD",
+            "/tmp/disk/uLOYmVZfWV",
+            "0.75 used: 1509592146007/2000000000000",
+            "0.25 free: 490407853993/2000000000000"
+        );
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportNodeWithoutJson() throws Exception {
     String dataNodeUuid = cluster.getDataNodes().get(0).getDatanodeUuid();
     final String planArg = String.format("-%s -%s %s",
@@ -612,33 +630,35 @@ public class TestDiskBalancerCommand {
     List<String> outputs = runCommand(cmdLine, cluster);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
-    assertThat(
-        outputs.get(1),
-        is(allOf(containsString("Reporting volume information for DataNode"),
-            containsString(dataNodeUuid))));
-    assertThat(
-        outputs.get(2),
-        is(allOf(containsString(dataNodeUuid),
-            containsString("2 volumes with node data density 0.00"))));
-    assertThat(
-        outputs.get(3),
-        is(allOf(containsString("DISK"),
-            containsString(new Path(cluster.getInstanceStorageDir(0, 0)
-                .getAbsolutePath()).toString()),
-            containsString("0.00"),
-            containsString("1.00"))));
-    assertThat(
-        outputs.get(4),
-        is(allOf(containsString("DISK"),
-            containsString(new Path(cluster.getInstanceStorageDir(0, 1)
-                .getAbsolutePath()).toString()),
-            containsString("0.00"),
-            containsString("1.00"))));
+        outputs.get(0)).contains("Processing report command");
+    assertThat(outputs.get(1))
+        .contains(
+            "Reporting volume information for DataNode",
+            dataNodeUuid
+        );
+    assertThat(outputs.get(2))
+        .contains(
+            dataNodeUuid,
+            "2 volumes with node data density 0.00"
+        );
+    assertThat(outputs.get(3))
+        .contains(
+            "DISK",
+            new Path(cluster.getInstanceStorageDir(0, 0).getAbsolutePath()).toString(),
+            "0.00",
+            "1.00"
+        );
+    assertThat(outputs.get(4))
+        .contains(
+            "DISK",
+            new Path(cluster.getInstanceStorageDir(0, 1).getAbsolutePath()).toString(),
+            "0.00",
+            "1.00"
+        );
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReadClusterFromJson() throws Exception {
     ClusterConnector jsonConnector = ConnectorFactory.getCluster(clusterJson,
         conf);
@@ -649,7 +669,8 @@ public class TestDiskBalancerCommand {
   }
 
   /* test -plan  DataNodeID */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testPlanNode() throws Exception {
     final String planArg = String.format("-%s %s", PLAN,
         cluster.getDataNodes().get(0).getDatanodeUuid());
@@ -661,7 +682,8 @@ public class TestDiskBalancerCommand {
   }
 
   /* test -plan  DataNodeID */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testPlanJsonNode() throws Exception {
     final String planArg = String.format("-%s %s", PLAN,
         "a87654a9-54c7-4693-8dd9-c9c7021dc340");
@@ -675,7 +697,8 @@ public class TestDiskBalancerCommand {
   }
 
   /* Test that illegal arguments are handled correctly*/
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testIllegalArgument() throws Exception {
     final String planArg = String.format("-%s %s", PLAN,
         "a87654a9-54c7-4693-8dd9-c9c7021dc340");
@@ -685,39 +708,46 @@ public class TestDiskBalancerCommand {
             "hdfs diskbalancer %s -report", planArg);
     // -plan and -report cannot be used together.
     // tests the validate command line arguments function.
-    thrown.expect(java.lang.IllegalArgumentException.class);
-    runCommand(cmdLine);
+    assertThrows(java.lang.IllegalArgumentException.class, () -> {
+      runCommand(cmdLine);
+    });
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCancelCommand() throws Exception {
     final String cancelArg = String.format("-%s %s", CANCEL, "nosuchplan");
     final String nodeArg = String.format("-%s %s", NODE,
         cluster.getDataNodes().get(0).getDatanodeUuid());
 
     // Port:Host format is expected. So cancel command will throw.
-    thrown.expect(java.lang.IllegalArgumentException.class);
-    final String cmdLine = String
-        .format(
-            "hdfs diskbalancer  %s %s", cancelArg, nodeArg);
-    runCommand(cmdLine);
+    assertThrows(java.lang.IllegalArgumentException.class, () -> {
+      final String cmdLine = String
+          .format(
+              "hdfs diskbalancer  %s %s", cancelArg, nodeArg);
+      runCommand(cmdLine);
+    });
   }
 
   /*
    Makes an invalid query attempt to non-existent Datanode.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testQueryCommand() throws Exception {
     final String queryArg = String.format("-%s %s", QUERY,
         cluster.getDataNodes().get(0).getDatanodeUuid());
-    thrown.expect(java.net.UnknownHostException.class);
-    final String cmdLine = String
-        .format(
-            "hdfs diskbalancer %s", queryArg);
-    runCommand(cmdLine);
+
+    assertThrows(java.net.UnknownHostException.class, () -> {
+      final String cmdLine = String
+          .format(
+              "hdfs diskbalancer %s", queryArg);
+      runCommand(cmdLine);
+    });
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testHelpCommand() throws Exception {
     final String helpArg = String.format("-%s", HELP);
     final String cmdLine = String
@@ -759,12 +789,10 @@ public class TestDiskBalancerCommand {
           miniCluster.getDataNodes().get(0).getDatanodeUuid()).toString();
 
       /* verify the path of plan */
-      assertEquals(
-          "There must be two lines: the 1st is writing plan to,"
-              + " the 2nd is actual full path of plan file.",
-          2, outputs.size());
-      assertThat(outputs.get(0), containsString("Writing plan to"));
-      assertThat(outputs.get(1), containsString(planFileFullName));
+      assertEquals(2, outputs.size(), "There must be two lines: the 1st is writing plan to,"
+          + " the 2nd is actual full path of plan file.");
+      assertThat(outputs.get(0)).contains("Writing plan to");
+      assertThat(outputs.get(1)).contains(planFileFullName);
     } finally {
       if (miniCluster != null) {
         miniCluster.shutdown();
@@ -834,13 +862,15 @@ public class TestDiskBalancerCommand {
           .getIpcPort(), dataNode2.getIpcPort());
       final String cmdLine = String.format("hdfs diskbalancer %s", queryArg);
       List<String> outputs = runCommand(cmdLine);
-      assertEquals(12,  outputs.size());
-      assertTrue("Expected outputs: " + outputs,
-          outputs.get(1).contains("localhost:" + dataNode1.getIpcPort()) ||
-              outputs.get(6).contains("localhost:" + dataNode1.getIpcPort()));
-      assertTrue("Expected outputs: " + outputs,
-          outputs.get(1).contains("localhost:" + dataNode2.getIpcPort()) ||
-              outputs.get(6).contains("localhost:" + dataNode2.getIpcPort()));
+      assertEquals(12, outputs.size());
+      assertTrue(
+          outputs.get(1).contains("localhost:" + dataNode1.getIpcPort())
+              || outputs.get(6).contains("localhost:" + dataNode1.getIpcPort()),
+          "Expected outputs: " + outputs);
+      assertTrue(
+          outputs.get(1).contains("localhost:" + dataNode2.getIpcPort())
+              || outputs.get(6).contains("localhost:" + dataNode2.getIpcPort()),
+          "Expected outputs: " + outputs);
     } finally {
       miniDFSCluster.shutdown();
     }
@@ -871,7 +901,8 @@ public class TestDiskBalancerCommand {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetNodeList() throws Exception {
     ClusterConnector jsonConnector =
         ConnectorFactory.getCluster(clusterJson, conf);
@@ -892,7 +923,8 @@ public class TestDiskBalancerCommand {
     assertEquals(nodeNum, nodeList.size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportCommandWithMultipleNodes() throws Exception {
     String dataNodeUuid1 = cluster.getDataNodes().get(0).getDatanodeUuid();
     String dataNodeUuid2 = cluster.getDataNodes().get(1).getDatanodeUuid();
@@ -905,11 +937,10 @@ public class TestDiskBalancerCommand {
 
   private void verifyOutputsOfReportCommand(List<String> outputs,
       String dataNodeUuid1, String dataNodeUuid2, boolean inputNodesStr) {
-    assertThat(outputs.get(0), containsString("Processing report command"));
+    assertThat(outputs.get(0)).contains("Processing report command");
     if (inputNodesStr) {
-      assertThat(outputs.get(1),
-          is(allOf(containsString("Reporting volume information for DataNode"),
-              containsString(dataNodeUuid1), containsString(dataNodeUuid2))));
+      assertThat(outputs.get(1)).contains("Reporting volume information for DataNode")
+          .contains(dataNodeUuid1, dataNodeUuid2);
     }
 
     // Since the order of input nodes will be disrupted when parse
@@ -920,7 +951,8 @@ public class TestDiskBalancerCommand {
         || outputs.get(6).contains(dataNodeUuid2));
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportCommandWithInvalidNode() throws Exception {
     String dataNodeUuid1 = cluster.getDataNodes().get(0).getDatanodeUuid();
     String invalidNode = "invalidNode";
@@ -930,21 +962,19 @@ public class TestDiskBalancerCommand {
     List<String> outputs = runCommand(cmdLine, cluster);
 
     assertThat(
-        outputs.get(0),
-        containsString("Processing report command"));
+        outputs.get(0)).contains("Processing report command");
     assertThat(
-        outputs.get(1),
-        is(allOf(containsString("Reporting volume information for DataNode"),
-            containsString(dataNodeUuid1), containsString(invalidNode))));
+        outputs.get(1)).contains("Reporting volume information for DataNode",
+        dataNodeUuid1, invalidNode);
 
     String invalidNodeInfo =
         String.format("The node(s) '%s' not found. "
-            + "Please make sure that '%s' exists in the cluster."
-            , invalidNode, invalidNode);
+            + "Please make sure that '%s' exists in the cluster.", invalidNode, invalidNode);
     assertTrue(outputs.get(2).contains(invalidNodeInfo));
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportCommandWithNullNodes() throws Exception {
     // don't input nodes
     final String planArg = String.format("-%s -%s ,", REPORT, NODE);
@@ -956,7 +986,8 @@ public class TestDiskBalancerCommand {
     assertTrue(outputs.get(2).contains(invalidNodeInfo));
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportCommandWithReadingHostFile() throws Exception {
     final String testDir = GenericTestUtils.getTestDir().getAbsolutePath();
     File includeFile = new File(testDir, "diskbalancer.include");
@@ -980,7 +1011,8 @@ public class TestDiskBalancerCommand {
     includeFile.delete();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testReportCommandWithInvalidHostFilePath() throws Exception {
     final String testDir = GenericTestUtils.getTestDir().getAbsolutePath();
     String invalidFilePath = testDir + "/diskbalancer-invalid.include";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectives.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCacheDirectives.java
@@ -26,17 +26,18 @@ import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_CACHING_ENABLED_
 import static org.apache.hadoop.hdfs.protocol.CachePoolInfo.RELATIVE_EXPIRY_NEVER;
 import static org.apache.hadoop.test.GenericTestUtils.assertExceptionContains;
 import static org.apache.hadoop.test.MockitoUtil.verifyZeroInteractions;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -92,10 +93,10 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.GSet;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.util.function.Supplier;
@@ -144,7 +145,7 @@ public class TestCacheDirectives {
     return this.conf;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = createCachingConf();
     cluster =
@@ -165,14 +166,14 @@ public class TestCacheDirectives {
     return (DistributedFileSystem) FileSystem.get(conf);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     // Remove cache directives left behind by tests so that we release mmaps.
     RemoteIterator<CacheDirectiveEntry> iter = dfs.listCacheDirectives(null);
     while (iter.hasNext()) {
       dfs.removeCacheDirective(iter.next().getInfo().getId());
     }
-    waitForCachedBlocks(namenode, 0, 0, "teardown");
+    waitForCachedBlocks(cluster.getNameNode(), 0, 0, "teardown");
     if (cluster != null) {
       cluster.shutdown();
       cluster = null;
@@ -181,7 +182,10 @@ public class TestCacheDirectives {
     NativeIO.POSIX.setCacheManipulator(prevCacheManipulator);
   }
 
-  @Test(timeout=60000)
+
+  @Test
+  @Timeout(value = 60)
+  @SuppressWarnings("checkstyle:methodlength")
   public void testBasicPoolOperations() throws Exception {
     final String poolName = "pool1";
     CachePoolInfo info = new CachePoolInfo(poolName).
@@ -345,7 +349,8 @@ public class TestCacheDirectives {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreateAndModifyPools() throws Exception {
     String poolName = "pool1";
     String ownerName = "abc";
@@ -380,7 +385,7 @@ public class TestCacheDirectives {
 
     dfs.removeCachePool(poolName);
     iter = dfs.listCachePools();
-    assertFalse("expected no cache pools after deleting pool", iter.hasNext());
+    assertFalse(iter.hasNext(), "expected no cache pools after deleting pool");
 
     proto.listCachePools(null);
 
@@ -402,18 +407,18 @@ public class TestCacheDirectives {
     }
 
     iter = dfs.listCachePools();
-    assertFalse("expected no cache pools after deleting pool", iter.hasNext());
+    assertFalse(iter.hasNext(), "expected no cache pools after deleting pool");
   }
 
   private static void validateListAll(
       RemoteIterator<CacheDirectiveEntry> iter,
       Long... ids) throws Exception {
-    for (Long id: ids) {
-      assertTrue("Unexpectedly few elements", iter.hasNext());
-      assertEquals("Unexpected directive ID", id,
-          iter.next().getInfo().getId());
+    for (Long id : ids) {
+      assertTrue(iter.hasNext(), "Unexpectedly few elements");
+      assertEquals(id,
+          iter.next().getInfo().getId(), "Unexpected directive ID");
     }
-    assertFalse("Unexpectedly many list elements", iter.hasNext());
+    assertFalse(iter.hasNext(), "Unexpectedly many list elements");
   }
 
   private static long addAsUnprivileged(
@@ -429,7 +434,9 @@ public class TestCacheDirectives {
         });
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
+  @SuppressWarnings("checkstyle:methodlength")
   public void testAddRemoveDirectives() throws Exception {
     proto.addCachePool(new CachePoolInfo("pool1").
         setMode(new FsPermission((short)0777)));
@@ -458,9 +465,8 @@ public class TestCacheDirectives {
 
     long alphaId = addAsUnprivileged(alpha);
     long alphaId2 = addAsUnprivileged(alpha);
-    assertFalse("Expected to get unique directives when re-adding an "
-        + "existing CacheDirectiveInfo",
-        alphaId == alphaId2);
+    assertFalse(alphaId == alphaId2,
+        "Expected to get unique directives when re-adding an " + "existing CacheDirectiveInfo");
     long betaId = addAsUnprivileged(beta);
 
     try {
@@ -631,7 +637,8 @@ public class TestCacheDirectives {
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCacheManagerRestart() throws Exception {
     SecondaryNameNode secondary = null;
     try {
@@ -652,14 +659,14 @@ public class TestCacheDirectives {
           .setLimit(limit)
           .setMaxRelativeExpiryMs(maxExpiry));
       RemoteIterator<CachePoolEntry> pit = dfs.listCachePools();
-      assertTrue("No cache pools found", pit.hasNext());
+      assertTrue(pit.hasNext(), "No cache pools found");
       CachePoolInfo info = pit.next().getInfo();
       assertEquals(pool, info.getPoolName());
       assertEquals(groupName, info.getGroupName());
       assertEquals(mode, info.getMode());
       assertEquals(limit, (long)info.getLimit());
       assertEquals(maxExpiry, (long)info.getMaxRelativeExpiryMs());
-      assertFalse("Unexpected # of cache pools found", pit.hasNext());
+      assertFalse(pit.hasNext(), "Unexpected # of cache pools found");
     
       // Create some cache entries
       int numEntries = 10;
@@ -677,13 +684,13 @@ public class TestCacheDirectives {
       RemoteIterator<CacheDirectiveEntry> dit
           = dfs.listCacheDirectives(null);
       for (int i=0; i<numEntries; i++) {
-        assertTrue("Unexpected # of cache entries: " + i, dit.hasNext());
+        assertTrue(dit.hasNext(), "Unexpected # of cache entries: " + i);
         CacheDirectiveInfo cd = dit.next().getInfo();
         assertEquals(i+1, cd.getId().longValue());
         assertEquals(entryPrefix + i, cd.getPath().toUri().getPath());
         assertEquals(pool, cd.getPool());
       }
-      assertFalse("Unexpected # of cache directives found", dit.hasNext());
+      assertFalse(dit.hasNext(), "Unexpected # of cache directives found");
       
       // Checkpoint once to set some cache pools and directives on 2NN side
       secondary.doCheckpoint();
@@ -701,8 +708,7 @@ public class TestCacheDirectives {
 
       // Checkpoint again forcing a reload of FSN state
       boolean fetchImage = secondary.doCheckpoint();
-      assertTrue("Secondary should have fetched a new fsimage from NameNode",
-          fetchImage);
+      assertTrue(fetchImage, "Secondary should have fetched a new fsimage from NameNode");
 
       // Remove temp pool and directive
       dfs.removeCachePool(imagePool);
@@ -712,7 +718,7 @@ public class TestCacheDirectives {
     
       // Check that state came back up
       pit = dfs.listCachePools();
-      assertTrue("No cache pools found", pit.hasNext());
+      assertTrue(pit.hasNext(), "No cache pools found");
       info = pit.next().getInfo();
       assertEquals(pool, info.getPoolName());
       assertEquals(pool, info.getPoolName());
@@ -720,18 +726,18 @@ public class TestCacheDirectives {
       assertEquals(mode, info.getMode());
       assertEquals(limit, (long)info.getLimit());
       assertEquals(maxExpiry, (long)info.getMaxRelativeExpiryMs());
-      assertFalse("Unexpected # of cache pools found", pit.hasNext());
+      assertFalse(pit.hasNext(), "Unexpected # of cache pools found");
     
       dit = dfs.listCacheDirectives(null);
       for (int i=0; i<numEntries; i++) {
-        assertTrue("Unexpected # of cache entries: " + i, dit.hasNext());
+        assertTrue(dit.hasNext(), "Unexpected # of cache entries: " + i);
         CacheDirectiveInfo cd = dit.next().getInfo();
         assertEquals(i+1, cd.getId().longValue());
         assertEquals(entryPrefix + i, cd.getPath().toUri().getPath());
         assertEquals(pool, cd.getPool());
         assertEquals(expiry.getTime(), cd.getExpiration().getMillis());
       }
-      assertFalse("Unexpected # of cache directives found", dit.hasNext());
+      assertFalse(dit.hasNext(), "Unexpected # of cache directives found");
   
       long nextId = dfs.addCacheDirective(
             new CacheDirectiveInfo.Builder().
@@ -755,6 +761,14 @@ public class TestCacheDirectives {
   private static void waitForCachedBlocks(NameNode nn,
       final int expectedCachedBlocks, final int expectedCachedReplicas,
       final String logString) throws Exception {
+    final String bpid = nn.getNamesystem().getBlockPoolId();
+    final NamenodeProtocols nnRpc = nn.getRpcServer();
+    Thread.sleep(5000);
+    for (DataNode dn : cluster.getDataNodes()) {
+      if (dn.getFSDataset() != null && dn.getFSDataset().getCacheUsed() == 0L) {
+        nnRpc.cacheReport(dn.getDNRegistrationForBP(bpid), bpid, Collections.emptyList());
+      }
+    }
     final FSNamesystem namesystem = nn.getNamesystem();
     final CacheManager cacheManager = namesystem.getCacheManager();
     LOG.info("Waiting for " + expectedCachedBlocks + " blocks with " +
@@ -819,7 +833,7 @@ public class TestCacheDirectives {
           fail("got IOException while calling " +
               "listCacheDirectives: " + e.getMessage());
         }
-        Assert.assertNotNull(entry);
+        assertNotNull(entry);
         CacheDirectiveStats stats = entry.getStats();
         if ((targetBytesNeeded == stats.getBytesNeeded()) &&
             (targetBytesCached == stats.getBytesCached()) &&
@@ -916,8 +930,8 @@ public class TestCacheDirectives {
       // round it up to full blocks
       final long numBlocks = (len + blockSize - 1) / blockSize;
       BlockLocation[] locs = dfs.getFileBlockLocations(p, 0, len);
-      assertEquals("Unexpected number of block locations for path " + p,
-          numBlocks, locs.length);
+      assertEquals(numBlocks, locs.length,
+          "Unexpected number of block locations for path " + p);
       for (BlockLocation l: locs) {
         if (l.getCachedHosts().length > 0) {
           numCachedBlocks++;
@@ -928,13 +942,14 @@ public class TestCacheDirectives {
     LOG.info("Found " + numCachedBlocks + " of " + expectedBlocks + " blocks");
     LOG.info("Found " + numCachedReplicas + " of " + expectedReplicas
         + " replicas");
-    assertEquals("Unexpected number of cached blocks", expectedBlocks,
-        numCachedBlocks);
-    assertEquals("Unexpected number of cached replicas", expectedReplicas,
-        numCachedReplicas);
+    assertEquals(expectedBlocks, numCachedBlocks,
+        "Unexpected number of cached blocks");
+    assertEquals(expectedReplicas, numCachedReplicas,
+        "Unexpected number of cached replicas");
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testWaitForCachedReplicas() throws Exception {
     FileSystemTestHelper helper = new FileSystemTestHelper();
     GenericTestUtils.waitFor(new Supplier<Boolean>() {
@@ -987,17 +1002,17 @@ public class TestCacheDirectives {
 
     // Check that the datanodes have the right cache values
     DatanodeInfo[] live = dfs.getDataNodeStats(DatanodeReportType.LIVE);
-    assertEquals("Unexpected number of live nodes", NUM_DATANODES, live.length);
+    assertEquals(NUM_DATANODES, live.length, "Unexpected number of live nodes");
     long totalUsed = 0;
     for (DatanodeInfo dn : live) {
       final long cacheCapacity = dn.getCacheCapacity();
       final long cacheUsed = dn.getCacheUsed();
       final long cacheRemaining = dn.getCacheRemaining();
-      assertEquals("Unexpected cache capacity", CACHE_CAPACITY, cacheCapacity);
-      assertEquals("Capacity not equal to used + remaining",
-          cacheCapacity, cacheUsed + cacheRemaining);
-      assertEquals("Remaining not equal to capacity - used",
-          cacheCapacity - cacheUsed, cacheRemaining);
+      assertEquals(CACHE_CAPACITY, cacheCapacity, "Unexpected cache capacity");
+      assertEquals(cacheCapacity, cacheUsed + cacheRemaining,
+          "Capacity not equal to used + remaining");
+      assertEquals(cacheCapacity - cacheUsed, cacheRemaining,
+          "Remaining not equal to capacity - used");
       totalUsed += cacheUsed;
     }
     assertEquals(expected*BLOCK_SIZE, totalUsed);
@@ -1014,7 +1029,8 @@ public class TestCacheDirectives {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testWaitForCachedReplicasInDirectory() throws Exception {
     // Create the pool
     final String pool = "friendlyPool";
@@ -1108,7 +1124,8 @@ public class TestCacheDirectives {
    * number of cached replicas and blocks as well as the advertised locations.
    * @throws Exception
    */
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testReplicationFactor() throws Exception {
     // Create the pool
     final String pool = "friendlyPool";
@@ -1163,11 +1180,12 @@ public class TestCacheDirectives {
     checkNumCachedReplicas(dfs, paths, 0, 0);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testListCachePoolPermissions() throws Exception {
     final UserGroupInformation myUser = UserGroupInformation
         .createRemoteUser("myuser");
-    final DistributedFileSystem myDfs = 
+    final DistributedFileSystem myDfs =
         (DistributedFileSystem)DFSTestUtil.getFileSystemAs(myUser, conf);
     final String poolName = "poolparty";
     dfs.addCachePool(new CachePoolInfo(poolName)
@@ -1176,11 +1194,11 @@ public class TestCacheDirectives {
     RemoteIterator<CachePoolEntry> it = myDfs.listCachePools();
     CachePoolInfo info = it.next().getInfo();
     assertFalse(it.hasNext());
-    assertEquals("Expected pool name", poolName, info.getPoolName());
-    assertNull("Unexpected owner name", info.getOwnerName());
-    assertNull("Unexpected group name", info.getGroupName());
-    assertNull("Unexpected mode", info.getMode());
-    assertNull("Unexpected limit", info.getLimit());
+    assertEquals(poolName, info.getPoolName(), "Expected pool name");
+    assertNull(info.getOwnerName(), "Unexpected owner name");
+    assertNull(info.getGroupName(), "Unexpected group name");
+    assertNull(info.getMode(), "Unexpected mode");
+    assertNull(info.getLimit(), "Unexpected limit");
     // Modify the pool so myuser is now the owner
     final long limit = 99;
     dfs.modifyCachePool(new CachePoolInfo(poolName)
@@ -1190,21 +1208,20 @@ public class TestCacheDirectives {
     it = myDfs.listCachePools();
     info = it.next().getInfo();
     assertFalse(it.hasNext());
-    assertEquals("Expected pool name", poolName, info.getPoolName());
-    assertEquals("Mismatched owner name", myUser.getShortUserName(),
-        info.getOwnerName());
-    assertNotNull("Expected group name", info.getGroupName());
-    assertEquals("Mismatched mode", (short) 0700,
-        info.getMode().toShort());
-    assertEquals("Mismatched limit", limit, (long)info.getLimit());
+    assertEquals(poolName, info.getPoolName(), "Expected pool name");
+    assertEquals(myUser.getShortUserName(), info.getOwnerName(), "Mismatched owner name");
+    assertNotNull(info.getGroupName(), "Expected group name");
+    assertEquals((short) 0700, info.getMode().toShort(), "Mismatched mode");
+    assertEquals(limit, (long) info.getLimit(), "Mismatched limit");
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testExpiry() throws Exception {
     String pool = "pool1";
     dfs.addCachePool(new CachePoolInfo(pool));
     Path p = new Path("/mypath");
-    DFSTestUtil.createFile(dfs, p, BLOCK_SIZE*2, (short)2, 0x999);
+    DFSTestUtil.createFile(dfs, p, BLOCK_SIZE * 2, (short) 2, 0x999);
     // Expire after test timeout
     Date start = new Date();
     Date expiry = DateUtils.addSeconds(start, 120);
@@ -1212,7 +1229,7 @@ public class TestCacheDirectives {
         .setPath(p)
         .setPool(pool)
         .setExpiration(CacheDirectiveInfo.Expiration.newAbsolute(expiry))
-        .setReplication((short)2)
+        .setReplication((short) 2)
         .build());
     waitForCachedBlocks(cluster.getNameNode(), 2, 4, "testExpiry:1");
     // Change it to expire sooner
@@ -1223,8 +1240,8 @@ public class TestCacheDirectives {
     CacheDirectiveEntry ent = it.next();
     assertFalse(it.hasNext());
     Date entryExpiry = new Date(ent.getInfo().getExpiration().getMillis());
-    assertTrue("Directive should have expired",
-        entryExpiry.before(new Date()));
+    assertTrue(entryExpiry.before(new Date()),
+        "Directive should have expired");
     // Change it back to expire later
     dfs.modifyCacheDirective(new CacheDirectiveInfo.Builder().setId(id)
         .setExpiration(Expiration.newRelative(120000)).build());
@@ -1233,8 +1250,8 @@ public class TestCacheDirectives {
     ent = it.next();
     assertFalse(it.hasNext());
     entryExpiry = new Date(ent.getInfo().getExpiration().getMillis());
-    assertTrue("Directive should not have expired",
-        entryExpiry.after(new Date()));
+    assertTrue(entryExpiry.after(new Date()),
+        "Directive should not have expired");
     // Verify that setting a negative TTL throws an error
     try {
       dfs.modifyCacheDirective(new CacheDirectiveInfo.Builder().setId(id)
@@ -1245,7 +1262,8 @@ public class TestCacheDirectives {
     }
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testLimit() throws Exception {
     try {
       dfs.addCachePool(new CachePoolInfo("poolofnegativity").setLimit(-99l));
@@ -1295,10 +1313,10 @@ public class TestCacheDirectives {
         1, 0,
         poolInfo, "testLimit:2");
     RemoteIterator<CachePoolEntry> it = dfs.listCachePools();
-    assertTrue("Expected a cache pool", it.hasNext());
+    assertTrue(it.hasNext(), "Expected a cache pool");
     CachePoolStats stats = it.next().getStats();
-    assertEquals("Overlimit bytes should be difference of needed and limit",
-        BLOCK_SIZE, stats.getBytesOverlimit());
+    assertEquals(BLOCK_SIZE, stats.getBytesOverlimit(),
+        "Overlimit bytes should be difference of needed and limit");
     // Moving a directive to a pool without enough limit should fail
     CachePoolInfo inadequate =
         new CachePoolInfo("poolofinadequacy").setLimit(BLOCK_SIZE);
@@ -1320,7 +1338,9 @@ public class TestCacheDirectives {
             .setPath(path1).build(), EnumSet.of(CacheFlag.FORCE));
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
+  @SuppressWarnings("checkstyle:methodlength")
   public void testMaxRelativeExpiry() throws Exception {
     // Test that negative and really big max expirations can't be set during add
     try {
@@ -1342,9 +1362,9 @@ public class TestCacheDirectives {
     dfs.addCachePool(coolPool.setMaxRelativeExpiryMs(poolExpiration));
     RemoteIterator<CachePoolEntry> poolIt = dfs.listCachePools();
     CachePoolInfo listPool = poolIt.next().getInfo();
-    assertFalse("Should only be one pool", poolIt.hasNext());
-    assertEquals("Expected max relative expiry to match set value",
-        poolExpiration, listPool.getMaxRelativeExpiryMs().longValue());
+    assertFalse(poolIt.hasNext(), "Should only be one pool");
+    assertEquals(poolExpiration, listPool.getMaxRelativeExpiryMs().longValue(),
+        "Expected max relative expiry to match set value");
     // Test that negative and really big max expirations can't be modified
     try {
       dfs.addCachePool(coolPool.setMaxRelativeExpiryMs(-1l));
@@ -1368,11 +1388,11 @@ public class TestCacheDirectives {
     RemoteIterator<CacheDirectiveEntry> dirIt =
         dfs.listCacheDirectives(defaultExpiry);
     CacheDirectiveInfo listInfo = dirIt.next().getInfo();
-    assertFalse("Should only have one entry in listing", dirIt.hasNext());
+    assertFalse(dirIt.hasNext(), "Should only have one entry in listing");
     long listExpiration = listInfo.getExpiration().getAbsoluteMillis()
         - new Date().getTime();
-    assertTrue("Directive expiry should be approximately the pool's max expiry",
-        Math.abs(listExpiration - poolExpiration) < 10*1000);
+    assertTrue(Math.abs(listExpiration - poolExpiration) < 10 * 1000,
+        "Directive expiry should be approximately the pool's max expiry");
     // Test that the max is enforced on add for relative and absolute
     CacheDirectiveInfo.Builder builder = new CacheDirectiveInfo.Builder()
         .setPath(new Path("/lolcat"))
@@ -1476,9 +1496,9 @@ public class TestCacheDirectives {
     listInfo = dirIt.next().getInfo();
     listExpiration = listInfo.getExpiration().getAbsoluteMillis()
         - new Date().getTime();
-    assertTrue("Unexpected relative expiry " + listExpiration
-        + " expected approximately " + poolExpiration/2,
-        Math.abs(poolExpiration/2 - listExpiration) < 10*1000);
+    assertTrue(Math.abs(poolExpiration / 2 - listExpiration) < 10 * 1000,
+        "Unexpected relative expiry " + listExpiration + " expected approximately "
+            + poolExpiration / 2);
     // Test that cache pool and directive expiry can be modified back to never
     dfs.modifyCachePool(destPool
         .setMaxRelativeExpiryMs(CachePoolInfo.RELATIVE_EXPIRY_NEVER));
@@ -1487,9 +1507,8 @@ public class TestCacheDirectives {
     while (!listPool.getPoolName().equals(destPool.getPoolName())) {
       listPool = poolIt.next().getInfo();
     }
-    assertEquals("Expected max relative expiry to match set value",
-        CachePoolInfo.RELATIVE_EXPIRY_NEVER,
-        listPool.getMaxRelativeExpiryMs().longValue());
+    assertEquals(CachePoolInfo.RELATIVE_EXPIRY_NEVER, listPool.getMaxRelativeExpiryMs().longValue(),
+        "Expected max relative expiry to match set value");
     dfs.modifyCacheDirective(new CacheDirectiveInfo.Builder()
         .setId(listInfo.getId())
         .setExpiration(Expiration.newRelative(RELATIVE_EXPIRY_NEVER))
@@ -1514,17 +1533,18 @@ public class TestCacheDirectives {
       for (DataNode dn : cluster.getDataNodes()) {
         DatanodeDescriptor descriptor =
             datanodeManager.getDatanode(dn.getDatanodeId());
-        Assert.assertTrue("Pending cached list of " + descriptor +
+        assertTrue(descriptor.getPendingCached().isEmpty(),
+            "Pending cached list of " + descriptor +
                 " is not empty, "
-                + Arrays.toString(descriptor.getPendingCached().toArray()), 
-            descriptor.getPendingCached().isEmpty());
+                + Arrays.toString(descriptor.getPendingCached().toArray()));
       }
     } finally {
       cluster.getNamesystem().readUnlock(RwLockMode.BM, "checkPendingCachedEmpty");
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testExceedsCapacity() throws Exception {
     // Create a giant file
     final Path fileName = new Path("/exceeds");
@@ -1548,7 +1568,8 @@ public class TestCacheDirectives {
     checkPendingCachedEmpty(cluster);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testNoBackingReplica() throws Exception {
     // Cache all three replicas for a file.
     final Path filename = new Path("/noback");
@@ -1580,7 +1601,8 @@ public class TestCacheDirectives {
     verifyZeroInteractions(locations);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testAddingCacheDirectiveInfosWhenCachingIsDisabled()
           throws Exception {
     cluster.shutdown();
@@ -1636,7 +1658,8 @@ public class TestCacheDirectives {
     return cluster.getFileSystem(0);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120)
   public void testExpiryTimeConsistency() throws Exception {
     conf.setInt(DFSConfigKeys.DFS_HA_LOGROLL_PERIOD_KEY, 1);
     conf.setInt(DFSConfigKeys.DFS_HA_TAILEDITS_PERIOD_KEY, 1);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestMetaSave.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestMetaSave.java
@@ -17,9 +17,10 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.DataInputStream;
@@ -43,14 +44,17 @@ import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * This class tests the creation and validation of metasave
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestMetaSave {
   static final int NUM_DATA_NODES = 2;
   static final long seed = 0xDEADBEEFL;
@@ -59,7 +63,7 @@ public class TestMetaSave {
   private static FileSystem fileSys = null;
   private static NamenodeProtocols nnRpc = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     // start a cluster
     Configuration conf = new HdfsConfiguration();
@@ -80,6 +84,7 @@ public class TestMetaSave {
   /**
    * Tests metasave
    */
+  @Order(1)
   @Test
   public void testMetaSave()
       throws IOException, InterruptedException, TimeoutException {
@@ -104,8 +109,7 @@ public class TestMetaSave {
     try {
       reader = new BufferedReader(new InputStreamReader(in));
       String line = reader.readLine();
-      Assert.assertEquals(
-          "3 files and directories, 2 blocks = 5 total filesystem objects",
+      assertEquals("3 files and directories, 2 blocks = 5 total filesystem objects",
           line);
       line = reader.readLine();
       assertTrue(line.equals("Live Datanodes: 1"));
@@ -277,7 +281,7 @@ public class TestMetaSave {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (fileSys != null)
       fileSys.close();
@@ -315,6 +319,6 @@ public class TestMetaSave {
         return BlockManagerTestUtil.isDatanodeRemoved(
             cluster.getNameNode(), dnToStop.getDatanodeUuid());
       }
-    }, 1000, 30000);
+    }, 1000, 60000);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFineGrainedFSNamesystemLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/fgl/TestFineGrainedFSNamesystemLock.java
@@ -46,11 +46,12 @@ public class TestFineGrainedFSNamesystemLock {
    * Test read/write lock of Global, FS and BM model through multi-threading.
    */
   @Test
-  @Timeout(value = 120)
+  @Timeout(value = 240)
   public void testMultipleThreadsUsingLocks()
       throws InterruptedException, ExecutionException {
     FineGrainedFSNamesystemLock fsn = new FineGrainedFSNamesystemLock(new Configuration(), null);
-    ExecutorService service = HadoopExecutors.newFixedThreadPool(1000);
+    int threads = Math.min(128, Runtime.getRuntime().availableProcessors() * 4);
+    ExecutorService service = HadoopExecutors.newFixedThreadPool(threads);
 
     AtomicLong globalCount = new AtomicLong(0);
     AtomicLong fsCount = new AtomicLong(0);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestOrderedSnapshotDeletionGc.java
@@ -51,7 +51,7 @@ import static org.apache.hadoop.hdfs.server.namenode.snapshot.SnapshotManager.DF
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.assertNotMarkedAsDeleted;
 import static org.apache.hadoop.hdfs.server.namenode.snapshot.TestOrderedSnapshotDeletion.getDeletedSnapshotName;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestSnapshotDeletion.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/sps/TestExternalStoragePolicySatisfier.java
@@ -99,7 +99,7 @@ import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -446,7 +446,7 @@ public class TestExternalStoragePolicySatisfier {
    * This test need not run as external scan is not a batch based scanning right
    * now.
    */
-  @Ignore("ExternalFileIdCollector is not batch based right now."
+  @Disabled("ExternalFileIdCollector is not batch based right now."
       + " So, ignoring it.")
   public void testBatchProcessingForSPSDirectory() throws Exception {
   }
@@ -454,7 +454,7 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * This test case is more specific to internal.
    */
-  @Ignore("This test is specific to internal, so skipping here.")
+  @Disabled("This test is specific to internal, so skipping here.")
   public void testWhenMoverIsAlreadyRunningBeforeStoragePolicySatisfier()
       throws Exception {
   }
@@ -462,14 +462,14 @@ public class TestExternalStoragePolicySatisfier {
   /**
    * This test is specific to internal SPS. So, ignoring it.
    */
-  @Ignore("This test is specific to internal SPS. So, ignoring it.")
+  @Disabled("This test is specific to internal SPS. So, ignoring it.")
   public void testTraverseWhenParentDeleted() throws Exception {
   }
 
   /**
    * This test is specific to internal SPS. So, ignoring it.
    */
-  @Ignore("This test is specific to internal SPS. So, ignoring it.")
+  @Disabled("This test is specific to internal SPS. So, ignoring it.")
   public void testTraverseWhenRootParentDeleted() throws Exception {
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/HostsFileWriter.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.HostFileManager;
 import org.apache.hadoop.hdfs.protocol.DatanodeAdminProperties;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo.AdminStates;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HostsFileWriter {
   private FileSystem localFileSys;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestCombinedHostsFileReader.java
@@ -26,19 +26,23 @@ import org.apache.hadoop.hdfs.protocol.DatanodeAdminProperties;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 
 /**
  * Test for JSON based HostsFileReader.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestCombinedHostsFileReader {
 
   // Using /test/build/data/tmp directory to store temporary files
@@ -64,7 +68,6 @@ public class TestCombinedHostsFileReader {
   public void tearDown() throws Exception {
     // Delete test file after running tests
     newFile.delete();
-
   }
 
   /*
@@ -134,6 +137,7 @@ public class TestCombinedHostsFileReader {
   /*
    * When timeout is enabled, test for IOException when execution is interrupted
    */
+  @Order(1)
   @Test
   public void testReadFileWithTimeoutInterruptedException() throws Exception {
     when(callable.call()).thenAnswer(new Answer<Void>() {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java8/org/apache/hadoop/hdfs/TestDFSClientFailover.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java8/org/apache/hadoop/hdfs/TestDFSClientFailover.java
@@ -17,10 +17,11 @@
  */
 package org.apache.hadoop.hdfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -34,6 +35,16 @@ import java.util.List;
 
 import javax.net.SocketFactory;
 
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.hdfs.HAUtil;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.hdfs.NameNodeProxies;
+import org.apache.hadoop.hdfs.NameNodeProxiesClient;
+import org.opentest4j.TestAbortedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -55,10 +66,10 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
@@ -73,8 +84,8 @@ public class TestDFSClientFailover {
   
   private final Configuration conf = new Configuration();
   private MiniDFSCluster cluster;
-  
-  @Before
+
+  @BeforeEach
   public void setUpCluster() throws IOException {
     cluster = new MiniDFSCluster.Builder(conf)
       .nnTopology(MiniDFSNNTopology.simpleHATopology())
@@ -82,8 +93,8 @@ public class TestDFSClientFailover {
     cluster.transitionToActive(0);
     cluster.waitActive();
   }
-  
-  @After
+
+  @AfterEach
   public void tearDownCluster() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -91,7 +102,7 @@ public class TestDFSClientFailover {
     }
   }
 
-  @After
+  @AfterEach
   public void clearConfig() {
     SecurityUtil.setTokenServiceUseIp(true);
   }
@@ -217,9 +228,9 @@ public class TestDFSClientFailover {
       fail("Successfully got proxy provider for misconfigured FS");
     } catch (IOException ioe) {
       LOG.info("got expected exception", ioe);
-      assertTrue("expected exception did not contain helpful message",
-          StringUtils.stringifyException(ioe).contains(
-          "Could not find any configured addresses for URI " + uri));
+      assertTrue(StringUtils.stringifyException(ioe)
+              .contains("Could not find any configured addresses for URI " + uri),
+          "expected exception did not contain helpful message");
     }
   }
 
@@ -233,7 +244,7 @@ public class TestDFSClientFailover {
     try {
       Field f = InetAddress.class.getDeclaredField("nameServices");
       f.setAccessible(true);
-      Assume.assumeNotNull(f);
+      assumeTrue(f != null);
       @SuppressWarnings("unchecked")
       List<NameService> nsList = (List<NameService>) f.get(null);
 
@@ -248,8 +259,7 @@ public class TestDFSClientFailover {
       LOG.info("Unable to spy on DNS. Skipping test.", t);
       // In case the JDK we're testing on doesn't work like Sun's, just
       // skip the test.
-      Assume.assumeNoException(t);
-      throw new RuntimeException(t);
+      throw new TestAbortedException(t.getMessage(), t);
     }
   }
   
@@ -296,7 +306,8 @@ public class TestDFSClientFailover {
    * Test that creating proxy doesn't ever try to DNS-resolve the logical URI.
    * Regression test for HDFS-9364.
    */
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testCreateProxyDoesntDnsResolveLogicalURI() throws IOException {
     final NameService spyNS = spyOnNameService();
     final Configuration conf = new HdfsConfiguration();
@@ -378,8 +389,8 @@ public class TestDFSClientFailover {
     SecurityUtil.setTokenServiceUseIp(false);
 
     // Logical URI should be used.
-    assertTrue("Legacy proxy providers should use logical URI.",
-        HAUtil.useLogicalUri(config, p.toUri()));
+    assertTrue(HAUtil.useLogicalUri(config, p.toUri()),
+        "Legacy proxy providers should use logical URI.");
   }
 
   /**
@@ -394,8 +405,8 @@ public class TestDFSClientFailover {
         nnUri.getHost(),
         IPFailoverProxyProvider.class.getName());
 
-    assertFalse("IPFailoverProxyProvider should not use logical URI.",
-        HAUtil.useLogicalUri(config, nnUri));
+    assertFalse(HAUtil.useLogicalUri(config, nnUri),
+        "IPFailoverProxyProvider should not use logical URI.");
   }
 
 }


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-12431. Upgrade JUnit from 4 to 5 in hadoop-hdfs Part17.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

