### PR TITLE
HDFS-17830. Fix failing TestZKDelegationTokenSecretManagerImpl due to…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/token/delegation/TestZKDelegationTokenSecretManager.java
@@ -96,6 +96,8 @@ public class TestZKDelegationTokenSecretManager {
     if (zkServer != null) {
       zkServer.close();
     }
+    // Prevent a STOPPED Curator from leaking into the next test.
+    ZKDelegationTokenSecretManager.setCurator(null);
   }
 
   protected Configuration getSecretConf(String connectString) {


### PR DESCRIPTION
### Description of PR
HDFS-17830. Fix failing TestZKDelegationTokenSecretManagerImpl due to static Curator reuse.

TestZKDelegationTokenSecretManagerImpl tests fail with “Expected state [STARTED] was [STOPPED]” due to static Curator reuse

```
IllegalStateException: Expected state [STARTED] was [STOPPED]
  at CuratorFrameworkImpl.checkState / usingNamespace
  at ZKDelegationTokenSecretManager.<init>(...)
```

CI evidence:
[https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java8-linux-x86_64/2051/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs-rbf.txt](https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java8-linux-x86_64/2051/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs-rbf.txt)

Under JUnit 5’s PER_METHOD lifecycle, static fields persist; this suite shares a static CuratorFramework that some tests close without resetting, so later tests reuse a STOPPED client and fail in ZKDelegationTokenSecretManagerImpl (“Expected [STARTED] was [STOPPED]”). It’s an isolation/cleanup issue, not a Curator change—reset or recreate the static client between tests (in @AfterEach).

### How was this patch tested?
CI Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

