### PR TITLE
HADOOP-19684. Add JDK 21 to Ubuntu 20.04 and 24.04 docker development images

### DIFF
--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -268,17 +268,20 @@
     ],
     "ubuntu:focal": [
       "temurin-24-jdk",
+      "temurin-21-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"
     ],
     "ubuntu:noble": [
       "temurin-24-jdk",
+      "temurin-21-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"
     ],
     "ubuntu:focal::arch64": [
       "temurin-24-jdk",
+      "temurin-21-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk"

--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -268,23 +268,23 @@
     ],
     "ubuntu:focal": [
       "temurin-24-jdk",
-      "temurin-21-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "openjdk-21-jdk"
     ],
     "ubuntu:noble": [
       "temurin-24-jdk",
-      "temurin-21-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "openjdk-21-jdk"
     ],
     "ubuntu:focal::arch64": [
       "temurin-24-jdk",
-      "temurin-21-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
-      "openjdk-17-jdk"
+      "openjdk-17-jdk",
+      "openjdk-21-jdk"
     ]
   },
   "pinentry-curses": {


### PR DESCRIPTION
### Description of PR

HADOOP-19684. Add JDK 21 to Ubuntu 20.04 and 24.04 docker development images.

Add JDK 21 to Ubuntu 20.04 and 24.04  docker development images

### How was this patch tested?

Built the default image locally and started JDK21.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

