### PR TITLE
HDFS-17841. TestWebHDFSTimeouts fail with JDK17.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/GenericTestUtils.java
@@ -334,9 +334,8 @@ public abstract class GenericTestUtils {
     if (msg == null) {
       throw new AssertionError(E_NULL_THROWABLE_STRING, t);
     }
-    if (expectedText != null && !msg.contains(expectedText)) {
-      String prefix = org.apache.commons.lang3.StringUtils.isEmpty(message)
-          ? "" : (message + ": ");
+    if (expectedText != null && !msg.toLowerCase().contains(expectedText.toLowerCase())) {
+      final String prefix = message == null || message.isEmpty() ? "" : message + ": ";
       throw new AssertionError(
           String.format("%s Expected to find '%s' %s: %s",
               prefix, expectedText, E_UNEXPECTED_EXCEPTION,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -555,10 +555,10 @@ public class TestDFSUtil {
     assertTrue(HAUtil.isHAEnabled(conf, "ns2"));
     assertFalse(HAUtil.isHAEnabled(conf, "ns3"));
 
-    assertEquals(resolvedName(NS1_NN1_HOST), map.get("ns1").get("ns1-nn1").toString());
-    assertEquals(resolvedName(NS1_NN2_HOST), map.get("ns1").get("ns1-nn2").toString());
-    assertEquals(resolvedName(NS2_NN1_HOST), map.get("ns2").get("ns2-nn1").toString());
-    assertEquals(resolvedName(NS2_NN2_HOST), map.get("ns2").get("ns2-nn2").toString());
+    assertInetSocketAddress(NS1_NN1_HOST, map.get("ns1").get("ns1-nn1"));
+    assertInetSocketAddress(NS1_NN2_HOST, map.get("ns1").get("ns1-nn2"));
+    assertInetSocketAddress(NS2_NN1_HOST, map.get("ns2").get("ns2-nn1"));
+    assertInetSocketAddress(NS2_NN2_HOST, map.get("ns2").get("ns2-nn2"));
 
     assertEquals(NS1_NN1_HOST,
         DFSUtil.getNamenodeServiceAddr(conf, "ns1", "ns1-nn1"));
@@ -626,7 +626,7 @@ public class TestDFSUtil {
   }
 
   @Test
-  public void testGetHaNnHttpAddresses() throws IOException {
+  public void testGetHaNnHttpAddresses() {
     final String LOGICAL_HOST_NAME = "ns1";
 
     Configuration conf = createWebHDFSHAConfiguration(LOGICAL_HOST_NAME, NS1_NN1_ADDR, NS1_NN2_ADDR);
@@ -634,8 +634,17 @@ public class TestDFSUtil {
     Map<String, Map<String, InetSocketAddress>> map =
         DFSUtilClient.getHaNnWebHdfsAddresses(conf, "webhdfs");
 
-    assertEquals(resolvedName(NS1_NN1_ADDR), map.get("ns1").get("nn1").toString());
-    assertEquals(resolvedName(NS1_NN2_ADDR), map.get("ns1").get("nn2").toString());
+    assertInetSocketAddress(NS1_NN1_ADDR, map.get("ns1").get("nn1"));
+    assertInetSocketAddress(NS1_NN2_ADDR, map.get("ns1").get("nn2"));
+  }
+
+  static void assertInetSocketAddress(String expected, InetSocketAddress computed) {
+    final int i = expected.indexOf(':');
+    final String host = expected.substring(0, i);
+    final int port = Integer.parseInt(expected.substring(i + 1));
+    assertEquals(host, computed.getHostName());
+    assertEquals(port, computed.getPort());
+    assertEquals(InetSocketAddress.createUnresolved(host, port), computed);
   }
 
   private static Configuration createWebHDFSHAConfiguration(String logicalHostName, String nnaddr1, String nnaddr2) {
@@ -956,7 +965,7 @@ public class TestDFSUtil {
     checkAllResults(new Long[]{1l}, true);
     checkAllResults(new Long[]{1l, 1l}, true);
     checkAllResults(new Long[]{1l, 1l, 1l}, true);
-    checkAllResults(new Long[]{new Long(1), new Long(1)}, true);
+    checkAllResults(new Long[]{1L, 1L}, true);
     checkAllResults(new Long[]{null, null, null}, true);
 
     checkAllResults(new Long[]{1l, 2l}, false);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUtil.java
@@ -555,10 +555,10 @@ public class TestDFSUtil {
     assertTrue(HAUtil.isHAEnabled(conf, "ns2"));
     assertFalse(HAUtil.isHAEnabled(conf, "ns3"));
 
-    assertInetSocketAddress(NS1_NN1_HOST, map.get("ns1").get("ns1-nn1"));
-    assertInetSocketAddress(NS1_NN2_HOST, map.get("ns1").get("ns1-nn2"));
-    assertInetSocketAddress(NS2_NN1_HOST, map.get("ns2").get("ns2-nn1"));
-    assertInetSocketAddress(NS2_NN2_HOST, map.get("ns2").get("ns2-nn2"));
+    assertEquals(resolvedName(NS1_NN1_HOST), map.get("ns1").get("ns1-nn1").toString());
+    assertEquals(resolvedName(NS1_NN2_HOST), map.get("ns1").get("ns1-nn2").toString());
+    assertEquals(resolvedName(NS2_NN1_HOST), map.get("ns2").get("ns2-nn1").toString());
+    assertEquals(resolvedName(NS2_NN2_HOST), map.get("ns2").get("ns2-nn2").toString());
 
     assertEquals(NS1_NN1_HOST,
         DFSUtil.getNamenodeServiceAddr(conf, "ns1", "ns1-nn1"));
@@ -626,7 +626,7 @@ public class TestDFSUtil {
   }
 
   @Test
-  public void testGetHaNnHttpAddresses() {
+  public void testGetHaNnHttpAddresses() throws IOException {
     final String LOGICAL_HOST_NAME = "ns1";
 
     Configuration conf = createWebHDFSHAConfiguration(LOGICAL_HOST_NAME, NS1_NN1_ADDR, NS1_NN2_ADDR);
@@ -634,17 +634,8 @@ public class TestDFSUtil {
     Map<String, Map<String, InetSocketAddress>> map =
         DFSUtilClient.getHaNnWebHdfsAddresses(conf, "webhdfs");
 
-    assertInetSocketAddress(NS1_NN1_ADDR, map.get("ns1").get("nn1"));
-    assertInetSocketAddress(NS1_NN2_ADDR, map.get("ns1").get("nn2"));
-  }
-
-  static void assertInetSocketAddress(String expected, InetSocketAddress computed) {
-    final int i = expected.indexOf(':');
-    final String host = expected.substring(0, i);
-    final int port = Integer.parseInt(expected.substring(i + 1));
-    assertEquals(host, computed.getHostName());
-    assertEquals(port, computed.getPort());
-    assertEquals(InetSocketAddress.createUnresolved(host, port), computed);
+    assertEquals(resolvedName(NS1_NN1_ADDR), map.get("ns1").get("nn1").toString());
+    assertEquals(resolvedName(NS1_NN2_ADDR), map.get("ns1").get("nn2").toString());
   }
 
   private static Configuration createWebHDFSHAConfiguration(String logicalHostName, String nnaddr1, String nnaddr2) {
@@ -965,7 +956,7 @@ public class TestDFSUtil {
     checkAllResults(new Long[]{1l}, true);
     checkAllResults(new Long[]{1l, 1l}, true);
     checkAllResults(new Long[]{1l, 1l, 1l}, true);
-    checkAllResults(new Long[]{1L, 1L}, true);
+    checkAllResults(new Long[]{new Long(1), new Long(1)}, true);
     checkAllResults(new Long[]{null, null, null}, true);
 
     checkAllResults(new Long[]{1l, 2l}, false);


### PR DESCRIPTION
### Description of PR
See HDFS-17841

Note that this is a test-only change.

### How was this patch tested?
Tested manually with JDK17.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

