### PR TITLE
YARN-11870 When manually switching Active to Standby, the ActiveStandbyElectorLock is not released.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -181,22 +181,6 @@ public class TestRMFailover extends ClientBaseWithFixes {
     }
   }
 
-  private void verifyRMTransitionToActive(ResourceManager rm)
-      throws InterruptedException {
-    try {
-      GenericTestUtils.waitFor(new Supplier<Boolean>() {
-        @Override
-        public Boolean get() {
-          return rm.getRMContext().getHAServiceState() ==
-              HAServiceState.ACTIVE;
-        }
-      }, 100, 20000);
-    } catch (TimeoutException e) {
-      fail("RM didn't transition to Active.");
-    }
-  }
-
-
   @Test
   public void testAutomaticFailover()
       throws YarnException, InterruptedException, IOException {
@@ -478,7 +462,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
   }
 
   @Test
-  public void testTransitionedToStandby()
+  public void testTransitionedToStandbyWhenAutoFailover()
       throws YarnException, InterruptedException, IOException {
     conf.set(YarnConfiguration.RM_CLUSTER_ID, "yarn-test-cluster");
     conf.set(YarnConfiguration.RM_ZK_ADDRESS, hostPort);
@@ -491,14 +475,14 @@ public class TestRMFailover extends ClientBaseWithFixes {
     assertNotEquals(-1, activeRMIndex, "RM never turned active");
     verifyConnections();
 
-    int standbyRMIndex = (activeRMIndex + 1) % 2;
     HAServiceProtocol.StateChangeRequestInfo requestInfo = new HAServiceProtocol.StateChangeRequestInfo(
         HAServiceProtocol.RequestSource.REQUEST_BY_USER_FORCED);
     // transit the active RM to standby.
     getAdminService(activeRMIndex).transitionToStandby(requestInfo);
     verifyRMTransitionToStandby(cluster.getResourceManager(activeRMIndex));
     // the standby RM transition to active.
-    verifyRMTransitionToActive(cluster.getResourceManager(standbyRMIndex));
+    int newActiveRMIndex = (activeRMIndex + 1) % 2;
+    assertEquals(newActiveRMIndex, cluster.getActiveRMIndex(),"Failover failed");
     verifyConnections();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -482,7 +482,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     verifyRMTransitionToStandby(cluster.getResourceManager(activeRMIndex));
     // the standby RM transition to active.
     int newActiveRMIndex = (activeRMIndex + 1) % 2;
-    assertEquals(newActiveRMIndex, cluster.getActiveRMIndex(),"Failover failed");
+    assertEquals(newActiveRMIndex, cluster.getActiveRMIndex(), "Failover failed");
     verifyConnections();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.yarn.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -179,6 +180,22 @@ public class TestRMFailover extends ClientBaseWithFixes {
       fail("RM didn't transition to Standby.");
     }
   }
+
+  private void verifyRMTransitionToActive(ResourceManager rm)
+      throws InterruptedException {
+    try {
+      GenericTestUtils.waitFor(new Supplier<Boolean>() {
+        @Override
+        public Boolean get() {
+          return rm.getRMContext().getHAServiceState() ==
+              HAServiceState.ACTIVE;
+        }
+      }, 100, 20000);
+    } catch (TimeoutException e) {
+      fail("RM didn't transition to Active.");
+    }
+  }
+
 
   @Test
   public void testAutomaticFailover()
@@ -458,5 +475,30 @@ public class TestRMFailover extends ClientBaseWithFixes {
     testThread.join();
 
     verify(spyRTEHandler).uncaughtException(testThread, rte);
+  }
+
+  @Test
+  public void testTransitionedToStandby()
+      throws YarnException, InterruptedException, IOException {
+    conf.set(YarnConfiguration.RM_CLUSTER_ID, "yarn-test-cluster");
+    conf.set(YarnConfiguration.RM_ZK_ADDRESS, hostPort);
+    conf.setInt(YarnConfiguration.RM_ZK_TIMEOUT_MS, 2000);
+
+    cluster.init(conf);
+    cluster.start();
+
+    int activeRMIndex = cluster.getActiveRMIndex();
+    assertNotEquals(-1, activeRMIndex, "RM never turned active");
+    verifyConnections();
+
+    int standbyRMIndex = (activeRMIndex + 1) % 2;
+    HAServiceProtocol.StateChangeRequestInfo requestInfo = new HAServiceProtocol.StateChangeRequestInfo(
+        HAServiceProtocol.RequestSource.REQUEST_BY_USER_FORCED);
+    // transit the active RM to standby.
+    getAdminService(activeRMIndex).transitionToStandby(requestInfo);
+    verifyRMTransitionToStandby(cluster.getResourceManager(activeRMIndex));
+    // the standby RM transition to active.
+    verifyRMTransitionToActive(cluster.getResourceManager(standbyRMIndex));
+    verifyConnections();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1586,6 +1586,8 @@ public class ResourceManager extends CompositeService
     if (state == HAServiceProtocol.HAServiceState.ACTIVE) {
       stopActiveServices();
       reinitialize(initialize);
+      EmbeddedElector elector = rmContext.getLeaderElectorService();
+      if (elector != null) elector.rejoinElection();
     }
     LOG.info("Transitioned to standby state");
   }


### PR DESCRIPTION
`yarn rmadmin -transitionToStandby rm1 --forcemanual `
When executing the above command to switch the ResourceManager from active to standby, it was found that the other standby node did not automatically switch to active. After investigation, it turned out that the original active node did not release the ActiveStandbyElectorLock.