### PR TITLE
YARN-11261. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-web-proxy.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestFedAppReportFetcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestFedAppReportFetcher.java
@@ -40,12 +40,12 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.util.StringHelper;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFedAppReportFetcher {
 
@@ -66,7 +66,7 @@ public class TestFedAppReportFetcher {
   private static FedAppReportFetcher fetcher;
   private final String appNotFoundExceptionMsg = "APP NOT FOUND";
 
-  @After
+  @AfterEach
   public void cleanUp() {
     history = null;
     fetcher = null;
@@ -132,16 +132,16 @@ public class TestFedAppReportFetcher {
         .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
     Mockito.verify(appManager2, Mockito.times(1))
         .getApplicationReport(Mockito.any(GetApplicationReportRequest.class));
-    Assert.assertNull("HistoryManager should be null as AHS is disabled", history);
+    Assertions.assertNull(history, "HistoryManager should be null as AHS is disabled");
   }
 
   @Test
   public void testGetRmAppPageUrlBase() throws IOException, YarnException {
     testHelper(true);
     String scheme = WebAppUtils.getHttpSchemePrefix(conf);
-    Assert.assertEquals(fetcher.getRmAppPageUrlBase(appId1),
+    Assertions.assertEquals(fetcher.getRmAppPageUrlBase(appId1),
         StringHelper.pjoin(scheme + clusterInfo1.getRMWebServiceAddress(), "cluster", "app"));
-    Assert.assertEquals(fetcher.getRmAppPageUrlBase(appId2),
+    Assertions.assertEquals(fetcher.getRmAppPageUrlBase(appId2),
         StringHelper.pjoin(scheme + clusterInfo2.getRMWebServiceAddress(), "cluster", "app"));
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServletFed.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-web-proxy/src/test/java/org/apache/hadoop/yarn/server/webproxy/TestWebAppProxyServletFed.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.yarn.server.webproxy;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,9 +57,10 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public class TestWebAppProxyServletFed {
   /**
    * Simple http server. Server should send answer with status 200
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     mockServer = new Server(0);
     ((QueuedThreadPool) mockServer.getThreadPool()).setMaxThreads(20);
@@ -102,7 +103,7 @@ public class TestWebAppProxyServletFed {
     LOG.info("Running embedded servlet container at: http://localhost:" + mockServerPort);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (mockServer != null) {
       mockServer.stop();
@@ -139,7 +140,8 @@ public class TestWebAppProxyServletFed {
     conn.disconnect();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testWebAppProxyServletFed() throws Exception {
 
     Configuration conf = new Configuration();


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11261. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-yarn-server-web-proxy.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

