### PR TITLE
HADOOP-19690. bump commons-lang3 to 3.18.0 due to CVE-2025-48924 (#7970)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -301,9 +301,9 @@ org.apache.commons:commons-compress:1.26.1
 org.apache.commons:commons-configuration2:2.10.1
 org.apache.commons:commons-csv:1.9.0
 org.apache.commons:commons-digester:1.8.1
-org.apache.commons:commons-lang3:3.17.0
+org.apache.commons:commons-lang3:3.18.0
 org.apache.commons:commons-math3:3.6.1
-org.apache.commons:commons-text:1.10.0
+org.apache.commons:commons-text:1.14.0
 org.apache.commons:commons-validator:1.6
 org.apache.curator:curator-client:5.2.0
 org.apache.curator:curator-framework:5.2.0

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -124,11 +124,11 @@
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-csv.version>1.9.0</commons-csv.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-logging.version>1.3.0</commons-logging.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.9.0</commons-net.version>
-    <commons-text.version>1.10.0</commons-text.version>
+    <commons-text.version>1.14.0</commons-text.version>
 
     <kerby.version>2.0.3</kerby.version>
     <ehcache.version>3.8.2</ehcache.version>


### PR DESCRIPTION
* relates to #7970 

* HADOOP-19690. bump commons-lang3 to 3.18.0 due to CVE-2025-48924

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

