### PR TITLE
YARN-11858. Make the default-application-priority attribute of queues globally configurable

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerConfiguration.java
@@ -335,6 +335,10 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
   public static final Integer DEFAULT_CONFIGURATION_APPLICATION_PRIORITY = 0;
 
   @Private
+  public static final String DEFAULT_APPLICATION_PRIORITY_GLOBAL =
+      PREFIX + "default-application-priority";
+
+  @Private
   public static final String AVERAGE_CAPACITY = "average-capacity";
 
   @Private
@@ -1815,11 +1819,17 @@ public class CapacitySchedulerConfiguration extends ReservationSchedulerConfigur
         YarnConfiguration.DEFAULT_CLUSTER_LEVEL_APPLICATION_PRIORITY));
   }
 
-  public Integer getDefaultApplicationPriorityConfPerQueue(QueuePath queue) {
-    Integer defaultPriority = getInt(getQueuePrefix(queue)
-        + DEFAULT_APPLICATION_PRIORITY,
+  /**
+   * Get the global default application priority setting.
+   * @return global default priority or DEFAULT_CONFIGURATION_APPLICATION_PRIORITY if not set */
+  private Integer getDefaultApplicationPriority() {
+    return getInt(DEFAULT_APPLICATION_PRIORITY_GLOBAL,
         DEFAULT_CONFIGURATION_APPLICATION_PRIORITY);
-    return defaultPriority;
+  }
+
+  public Integer getDefaultApplicationPriorityConfPerQueue(QueuePath queue) {
+    return getInt(getQueuePrefix(queue) + DEFAULT_APPLICATION_PRIORITY,
+        getDefaultApplicationPriority());
   }
 
   @VisibleForTesting

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestApplicationLimits.java
@@ -384,6 +384,20 @@ public class TestApplicationLimits {
         csConf.getMaximumApplicationMasterResourcePerQueuePercent(
           queue.getQueuePathObject()), epsilon);
 
+    assertEquals(
+        (int)CapacitySchedulerConfiguration.DEFAULT_CONFIGURATION_APPLICATION_PRIORITY,
+        (int)csConf.getDefaultApplicationPriorityConfPerQueue(
+            queue.getQueuePathObject())
+    );
+
+    csConf.setInt(PREFIX + queue.getQueuePath()
+        + ".default-application-priority", 6);
+
+    assertEquals((int) 6,
+        (int) csConf.getDefaultApplicationPriorityConfPerQueue(
+            queue.getQueuePathObject())
+    );
+
     assertThat(queue.calculateAndGetAMResourceLimit()).isEqualTo(
         Resource.newInstance(800 * GB, 1));
     assertThat(queue.getUserAMResourceLimit()).isEqualTo(


### PR DESCRIPTION
Currently, if the yarn.cluster.max-application-priority is set to 10, and we want the default application priority of queues to be configured as 5—allowing tasks to lower their application priority if they are less important or raise it if they are more important—the current behavior is that if the default-application-priority of a queue is not explicitly set, it defaults to 0. To achieve the desired effect, each queue must be individually set to 5, which is cumbersome. There is a need for a global default configuration that sets this value to 5.
