### PR TITLE
HDFS-17839. Rename skips path without valid 'DirectoryWithQuotaFeature' in FSDirRenameOp

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
@@ -224,7 +224,7 @@ class FSDirMkdirOp {
         timestamp);
 
     INodesInPath iip = fsd.addLastINode(parent, dir, permission.getPermission(),
-        true, Optional.empty());
+        true, Optional.empty(), true);
     if (iip != null && aclEntries != null) {
       AclStorage.updateINodeAcl(dir, aclEntries, Snapshot.CURRENT_STATE_ID);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -82,11 +82,14 @@ class FSDirRenameOp {
       return Triple.of(false, srcDelta, dstDelta);
     }
 
-    // Verify srcPath and dstPath without valid 'DirectoryWithQuotaFeature'
-    // Note: In overwrite scenarios, quota calculation is still required because:
-    // Overwrite operations delete existing content (affecting rootDir's quota)
-    if (!overwrite && FSDirectory.verifyPathWithoutValidQuotaFeature(src)
-        && FSDirectory.verifyPathWithoutValidQuotaFeature(dst)) {
+    // Verify path without valid 'DirectoryWithQuotaFeature' or 'DirectorySnapshottableFeature'
+    // Note: 
+    // 1. In overwrite scenarios, quota calculation is still required, 
+    //    overwrite operations delete existing content, which affects the root directory's quota.
+    // 2. For directories enabled for snapshot creation, quota calculation is also necessary,
+    //    deleting snapshot files may affect the root directory's quota.
+    if (!overwrite && FSDirectory.verifyPathWithoutValidFeature(src)
+        && FSDirectory.verifyPathWithoutValidFeature(dst)) {
       return Triple.of(false, srcDelta, dstDelta);
     }
     

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -85,9 +85,8 @@ class FSDirRenameOp {
     // Verify srcPath and dstPath without valid 'DirectoryWithQuotaFeature'
     // Note: In overwrite scenarios, quota calculation is still required because:
     // Overwrite operations delete existing content (affecting rootDir's quota)
-    if (FSDirectory.verifyPathWithoutValidQuotaFeature(src, src.length() - 1)
-        && FSDirectory.verifyPathWithoutValidQuotaFeature(dst, dst.length() - 1) 
-        && !overwrite) {
+    if (!overwrite && FSDirectory.verifyPathWithoutValidQuotaFeature(src)
+        && FSDirectory.verifyPathWithoutValidQuotaFeature(dst)) {
       return Triple.of(false, srcDelta, dstDelta);
     }
     
@@ -768,9 +767,9 @@ class FSDirRenameOp {
         throw new IOException(error);
       } else {
         // update the quota count if necessary
-        Optional<QuotaCounts> countOp = sameStoragePolicy ?
-            srcSubTreeCount : Optional.empty();
         if (updateQuota) {
+          Optional<QuotaCounts> countOp = sameStoragePolicy ?
+              srcSubTreeCount : Optional.empty();
           fsd.updateCountForDelete(srcChild, srcIIP, countOp);
         }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
@@ -787,9 +786,9 @@ class FSDirRenameOp {
         return false;
       } else {
         // update the quota count if necessary
-        Optional<QuotaCounts> countOp = sameStoragePolicy ?
-            srcSubTreeCount : Optional.empty();
         if (updateQuota) {
+          Optional<QuotaCounts> countOp = sameStoragePolicy ?
+              srcSubTreeCount : Optional.empty();
           fsd.updateCountForDelete(srcChild, srcIIP, countOp);
         }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -72,14 +72,25 @@ class FSDirRenameOp {
    * Verify quota for rename operation where srcInodes[srcInodes.length-1] moves
    * dstInodes[dstInodes.length-1]
    */
-  private static Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> verifyQuotaForRename(
-      FSDirectory fsd, INodesInPath src, INodesInPath dst) throws QuotaExceededException {
+  private static Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> verifyQuotaForRename(
+      FSDirectory fsd, INodesInPath src, INodesInPath dst, boolean overwrite)
+      throws QuotaExceededException {
     Optional<QuotaCounts> srcDelta = Optional.empty();
     Optional<QuotaCounts> dstDelta = Optional.empty();
     if (!fsd.getFSNamesystem().isImageLoaded() || fsd.shouldSkipQuotaChecks()) {
       // Do not check quota if edits log is still being processed
-      return Pair.of(srcDelta, dstDelta);
+      return Triple.of(false, srcDelta, dstDelta);
     }
+
+    // Verify srcPath and dstPath without valid 'DirectoryWithQuotaFeature'
+    // Note: In overwrite scenarios, quota calculation is still required because:
+    // Overwrite operations delete existing content (affecting rootDir's quota)
+    if (FSDirectory.verifyPathWithoutValidQuotaFeature(src, src.length() - 1)
+        && FSDirectory.verifyPathWithoutValidQuotaFeature(dst, dst.length() - 1) 
+        && !overwrite) {
+      return Triple.of(false, srcDelta, dstDelta);
+    }
+    
     int i = 0;
     while (src.getINode(i) == dst.getINode(i)) {
       i++;
@@ -108,7 +119,7 @@ class FSDirRenameOp {
       delta.subtract(counts);
     }
     FSDirectory.verifyQuota(dst, dst.length() - 1, delta, src.getINode(i - 1));
-    return Pair.of(srcDelta, dstDelta);
+    return Triple.of(true, srcDelta, dstDelta);
   }
 
   /**
@@ -216,10 +227,10 @@ class FSDirRenameOp {
     fsd.ezManager.checkMoveValidity(srcIIP, dstIIP);
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> countPair =
-        verifyQuotaForRename(fsd, srcIIP, dstIIP);
+    Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> countTriple =
+        verifyQuotaForRename(fsd, srcIIP, dstIIP, false);
 
-    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countPair);
+    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countTriple);
 
     boolean added = false;
 
@@ -436,10 +447,10 @@ class FSDirRenameOp {
 
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> quotaPair =
-        verifyQuotaForRename(fsd, srcIIP, dstIIP);
+    Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> countTriple =
+        verifyQuotaForRename(fsd, srcIIP, dstIIP, overwrite);
 
-    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, quotaPair);
+    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countTriple);
 
     boolean undoRemoveSrc = true;
     tx.removeSrc();
@@ -656,13 +667,14 @@ class FSDirRenameOp {
     private final boolean srcChildIsReference;
     private final QuotaCounts oldSrcCountsInSnapshot;
     private final boolean sameStoragePolicy;
+    private final boolean updateQuota;
     private final Optional<QuotaCounts> srcSubTreeCount;
     private final Optional<QuotaCounts> dstSubTreeCount;
     private INode srcChild;
     private INode oldDstChild;
 
     RenameOperation(FSDirectory fsd, INodesInPath srcIIP, INodesInPath dstIIP,
-        Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> quotaPair) {
+        Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> quotaPair) {
       this.fsd = fsd;
       this.srcIIP = srcIIP;
       this.dstIIP = dstIIP;
@@ -711,9 +723,10 @@ class FSDirRenameOp {
       } else {
         withCount = null;
       }
+      this.updateQuota = quotaPair.getLeft();
       // Set quota for src and dst, ignore src is in Snapshot or is Reference
       this.srcSubTreeCount = withCount == null ?
-          quotaPair.getLeft() : Optional.empty();
+          quotaPair.getMiddle() : Optional.empty();
       this.dstSubTreeCount = quotaPair.getRight();
     }
 
@@ -757,7 +770,9 @@ class FSDirRenameOp {
         // update the quota count if necessary
         Optional<QuotaCounts> countOp = sameStoragePolicy ?
             srcSubTreeCount : Optional.empty();
-        fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        if (updateQuota) {
+          fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return removedNum;
       }
@@ -774,7 +789,9 @@ class FSDirRenameOp {
         // update the quota count if necessary
         Optional<QuotaCounts> countOp = sameStoragePolicy ?
             srcSubTreeCount : Optional.empty();
-        fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        if (updateQuota) {
+          fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return true;
       }
@@ -785,7 +802,9 @@ class FSDirRenameOp {
       if (removedNum != -1) {
         oldDstChild = dstIIP.getLastINode();
         // update the quota count if necessary
-        fsd.updateCountForDelete(oldDstChild, dstIIP, dstSubTreeCount);
+        if (updateQuota) {
+          fsd.updateCountForDelete(oldDstChild, dstIIP, dstSubTreeCount);
+        }
         dstIIP = INodesInPath.replace(dstIIP, dstIIP.length() - 1, null);
       }
       return removedNum;
@@ -803,7 +822,7 @@ class FSDirRenameOp {
         toDst = new INodeReference.DstReference(dstParent.asDirectory(),
             withCount, dstIIP.getLatestSnapshotId());
       }
-      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst, srcSubTreeCount);
+      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst, srcSubTreeCount, updateQuota);
     }
 
     void updateMtimeAndLease(long timestamp) {
@@ -837,7 +856,7 @@ class FSDirRenameOp {
         // the srcChild back
         Optional<QuotaCounts> countOp = sameStoragePolicy ?
             srcSubTreeCount : Optional.empty();
-        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild, countOp);
+        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild, countOp, updateQuota);
       }
     }
 
@@ -847,7 +866,7 @@ class FSDirRenameOp {
       if (dstParent.isWithSnapshot()) {
         dstParent.undoRename4DstParent(bsps, oldDstChild, dstIIP.getLatestSnapshotId());
       } else {
-        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild, dstSubTreeCount);
+        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild, dstSubTreeCount, updateQuota);
       }
       if (oldDstChild != null && oldDstChild.isReference()) {
         final INodeReference removedDstRef = oldDstChild.asReference();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1196,7 +1196,7 @@ public class FSDirectory implements Closeable {
     cacheName(child);
     writeLock();
     try {
-      return addLastINode(existing, child, modes, true, Optional.empty());
+      return addLastINode(existing, child, modes, true, Optional.empty(), true);
     } finally {
       writeUnlock();
     }
@@ -1240,6 +1240,27 @@ public class FSDirectory implements Closeable {
         }
       }
     }
+  }
+  
+  /**
+   * Verifies that the path from the specified position to the root
+   * (excluding the root itself) does not contain any valid quota features.
+   *
+   * @param iip the INodesInPath containing all the ancestral INodes.
+   * @param pos Starting position in the path (0-based index).
+   * @return true if no valid quota features are found along the path (root excluded),
+   * false if any directory in the path has an active quota feature.
+   */
+  static boolean verifyPathWithoutValidQuotaFeature(INodesInPath iip, int pos) {
+    // Does not include the root path
+    for (int i = Math.min(pos, iip.length()) - 1; i >= 1; i--) {
+      final DirectoryWithQuotaFeature q =
+          iip.getINode(i).asDirectory().getDirectoryWithQuotaFeature();
+      if (q != null) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /** Verify if the inode name is legal. */
@@ -1347,7 +1368,7 @@ public class FSDirectory implements Closeable {
    */
   @VisibleForTesting
   public INodesInPath addLastINode(INodesInPath existing, INode inode,
-      FsPermission modes, boolean checkQuota, Optional<QuotaCounts> quotaCount)
+      FsPermission modes, boolean checkQuota, Optional<QuotaCounts> quotaCount, boolean updateQuota)
       throws QuotaExceededException {
     assert existing.getLastINode() != null &&
         existing.getLastINode().isDirectory();
@@ -1379,16 +1400,23 @@ public class FSDirectory implements Closeable {
     // always verify inode name
     verifyINodeName(inode.getLocalNameBytes());
 
-    final QuotaCounts counts = quotaCount.orElseGet(() -> inode.
-        computeQuotaUsage(getBlockStoragePolicySuite(),
-            parent.getStoragePolicyID(), false,
-            Snapshot.CURRENT_STATE_ID));
-    updateCount(existing, pos, counts, checkQuota);
+    QuotaCounts counts;
+    if (updateQuota) {
+      counts = quotaCount.orElseGet(() -> inode.
+          computeQuotaUsage(getBlockStoragePolicySuite(),
+          parent.getStoragePolicyID(), false,
+          Snapshot.CURRENT_STATE_ID));
+      updateCount(existing, pos, counts, checkQuota);
+    }
 
     boolean isRename = (inode.getParent() != null);
     final boolean added = parent.addChild(inode, true,
         existing.getLatestSnapshotId());
-    if (!added) {
+    if (!added && updateQuota) {
+      counts = quotaCount.orElseGet(() -> inode.
+          computeQuotaUsage(getBlockStoragePolicySuite(),
+          parent.getStoragePolicyID(), false,
+          Snapshot.CURRENT_STATE_ID));
       updateCountNoQuotaCheck(existing, pos, counts.negation());
       return null;
     } else {
@@ -1401,10 +1429,10 @@ public class FSDirectory implements Closeable {
   }
 
   INodesInPath addLastINodeNoQuotaCheck(INodesInPath existing, INode i,
-      Optional<QuotaCounts> quotaCount) {
+      Optional<QuotaCounts> quotaCount, boolean updateQuota) {
     try {
       // All callers do not have create modes to pass.
-      return addLastINode(existing, i, null, false, quotaCount);
+      return addLastINode(existing, i, null, false, quotaCount, updateQuota);
     } catch (QuotaExceededException e) {
       NameNode.LOG.warn("FSDirectory.addChildNoQuotaCheck - unexpected", e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
+import org.apache.hadoop.hdfs.server.namenode.snapshot.DirectorySnapshottableFeature;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot;
 import org.apache.hadoop.util.StringUtils;
 
@@ -1244,18 +1245,22 @@ public class FSDirectory implements Closeable {
 
   /**
    * Verifies that the path from the specified position to the root
-   * (excluding the root itself) does not contain any valid quota features.
+   * does not contain any valid features.
    *
    * @param iip the INodesInPath containing all the ancestral INodes.
-   * @return true if no valid quota features are found along the path (root excluded),
-   * false if any directory in the path has an active quota feature.
+   * @return true if no valid features are found along the path,
+   * false if any directory in the path has an active feature.
    */
-  static boolean verifyPathWithoutValidQuotaFeature(INodesInPath iip) {
+  static boolean verifyPathWithoutValidFeature(INodesInPath iip) {
+    // Check whether the root inode with 'DirectoryWithSnapshotFeature'
+    INodeDirectory d = iip.getINode(0).asDirectory();
+    if (d.isWithSnapshot()) {
+      return false;
+    }
     // Exclude the root inode
     for (int i = iip.length() - 2; i >= 1; i--) {
-      final DirectoryWithQuotaFeature q =
-          iip.getINode(i).asDirectory().getDirectoryWithQuotaFeature();
-      if (q != null) {
+      d = iip.getINode(i).asDirectory();
+      if (d.isWithSnapshot() || d.isWithQuota()) {
         return false;
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1241,19 +1241,18 @@ public class FSDirectory implements Closeable {
       }
     }
   }
-  
+
   /**
    * Verifies that the path from the specified position to the root
    * (excluding the root itself) does not contain any valid quota features.
    *
    * @param iip the INodesInPath containing all the ancestral INodes.
-   * @param pos Starting position in the path (0-based index).
    * @return true if no valid quota features are found along the path (root excluded),
    * false if any directory in the path has an active quota feature.
    */
-  static boolean verifyPathWithoutValidQuotaFeature(INodesInPath iip, int pos) {
-    // Does not include the root path
-    for (int i = Math.min(pos, iip.length()) - 1; i >= 1; i--) {
+  static boolean verifyPathWithoutValidQuotaFeature(INodesInPath iip) {
+    // Exclude the root inode
+    for (int i = iip.length() - 2; i >= 1; i--) {
       final DirectoryWithQuotaFeature q =
           iip.getINode(i).asDirectory().getDirectoryWithQuotaFeature();
       if (q != null) {
@@ -1367,8 +1366,8 @@ public class FSDirectory implements Closeable {
    * @return an INodesInPath instance containing the new INode
    */
   @VisibleForTesting
-  public INodesInPath addLastINode(INodesInPath existing, INode inode,
-      FsPermission modes, boolean checkQuota, Optional<QuotaCounts> quotaCount, boolean updateQuota)
+  public INodesInPath addLastINode(INodesInPath existing, INode inode, FsPermission modes,
+      boolean checkQuota, Optional<QuotaCounts> quotaCount, boolean updateQuota)
       throws QuotaExceededException {
     assert existing.getLastINode() != null &&
         existing.getLastINode().isDirectory();
@@ -1400,9 +1399,8 @@ public class FSDirectory implements Closeable {
     // always verify inode name
     verifyINodeName(inode.getLocalNameBytes());
 
-    QuotaCounts counts;
     if (updateQuota) {
-      counts = quotaCount.orElseGet(() -> inode.
+      QuotaCounts counts = quotaCount.orElseGet(() -> inode.
           computeQuotaUsage(getBlockStoragePolicySuite(),
           parent.getStoragePolicyID(), false,
           Snapshot.CURRENT_STATE_ID));
@@ -1413,7 +1411,7 @@ public class FSDirectory implements Closeable {
     final boolean added = parent.addChild(inode, true,
         existing.getLatestSnapshotId());
     if (!added && updateQuota) {
-      counts = quotaCount.orElseGet(() -> inode.
+      QuotaCounts counts = quotaCount.orElseGet(() -> inode.
           computeQuotaUsage(getBlockStoragePolicySuite(),
           parent.getStoragePolicyID(), false,
           Snapshot.CURRENT_STATE_ID));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -79,24 +80,32 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
     DFSTestUtil.createFile(dfs, file2, fileLen, replication, 0);
 
     final Path dstDir1 = new Path(testParentDir2, "dst-dir");
+    // If dstDir1 not exist, after the rename operation, 
+    // the root dir's quota usage should remain unchanged.
+    QuotaUsage quotaUsage1 = dfs.getQuotaUsage(new Path("/"));
     ContentSummary cs1 = dfs.getContentSummary(testParentDir1);
     // srcDir=/root/test1/src/dir
     // dstDir1=/root/test2/dst-dir dstDir1 not exist
     boolean rename = dfs.rename(srcDir, dstDir1);
     assertEquals(true, rename);
+    QuotaUsage quotaUsage2 = dfs.getQuotaUsage(new Path("/"));
     ContentSummary cs2 = dfs.getContentSummary(testParentDir2);
+    assertEquals(quotaUsage1, quotaUsage2);
     assertTrue(cs1.equals(cs2));
 
 
     final Path dstDir2 = new Path(testParentDir3, "dst-dir");
     assertTrue(dfs.mkdirs(dstDir2));
+    QuotaUsage quotaUsage3 = dfs.getQuotaUsage(testParentDir2);
     ContentSummary cs3 = dfs.getContentSummary(testParentDir2);
 
     //Src and  dst must be same (all file or all dir)
     // dstDir1=/root/test2/dst-dir
     // dstDir2=/root/test3/dst-dir
     dfs.rename(dstDir1, dstDir2, Options.Rename.OVERWRITE);
+    QuotaUsage quotaUsage4 = dfs.getQuotaUsage(testParentDir3);
     ContentSummary cs4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(quotaUsage3, quotaUsage4);
     assertTrue(cs3.equals(cs4));
   }
 
@@ -157,5 +166,59 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
 
     QuotaCounts subtract = dstCountsAfterRename.subtract(dstCountsBeforeRename);
     assertTrue(subtract.equals(srcCounts));
+  }
+
+  @Test
+  public void testRenameWithoutValidQuotaFeature() throws Exception {
+    final int fileLen = 1024;
+    final short replication = 3;
+    final Path root = new Path("/testRoot");
+    assertTrue(dfs.mkdirs(root));
+
+    Path testParentDir1 = new Path(root, "testDir1");
+    assertTrue(dfs.mkdirs(testParentDir1));
+    Path testParentDir2 = new Path(root, "testDir2");
+    assertTrue(dfs.mkdirs(testParentDir2));
+    Path testParentDir3 = new Path(root, "testDir3");
+    assertTrue(dfs.mkdirs(testParentDir3));
+
+    final Path srcDir = new Path(testParentDir1, "src-dir");
+    for (int i = 0; i < 2; i++) {
+      Path file1 = new Path(srcDir, "file" + i);
+      DFSTestUtil.createFile(dfs, file1, fileLen, replication, 0);
+    }
+
+    // 1. Test rename1
+    QuotaUsage quotaUsage1 = dfs.getQuotaUsage(new Path("/"));
+    final Path dstDir1 = new Path(testParentDir2, "dst-dir");
+    ContentSummary cs1 = dfs.getContentSummary(testParentDir1);
+
+    // srcDir=/testRoot/testDir1/src-dir
+    // dstDir=/testRoot/testDir2/dst-dir dstDir1 not exist
+    boolean rename = dfs.rename(srcDir, dstDir1);
+    assertTrue(rename);
+    ContentSummary cs2 = dfs.getContentSummary(testParentDir2);
+    assertEquals(cs1, cs2);
+
+    QuotaUsage quotaUsage2 = dfs.getQuotaUsage(new Path("/"));
+    assertEquals(quotaUsage1.getFileAndDirectoryCount(), quotaUsage2.getFileAndDirectoryCount());
+
+    // 2. Test rename2
+    final Path dstDir2 = new Path(testParentDir3, "dst-dir");
+    assertTrue(dfs.mkdirs(dstDir2));
+    long originDstDir2Usage = dfs.getQuotaUsage(dstDir2).getFileAndDirectoryCount();
+    // The usage for covering the root dir should not include dstDir2 usage
+    long rootINodeCount1 =
+        dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount() - originDstDir2Usage;
+    ContentSummary cs3 = dfs.getContentSummary(testParentDir2);
+
+    // Src and dst must be same (all file or all dir)
+    // dstDir1=/testRoot/testDir3/dst-dir
+    // dstDir2=/testRoot/testDir3/dst-dir
+    dfs.rename(dstDir1, dstDir2, Options.Rename.OVERWRITE);
+    long rootINodeCount2 = dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount();
+    assertEquals(rootINodeCount1, rootINodeCount2);
+    ContentSummary cs4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(cs3, cs4);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
@@ -172,7 +172,7 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
   public void testRenameWithoutValidQuotaFeature() throws Exception {
     final int fileLen = 1024;
     final short replication = 3;
-    final Path root = new Path("/testRoot");
+    final Path root = new Path("/testRename");
     assertTrue(dfs.mkdirs(root));
 
     Path testParentDir1 = new Path(root, "testDir1");
@@ -189,36 +189,38 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
     }
 
     // 1. Test rename1
-    QuotaUsage quotaUsage1 = dfs.getQuotaUsage(new Path("/"));
-    final Path dstDir1 = new Path(testParentDir2, "dst-dir");
-    ContentSummary cs1 = dfs.getContentSummary(testParentDir1);
-
-    // srcDir=/testRoot/testDir1/src-dir
-    // dstDir=/testRoot/testDir2/dst-dir dstDir1 not exist
-    boolean rename = dfs.rename(srcDir, dstDir1);
-    assertTrue(rename);
-    ContentSummary cs2 = dfs.getContentSummary(testParentDir2);
-    assertEquals(cs1, cs2);
-
-    QuotaUsage quotaUsage2 = dfs.getQuotaUsage(new Path("/"));
-    assertEquals(quotaUsage1.getFileAndDirectoryCount(), quotaUsage2.getFileAndDirectoryCount());
+    ContentSummary rootContentSummary1 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage1 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary1 = dfs.getContentSummary(testParentDir1);
+    // srcDir=/testRename/testDir1/src-dir
+    // dstDir=/testRename/testDir2/dst-dir dstDir1 not exist
+    final Path dstDir2 = new Path(testParentDir2, "dst-dir");
+    assertTrue(dfs.rename(srcDir, dstDir2));
+    ContentSummary contentSummary2 = dfs.getContentSummary(testParentDir2);
+    assertEquals(contentSummary1, contentSummary2);
+    QuotaUsage rootQuotaUsage2 = dfs.getQuotaUsage(new Path("/"));
+    assertEquals(rootQuotaUsage1.getFileAndDirectoryCount(),
+        rootQuotaUsage2.getFileAndDirectoryCount());
+    // The return values of the getContentSummary() and getQuotaUsage() should be consistent
+    assertEquals(rootContentSummary1.getFileAndDirectoryCount(),
+        rootQuotaUsage2.getFileAndDirectoryCount());
 
     // 2. Test rename2
-    final Path dstDir2 = new Path(testParentDir3, "dst-dir");
-    assertTrue(dfs.mkdirs(dstDir2));
-    long originDstDir2Usage = dfs.getQuotaUsage(dstDir2).getFileAndDirectoryCount();
-    // The usage for covering the root dir should not include dstDir2 usage
+    final Path dstDir3 = new Path(testParentDir3, "dst-dir");
+    assertTrue(dfs.mkdirs(dstDir3));
+    long originDstDir2Usage = dfs.getQuotaUsage(dstDir3).getFileAndDirectoryCount();
+    // Exclude dstDir2 usage
     long rootINodeCount1 =
         dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount() - originDstDir2Usage;
-    ContentSummary cs3 = dfs.getContentSummary(testParentDir2);
+    ContentSummary contentSummary3 = dfs.getContentSummary(testParentDir2);
 
     // Src and dst must be same (all file or all dir)
-    // dstDir1=/testRoot/testDir3/dst-dir
-    // dstDir2=/testRoot/testDir3/dst-dir
-    dfs.rename(dstDir1, dstDir2, Options.Rename.OVERWRITE);
+    // dstDir2=/testRename/testDir3/dst-dir
+    // dstDir3=/testRename/testDir3/dst-dir
+    dfs.rename(dstDir2, dstDir3, Options.Rename.OVERWRITE);
     long rootINodeCount2 = dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount();
     assertEquals(rootINodeCount1, rootINodeCount2);
-    ContentSummary cs4 = dfs.getContentSummary(testParentDir3);
-    assertEquals(cs3, cs4);
+    ContentSummary contentSummary4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(contentSummary3, contentSummary4);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1650,7 +1650,7 @@ public class TestRenameWithSnapshots {
     final Path foo2 = new Path(subdir2, foo.getName());
     FSDirectory fsdir2 = Mockito.spy(fsdir);
     Mockito.doThrow(new NSQuotaExceededException("fake exception")).when(fsdir2)
-        .addLastINode(any(), any(), any(), anyBoolean(), any());
+        .addLastINode(any(), any(), any(), anyBoolean(), any(), anyBoolean());
     Whitebox.setInternalState(fsn, "dir", fsdir2);
     // rename /test/dir1/foo to /test/dir2/subdir2/foo. 
     // FSDirectory#verifyQuota4Rename will pass since the remaining quota is 2.


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HDFS-17839

Calculating quota usage is primarily used to update directories labeled with the DirectoryWithQuotaFeature tag. When there is no valid DirectoryWithQuotaFeature in the paths of src and dst (excluding the root directory), the quota should not be calculated in rename scenarios:
1. rename1 does not change the quota of the root directory, so neither src nor dst contains DirectoryWithQuotaFeature. The operation of calculating quota should be skipped.
2. In the scenario of overwriting, rename2 still needs to consider calculating quota, otherwise it will affect the quotausage value of the root directory.
3. For directories enabled for snapshot creation, quota calculation is also necessary; otherwise, deleting snapshot files may affect the root directory's quota.

### How was this patch tested?
Add UT

