### PR TITLE
HADOOP-19680. Update non-thirdparty Guava version to 32.0.1

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -108,7 +108,7 @@
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.6.1</dnsjava.version>
 
-    <guava.version>27.0-jre</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 
     <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
same as the current thirdparty Guava version

### Description of PR

Guava has been already updated to 32.0.1 in hadoop-thirdparty.
However, Hadoop also dependency manages the non-thirdparty guava version (coming from dependencies), which is still at 27.0-jre , showing up on static scanners.

Sync the non-thirdparty Guava version to the thirdparty one.

### How was this patch tested?

Test suite in CI (on this PR)

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

