### PR TITLE
HADOOP-19425. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-azure Part4.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsJobThroughManifestCommitter.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsJobThroughManifestCommitter.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.FixMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -43,7 +43,7 @@ import static org.apache.hadoop.fs.azurebfs.commit.AbfsCommitTestHelper.prepareT
 /**
  * Test the Manifest committer stages against ABFS.
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class ITestAbfsJobThroughManifestCommitter
     extends TestJobThroughManifestCommitter {
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsTerasort.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/commit/ITestAbfsTerasort.java
@@ -26,10 +26,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import org.junit.FixMethodOrder;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
  * The tests run in sequence, so each operation is isolated.
  * Scale test only (it is big and slow)
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @SuppressWarnings({"StaticNonFinalField", "OptionalUsedAsFieldOrParameterType"})
 public class ITestAbfsTerasort extends AbstractAbfsClusterITest {
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.fs.azurebfs.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -53,7 +53,7 @@ public class ITestAbfsFileSystemContractRootDirectory extends AbstractContractRo
   }
 
   @Override
-  @Ignore("ABFS always return false when non-recursively remove root dir")
+  @Disabled("ABFS always return false when non-recursively remove root dir")
   public void testRmNonEmptyRootDirNonRecursive() throws Throwable {
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestExponentialRetryPolicy.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_A
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_ACCOUNT_NAME;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.TEST_CONFIGURATION_FILE_NAME;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -154,8 +154,8 @@ public class ITestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
       // check if accountName is set using different config key
       accountName = config.get(FS_AZURE_ABFS_ACCOUNT1_NAME);
     }
-    assumeTrue("Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME,
-        accountName != null && !accountName.isEmpty());
+    assumeTrue(accountName != null && !accountName.isEmpty(),
+        "Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME);
 
     Configuration rawConfig1 = new Configuration();
     rawConfig1.addResource(TEST_CONFIGURATION_FILE_NAME);
@@ -173,8 +173,8 @@ public class ITestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
     AbfsThrottlingIntercept instance1 = AbfsThrottlingInterceptFactory.getInstance(accountName, configuration);
     String accountName1 = config.get(FS_AZURE_ABFS_ACCOUNT1_NAME);
 
-    assumeTrue("Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME,
-        accountName1 != null && !accountName1.isEmpty());
+    assumeTrue(accountName1 != null && !accountName1.isEmpty(),
+        "Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME);
 
     AbfsThrottlingIntercept instance2 = AbfsThrottlingInterceptFactory.getInstance(accountName1, configuration);
     //if singleton is enabled, for different accounts both the instances should return same value
@@ -233,8 +233,8 @@ public class ITestExponentialRetryPolicy extends AbstractAbfsIntegrationTest {
     AzureBlobFileSystem fs1 = new AzureBlobFileSystem();
     Configuration config = new Configuration(getRawConfiguration());
     String accountName1 = config.get(FS_AZURE_ABFS_ACCOUNT1_NAME);
-    assumeTrue("Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME,
-        accountName1 != null && !accountName1.isEmpty());
+    assumeTrue(accountName1 != null && !accountName1.isEmpty(),
+        "Not set: " + FS_AZURE_ABFS_ACCOUNT1_NAME);
     final String abfsUrl1 = this.getFileSystemName() + "12" + "@" + accountName1;
     URI defaultUri1 = null;
     defaultUri1 = new URI("abfss", abfsUrl1, null, null, null);


### PR DESCRIPTION
### Description of PR
JIRA:HADOOP-19425. [JDK17] Upgrade JUnit from 4 to 5 in hadoop-azure Part4.

### How was this patch tested?
Junit Test.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

