### PR TITLE
HDFS-17830. Fix failing TestZKDelegationTokenSecretManagerImpl due to static Curator reuse.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/token/TestZKDelegationTokenSecretManagerImpl.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/test/java/org/apache/hadoop/hdfs/server/federation/security/token/TestZKDelegationTokenSecretManagerImpl.java
@@ -32,9 +32,11 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.TestZKDelegationTokenSecretManager;
+import org.apache.hadoop.security.token.delegation.ZKDelegationTokenSecretManager;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenManager;
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,14 @@ public class TestZKDelegationTokenSecretManagerImpl
     extends TestZKDelegationTokenSecretManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestZKDelegationTokenSecretManagerImpl.class);
+
+  @Override
+  @AfterEach
+  public void tearDown() throws Exception {
+    super.tearDown();
+    // Prevent a STOPPED Curator from leaking into the next test.
+    ZKDelegationTokenSecretManager.setCurator(null);
+  }
 
   @SuppressWarnings("unchecked")
   @Test


### PR DESCRIPTION
### Description of PR
HDFS-17830. Fix failing TestZKDelegationTokenSecretManagerImpl due to static Curator reuse.

TestZKDelegationTokenSecretManagerImpl tests fail with “Expected state [STARTED] was [STOPPED]” due to static Curator reuse

```
IllegalStateException: Expected state [STARTED] was [STOPPED]
  at CuratorFrameworkImpl.checkState / usingNamespace
  at ZKDelegationTokenSecretManager.<init>(...)
```

CI evidence:
[https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java8-linux-x86_64/2051/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs-rbf.txt](https://ci-hadoop.apache.org/job/hadoop-qbt-trunk-java8-linux-x86_64/2051/artifact/out/patch-unit-hadoop-hdfs-project_hadoop-hdfs-rbf.txt)

Under JUnit 5’s PER_METHOD lifecycle, static fields persist; this suite shares a static CuratorFramework that some tests close without resetting, so later tests reuse a STOPPED client and fail in ZKDelegationTokenSecretManagerImpl (“Expected [STARTED] was [STOPPED]”). It’s an isolation/cleanup issue, not a Curator change—reset or recreate the static client between tests (in @AfterEach).

### How was this patch tested?
CI Test.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

