### PR TITLE
YARN-11863. [JDK17] Remove JUnit4 NoExitSecurityManager.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ExitUtil.java
@@ -152,6 +152,13 @@ public final class ExitUtil {
   }
 
   /**
+   * Enable the use of System.exit for testing.
+   */
+  public static void enableSystemExit() {
+    systemExitDisabled = false;
+  }
+
+  /**
    * Disable the use of {@code Runtime.getRuntime().halt() } for testing.
    */
   public static void disableSystemHalt() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -84,16 +84,13 @@ import org.apache.hadoop.yarn.util.resource.Resources;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -140,7 +137,7 @@ import static org.mockito.Mockito.when;
  * Testing applications being retired from RM.
  *
  */
-
+@Disabled("surefire crash")
 public class TestAppManager extends AppManagerTestBase{
 
   @RegisterExtension

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -84,13 +84,16 @@ import org.apache.hadoop.yarn.util.resource.Resources;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.Maps;
 
-import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -137,7 +140,7 @@ import static org.mockito.Mockito.when;
  * Testing applications being retired from RM.
  *
  */
-@Disabled("surefire crash")
+
 public class TestAppManager extends AppManagerTestBase{
 
   @RegisterExtension

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestCapacitySchedulerAsyncScheduling.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.spy;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -76,11 +77,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.Candida
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.placement.SimpleCandidateNodeSet;
 import org.apache.hadoop.yarn.server.scheduler.SchedulerRequestKey;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.contrib.java.lang.system.internal.NoExitSecurityManager;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -1104,17 +1103,7 @@ public class TestCapacitySchedulerAsyncScheduling {
   @Test
   @Timeout(value = 30)
   public void testAsyncScheduleThreadExit() throws Exception {
-
-    // Set no exit security manager to catch System.exit
-    SecurityManager originalSecurityManager = System.getSecurityManager();
-    NoExitSecurityManager noExitSecurityManager =
-        new NoExitSecurityManager(originalSecurityManager);
-    try {
-      System.setSecurityManager(noExitSecurityManager);
-    } catch (UnsupportedOperationException e) {
-      Assumptions.assumeTrue(false,
-          "Test is skipped because SecurityManager cannot be set (JEP411)");
-    }
+    ExitUtil.disableSystemExit();
 
     // init RM & NM
     final MockRM rm = new MockRM(conf);
@@ -1131,11 +1120,14 @@ public class TestCapacitySchedulerAsyncScheduling {
       cs.setResourceCalculator(null);
 
       // wait for RM to be shutdown until timeout
-      GenericTestUtils.waitFor(noExitSecurityManager::isCheckExitCalled,
+      GenericTestUtils.waitFor(() -> ExitUtil.getFirstExitException() != null,
           100, 5000);
     } finally {
-      System.setSecurityManager(originalSecurityManager);
-      rm.stop();
+      ExitUtil.enableSystemExit();
+      ExitUtil.resetFirstExitException();
+      if (rm != null) {
+        rm.stop();
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11863. [JDK17] Remove JUnit4 NoExitSecurityManager.

During the process of completely removing JUnit4 dependencies, we found that the NoExitSecurityManager class is still used in the project. To further reduce JUnit4 dependencies and maintain code cleanliness, it needs to be removed.

### How was this patch tested?

Manual testing.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

