### PR TITLE
HDFS-17828. SocketTimeoutException not recognized in TestWebHdfsTimeouts with Java 24

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -320,6 +320,17 @@ public abstract class GenericTestUtils {
 
   /**
    * Assert that an exception's <code>toString()</code> value
+   * matches the regex pattern.
+   * @param pattern regex pattern to match
+   * @param t thrown exception
+   * @throws AssertionError if the pattern does not match
+   */
+  public static void assertExceptionMatches(Pattern pattern, Throwable t) {
+    assertExceptionMatches(pattern, t, "");
+  }
+
+  /**
+   * Assert that an exception's <code>toString()</code> value
    * contained the expected text.
    * @param expectedText expected string
    * @param t thrown exception
@@ -340,6 +351,33 @@ public abstract class GenericTestUtils {
       throw new AssertionError(
           String.format("%s Expected to find '%s' %s: %s",
               prefix, expectedText, E_UNEXPECTED_EXCEPTION,
+              StringUtils.stringifyException(t)),
+          t);
+    }
+  }
+
+  /**
+   * Assert that an exception's <code>toString()</code> value
+   * matches the pattern.
+   * @param pattern regex pattern to match
+   * @param t thrown exception
+   * @param message any extra text for the string
+   * @throws AssertionError if the expected string is not found
+   */
+  public static void assertExceptionMatches(Pattern pattern,
+      Throwable t,
+      String message) {
+    assertNotNull(t, E_NULL_THROWABLE);
+    String msg = t.toString();
+    if (msg == null) {
+      throw new AssertionError(E_NULL_THROWABLE_STRING, t);
+    }
+    if (pattern != null && !pattern.matcher(msg).matches()) {
+      String prefix = org.apache.commons.lang3.StringUtils.isEmpty(message)
+          ? "" : (message + ": ");
+      throw new AssertionError(
+          String.format("%s Expected to match '%s' %s: %s",
+              prefix, pattern, E_UNEXPECTED_EXCEPTION,
               StringUtils.stringifyException(t)),
           t);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
@@ -37,33 +37,39 @@ public class TestGenericTestUtils extends GenericTestUtils {
 
   @Test
   public void testAssertExceptionContainsNullEx() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionContains("", null);
     } catch (AssertionError e) {
-      // AssertionError not actually thrown
+      assertTriggered = true;
       if (!e.toString().contains(E_NULL_THROWABLE)) {
         throw e;
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test
   public void testAssertExceptionContainsNullString() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionContains("", new BrokenException());
     } catch (AssertionError e) {
-      // AssertionError not actually thrown
+      assertTriggered = true;
       if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
         throw e;
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test
   public void testAssertExceptionContainsWrongText() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionContains("Expected", new Exception("(actual)"));
     } catch (AssertionError e) {
+      assertTriggered = true;
       String s = e.toString();
       if (!s.contains(E_UNEXPECTED_EXCEPTION)
           || !s.contains("(actual)") ) {
@@ -73,6 +79,7 @@ public class TestGenericTestUtils extends GenericTestUtils {
         throw new AssertionError("No nested cause in assertion", e);
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test
@@ -82,33 +89,40 @@ public class TestGenericTestUtils extends GenericTestUtils {
 
   @Test
   public void testAssertExceptionMatchesNullEx() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionMatches(null, null);
     } catch (AssertionError e) {
-      // AssertionError not actually thrown
+      assertTriggered = true;
       if (!e.toString().contains(E_NULL_THROWABLE)) {
         throw e;
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test
   public void testAssertExceptionMatchesNullString() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionMatches(null, new BrokenException());
+      fail("assertion should have failed");
     } catch (AssertionError e) {
-      // AssertionError not actually thrown
+      assertTriggered = true;
       if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
         throw e;
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test
   public void testAssertExceptionMatchesWrongText() throws Throwable {
+    boolean assertTriggered = false;
     try {
       assertExceptionMatches(Pattern.compile(".*Expected.*"), new Exception("(actual)"));
     } catch (AssertionError e) {
+      assertTriggered = true;
       String s = e.toString();
       if (!s.contains(E_UNEXPECTED_EXCEPTION)
           || !s.contains("(actual)") ) {
@@ -118,6 +132,7 @@ public class TestGenericTestUtils extends GenericTestUtils {
         throw new AssertionError("No nested cause in assertion", e);
       }
     }
+    assertTrue(assertTriggered);
   }
 
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
@@ -25,6 +25,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
 import org.slf4j.event.Level;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,6 +40,7 @@ public class TestGenericTestUtils extends GenericTestUtils {
     try {
       assertExceptionContains("", null);
     } catch (AssertionError e) {
+      // AssertionError not actually thrown
       if (!e.toString().contains(E_NULL_THROWABLE)) {
         throw e;
       }
@@ -49,6 +52,7 @@ public class TestGenericTestUtils extends GenericTestUtils {
     try {
       assertExceptionContains("", new BrokenException());
     } catch (AssertionError e) {
+      // AssertionError not actually thrown
       if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
         throw e;
       }
@@ -74,6 +78,51 @@ public class TestGenericTestUtils extends GenericTestUtils {
   @Test
   public void testAssertExceptionContainsWorking() throws Throwable {
     assertExceptionContains("Expected", new Exception("Expected"));
+  }
+
+  @Test
+  public void testAssertExceptionMatchesNullEx() throws Throwable {
+    try {
+      assertExceptionMatches(null, null);
+    } catch (AssertionError e) {
+      // AssertionError not actually thrown
+      if (!e.toString().contains(E_NULL_THROWABLE)) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void testAssertExceptionMatchesNullString() throws Throwable {
+    try {
+      assertExceptionMatches(null, new BrokenException());
+    } catch (AssertionError e) {
+      // AssertionError not actually thrown
+      if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void testAssertExceptionMatchesWrongText() throws Throwable {
+    try {
+      assertExceptionMatches(Pattern.compile(".*Expected.*"), new Exception("(actual)"));
+    } catch (AssertionError e) {
+      String s = e.toString();
+      if (!s.contains(E_UNEXPECTED_EXCEPTION)
+          || !s.contains("(actual)") ) {
+        throw e;
+      }
+      if (e.getCause() == null) {
+        throw new AssertionError("No nested cause in assertion", e);
+      }
+    }
+  }
+
+  @Test
+  public void testAssertExceptionMatchesWorking() throws Throwable {
+    assertExceptionMatches(Pattern.compile(".*Expected.*"), new Exception("Expected"));
   }
 
   private static class BrokenException extends Exception {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TestGenericTestUtils.java
@@ -29,57 +29,34 @@ import java.util.regex.Pattern;
 
 import org.slf4j.event.Level;
 
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 
 public class TestGenericTestUtils extends GenericTestUtils {
 
   @Test
   public void testAssertExceptionContainsNullEx() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionContains("", null);
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      if (!e.toString().contains(E_NULL_THROWABLE)) {
-        throw e;
-      }
-    }
-    assertTrue(assertTriggered);
+    intercept(AssertionError.class, E_NULL_THROWABLE, () -> assertExceptionContains("", null));
   }
 
   @Test
   public void testAssertExceptionContainsNullString() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionContains("", new BrokenException());
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
-        throw e;
-      }
-    }
-    assertTrue(assertTriggered);
+    intercept(AssertionError.class, E_NULL_THROWABLE_STRING, () -> assertExceptionContains("", new BrokenException()));
   }
 
   @Test
   public void testAssertExceptionContainsWrongText() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionContains("Expected", new Exception("(actual)"));
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      String s = e.toString();
-      if (!s.contains(E_UNEXPECTED_EXCEPTION)
-          || !s.contains("(actual)") ) {
-        throw e;
-      }
-      if (e.getCause() == null) {
-        throw new AssertionError("No nested cause in assertion", e);
-      }
+    AssertionError e = intercept(AssertionError.class, E_UNEXPECTED_EXCEPTION,
+        () -> assertExceptionContains("Expected", new Exception("(actual)")));
+    if (!e.toString().contains("(actual)")) {
+      throw new AssertionError("no actual string in exception", e);
     }
-    assertTrue(assertTriggered);
+    if (e.getCause() == null) {
+      throw new AssertionError("No nested cause in assertion", e);
+    }
   }
 
   @Test
@@ -89,50 +66,24 @@ public class TestGenericTestUtils extends GenericTestUtils {
 
   @Test
   public void testAssertExceptionMatchesNullEx() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionMatches(null, null);
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      if (!e.toString().contains(E_NULL_THROWABLE)) {
-        throw e;
-      }
-    }
-    assertTrue(assertTriggered);
+    intercept(AssertionError.class, E_NULL_THROWABLE, () -> assertExceptionMatches(null, null));
   }
 
   @Test
   public void testAssertExceptionMatchesNullString() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionMatches(null, new BrokenException());
-      fail("assertion should have failed");
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      if (!e.toString().contains(E_NULL_THROWABLE_STRING)) {
-        throw e;
-      }
-    }
-    assertTrue(assertTriggered);
+    intercept(AssertionError.class, E_NULL_THROWABLE_STRING, () -> assertExceptionMatches(null, new BrokenException()));
   }
 
   @Test
   public void testAssertExceptionMatchesWrongText() throws Throwable {
-    boolean assertTriggered = false;
-    try {
-      assertExceptionMatches(Pattern.compile(".*Expected.*"), new Exception("(actual)"));
-    } catch (AssertionError e) {
-      assertTriggered = true;
-      String s = e.toString();
-      if (!s.contains(E_UNEXPECTED_EXCEPTION)
-          || !s.contains("(actual)") ) {
-        throw e;
-      }
-      if (e.getCause() == null) {
-        throw new AssertionError("No nested cause in assertion", e);
-      }
+    AssertionError e = intercept(AssertionError.class, E_UNEXPECTED_EXCEPTION,
+        () -> assertExceptionMatches(Pattern.compile(".*Expected.*"), new Exception("(actual)")));
+    if (!e.toString().contains("(actual)")) {
+      throw new AssertionError("no actual string in exception", e);
     }
-    assertTrue(assertTriggered);
+    if (e.getCause() == null) {
+      throw new AssertionError("No nested cause in assertion", e);
+    }
   }
 
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTimeouts.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestWebHdfsTimeouts.java
@@ -37,12 +37,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
@@ -152,8 +154,8 @@ public class TestWebHdfsTimeouts {
       fs.listFiles(new Path("/"), false);
       fail("expected timeout");
     } catch (SocketTimeoutException e) {
-      GenericTestUtils.assertExceptionContains(fs.getUri().getAuthority()
-          + ": connect timed out",e);
+      GenericTestUtils.assertExceptionMatches(Pattern.compile(
+          ".*" + Pattern.quote(fs.getUri().getAuthority()) + ": [Cc]onnect timed out"), e);
     }
   }
 
@@ -190,8 +192,8 @@ public class TestWebHdfsTimeouts {
       fs.getDelegationToken("renewer");
       fail("expected timeout");
     } catch (SocketTimeoutException e) {
-      GenericTestUtils.assertExceptionContains(fs.getUri().getAuthority() +
-          ": connect timed out", e);
+      GenericTestUtils.assertExceptionMatches(Pattern.compile(
+          ".*" + Pattern.quote(fs.getUri().getAuthority()) + ": [Cc]onnect timed out"), e);
     }
   }
 
@@ -230,8 +232,8 @@ public class TestWebHdfsTimeouts {
       fail("expected timeout");
     } catch (SocketTimeoutException e) {
       assumeBacklogConsumed();
-      GenericTestUtils.assertExceptionContains(
-          fs.getUri().getAuthority() + ": connect timed out", e);
+      GenericTestUtils.assertExceptionMatches(Pattern.compile(
+          ".*" + Pattern.quote(fs.getUri().getAuthority()) + ": [Cc]onnect timed out"), e);
     }
   }
 
@@ -272,8 +274,8 @@ public class TestWebHdfsTimeouts {
       fail("expected timeout");
     } catch (SocketTimeoutException e) {
       assumeBacklogConsumed();
-      GenericTestUtils.assertExceptionContains(
-          fs.getUri().getAuthority() + ": connect timed out", e);
+      GenericTestUtils.assertExceptionMatches(Pattern.compile(
+          ".*" + Pattern.quote(fs.getUri().getAuthority()) + ": [Cc]onnect timed out"), e);
     } finally {
       IOUtils.cleanupWithLogger(LOG, os);
     }


### PR DESCRIPTION
### Description of PR

Fixes a test issue where TestWebHdfsTimeouts exepects "connect timed out", but Java 24 returns "Connect timed out"
in the exception message.

### How was this patch tested?

Ran the test with Java 24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

