### PR TITLE
HADOOP-19701. Remove invalid `licenses` field of `hadoop-aliyun` SBOM by upgrading `cyclonedx` to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.1</jsonschema2pojo-maven-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-    <cyclonedx.version>2.7.10</cyclonedx.version>
+    <cyclonedx.version>2.9.1</cyclonedx.version>
     <docker-maven-plugin.version>0.29.0</docker-maven-plugin.version>
 
     <shell-executable>bash</shell-executable>


### PR DESCRIPTION
### Description of PR

HADOOP-19701. Remove invalid licenses field of hadoop-aliyun SBOM by upgrading cyclonedx to 2.9.1.

This PR aims to improve `hadoop-aliyun` SBOM by removing invalid `licenses` field via upgrading `cyclonedx` to 2.9.1.

Technically, `SBOM` scheme is going to be upgraded to `1.6` from `1.4`.

```
$ head -n2 before
<?xml version="1.0" encoding="UTF-8"?>
<bom serialNumber="urn:uuid:82616609-099a-4b8a-bc63-9c4b39c554b0" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">

$ head -n2 after
<?xml version="1.0" encoding="UTF-8"?>
<bom serialNumber="urn:uuid:d33de7e3-2887-37ef-ab07-bd272ebe378c" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
```

According to the testing, it turns out that the empty license field of `aliyun-sdk-oss` is considered invalid in the latest CycloneDX Schema 1.5 and 1.6. For example, this causes a parsing error when a downstream to try to validate it with `Schema Version 1.6`.

```
$ curl -s https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.4.2/hadoop-aliyun-3.4.2-cyclonedx.xml | grep -C3 '<name></name>'
      </hashes>
      <licenses>
        <license>
          <name></name>
        </license>
      </licenses>
      <purl>pkg:maven/com.aliyun.oss/aliyun-sdk-oss@3.13.2?type=jar</purl>
--
      </hashes>
      <licenses>
        <license>
          <name></name>
        </license>
      </licenses>
      <purl>pkg:maven/com.aliyun/aliyun-java-sdk-core@4.5.10?type=jar</purl>
--
      </hashes>
      <licenses>
        <license>
          <name></name>
        </license>
      </licenses>
      <purl>pkg:maven/com.aliyun/aliyun-java-sdk-ram@3.1.0?type=jar</purl>
--
      </hashes>
      <licenses>
        <license>
          <name></name>
        </license>
      </licenses>
      <purl>pkg:maven/com.aliyun/aliyun-java-sdk-kms@2.11.0?type=jar</purl>
```

```
The content of element 'license' is not complete.
One of '{"http://cyclonedx.org/schema/bom/1.6":id, "http://cyclonedx.org/schema/bom/1.6":name}' is expected.
...
        at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:135)
```

Since all published `SBOM` files of `hadoop-aliyun` are in the same situation, we had better upgrade the plugin for next Apache Hadoop release.
- https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.3.6/hadoop-aliyun-3.3.6-cyclonedx.xml
- https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.4.0/hadoop-aliyun-3.4.0-cyclonedx.xml
- https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.4.0/hadoop-aliyun-3.4.1-cyclonedx.xml
- https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aliyun/3.4.0/hadoop-aliyun-3.4.2-cyclonedx.xml

### How was this patch tested?

After upgrading the plugin, this invalid empty license field will be removed like the following.

```
$ cat after | grep -C3 '<name></name>' | wc -l
       0
```

### For code changes:

This is only a build dependency upgrade to bring the latest robust version.

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

