### PR TITLE
HADOOP-19693 Update Java 24 to 25 in docker images

### DIFF
--- a/dev-support/docker/pkg-resolver/packages.json
+++ b/dev-support/docker/pkg-resolver/packages.json
@@ -270,20 +270,20 @@
       "openjdk-17-jdk"
     ],
     "ubuntu:focal": [
-      "temurin-24-jdk",
+      "temurin-25-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk",
       "openjdk-21-jdk"
     ],
     "ubuntu:noble": [
-      "temurin-24-jdk",
+      "temurin-25-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk",
       "openjdk-21-jdk"
     ],
     "ubuntu:focal::arch64": [
-      "temurin-24-jdk",
+      "temurin-25-jdk",
       "openjdk-8-jdk",
       "openjdk-11-jdk",
       "openjdk-17-jdk",


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19693. Update Java 24 to 25 in docker images.

Update Java 24 to 25 in docker images

### How was this patch tested?

Built ubuntu_20 and ubuntu_24 x64 images, and ran java 25 in them.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

