### PR TITLE
HADOOP-19691. [JDK17] Disallow JUnit4 Imports After JUnit5 Migration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
                       <bannedImport>org.apache.commons.logging.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports>
+                     <includeTestCode>true</includeTestCode>
+                     <reason>Use JUnit5</reason>
+                     <bannedImports>
+                        <bannedImport>org.junit.**</bannedImport>
+                     </bannedImports>
+                     <allowedImports>
+                        <allowedImport>org.junit.jupiter.**</allowedImport>
+                        <allowedImport>org.junit.platform.**</allowedImport>
+                     </allowedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19691. [JDK17] Disallow JUnit4 Imports After JUnit5 Migration.

As our project has fully migrated to JUnit5, we should now enforce a rule that prevents the import and usage of JUnit4 classes (such as org.junit.Test, org.junit.Assert, etc.) to ensure consistency, avoid regressions, and allow safe removal of legacy dependencies.

This task involves identifying and eliminating any remaining JUnit4 imports, and introducing static code analysis or linting rules to ban future usage.


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

