### PR TITLE
HDFS-17833. TestObserverReadProxyProvider fails with Java 24 because of InetSocketAddress.toString changes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -145,7 +145,7 @@ public class TestObserverReadProxyProvider {
               InetSocketAddress nnAddr, Class<ClientProtocol> xface,
               UserGroupInformation ugi, boolean withRetries,
               AtomicBoolean fallbackToSimpleAuth) {
-            return proxyMap.get(nnAddr.toString());
+            return proxyMap.get(nnAddr.toString().replaceAll("/<unresolved>",""));
           }
         })  {
       @Override
@@ -530,7 +530,7 @@ public class TestObserverReadProxyProvider {
   }
 
   private void assertHandledBy(int namenodeIdx) {
-    assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo);
+    assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo.replaceAll("/<unresolved>", ""));
   }
 
   private static void doWrite(ClientProtocol client) throws Exception {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/ha/TestObserverReadProxyProvider.java
@@ -145,7 +145,7 @@ public class TestObserverReadProxyProvider {
               InetSocketAddress nnAddr, Class<ClientProtocol> xface,
               UserGroupInformation ugi, boolean withRetries,
               AtomicBoolean fallbackToSimpleAuth) {
-            return proxyMap.get(nnAddr.toString().replaceAll("/<unresolved>",""));
+            return proxyMap.get(nnAddr.toString().replaceAll("/<unresolved>", ""));
           }
         })  {
       @Override
@@ -530,7 +530,8 @@ public class TestObserverReadProxyProvider {
   }
 
   private void assertHandledBy(int namenodeIdx) {
-    assertEquals(namenodeAddrs[namenodeIdx], proxyProvider.getLastProxy().proxyInfo.replaceAll("/<unresolved>", ""));
+    assertEquals(namenodeAddrs[namenodeIdx],
+        proxyProvider.getLastProxy().proxyInfo.replaceAll("/<unresolved>", ""));
   }
 
   private static void doWrite(ClientProtocol client) throws Exception {


### PR DESCRIPTION
### Description of PR

Handle the /<unresolved> string added by InetAddress/InetSocketAddress in Java 24

JIRA: HDFS-17833. TestObserverReadProxyProvider fails with Java 24 because of InetSocketAddress.toString changes

### How was this patch tested?

Ran test on Java 8 and 24

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

