### PR TITLE
Add NormalUnderReplBlocksCount and BadlyDistributedBlocksCount to getStats() NN RPC

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2104,6 +2104,24 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory,
   }
 
   /**
+   * Returns count of blocks with one or more replicas missing.
+   * @throws IOException
+   */
+  public long getNormalLowRedundancyBlocksCount() throws IOException {
+    return getStateByIndex(ClientProtocol.
+        GET_STATS_NORMAL_LOW_REDUNDANCY_BLOCKS_IDX);
+  }
+
+  /**
+   * Returns count of blocks that are badly distributed as per BPP.
+   * @throws IOException
+   */
+  public long getBadlyDistributedBlocksCount() throws IOException {
+    return getStateByIndex(ClientProtocol.
+        GET_STATS_BADLY_DISTRIBUTED_BLOCKS_IDX);
+  }
+
+  /**
    * Returns number of bytes that reside in Blocks with future generation
    * stamps.
    * @return Bytes in Blocks with future generation stamps.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -804,7 +804,9 @@ public interface ClientProtocol {
   int GET_STATS_MISSING_REPL_ONE_BLOCKS_IDX = 6;
   int GET_STATS_BYTES_IN_FUTURE_BLOCKS_IDX = 7;
   int GET_STATS_PENDING_DELETION_BLOCKS_IDX = 8;
-  int STATS_ARRAY_LENGTH = 9;
+  int GET_STATS_BADLY_DISTRIBUTED_BLOCKS_IDX = 9;
+  int GET_STATS_NORMAL_LOW_REDUNDANCY_BLOCKS_IDX = 10;
+  int STATS_ARRAY_LENGTH = 11;
 
   /**
    * Get an array of aggregated statistics combining blocks of both type

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/HeartbeatManager.java
@@ -210,6 +210,8 @@ class HeartbeatManager implements DatanodeStatistics {
                        -1L,
                        -1L,
                        -1L,
+                       -1L,
+                       -1L,
                        -1L};
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -4848,6 +4848,13 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
         blockManager.getBytesInFuture();
     stats[ClientProtocol.GET_STATS_PENDING_DELETION_BLOCKS_IDX] =
         blockManager.getPendingDeletionBlocksCount();
+    stats[ClientProtocol.GET_STATS_BADLY_DISTRIBUTED_BLOCKS_IDX] =
+        getBadlyDistributedBlocksCount();
+    // GET_STATS_LOW_REDUNDANCY_IDX uses getLowRedundancyBlocksCount() which gives us the count of
+    // all types of low redundancy blocks. GET_STATS_NORMAL_LOW_REDUNDANCY_BLOCKS_IDX will give the count
+    // of normal low redundancy blocks only using getLowRedundancyBlocks().
+    stats[ClientProtocol.GET_STATS_NORMAL_LOW_REDUNDANCY_BLOCKS_IDX] =
+        blockManager.getLowRedundancyBlocks();
     return stats;
   }
 


### PR DESCRIPTION
### Description of PR
At LinkedIn, we use the stats from the getStats() NN RPC call to evaluate safety checks that ensure that various maintenance ops are safe to run.

Due to a migration we are undertaking, the badly distributed block count is very high for the cluster undergoing migration. This is not a safety problem. However, to distinguish it from the actual low redundancy block count, we need both these values to be available from the getStats() RPC. The current low redundancy blocks count value available is the [sum](https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/LowRedundancyBlocks.java#L138-L146) of all the different types of low redundancy blocks, including normal low redundancy blocks and badly distributed blocks.

This PR adds these 2 values separately to the array returned by getStats() RPC.

### How was this patch tested?
Trivial change. It has been running in our prod cluster for a bit now.
Build passes:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42:50 min
[INFO] Finished at: 2025-05-19T14:51:09+05:30
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

