### PR TITLE
HDFS-17720. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs-rbf Part3.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/rbfbalance/TestRouterDistCpProcedure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/rbfbalance/TestRouterDistCpProcedure.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.tools.fedbalance.DistCpProcedure.Stage;
 import org.apache.hadoop.tools.fedbalance.FedBalanceContext;
 import org.apache.hadoop.tools.fedbalance.TestDistCpProcedure;
 import org.apache.hadoop.util.Time;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -47,8 +47,7 @@ import java.util.Collections;
 
 import static org.apache.hadoop.hdfs.server.federation.FederationTestUtils.createNamenodeReport;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRouterDistCpProcedure extends TestDistCpProcedure {
   private static StateStoreDFSCluster cluster;
@@ -56,7 +55,7 @@ public class TestRouterDistCpProcedure extends TestDistCpProcedure {
   private static Configuration routerConf;
   private static StateStoreService stateStore;
 
-  @BeforeClass
+  @BeforeAll
   public static void globalSetUp() throws Exception {
     cluster = new StateStoreDFSCluster(false, 1);
     // Build and start a router with State Store + admin + RPC
@@ -113,7 +112,7 @@ public class TestRouterDistCpProcedure extends TestDistCpProcedure {
         .mkdirs(mount + "/dir", new FsPermission(020), false));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     cluster.stopRouter(routerContext);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/token/TestZKDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/token/TestZKDelegationTokenSecretManagerImpl.java
@@ -22,7 +22,8 @@ import static org.apache.hadoop.hdfs.server.federation.router.security.token.ZKD
 import static org.apache.hadoop.security.token.delegation.ZKDelegationTokenSecretManager.ZK_DTSM_TOKEN_WATCHER_ENABLED;
 import static org.apache.hadoop.security.token.delegation.web.DelegationTokenManager.REMOVAL_SCAN_INTERVAL;
 import static org.apache.hadoop.security.token.delegation.web.DelegationTokenManager.RENEW_INTERVAL;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.server.federation.router.security.token.ZKDelegationTokenSecretManagerImpl;
@@ -34,8 +35,7 @@ import org.apache.hadoop.security.token.delegation.TestZKDelegationTokenSecretMa
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenManager;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +68,7 @@ public class TestZKDelegationTokenSecretManagerImpl
       Token<DelegationTokenIdentifier> token =
           (Token<DelegationTokenIdentifier>) tm1.createToken(
               UserGroupInformation.getCurrentUser(), "foo");
-      Assert.assertNotNull(token);
+      assertNotNull(token);
       tm2.verifyToken(token);
       tm2.renewToken(token, "foo");
       tm1.verifyToken(token);
@@ -82,7 +82,7 @@ public class TestZKDelegationTokenSecretManagerImpl
 
       token = (Token<DelegationTokenIdentifier>) tm2.createToken(
           UserGroupInformation.getCurrentUser(), "bar");
-      Assert.assertNotNull(token);
+      assertNotNull(token);
       tm1.verifyToken(token);
       tm1.renewToken(token, "bar");
       tm2.verifyToken(token);
@@ -133,7 +133,7 @@ public class TestZKDelegationTokenSecretManagerImpl
       Token<DelegationTokenIdentifier> token =
           (Token<DelegationTokenIdentifier>) tm1.createToken(
               UserGroupInformation.getCurrentUser(), "foo");
-      Assert.assertNotNull(token);
+      assertNotNull(token);
       tm2.verifyToken(token);
 
       // time: X + 9
@@ -198,7 +198,7 @@ public class TestZKDelegationTokenSecretManagerImpl
       Token<DelegationTokenIdentifier> token =
           (Token<DelegationTokenIdentifier>) tm1.createToken(
               UserGroupInformation.getCurrentUser(), "foo");
-      Assert.assertNotNull(token);
+      assertNotNull(token);
       tm2.verifyToken(token);
 
       // time: X + 9


### PR DESCRIPTION
### Description of PR
JIRA:HDFS-17720.  [JDK17] Upgrade JUnit from 4 to 5 in hadoop-hdfs-rbf Part3.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

