### PR TITLE
HADOOP-19681: Fix S3A failing to initialize S3 buckets having namespace with dot followed by number

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -335,7 +335,7 @@ public abstract class AbstractFileSystem implements PathCapabilities {
     int port = uri.getPort();
     port = (port == -1 ? defaultPort : port);
     if (port == -1) { // no port supplied and default port is not specified
-      return URI.create(supportedScheme + "://" + authority);
+      return URI.create(supportedScheme + "://" + authority + "/");
     }
     return new URI(supportedScheme + "://" + uri.getHost() + ":" + port);
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/AbstractFileSystem.java
@@ -335,7 +335,7 @@ public abstract class AbstractFileSystem implements PathCapabilities {
     int port = uri.getPort();
     port = (port == -1 ? defaultPort : port);
     if (port == -1) { // no port supplied and default port is not specified
-      return new URI(supportedScheme, authority, "/", null);
+      return URI.create(supportedScheme + "://" + authority);
     }
     return new URI(supportedScheme + "://" + uri.getHost() + ":" + port);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -573,8 +573,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   public void initialize(URI name, Configuration originalConf)
       throws IOException {
-    // get the host; this is guaranteed to be non-null, non-empty
+    // get the host; fallback to authority if getHost() returns null
     bucket = name.getHost();
+    if (bucket == null) {
+      bucket = name.getAuthority();
+    }
     AuditSpan span = null;
     // track initialization duration; will only be set after
     // statistics are set up.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/BucketTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/BucketTool.java
@@ -172,7 +172,7 @@ public final class BucketTool extends S3GuardTool {
     final String bucketPath = parsedArgs.get(0);
     final Path source = new Path(bucketPath);
     URI fsURI = source.toUri();
-    String bucket = fsURI.getHost();
+    String bucket = fsURI.getHost() != null ? fsURI.getHost() : fsURI.getAuthority();
 
     println(out, "Filesystem %s", fsURI);
     if (!"s3a".equals(fsURI.getScheme())) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3native/S3xLoginHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3native/S3xLoginHelper.java
@@ -56,8 +56,12 @@ public final class S3xLoginHelper {
     // look for login secrets and fail if they are present.
     Objects.requireNonNull(uri, "null uri");
     Objects.requireNonNull(uri.getScheme(), "null uri.getScheme()");
-    Objects.requireNonNull(uri.getHost(), "null uri host.");
-    return URI.create(uri.getScheme() + "://" + uri.getHost());
+    String host = uri.getHost();
+    if (host == null) {
+      host = uri.getAuthority();
+    }
+    Objects.requireNonNull(host, "null uri host.");
+    return URI.create(uri.getScheme() + "://" + host);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
+++ b/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md
@@ -31,6 +31,12 @@ before 2021.
 Consult [S3A and Directory Markers](directory_markers.html) for
 full details.
 
+### <a name="bucket-name-compatibility"></a> S3 Bucket Name Compatibility
+
+This release adds support for S3 bucket names containing dots followed by numbers
+(e.g., `my-bucket-v1.1`, `data-store.v2.3`). Previous versions of the Hadoop S3A
+client failed to initialize such buckets due to URI parsing limitations.
+
 ## <a name="documents"></a> Documents
 
 * [Connecting](./connecting.html)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -48,7 +48,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -607,17 +607,6 @@ public class ITestS3AConfiguration extends AbstractHadoopTestBase {
   }
 
   @Test
-  public void testBucketNameWithDotAndNumber() throws Exception {
-    Configuration config = new Configuration();
-    Path path = new Path("s3a://test-bucket-v1.1");
-    try (FileSystem fs = path.getFileSystem(config)) {
-      assertThat(fs instanceof S3AFileSystem)
-          .describedAs("FileSystem should be S3AFileSystem instance")
-          .isTrue();
-    }
-  }
-
-  @Test
   @Timeout(10)
   public void testS3SpecificSignerOverride() throws Exception {
     Configuration config = new Configuration();

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AConfiguration.java
@@ -48,6 +48,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -594,11 +595,26 @@ public class ITestS3AConfiguration extends AbstractHadoopTestBase {
   public void testConfOptionPropagationToFS() throws Exception {
     Configuration config = new Configuration();
     String testFSName = config.getTrimmed(TEST_FS_S3A_NAME, "");
-    String bucket = new URI(testFSName).getHost();
+    URI uri = new URI(testFSName);
+    String bucket = uri.getHost();
+    if (bucket == null) {
+      bucket = uri.getAuthority();
+    }
     setBucketOption(config, bucket, "propagation", "propagated");
     fs = S3ATestUtils.createTestFileSystem(config);
     Configuration updated = fs.getConf();
     assertOptionEquals(updated, "fs.s3a.propagation", "propagated");
+  }
+
+  @Test
+  public void testBucketNameWithDotAndNumber() throws Exception {
+    Configuration config = new Configuration();
+    Path path = new Path("s3a://test-bucket-v1.1");
+    try (FileSystem fs = path.getFileSystem(config)) {
+      assertThat(fs instanceof S3AFileSystem)
+          .describedAs("FileSystem should be S3AFileSystem instance")
+          .isTrue();
+    }
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -883,7 +883,11 @@ public final class S3ATestUtils {
   public static String getTestBucketName(final Configuration conf) {
     String bucket = checkNotNull(conf.get(TEST_FS_S3A_NAME),
         "No test bucket");
-    return URI.create(bucket).getHost();
+    URI uri = URI.create(bucket);
+    if (uri.getHost() != null) {
+      return uri.getHost();
+    }
+    return uri.getAuthority();
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.security.ProviderUtils;
@@ -92,6 +93,38 @@ public class TestBucketConfiguration extends AbstractHadoopTestBase {
     URI multiDotUri = URI.create("s3a://bucket.v1.2.test/path");
     URI multiDotResult = S3xLoginHelper.buildFSURI(multiDotUri);
     assertEquals("s3a://bucket.v1.2.test", multiDotResult.toString());
+  }
+
+  @Test
+  public void testBucketNameWithDotAndNumber() throws Exception {
+    Configuration config = new Configuration();
+    URI uri = URI.create("s3a://test-bucket-v1.1");
+    String bucket = uri.getHost();
+    if (bucket == null) {
+      bucket = uri.getAuthority();
+    }
+    assertThat(bucket)
+        .describedAs("Bucket name should be extracted correctly")
+        .isEqualTo("test-bucket-v1.1");
+  }
+
+  @Test
+  public void testFileSystemCacheForBucketWithDotAndNumber() throws Exception {
+    Configuration config = new Configuration();
+    URI uri1 = URI.create("s3a://test-bucket-v1.1");
+    URI uri2 = URI.create("s3a://test-bucket-v1.2");
+    
+    FileSystem fs1a = FileSystem.get(uri1, config);
+    FileSystem fs1b = FileSystem.get(uri1, config);
+    FileSystem fs2 = FileSystem.get(uri2, config);
+    
+    assertThat(fs1a)
+        .describedAs("FileSystem.get should return same cached instance for same URI")
+        .isSameAs(fs1b);
+    
+    assertThat(fs1a)
+        .describedAs("FileSystem.get should return different instance for different bucket")
+        .isNotSameAs(fs2);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
@@ -116,11 +116,11 @@ public class TestBucketConfiguration extends AbstractHadoopTestBase {
     FileSystem fs1a = FileSystem.get(uri1, config);
     FileSystem fs1b = FileSystem.get(uri1, config);
     FileSystem fs2 = FileSystem.get(uri2, config);
-    
+
     assertThat(fs1a)
         .describedAs("The call should return same cached instance for same URI")
         .isSameAs(fs1b);
-    
+
     assertThat(fs1a)
         .describedAs("The call should return different instance for different bucket")
         .isNotSameAs(fs2);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
@@ -98,14 +98,13 @@ public class TestBucketConfiguration extends AbstractHadoopTestBase {
   @Test
   public void testBucketNameWithDotAndNumber() throws Exception {
     Configuration config = new Configuration();
-    URI uri = URI.create("s3a://test-bucket-v1.1");
-    String bucket = uri.getHost();
-    if (bucket == null) {
-      bucket = uri.getAuthority();
+    org.apache.hadoop.fs.Path path =
+        new org.apache.hadoop.fs.Path("s3a://test-bucket-v1.1");
+    try (FileSystem fs = path.getFileSystem(config)) {
+      assertThat(fs)
+          .describedAs("FileSystem should be S3AFileSystem instance")
+          .isInstanceOf(S3AFileSystem.class);
     }
-    assertThat(bucket)
-        .describedAs("Bucket name should be extracted correctly")
-        .isEqualTo("test-bucket-v1.1");
   }
 
   @Test
@@ -119,11 +118,11 @@ public class TestBucketConfiguration extends AbstractHadoopTestBase {
     FileSystem fs2 = FileSystem.get(uri2, config);
     
     assertThat(fs1a)
-        .describedAs("FileSystem.get should return same cached instance for same URI")
+        .describedAs("The call should return same cached instance for same URI")
         .isSameAs(fs1b);
     
     assertThat(fs1a)
-        .describedAs("FileSystem.get should return different instance for different bucket")
+        .describedAs("The call should return different instance for different bucket")
         .isNotSameAs(fs2);
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestBucketConfiguration.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
+import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
@@ -73,6 +74,24 @@ public class TestBucketConfiguration extends AbstractHadoopTestBase {
   public void setup() throws Exception {
     // forces in deprecation wireup, even when this test method is running isolated
     S3AFileSystem.initializeClass();
+  }
+
+  @Test
+  public void testS3xLoginHelperWithDotInBucketName() throws Throwable {
+    // Test buildFSURI with bucket name containing dot followed by number
+    URI uri = URI.create("s3a://bucket-v1.1/path");
+    URI result = S3xLoginHelper.buildFSURI(uri);
+    assertEquals("s3a://bucket-v1.1", result.toString());
+
+    // Test with normal bucket name
+    URI normalUri = URI.create("s3a://normal-bucket/path");
+    URI normalResult = S3xLoginHelper.buildFSURI(normalUri);
+    assertEquals("s3a://normal-bucket", normalResult.toString());
+
+    // Test edge case with multiple dots
+    URI multiDotUri = URI.create("s3a://bucket.v1.2.test/path");
+    URI multiDotResult = S3xLoginHelper.buildFSURI(multiDotUri);
+    assertEquals("s3a://bucket.v1.2.test", multiDotResult.toString());
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestCustomSigner.java
@@ -283,6 +283,17 @@ public class ITestCustomSigner extends AbstractS3ATestBase {
 
       String host = request.host();
       String bucketName = parseBucketFromHost(host);
+      // If host-based parsing fails (path-style requests), extract from path
+      if (bucketName.equals("s3")) {
+        String path = request.encodedPath();
+        if (path != null && path.startsWith("/") && path.length() > 1) {
+          String[] pathParts = path.substring(1).split("/", 2);
+          if (pathParts.length > 0 && !pathParts[0].isEmpty()) {
+            bucketName = pathParts[0];
+          }
+        }
+      }
+
       try {
         lastStoreValue = CustomSignerInitializer
             .getStoreValue(bucketName, UserGroupInformation.getCurrentUser());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestJceksIO.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestJceksIO.java
@@ -187,8 +187,12 @@ public class ITestJceksIO extends AbstractS3ATestBase {
    */
   private String toJceksProvider(Path keystore) {
     final URI uri = keystore.toUri();
+    String bucket = uri.getHost();
+    if (bucket == null) {
+      bucket = uri.getAuthority();
+    }
     return String.format("jceks://%s@%s%s",
-        uri.getScheme(), uri.getHost(), uri.getPath());
+        uri.getScheme(), bucket, uri.getPath());
   }
 
 }


### PR DESCRIPTION
### Description of PR

S3A fails to initialize when S3 bucket namespace is having dot followed by a number. 

Specific Problem: URI parsing fails when S3 bucket names contain a dot followed by a number (like bucket-v1.1-us-east-1). Java's
URI.getHost() method incorrectly interprets the dot-number pattern as a port specification, causing it to return null.


### How was this patch tested?

Tested in us-east-1 with bucket having namespace with dot followed by a number.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

