### PR TITLE
HDFS-17839. Rename skips path without valid 'DirectoryWithQuotaFeature' in FSDirRenameOp

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirMkdirOp.java
@@ -224,7 +224,7 @@ class FSDirMkdirOp {
         timestamp);
 
     INodesInPath iip = fsd.addLastINode(parent, dir, permission.getPermission(),
-        true, Optional.empty());
+        true, Optional.empty(), true);
     if (iip != null && aclEntries != null) {
       AclStorage.updateINodeAcl(dir, aclEntries, Snapshot.CURRENT_STATE_ID);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.namenode;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -72,18 +72,28 @@ class FSDirRenameOp {
    * Verify quota for rename operation where srcInodes[srcInodes.length-1] moves
    * dstInodes[dstInodes.length-1]
    */
-  private static Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> verifyQuotaForRename(
-      FSDirectory fsd, INodesInPath src, INodesInPath dst) throws QuotaExceededException {
+  private static Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> verifyQuotaForRename(
+      FSDirectory fsd, INodesInPath src, INodesInPath dst, boolean overwrite)
+      throws QuotaExceededException {
     Optional<QuotaCounts> srcDelta = Optional.empty();
     Optional<QuotaCounts> dstDelta = Optional.empty();
     if (!fsd.getFSNamesystem().isImageLoaded() || fsd.shouldSkipQuotaChecks()) {
       // Do not check quota if edits log is still being processed
-      return Pair.of(srcDelta, dstDelta);
+      return Triple.of(false, srcDelta, dstDelta);
     }
     int i = 0;
     while (src.getINode(i) == dst.getINode(i)) {
       i++;
     }
+
+    // Verify path without valid 'DirectoryWithQuotaFeature'
+    // Note: In overwrite scenarios, quota calculation is still required,
+    // overwrite operations delete existing content, which will affects the root directory's quota.
+    // (i - 1) is common ancestor inode index.
+    if (!overwrite && verifyPathWithoutValidQuotaFeature(src, dst, i - 1)) {
+      return Triple.of(false, srcDelta, dstDelta);
+    }
+
     // src[i - 1] is the last common ancestor.
     BlockStoragePolicySuite bsps = fsd.getBlockStoragePolicySuite();
     // Assume dstParent existence check done by callers.
@@ -108,7 +118,7 @@ class FSDirRenameOp {
       delta.subtract(counts);
     }
     FSDirectory.verifyQuota(dst, dst.length() - 1, delta, src.getINode(i - 1));
-    return Pair.of(srcDelta, dstDelta);
+    return Triple.of(true, srcDelta, dstDelta);
   }
 
   /**
@@ -125,6 +135,25 @@ class FSDirRenameOp {
     if (srcIIP.getINode(-2) != dstIIP.getINode(-2)) {
       fsd.verifyMaxDirItems(dstIIP.getINode(-2).asDirectory(), parentPath);
     }
+  }
+
+  /**
+   * Verify that the src and dst path does not contain valid quota feature.
+   *
+   * @param src   source path.
+   * @param dst   destination path.
+   * @param index common ancestor inode index.
+   * @return true if no valid quota feature, otherwise false.
+   */
+  static boolean verifyPathWithoutValidQuotaFeature(INodesInPath src, INodesInPath dst, int index) {
+    // Excluding root directory
+    if (!FSDirectory.verifyWithoutQuotaFeature(src, index, 1)) {
+      return false;
+    }
+    if (!FSDirectory.verifyWithoutQuotaFeature(src, src.length() - 2, index - 1)) {
+      return false;
+    }
+    return FSDirectory.verifyWithoutQuotaFeature(dst, dst.length() - 2, index - 1);
   }
 
   /**
@@ -216,10 +245,10 @@ class FSDirRenameOp {
     fsd.ezManager.checkMoveValidity(srcIIP, dstIIP);
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> countPair =
-        verifyQuotaForRename(fsd, srcIIP, dstIIP);
+    Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> countTriple =
+        verifyQuotaForRename(fsd, srcIIP, dstIIP, false);
 
-    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countPair);
+    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countTriple);
 
     boolean added = false;
 
@@ -436,10 +465,10 @@ class FSDirRenameOp {
 
     // Ensure dst has quota to accommodate rename
     verifyFsLimitsForRename(fsd, srcIIP, dstIIP);
-    Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> quotaPair =
-        verifyQuotaForRename(fsd, srcIIP, dstIIP);
+    Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> countTriple =
+        verifyQuotaForRename(fsd, srcIIP, dstIIP, overwrite);
 
-    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, quotaPair);
+    RenameOperation tx = new RenameOperation(fsd, srcIIP, dstIIP, countTriple);
 
     boolean undoRemoveSrc = true;
     tx.removeSrc();
@@ -656,13 +685,14 @@ class FSDirRenameOp {
     private final boolean srcChildIsReference;
     private final QuotaCounts oldSrcCountsInSnapshot;
     private final boolean sameStoragePolicy;
+    private final boolean updateQuota;
     private final Optional<QuotaCounts> srcSubTreeCount;
     private final Optional<QuotaCounts> dstSubTreeCount;
     private INode srcChild;
     private INode oldDstChild;
 
     RenameOperation(FSDirectory fsd, INodesInPath srcIIP, INodesInPath dstIIP,
-        Pair<Optional<QuotaCounts>, Optional<QuotaCounts>> quotaPair) {
+        Triple<Boolean, Optional<QuotaCounts>, Optional<QuotaCounts>> countTriple) {
       this.fsd = fsd;
       this.srcIIP = srcIIP;
       this.dstIIP = dstIIP;
@@ -712,9 +742,10 @@ class FSDirRenameOp {
         withCount = null;
       }
       // Set quota for src and dst, ignore src is in Snapshot or is Reference
+      this.updateQuota = countTriple.getLeft() || withCount != null;
       this.srcSubTreeCount = withCount == null ?
-          quotaPair.getLeft() : Optional.empty();
-      this.dstSubTreeCount = quotaPair.getRight();
+          countTriple.getMiddle() : Optional.empty();
+      this.dstSubTreeCount = countTriple.getRight();
     }
 
     boolean isSameStoragePolicy() {
@@ -755,9 +786,11 @@ class FSDirRenameOp {
         throw new IOException(error);
       } else {
         // update the quota count if necessary
-        Optional<QuotaCounts> countOp = sameStoragePolicy ?
-            srcSubTreeCount : Optional.empty();
-        fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        if (updateQuota) {
+          Optional<QuotaCounts> countOp = sameStoragePolicy ?
+              srcSubTreeCount : Optional.empty();
+          fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return removedNum;
       }
@@ -772,9 +805,11 @@ class FSDirRenameOp {
         return false;
       } else {
         // update the quota count if necessary
-        Optional<QuotaCounts> countOp = sameStoragePolicy ?
-            srcSubTreeCount : Optional.empty();
-        fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        if (updateQuota) {
+          Optional<QuotaCounts> countOp = sameStoragePolicy ?
+              srcSubTreeCount : Optional.empty();
+          fsd.updateCountForDelete(srcChild, srcIIP, countOp);
+        }
         srcIIP = INodesInPath.replace(srcIIP, srcIIP.length() - 1, null);
         return true;
       }
@@ -785,7 +820,9 @@ class FSDirRenameOp {
       if (removedNum != -1) {
         oldDstChild = dstIIP.getLastINode();
         // update the quota count if necessary
-        fsd.updateCountForDelete(oldDstChild, dstIIP, dstSubTreeCount);
+        if (updateQuota) {
+          fsd.updateCountForDelete(oldDstChild, dstIIP, dstSubTreeCount);
+        }
         dstIIP = INodesInPath.replace(dstIIP, dstIIP.length() - 1, null);
       }
       return removedNum;
@@ -803,7 +840,7 @@ class FSDirRenameOp {
         toDst = new INodeReference.DstReference(dstParent.asDirectory(),
             withCount, dstIIP.getLatestSnapshotId());
       }
-      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst, srcSubTreeCount);
+      return fsd.addLastINodeNoQuotaCheck(dstParentIIP, toDst, srcSubTreeCount, updateQuota);
     }
 
     void updateMtimeAndLease(long timestamp) {
@@ -837,7 +874,7 @@ class FSDirRenameOp {
         // the srcChild back
         Optional<QuotaCounts> countOp = sameStoragePolicy ?
             srcSubTreeCount : Optional.empty();
-        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild, countOp);
+        fsd.addLastINodeNoQuotaCheck(srcParentIIP, srcChild, countOp, updateQuota);
       }
     }
 
@@ -847,7 +884,7 @@ class FSDirRenameOp {
       if (dstParent.isWithSnapshot()) {
         dstParent.undoRename4DstParent(bsps, oldDstChild, dstIIP.getLatestSnapshotId());
       } else {
-        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild, dstSubTreeCount);
+        fsd.addLastINodeNoQuotaCheck(dstParentIIP, oldDstChild, dstSubTreeCount, updateQuota);
       }
       if (oldDstChild != null && oldDstChild.isReference()) {
         final INodeReference removedDstRef = oldDstChild.asReference();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -1196,7 +1196,7 @@ public class FSDirectory implements Closeable {
     cacheName(child);
     writeLock();
     try {
-      return addLastINode(existing, child, modes, true, Optional.empty());
+      return addLastINode(existing, child, modes, true, Optional.empty(), true);
     } finally {
       writeUnlock();
     }
@@ -1240,6 +1240,25 @@ public class FSDirectory implements Closeable {
         }
       }
     }
+  }
+
+  /**
+   * Verify that the iNodesInPath from the start position to the end position
+   * does not contain any valid quota feature.
+   *
+   * @param iip   the INodesInPath instance containing all the INodes for the path.
+   * @param start path inode start index.
+   * @param end   path inode end index.
+   * @return true if no valid quota feature, otherwise false.
+   */
+  static boolean verifyWithoutQuotaFeature(INodesInPath iip, int start, int end) {
+    for (int i = start; i >= end; i--) {
+      INodeDirectory d = iip.getINode(i).asDirectory();
+      if (d.isWithQuota()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /** Verify if the inode name is legal. */
@@ -1343,11 +1362,12 @@ public class FSDirectory implements Closeable {
    * @param inode the new INode to add
    * @param modes create modes
    * @param checkQuota whether to check quota
+   * @param updateQuota whether to update quota
    * @return an INodesInPath instance containing the new INode
    */
   @VisibleForTesting
-  public INodesInPath addLastINode(INodesInPath existing, INode inode,
-      FsPermission modes, boolean checkQuota, Optional<QuotaCounts> quotaCount)
+  public INodesInPath addLastINode(INodesInPath existing, INode inode, FsPermission modes,
+      boolean checkQuota, Optional<QuotaCounts> quotaCount, boolean updateQuota)
       throws QuotaExceededException {
     assert existing.getLastINode() != null &&
         existing.getLastINode().isDirectory();
@@ -1379,17 +1399,23 @@ public class FSDirectory implements Closeable {
     // always verify inode name
     verifyINodeName(inode.getLocalNameBytes());
 
-    final QuotaCounts counts = quotaCount.orElseGet(() -> inode.
-        computeQuotaUsage(getBlockStoragePolicySuite(),
-            parent.getStoragePolicyID(), false,
-            Snapshot.CURRENT_STATE_ID));
-    updateCount(existing, pos, counts, checkQuota);
+    QuotaCounts counts = null;
+    if (updateQuota) {
+      counts = quotaCount.orElseGet(() -> inode.
+          computeQuotaUsage(getBlockStoragePolicySuite(),
+          parent.getStoragePolicyID(), false,
+          Snapshot.CURRENT_STATE_ID));
+      updateCount(existing, pos, counts, checkQuota);
+    }
 
     boolean isRename = (inode.getParent() != null);
     final boolean added = parent.addChild(inode, true,
         existing.getLatestSnapshotId());
     if (!added) {
-      updateCountNoQuotaCheck(existing, pos, counts.negation());
+      // When adding INode fails, if 'updateQuota' is true, rollback quota.
+      if (updateQuota) {
+        updateCountNoQuotaCheck(existing, pos, counts.negation());
+      }
       return null;
     } else {
       if (!isRename) {
@@ -1401,10 +1427,10 @@ public class FSDirectory implements Closeable {
   }
 
   INodesInPath addLastINodeNoQuotaCheck(INodesInPath existing, INode i,
-      Optional<QuotaCounts> quotaCount) {
+      Optional<QuotaCounts> quotaCount, boolean updateQuota) {
     try {
       // All callers do not have create modes to pass.
-      return addLastINode(existing, i, null, false, quotaCount);
+      return addLastINode(existing, i, null, false, quotaCount, updateQuota);
     } catch (QuotaExceededException e) {
       NameNode.LOG.warn("FSDirectory.addChildNoQuotaCheck - unexpected", e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCorrectnessOfQuotaAfterRenameOp.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.hadoop.fs.QuotaUsage;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -28,17 +29,23 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.server.blockmanagement.BlockStoragePolicySuite;
 import org.apache.hadoop.hdfs.server.namenode.snapshot.Snapshot;
+import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.HOT_STORAGE_POLICY_NAME;
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.ONESSD_STORAGE_POLICY_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 
 public class TestCorrectnessOfQuotaAfterRenameOp {
   private static MiniDFSCluster cluster;
@@ -79,24 +86,32 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
     DFSTestUtil.createFile(dfs, file2, fileLen, replication, 0);
 
     final Path dstDir1 = new Path(testParentDir2, "dst-dir");
+    // If dstDir1 not exist, after the rename operation,
+    // the root dir's quota usage should remain unchanged.
+    QuotaUsage quotaUsage1 = dfs.getQuotaUsage(new Path("/"));
     ContentSummary cs1 = dfs.getContentSummary(testParentDir1);
     // srcDir=/root/test1/src/dir
     // dstDir1=/root/test2/dst-dir dstDir1 not exist
     boolean rename = dfs.rename(srcDir, dstDir1);
     assertEquals(true, rename);
+    QuotaUsage quotaUsage2 = dfs.getQuotaUsage(new Path("/"));
     ContentSummary cs2 = dfs.getContentSummary(testParentDir2);
+    assertEquals(quotaUsage1, quotaUsage2);
     assertTrue(cs1.equals(cs2));
 
 
     final Path dstDir2 = new Path(testParentDir3, "dst-dir");
     assertTrue(dfs.mkdirs(dstDir2));
+    QuotaUsage quotaUsage3 = dfs.getQuotaUsage(testParentDir2);
     ContentSummary cs3 = dfs.getContentSummary(testParentDir2);
 
     //Src and  dst must be same (all file or all dir)
     // dstDir1=/root/test2/dst-dir
     // dstDir2=/root/test3/dst-dir
     dfs.rename(dstDir1, dstDir2, Options.Rename.OVERWRITE);
+    QuotaUsage quotaUsage4 = dfs.getQuotaUsage(testParentDir3);
     ContentSummary cs4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(quotaUsage3, quotaUsage4);
     assertTrue(cs3.equals(cs4));
   }
 
@@ -157,5 +172,187 @@ public class TestCorrectnessOfQuotaAfterRenameOp {
 
     QuotaCounts subtract = dstCountsAfterRename.subtract(dstCountsBeforeRename);
     assertTrue(subtract.equals(srcCounts));
+  }
+
+  @Test
+  public void testRenameWithoutValidFeature() throws Exception {
+    final int fileLen = 1024;
+    final short replication = 3;
+    final Path root = new Path("/testRename");
+    assertTrue(dfs.mkdirs(root));
+
+    Path testParentDir1 = new Path(root, "testDir1");
+    assertTrue(dfs.mkdirs(testParentDir1));
+    Path testParentDir2 = new Path(root, "testDir2");
+    assertTrue(dfs.mkdirs(testParentDir2));
+    Path testParentDir3 = new Path(root, "testDir3");
+    assertTrue(dfs.mkdirs(testParentDir3));
+
+    final Path srcDir = new Path(testParentDir1, "src-dir");
+    for (int i = 0; i < 2; i++) {
+      Path file1 = new Path(srcDir, "file" + i);
+      DFSTestUtil.createFile(dfs, file1, fileLen, replication, 0);
+    }
+
+    // 1. Test rename1
+    ContentSummary rootContentSummary1 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage1 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary1 = dfs.getContentSummary(testParentDir1);
+    // srcDir=/testRename/testDir1/src-dir
+    // dstDir=/testRename/testDir2/dst-dir dstDir not exist
+    final Path dstDir2 = new Path(testParentDir2, "dst-dir");
+    assertTrue(dfs.rename(srcDir, dstDir2));
+    ContentSummary contentSummary2 = dfs.getContentSummary(testParentDir2);
+    assertEquals(contentSummary1, contentSummary2);
+    QuotaUsage rootQuotaUsage2 = dfs.getQuotaUsage(new Path("/"));
+    assertEquals(rootQuotaUsage1.getFileAndDirectoryCount(),
+        rootQuotaUsage2.getFileAndDirectoryCount());
+    // The return values of the getContentSummary() and getQuotaUsage() should be consistent
+    assertEquals(rootContentSummary1.getFileAndDirectoryCount(),
+        rootQuotaUsage2.getFileAndDirectoryCount());
+
+    // 2. Test rename2
+    final Path dstDir3 = new Path(testParentDir3, "dst-dir");
+    assertTrue(dfs.mkdirs(dstDir3));
+    long originDstDirUsage = dfs.getQuotaUsage(dstDir3).getFileAndDirectoryCount();
+    // Overwrite the rename destination, the usage of dstDir3 should be excluded
+    long expectedCount =
+        dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount() - originDstDirUsage;
+    ContentSummary contentSummary3 = dfs.getContentSummary(testParentDir2);
+    // Src and dst must be same
+    // dstDir2=/testRename/testDir2/dst-dir
+    // dstDir3=/testRename/testDir3/dst-dir
+    dfs.rename(dstDir2, dstDir3, Options.Rename.OVERWRITE);
+    long actualCount = dfs.getQuotaUsage(new Path("/")).getFileAndDirectoryCount();
+    assertEquals(expectedCount, actualCount);
+    ContentSummary contentSummary4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(contentSummary3, contentSummary4);
+  }
+
+  @Test
+  public void testRenameUndoWithoutValidFeature() throws Exception {
+    final int fileLen = 1024;
+    final short replication = 3;
+    final Path root = new Path("/testRenameUndo");
+    assertTrue(dfs.mkdirs(root));
+
+    Path testParentDir1 = new Path(root, "testDir1");
+    assertTrue(dfs.mkdirs(testParentDir1));
+    Path testParentDir2 = new Path(root, "testDir2");
+    assertTrue(dfs.mkdirs(testParentDir2));
+    Path testParentDir3 = new Path(root, "testDir3");
+    assertTrue(dfs.mkdirs(testParentDir3));
+    Path testParentDir4 = new Path(root, "testDir4");
+    assertTrue(dfs.mkdirs(testParentDir4));
+
+    final Path srcDir1 = new Path(testParentDir1, "src-dir");
+    for (int i = 0; i < 2; i++) {
+      Path file1 = new Path(srcDir1, "file" + i);
+      DFSTestUtil.createFile(dfs, file1, fileLen, replication, 0);
+    }
+
+    final Path srcDir3 = new Path(testParentDir3, "src-dir");
+    for (int i = 0; i < 2; i++) {
+      Path file1 = new Path(srcDir3, "file" + i);
+      DFSTestUtil.createFile(dfs, file1, fileLen, replication, 0);
+    }
+
+    // Test rename1
+    ContentSummary rootContentSummary1 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage1 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary1 = dfs.getContentSummary(testParentDir1);
+
+    FSNamesystem fsn = cluster.getNamesystem();
+    FSDirectory fsDirectory = fsn.getFSDirectory();
+
+    // Replace INode, expected addChild return false
+    INodeDirectory dir = fsDirectory.getINode4Write(testParentDir2.toString()).asDirectory();
+    INodeDirectory mockDir = Mockito.spy(dir);
+    INode srcInode = fsDirectory.getINode(srcDir3.toString());
+    // Fail the rename but succeed in undo
+    Mockito.doReturn(false).when(mockDir).addChild(Mockito.eq(srcInode), anyBoolean(), anyInt());
+    INodeDirectory rootDir = fsDirectory.getINode4Write(root.toString()).asDirectory();
+    rootDir.replaceChild(dir, mockDir, fsDirectory.getINodeMap());
+    mockDir.setParent(rootDir);
+
+    // srcDir=/testRenameUndo/testDir1/src-dir
+    // dstDir=/testRenameUndo/testDir2/
+    assertFalse(dfs.rename(srcDir3, testParentDir2));
+
+    ContentSummary rootContentSummary2 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage2 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary2 = dfs.getContentSummary(testParentDir1);
+    assertEquals(rootContentSummary1.toString(), rootContentSummary2.toString());
+    assertEquals(rootQuotaUsage1.toString(), rootQuotaUsage2.toString());
+    assertEquals(contentSummary1.toString(), contentSummary2.toString());
+    assertEquals(rootContentSummary1.getFileAndDirectoryCount(),
+        rootQuotaUsage2.getFileAndDirectoryCount());
+
+    // Test rename2
+    final Path dstDir4 = new Path(testParentDir4, "src-dir");
+    assertTrue(dfs.mkdirs(dstDir4));
+    ContentSummary rootContentSummary3 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage3 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary3 = dfs.getContentSummary(testParentDir3);
+
+    // Replace INode, expected addChild return false
+    INodeDirectory dir4 = fsDirectory.getINode4Write(testParentDir4.toString()).asDirectory();
+    INodeDirectory mockDir4 = Mockito.spy(dir4);
+    INode srcInode3 = fsDirectory.getINode(srcDir3.toString());
+    Mockito.doReturn(false).when(mockDir4).addChild(Mockito.eq(srcInode3), anyBoolean(), anyInt());
+    rootDir.replaceChild(dir4, mockDir4, fsDirectory.getINodeMap());
+    mockDir4.setParent(rootDir);
+
+    // srcDir=/testRenameUndo/testDir3/src-dir
+    // dstDir=/testRenameUndo/testDir4/src-dir dstDir exist
+    assertThrows(RemoteException.class,
+        () -> dfs.rename(srcDir3, dstDir4, Options.Rename.OVERWRITE));
+
+    ContentSummary rootContentSummary4 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage rootQuotaUsage4 = dfs.getQuotaUsage(new Path("/"));
+    ContentSummary contentSummary4 = dfs.getContentSummary(testParentDir3);
+    assertEquals(rootContentSummary3.toString(), rootContentSummary4.toString());
+    assertEquals(rootQuotaUsage3.toString(), rootQuotaUsage4.toString());
+    assertEquals(contentSummary3.toString(), contentSummary4.toString());
+    assertEquals(rootContentSummary3.getFileAndDirectoryCount(),
+        rootQuotaUsage4.getFileAndDirectoryCount());
+  }
+
+  @Test
+  public void testRenameFileInSnapshotDirWithoutValidFeature() throws Exception {
+    final int fileLen = 1024;
+    final short replication = 3;
+    final Path root = new Path("/testRenameFileInSnapshotDir");
+    assertTrue(dfs.mkdirs(root));
+
+    Path testParentDir1 = new Path(root, "testDir1");
+    assertTrue(dfs.mkdirs(testParentDir1));
+    Path file = new Path(testParentDir1, "file1");
+    DFSTestUtil.createFile(dfs, file, fileLen, replication, 0);
+    dfs.allowSnapshot(testParentDir1);
+    dfs.createSnapshot(testParentDir1, "snapshot1");
+
+    Path testParentDir2 = new Path(root, "testDir2");
+    assertTrue(dfs.mkdirs(testParentDir2));
+
+    ContentSummary contentSummary1 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage quotaUsage1 = dfs.getQuotaUsage(new Path("/"));
+    assertEquals(contentSummary1.getSpaceConsumed(), quotaUsage1.getSpaceConsumed());
+    assertEquals(contentSummary1.getFileAndDirectoryCount(),
+        quotaUsage1.getFileAndDirectoryCount());
+
+    // The snapshot of file1 not be cleaned up
+    assertTrue(dfs.rename(new Path(testParentDir1, "file1"), testParentDir2));
+
+    ContentSummary contentSummary2 = dfs.getContentSummary(new Path("/"));
+    QuotaUsage quotaUsage2 = dfs.getQuotaUsage(new Path("/"));
+    assertEquals(quotaUsage1.getFileAndDirectoryCount() + 1,
+        quotaUsage2.getFileAndDirectoryCount());
+    assertEquals(quotaUsage1.getSpaceConsumed() + fileLen * replication,
+        quotaUsage2.getSpaceConsumed());
+    // Root directory's quota usage must match actual capacity
+    assertEquals(contentSummary2.getFileAndDirectoryCount(),
+        quotaUsage2.getFileAndDirectoryCount());
+    assertEquals(contentSummary2.getSpaceConsumed(), quotaUsage2.getSpaceConsumed());
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/snapshot/TestRenameWithSnapshots.java
@@ -1650,7 +1650,7 @@ public class TestRenameWithSnapshots {
     final Path foo2 = new Path(subdir2, foo.getName());
     FSDirectory fsdir2 = Mockito.spy(fsdir);
     Mockito.doThrow(new NSQuotaExceededException("fake exception")).when(fsdir2)
-        .addLastINode(any(), any(), any(), anyBoolean(), any());
+        .addLastINode(any(), any(), any(), anyBoolean(), any(), anyBoolean());
     Whitebox.setInternalState(fsn, "dir", fsdir2);
     // rename /test/dir1/foo to /test/dir2/subdir2/foo. 
     // FSDirectory#verifyQuota4Rename will pass since the remaining quota is 2.


### PR DESCRIPTION
### Description of PR
JIRA: https://issues.apache.org/jira/browse/HDFS-17839

Calculating quotaUsage is primarily used to update directories labeled with the DirectoryWithQuotaFeature. When there is no valid DirectoryWithQuotaFeature in the paths of src and dst (excluding the root directory), the quota should not be calculated in rename scenarios:

1. `rename1` does not change the quotaUsage of the root directory, so neither src nor dst contains "DirectoryWithQuotaFeature" label (excluding the root directory). The operation of calculating quotaUsage should be skipped.
2. In the scenario of overwriting, `rename2` still needs to consider calculating quota, otherwise it will affect the quotaUsage value of the root directory.

By default, the root directory has the "DirectoryWithQuotaFeature" label.
```java
private static INodeDirectory createRoot(FSNamesystem namesystem) {
   final INodeDirectory r = new INodeDirectory(
       INodeId.ROOT_INODE_ID,
       INodeDirectory.ROOT_NAME,
       namesystem.createFsOwnerPermissions(new FsPermission((short) 0755)),
       0L);
   r.addDirectoryWithQuotaFeature(
       new DirectoryWithQuotaFeature.Builder().
           nameSpaceQuota(DirectoryWithQuotaFeature.DEFAULT_NAMESPACE_QUOTA).
           storageSpaceQuota(DirectoryWithQuotaFeature.DEFAULT_STORAGE_SPACE_QUOTA).
           build());
   r.addSnapshottableFeature();
   r.setSnapshotQuota(0);
   return r;
 }
```

​​Performance Improvement in Renaming **50 million files** Directory Without Quotas​​:

Repeat the client command 20 times, Test results show a significant performance improvement when renaming a directory containing **50 million files** without quota restrictions:

`hadoop fs -mv "$src_path" "$dst_path"`

- Before​​: **26,998.55 ms**
- After​​: **1,662.35 ms**

Performance improvement​​: **94%** reduction in execution time, the operation about **16 times** faster than the original implementation.

### How was this patch tested?
Add UT