### PR TITLE
HADOOP-19594. (Followup) Gloablly configure surefire.failIfNoSpecifiedTests=false

### DIFF
--- a/hadoop-assemblies/pom.xml
+++ b/hadoop-assemblies/pom.xml
@@ -31,10 +31,6 @@
   <name>Apache Hadoop Assemblies</name>
   <description>Apache Hadoop Assemblies</description>
 
-  <properties>
-    <failIfNoTests>false</failIfNoTests>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/hadoop-build-tools/pom.xml
+++ b/hadoop-build-tools/pom.xml
@@ -25,9 +25,6 @@
   <description>Apache Hadoop Build Tools Project</description>
   <name>Apache Hadoop Build Tools</name>
 
-  <properties>
-    <failIfNoTests>false</failIfNoTests>
-  </properties>
   <build>
     <resources>
       <resource>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -33,7 +33,6 @@
     <!-- Set the Release year during release -->
     <release-year>2025</release-year>
 
-    <failIfNoTests>false</failIfNoTests>
     <!--Whether to proceed to next module if any test failures exist-->
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -193,13 +192,6 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
-    <!--
-     Surefire option to not fail a build if -Dtest=NAME doesn't find a
-     test called NAME. This is needed when running integration tests through
-     failsafe, as setting -Dtest=none is the way to stop surefire
-     running all unit tests before the it.test option is picked up.
-    -->
-    <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <!-- Flag to stop surefire from shortening test stacks  -->
     <trimStackTrace>false</trimStackTrace>
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <shell-executable>bash</shell-executable>
 
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
+
+    <!--
+     Surefire option to not fail a build if -Dtest=NAME doesn't find a
+     test called NAME. This is needed when running integration tests through
+     failsafe, as setting -Dtest=none is the way to stop surefire
+     running all unit tests before the it.test option is picked up.
+    -->
+    <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
   </properties>
 
   <modules>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

older versions of surefire plugin use `failIfNoTests` while newer versions use `surefire.failIfNoSpecifiedTests` to configure whether to fail when no test cases are matched.

there are a few modules use `hadoop-main` instead of `hadoop-project` as the parent, this PR moves the definition of `surefire.failIfNoSpecifiedTests` to the top-level `hadoop-main`'s `pom.xml` to fix the CI failure.

### How was this patch tested?

Run locally.

```
$ mvn verify -fae -am -pl hadoop-client-modules/hadoop-client-check-invariants -pl hadoop-client-modules/hadoop-client-check-test-invariants -pl hadoop-client-modules/hadoop-client-integration-tests -Dtest=NoUnitTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true
```

Fails on trunk
```
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.923 s
[INFO] Finished at: 2025-09-24T14:29:15+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.5:test (default-test) on project hadoop-build-tools: No tests matching pattern "NoUnitTests" were executed! (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) -> [Help 1]                                                                                                                                                                                                                                   
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :hadoop-build-tools
```

Fixed in this PR.
```
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:04 min
[INFO] Finished at: 2025-09-24T14:28:37+08:00
[INFO] ------------------------------------------------------------------------
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

