### PR TITLE
HDFS-17832. TestNameNodeResourceChecker fails with Java 24

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourceChecker.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameNodeResourceChecker.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -109,7 +110,7 @@ public class TestNameNodeResourceChecker {
       boolean isNameNodeMonitorRunning = false;
       Set<Thread> runningThreads = Thread.getAllStackTraces().keySet();
       for (Thread runningThread : runningThreads) {
-        if (runningThread.toString().startsWith("Thread[" + name)) {
+        if (runningThread.toString().matches("Thread\\[(#\\d+,)?" + Pattern.quote(name) + ".*")) {
           isNameNodeMonitorRunning = true;
           break;
         }


### PR DESCRIPTION
### Description of PR

Accept the Thread.toString() output in Java 24 in the test

### How was this patch tested?

Ran test with Java 8 and 24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

