### PR TITLE
[DOCS] Add cross-link from FileSystemShell.md to FileSystem API

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/FileSystemShell.md
@@ -27,6 +27,10 @@ Most of the commands in FS shell behave like corresponding Unix commands. Differ
 
 If HDFS is being used, `hdfs dfs` is a synonym.
 
+See also: [FileSystem API](../api/org/apache/hadoop/fs/FileSystem.html) for programmatic access
+to the same operations.
+
+
 Relative paths can be used. For HDFS, the current working directory is the
 HDFS home directory `/user/<username>` that often has to be created manually.
 The HDFS home directory can also be implicitly accessed, e.g., when using the


### PR DESCRIPTION
### What
Add a short “See also” paragraph pointing from the HDFS shell docs to the FileSystem API.

### Why
Helps readers discover programmatic equivalents of common HDFS shell operations.

### How
- Edited hadoop-project-dist/hadoop-*/src/site/markdown/<your-file>.md to include the API cross-link.

### Notes
Trivial docs-only change; no JIRA ticket required
