### PR TITLE
HADOOP-19675. Addendum. Close stale PRs updated over 100 days ago.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/stale@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
             We're closing this stale PR because it has been open for 100 days with
             no activity. This isn't a judgement on the merit of the PR in any way.


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
This PR adds a GitHub workflow to automatically close stale PRs which have no activity over 100 days, linked https://github.com/apache/hadoop/pull/7930.

Addendum. add github token.

### How was this patch tested?
No.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

