### PR TITLE
HADOOP-19415. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-common Part13.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProviderCryptoExtension.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProviderCryptoExtension.java
@@ -25,7 +25,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -34,9 +33,8 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.EncryptedKeyVersion;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.crypto.key.KeyProvider.KeyVersion;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -46,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@Timeout(180)
 public class TestKeyProviderCryptoExtension {
 
   private static final String CIPHER = "AES";
@@ -56,9 +55,6 @@ public class TestKeyProviderCryptoExtension {
   private static KeyProviderCryptoExtension kpExt;
   private static KeyProvider.Options options;
   private static KeyVersion encryptionKey;
-
-  @Rule
-  public Timeout testTimeout = new Timeout(180000, TimeUnit.MILLISECONDS);
 
   @BeforeAll
   public static void setup() throws Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestSymlinkLocalFS.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestSymlinkLocalFS.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestResult.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/find/TestResult.java
@@ -19,16 +19,11 @@ package org.apache.hadoop.fs.shell.find;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import java.util.concurrent.TimeUnit;
-
+@Timeout(10)
 public class TestResult {
-
-  @Rule
-  public Timeout globalTimeout = new Timeout(10000, TimeUnit.MILLISECONDS);
 
   // test the PASS value
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestProtoBufRpc.java
@@ -53,7 +53,7 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounterGt;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Test for testing protocol buffer based RPC mechanism.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestJNIGroupsMapping.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestJNIGroupsMapping.java
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 package org.apache.hadoop.security;
-import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/authorize/TestDefaultImpersonationProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/authorize/TestDefaultImpersonationProvider.java
@@ -24,16 +24,14 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Test class for @DefaultImpersonationProvider
  */
+@Timeout(10)
 public class TestDefaultImpersonationProvider {
 
   private String proxyUser;
@@ -44,8 +42,6 @@ public class TestDefaultImpersonationProvider {
   private UserGroupInformation realUserUGI = Mockito
       .mock(UserGroupInformation.class);
   private Configuration conf;
-  @Rule
-  public Timeout globalTimeout = new Timeout(10000, TimeUnit.MILLISECONDS);
 
   @BeforeEach
   public void setup() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestDelegatingSSLSocketFactory.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.hadoop.util.NativeCodeLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests for {@link DelegatingSSLSocketFactory}.
@@ -35,10 +35,10 @@ public class TestDelegatingSSLSocketFactory {
 
   @Test
   public void testOpenSSL() throws IOException {
-    assumeTrue("Unable to load native libraries",
-            NativeCodeLoader.isNativeCodeLoaded());
-    assumeTrue("Build was not compiled with support for OpenSSL",
-            NativeCodeLoader.buildSupportsOpenssl());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded(),
+        "Unable to load native libraries");
+    assumeTrue(NativeCodeLoader.buildSupportsOpenssl(),
+        "Build was not compiled with support for OpenSSL");
     DelegatingSSLSocketFactory.initializeDefaultFactory(
             DelegatingSSLSocketFactory.SSLChannelMode.OpenSSL);
     assertThat(DelegatingSSLSocketFactory.getDefaultFactory()
@@ -47,8 +47,8 @@ public class TestDelegatingSSLSocketFactory {
 
   @Test
   public void testJSEENoGCMJava8() throws IOException {
-    assumeTrue("Not running on Java 8",
-            System.getProperty("java.version").startsWith("1.8"));
+    assumeTrue(System.getProperty("java.version").startsWith("1.8"),
+        "Not running on Java 8");
     DelegatingSSLSocketFactory.initializeDefaultFactory(
             DelegatingSSLSocketFactory.SSLChannelMode.Default_JSSE);
     assertThat(Arrays.stream(DelegatingSSLSocketFactory.getDefaultFactory()


### PR DESCRIPTION
### Description of PR
JIRA:HADOOP-19415. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-common Part13.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

