### PR TITLE
YARN-11864. [JDK17] Remove Usage of org.hamcrest in Unit Tests.

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2005,11 +2005,6 @@
           <version>${snakeyaml.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-          <version>1.3</version>
-        </dependency>
-        <dependency>
           <groupId>org.assertj</groupId>
           <artifactId>assertj-core</artifactId>
           <version>${assertj.version}</version>

--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -573,11 +573,6 @@
       <artifactId>hadoop-minikdc</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Used to create SSL certs for a secure Keystore -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -340,11 +340,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/hadoop-tools/hadoop-distcp/pom.xml
+++ b/hadoop-tools/hadoop-distcp/pom.xml
@@ -110,12 +110,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/pom.xml
@@ -81,6 +81,11 @@
           <artifactId>junit-platform-launcher</artifactId>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <scope>test</scope>
+      </dependency>
 
       <dependency>
             <groupId>org.apache.solr</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppDetailsControllerTest.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.appcatalog.model.AppEntry;
 import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.api.records.Container;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,8 +30,7 @@ import org.mockito.Mockito;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -126,14 +126,15 @@ public class AppDetailsControllerTest {
   void testPathAnnotation() throws Exception {
     assertNotNull(this.controller.getClass()
         .getAnnotations());
-    assertThat("The controller has the annotation Path",
-        this.controller.getClass()
-            .isAnnotationPresent(Path.class));
 
-    final Path path = this.controller.getClass()
-        .getAnnotation(Path.class);
-    assertThat("The path is /app_details", path.value(),
-        is("/app_details"));
+    assertThat(this.controller.getClass().isAnnotationPresent(Path.class))
+        .as("The controller has the annotation Path")
+        .isTrue();
+
+    final Path path = this.controller.getClass().getAnnotation(Path.class);
+    assertThat(path.value())
+        .as("The path is /app_details")
+        .isEqualTo("/app_details");
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppListControllerTest.java
@@ -27,8 +27,7 @@ import org.mockito.Mockito;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -85,12 +84,15 @@ public class AppListControllerTest {
   void testPathAnnotation() throws Exception {
     assertNotNull(this.controller.getClass()
         .getAnnotations());
-    assertThat("The controller has the annotation Path",
-        this.controller.getClass().isAnnotationPresent(Path.class));
 
-    final Path path = this.controller.getClass()
-        .getAnnotation(Path.class);
-    assertThat("The path is /app_list", path.value(), is("/app_list"));
+    assertThat(this.controller.getClass().isAnnotationPresent(Path.class))
+        .as("The controller has the annotation Path")
+            .isTrue();
+
+    final Path path = this.controller.getClass().getAnnotation(Path.class);
+    assertThat(path.value())
+        .as("The path is /app_list")
+        .isEqualTo("/app_list");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/src/test/java/org/apache/hadoop/yarn/appcatalog/controller/AppStoreControllerTest.java
@@ -27,8 +27,7 @@ import org.mockito.Mockito;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -86,13 +85,14 @@ public class AppStoreControllerTest {
   void testPathAnnotation() throws Exception {
     assertNotNull(this.controller.getClass()
         .getAnnotations());
-    assertThat("The controller has the annotation Path",
-        this.controller.getClass()
-            .isAnnotationPresent(Path.class));
 
-    final Path path = this.controller.getClass()
-        .getAnnotation(Path.class);
-    assertThat("The path is /app_store", path.value(), is("/app_store"));
+    assertThat(this.controller.getClass().isAnnotationPresent(Path.class))
+        .as("The controller has the annotation Path")
+        .isTrue();
+
+    final Path path = this.controller.getClass().getAnnotation(Path.class);
+    assertThat(path.value())
+        .as("The path is /app_store")
+        .isEqualTo("/app_store");
   }
-
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestResourceCalculatorProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/test/java/org/apache/hadoop/yarn/util/TestResourceCalculatorProcessTree.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsSame.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -80,7 +78,7 @@ public class TestResourceCalculatorProcessTree {
     ResourceCalculatorProcessTree tree;
     tree = ResourceCalculatorProcessTree.getResourceCalculatorProcessTree("1", EmptyProcessTree.class, new Configuration());
     assertNotNull(tree);
-    assertThat(tree, instanceOf(EmptyProcessTree.class));
+    assertThat(tree).isInstanceOf(EmptyProcessTree.class);
   }
 
   @Test
@@ -89,6 +87,6 @@ public class TestResourceCalculatorProcessTree {
     Configuration conf = new Configuration();
     tree = ResourceCalculatorProcessTree.getResourceCalculatorProcessTree("1", EmptyProcessTree.class, conf);
     assertNotNull(tree);
-    assertThat(tree.getConf(), sameInstance(conf));
+    assertThat(tree).isInstanceOf(EmptyProcessTree.class);
   } 
 }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11864. [JDK17] Remove Usage of org.hamcrest in Unit Tests.


### How was this patch tested?

This pr removes the usage of org.hamcrest in the unit tests. All assertions that previously relied on the Hamcrest library have been refactored to use AssertJ for a more modern, fluent, and readable testing style.

Changes include:

Replaced Hamcrest assertions (assertThat) with AssertJ equivalents.
Removed any imports or references to org.hamcrest in the unit tests.
This update enhances the maintainability and consistency of our test suite by using AssertJ, which is better aligned with our current testing practices.




### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

