### PR TITLE
HADOOP-19646. [Addendum] [JDK17] Migrate hadoop-aws module from JUnit4 Assume to JUnit5 Assumptions.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractSeek.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractSeek.java
@@ -59,7 +59,7 @@ import static org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory.
         SSLChannelMode.Default_JSSE_with_GCM;
 import static org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory.
         SSLChannelMode.OpenSSL;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
 /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestTreewalkProblems.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestTreewalkProblems.java
@@ -316,7 +316,7 @@ public class ITestTreewalkProblems extends AbstractS3ACostTest {
           options, getConfiguration());
     } else {
       // distcp fails if uploads are visible
-      intercept(org.junit.ComparisonFailure.class, () -> {
+      intercept(org.opentest4j.AssertionFailedError.class, () -> {
         DistCpTestUtils.assertRunDistCp(DistCpConstants.SUCCESS, src.toString(), dest.toString(),
             options, getConfiguration());
       });
@@ -339,7 +339,7 @@ public class ITestTreewalkProblems extends AbstractS3ACostTest {
           options, getConfiguration());
     } else {
       // distcp fails if uploads are visible
-      intercept(org.junit.ComparisonFailure.class, () -> {
+      intercept(org.opentest4j.AssertionFailedError.class, () -> {
         DistCpTestUtils.assertRunDistCp(DistCpConstants.SUCCESS, src.toString(), dest.toString(),
             options, getConfiguration());
       });

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestTreewalkProblems.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/ITestTreewalkProblems.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 import software.amazon.awssdk.services.s3.model.MultipartUpload;
 
 import org.apache.hadoop.conf.Configuration;
@@ -316,7 +317,7 @@ public class ITestTreewalkProblems extends AbstractS3ACostTest {
           options, getConfiguration());
     } else {
       // distcp fails if uploads are visible
-      intercept(org.opentest4j.AssertionFailedError.class, () -> {
+      intercept(AssertionFailedError.class, () -> {
         DistCpTestUtils.assertRunDistCp(DistCpConstants.SUCCESS, src.toString(), dest.toString(),
             options, getConfiguration());
       });
@@ -339,7 +340,7 @@ public class ITestTreewalkProblems extends AbstractS3ACostTest {
           options, getConfiguration());
     } else {
       // distcp fails if uploads are visible
-      intercept(org.opentest4j.AssertionFailedError.class, () -> {
+      intercept(AssertionFailedError.class, () -> {
         DistCpTestUtils.assertRunDistCp(DistCpConstants.SUCCESS, src.toString(), dest.toString(),
             options, getConfiguration());
       });


### PR DESCRIPTION
### Description of PR
JIRA:HADOOP-19646. [Addendum] [JDK17] Migrate hadoop-aws module from JUnit4 Assume to JUnit5 Assumptions.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

