### PR TITLE
YARN-11857. Update YARN Resource Manager REST Documentation for deSelects Params

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DeSelectFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DeSelectFields.java
@@ -93,7 +93,7 @@ public class DeSelectFields {
      */
     RESOURCE_REQUESTS("resourceRequests"),
     /**
-     * <code>APP_TIMEOUTS, APP_NODE_LABEL_EXPRESSION, AM_NODE_LABEL_EXPRESSION,
+     * <code>TIMEOUTS, APP_NODE_LABEL_EXPRESSION, AM_NODE_LABEL_EXPRESSION,
      * RESOURCE_INFO</code> are additionally supported parameters added in
      * YARN-6871.
      */

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-site/src/site/markdown/ResourceManagerRest.md
@@ -4520,6 +4520,10 @@ Current supported items:
 | Item | Data Type | Description |
 |:---- |:---- |:---- |
 | resourceRequests | comma separated string | Skip resource requests of application in return |
+| timeouts | comma separated string | Skip timeouts of application in return |
+| appNodeLabelExpression | comma separated string | Skip app node label expression of application in return |
+| amNodeLabelExpression | comma separated string | Skip am node label expression of application in return |
+| resourceInfo | comma separated string | Skip resource info of application in return |
 
 e.g:
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11857. Update YARN Resource Manager REST Documentation for deSelects Params

Support for additional fields in deSelect params was added in this commit: https://github.com/apache/hadoop/commit/8facf1f976d7e12a846f12baabf54be1b7a49f9d#diff-8448ab6a1e47a26fe8b8f2767e83983a6a15ee883d6bdd7dc76b331c4d2bf81c.

However, the documentation does not have those listed. Updating the documentation to include these fields to make them accessible to users.

### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

