### PR TITLE
HADOOP-19702. Update non-thirdparty Guava version to 33.4.8-jre

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -111,7 +111,7 @@
     <findbugs.version>3.0.5</findbugs.version>
     <dnsjava.version>3.6.1</dnsjava.version>
 
-    <guava.version>32.0.1-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 
     <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
### Description of PR

JIRA: HADOOP-19702. Update non-thirdparty Guava version to 33.4.8-jre

Update non-thirdparty Guava version to 33.4.8-jre

The motivation is the same as for updating the thirdparty one.

### How was this patch tested?

CI

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

