### PR TITLE
HDFS-17831. Unexpected exception in org.apache.hadoop.hdfs.server.namenode.TestCheckpoint with Java 24

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.ExitUtil.ExitException;
 import org.apache.hadoop.util.Lists;
+import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.concurrent.SubjectInheritingThread;
 import org.slf4j.event.Level;
@@ -654,7 +655,9 @@ public class TestCheckpoint {
     
     Mockito.doReturn(true).when(faultInjector)
       .shouldSendShortFile(filePathContaining("fsimage"));
-    doSendFailTest("is not of the advertised size");
+    String expectedText = Shell.isJavaVersionAtLeast(24) ? "Premature EOF" :
+        "is not of the advertised size";
+    doSendFailTest(expectedText);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
@@ -655,8 +655,8 @@ public class TestCheckpoint {
     
     Mockito.doReturn(true).when(faultInjector)
       .shouldSendShortFile(filePathContaining("fsimage"));
-    String expectedText = Shell.isJavaVersionAtLeast(24) ? "Premature EOF" :
-        "is not of the advertised size";
+    String expectedText = Shell.isJavaVersionAtLeast(24) ? "Premature EOF"
+        : "is not of the advertised size";
     doSendFailTest(expectedText);
   }
 


### PR DESCRIPTION
### Description of PR

Java 24 has changed the behaviour for HTTP short reads, and now throws an IOException.
Update the expected Exception for Java 24.

### How was this patch tested?

Ran test with Java 8 and 24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

