### PR TITLE
YARN-11871. Make client retry when no active sub-cluster available.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/RMProxy.java
@@ -343,7 +343,7 @@ public class RMProxy<T> {
 
       return RetryPolicies.failoverOnNetworkException(
           RetryPolicies.TRY_ONCE_THEN_FAIL, maxFailoverAttempts,
-          failoverSleepBaseMs, failoverSleepMaxMs);
+          maxFailoverAttempts, failoverSleepBaseMs, failoverSleepMaxMs);
     }
 
     if (rmConnectionRetryIntervalMS < 0) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
@@ -18,8 +18,10 @@
 
 package org.apache.hadoop.yarn.server.federation.policies;
 
+import java.io.IOException;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
@@ -137,16 +139,16 @@ public abstract class AbstractConfigurableFederationPolicy
    *
    * @return the map of ids to info for all active subclusters.
    *
-   * @throws YarnException if we can't get the list.
+   * @throws IOException if we can't get the list.
    */
   protected Map<SubClusterId, SubClusterInfo> getActiveSubclusters()
-      throws YarnException {
+      throws YarnException, IOException {
 
     Map<SubClusterId, SubClusterInfo> activeSubclusters =
         getPolicyContext().getFederationStateStoreFacade().getSubClusters(true);
 
     if (activeSubclusters == null || activeSubclusters.size() < 1) {
-      throw new NoActiveSubclustersException(
+      throw new RetriableException(
           "Zero active subclusters, cannot pick where to send job.");
     }
     return activeSubclusters;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/AbstractConfigurableFederationPolicy.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.NoActiveSubclustersException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 
@@ -139,7 +138,8 @@ public abstract class AbstractConfigurableFederationPolicy
    *
    * @return the map of ids to info for all active subclusters.
    *
-   * @throws IOException if we can't get the list.
+   * @throws YarnException if we can't get the list.
+   * @throws IOException if no active subclusters.
    */
   protected Map<SubClusterId, SubClusterInfo> getActiveSubclusters()
       throws YarnException, IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.policies.manager.FederationPolicyManager;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/FederationPolicyUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.Random;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
@@ -185,12 +187,12 @@ public final class FederationPolicyUtils {
    * @param blackListSubClusters the list of subClusters as identified by
    *          {@link SubClusterId} to blackList from the selection of the home
    *          subCluster.
-   * @throws FederationPolicyException if there are no usable subclusters.
+   * @throws IOException if there are no usable subclusters.
    */
   public static void validateSubClusterAvailability(
       Collection<SubClusterId> activeSubClusters,
       Collection<SubClusterId> blackListSubClusters)
-      throws FederationPolicyException {
+      throws IOException {
     if (activeSubClusters != null && !activeSubClusters.isEmpty()) {
       if (blackListSubClusters == null) {
         return;
@@ -202,7 +204,7 @@ public final class FederationPolicyUtils {
         }
       }
     }
-    throw new FederationPolicyException(
+    throw new RetriableException(
         FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -127,7 +128,7 @@ public class RouterPolicyFacade {
    */
   public SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
-      List<SubClusterId> blackListSubClusters) throws YarnException {
+      List<SubClusterId> blackListSubClusters) throws YarnException, IOException {
 
     // the maps are concurrent, but we need to protect from reset()
     // reinitialization mid-execution by creating a new reference local to this
@@ -233,7 +234,7 @@ public class RouterPolicyFacade {
    *           valid sub-cluster id could be found for this reservation.
    */
   public SubClusterId getReservationHomeSubCluster(
-      ReservationSubmissionRequest request) throws YarnException {
+      ReservationSubmissionRequest request) throws YarnException, IOException {
 
     // the maps are concurrent, but we need to protect from reset()
     // reinitialization mid-execution by creating a new reference local to this

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/RouterPolicyFacade.java
@@ -125,6 +125,7 @@ public class RouterPolicyFacade {
    *
    * @throws YarnException if there are issues initializing policies, or no
    *           valid sub-cluster id could be found for this app.
+   * @throws IOException if no active subclusters.
    */
   public SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
@@ -232,6 +233,7 @@ public class RouterPolicyFacade {
    *
    * @throws YarnException if there are issues initializing policies, or no
    *           valid sub-cluster id could be found for this reservation.
+   * @throws IOException if no active subclusters.
    */
   public SubClusterId getReservationHomeSubCluster(
       ReservationSubmissionRequest request) throws YarnException, IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/BroadcastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/BroadcastAMRMProxyPolicy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.amrmproxy;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class BroadcastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
   @Override
   public Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> resourceRequests,
-      Set<SubClusterId> timedOutSubClusters) throws YarnException {
+      Set<SubClusterId> timedOutSubClusters) throws YarnException, IOException {
 
     Map<SubClusterId, SubClusterInfo> activeSubclusters =
         getActiveSubclusters();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/FederationAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/FederationAMRMProxyPolicy.java
@@ -47,6 +47,7 @@ public interface FederationAMRMProxyPolicy
    *         list of {@link ResourceRequest}s that should be forwarded to it
    * @throws YarnException in case the request is malformed or no viable
    *           sub-clusters can be found.
+   * @throws IOException if no active subclusters.
    */
   Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> resourceRequests,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/FederationAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/FederationAMRMProxyPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.amrmproxy;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +50,7 @@ public interface FederationAMRMProxyPolicy
    */
   Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> resourceRequests,
-      Set<SubClusterId> timedOutSubClusters) throws YarnException;
+      Set<SubClusterId> timedOutSubClusters) throws YarnException, IOException;
 
   /**
    * This method should be invoked to notify the policy about responses being

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/HomeAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/HomeAMRMProxyPolicy.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.amrmproxy;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
@@ -57,14 +59,14 @@ public class HomeAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
   @Override
   public Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> resourceRequests,
-      Set<SubClusterId> timedOutSubClusters) throws YarnException {
+      Set<SubClusterId> timedOutSubClusters) throws YarnException, IOException {
     if (homeSubcluster == null) {
       throw new FederationPolicyException("No home subcluster available");
     }
 
     Map<SubClusterId, SubClusterInfo> active = getActiveSubclusters();
     if (!active.containsKey(homeSubcluster)) {
-      throw new FederationPolicyException(
+      throw new RetriableException(
           "The local subcluster " + homeSubcluster + " is not active");
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/LocalityMulticastAMRMProxyPolicy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.amrmproxy;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.records.EnhancedHeadroom;
@@ -46,7 +48,6 @@ import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.NoActiveSubclustersException;
 import org.apache.hadoop.yarn.server.federation.resolver.SubClusterResolver;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
@@ -267,7 +268,7 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
   @Override
   public Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> resourceRequests,
-      Set<SubClusterId> timedOutSubClusters) throws YarnException {
+      Set<SubClusterId> timedOutSubClusters) throws YarnException, IOException {
 
     // object used to accumulate statistics about the answer, initialize with
     // active subclusters. Create a new instance per call because this method
@@ -712,7 +713,8 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
 
     private void reinitialize(
         Map<SubClusterId, SubClusterInfo> activeSubclusters,
-        Set<SubClusterId> timedOutSubClusters, Configuration pConf) throws YarnException {
+        Set<SubClusterId> timedOutSubClusters, Configuration pConf)
+        throws YarnException, IOException {
 
       if (MapUtils.isEmpty(activeSubclusters)) {
         throw new YarnRuntimeException("null activeSubclusters received");
@@ -752,7 +754,7 @@ public class LocalityMulticastAMRMProxyPolicy extends AbstractAMRMProxyPolicy {
         String errorMsg = "None of the subClusters enabled in this Policy (weight > 0) are "
             + "currently active we cannot forward the ResourceRequest(s)";
         if (failOnError) {
-          throw new NoActiveSubclustersException(errorMsg);
+          throw new RetriableException(errorMsg);
         } else {
           LOG.error(errorMsg + ", continuing by enabling all active subClusters.");
           activeAndEnabledSC.addAll(activeSubclusters.keySet());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
@@ -83,6 +83,7 @@ public abstract class AbstractRouterPolicy extends
    * @return the chosen sub-cluster
    *
    * @throws YarnException if the policy fails to choose a sub-cluster
+   * @throws IOException if no active subclusters.
    */
   protected abstract SubClusterId chooseSubCluster(String queue,
       Map<SubClusterId, SubClusterInfo> preSelectSubClusters)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/AbstractRouterPolicy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Collections;
@@ -84,7 +85,8 @@ public abstract class AbstractRouterPolicy extends
    * @throws YarnException if the policy fails to choose a sub-cluster
    */
   protected abstract SubClusterId chooseSubCluster(String queue,
-      Map<SubClusterId, SubClusterInfo> preSelectSubClusters) throws YarnException;
+      Map<SubClusterId, SubClusterInfo> preSelectSubClusters)
+          throws YarnException, IOException;
 
   /**
    * Filter chosen SubCluster based on reservationId.
@@ -130,11 +132,11 @@ public abstract class AbstractRouterPolicy extends
    * @return a hash-based chosen {@link SubClusterId} that will be the "home"
    *         for this application.
    *
-   * @throws YarnException if there are no active subclusters.
+   * @throws IOException if there are no active subclusters.
    */
   @Override
   public SubClusterId getHomeSubcluster(ApplicationSubmissionContext appContext,
-      List<SubClusterId> blackLists) throws YarnException {
+      List<SubClusterId> blackLists) throws YarnException, IOException {
 
     // null checks and default-queue behavior
     validate(appContext);
@@ -169,7 +171,7 @@ public abstract class AbstractRouterPolicy extends
    */
   @Override
   public SubClusterId getReservationHomeSubcluster(ReservationSubmissionRequest request)
-      throws YarnException {
+      throws YarnException, IOException {
     if (request == null) {
       throw new FederationPolicyException("The ReservationSubmissionRequest cannot be null.");
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/FederationRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/FederationRouterPolicy.java
@@ -47,6 +47,7 @@ public interface FederationRouterPolicy extends ConfigurableFederationPolicy {
    *         application.
    *
    * @throws YarnException if the policy cannot determine a viable subcluster.
+   * @throws IOException if no active subclusters.
    */
   SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
@@ -60,6 +61,7 @@ public interface FederationRouterPolicy extends ConfigurableFederationPolicy {
    * @return a mapping of sub-clusters and the requests
    *
    * @throws YarnException if the policy fails to choose a sub-cluster
+   * @throws IOException if no active subclusters.
    */
   SubClusterId getReservationHomeSubcluster(
       ReservationSubmissionRequest request) throws YarnException, IOException;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/FederationRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/FederationRouterPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.yarn.api.protocolrecords.ReservationSubmissionRequest;
@@ -49,7 +50,7 @@ public interface FederationRouterPolicy extends ConfigurableFederationPolicy {
    */
   SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
-      List<SubClusterId> blackListSubClusters) throws YarnException;
+      List<SubClusterId> blackListSubClusters) throws YarnException, IOException;
 
   /**
    * Determines the sub-cluster where a ReservationSubmissionRequest should be
@@ -61,5 +62,5 @@ public interface FederationRouterPolicy extends ConfigurableFederationPolicy {
    * @throws YarnException if the policy fails to choose a sub-cluster
    */
   SubClusterId getReservationHomeSubcluster(
-      ReservationSubmissionRequest request) throws YarnException;
+      ReservationSubmissionRequest request) throws YarnException, IOException;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LoadBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LoadBasedRouterPolicy.java
@@ -17,8 +17,10 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
@@ -62,7 +64,8 @@ public class LoadBasedRouterPolicy extends AbstractRouterPolicy {
 
   @Override
   protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters)
+          throws YarnException, IOException {
     Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights();
     SubClusterIdInfo chosen = null;
     long currBestMem = -1;
@@ -77,7 +80,7 @@ public class LoadBasedRouterPolicy extends AbstractRouterPolicy {
       }
     }
     if (chosen == null) {
-      throw new FederationPolicyException(
+      throw new RetriableException(
           "Zero Active Subcluster with weight 1.");
     }
     return chosen.toId();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LoadBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LoadBasedRouterPolicy.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LocalityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/LocalityRouterPolicy.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +91,7 @@ public class LocalityRouterPolicy extends WeightedRandomRouterPolicy {
   @Override
   public SubClusterId getHomeSubcluster(
       ApplicationSubmissionContext appSubmissionContext,
-      List<SubClusterId> blackListSubClusters) throws YarnException {
+      List<SubClusterId> blackListSubClusters) throws YarnException, IOException {
 
     // null checks and default-queue behavior
     validate(appSubmissionContext);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/PriorityRouterPolicy.java
@@ -17,8 +17,10 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
@@ -34,7 +36,8 @@ public class PriorityRouterPolicy extends AbstractRouterPolicy {
 
   @Override
   protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters)
+          throws YarnException, IOException {
     // This finds the sub-cluster with the highest weight among the
     // currently active ones.
     Map<SubClusterIdInfo, Float> weights = getPolicyInfo().getRouterPolicyWeights();
@@ -48,7 +51,7 @@ public class PriorityRouterPolicy extends AbstractRouterPolicy {
       }
     }
     if (chosen == null) {
-      throw new FederationPolicyException(
+      throw new RetriableException(
           "No Active Subcluster with weight vector greater than zero.");
     }
     return chosen;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContextValidator;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/UniformRandomRouterPolicy.java
@@ -17,11 +17,13 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContext;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyInitializationContextValidator;
@@ -59,9 +61,10 @@ public class UniformRandomRouterPolicy extends AbstractRouterPolicy {
 
   @Override
   protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters)
+          throws YarnException, IOException {
     if (preSelectSubclusters == null || preSelectSubclusters.isEmpty()) {
-      throw new FederationPolicyException("No available subcluster to choose from.");
+      throw new RetriableException("No available subcluster to choose from.");
     }
     List<SubClusterId> list = new ArrayList<>(preSelectSubclusters.keySet());
     return list.get(rand.nextInt(list.size()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/policies/router/WeightedRandomRouterPolicy.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
@@ -35,7 +37,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;
 public class WeightedRandomRouterPolicy extends AbstractRouterPolicy {
   @Override
   protected SubClusterId chooseSubCluster(
-      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters) throws YarnException {
+      String queue, Map<SubClusterId, SubClusterInfo> preSelectSubclusters)
+          throws YarnException, IOException {
 
     // note: we cannot pre-compute the weights, as the set of activeSubCluster
     // changes dynamically (and this would unfairly spread the load to
@@ -55,7 +58,7 @@ public class WeightedRandomRouterPolicy extends AbstractRouterPolicy {
 
     int pickedIndex = FederationPolicyUtils.getWeightedRandom(weightList);
     if (pickedIndex == -1) {
-      throw new FederationPolicyException("No positive weight found on active subclusters");
+      throw new RetriableException("No positive weight found on active subclusters");
     }
     return scIdList.get(pickedIndex);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.io.retry.RetryProxy;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.security.token.delegation.DelegationKey;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Time;
@@ -800,16 +801,16 @@ public final class FederationStateStoreFacade {
    * @param activeSubClusters List of active subClusters.
    * @param blackList blacklist.
    * @return Active SubClusterId.
-   * @throws YarnException When there is no Active SubCluster,
+   * @throws IOException When there is no Active SubCluster,
    * an exception will be thrown (No active SubCluster available to submit the request.)
    */
   public static SubClusterId getRandomActiveSubCluster(
       Map<SubClusterId, SubClusterInfo> activeSubClusters, List<SubClusterId> blackList)
-      throws YarnException {
+      throws YarnException, IOException {
 
     // Check if activeSubClusters is empty, if it is empty, we need to throw an exception
     if (MapUtils.isEmpty(activeSubClusters)) {
-      throw new FederationPolicyException(
+      throw new RetriableException(
           FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE);
     }
 
@@ -823,7 +824,7 @@ public final class FederationStateStoreFacade {
 
     // Check there are still active subcluster after removing the blacklist
     if (CollectionUtils.isEmpty(subClusterIds)) {
-      throw new FederationPolicyException(
+      throw new RetriableException(
           FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE);
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/federation/utils/FederationStateStoreFacade.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.federation.cache.FederationCache;
 import org.apache.hadoop.yarn.server.federation.policies.FederationPolicyUtils;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.resolver.SubClusterResolver;
 import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.exception.FederationStateStoreRetriableException;
@@ -806,7 +805,7 @@ public final class FederationStateStoreFacade {
    */
   public static SubClusterId getRandomActiveSubCluster(
       Map<SubClusterId, SubClusterInfo> activeSubClusters, List<SubClusterId> blackList)
-      throws YarnException, IOException {
+      throws IOException {
 
     // Check if activeSubClusters is empty, if it is empty, we need to throw an exception
     if (MapUtils.isEmpty(activeSubClusters)) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -141,11 +141,7 @@ public abstract class BaseFederationPoliciesTest {
             .getHomeSubcluster(getApplicationSubmissionContext(), null);
         fail();
       } catch (Exception e) {
-        if (localPolicy instanceof RejectRouterPolicy) {
-          assertTrue(e instanceof FederationPolicyException);
-        } else {
-          assertTrue(e instanceof RetriableException);
-        }
+        assertTrue(e instanceof RetriableException);
       }
     } else {
       try {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.policies.router.FederationRouterPolicy;
-import org.apache.hadoop.yarn.server.federation.policies.router.RejectRouterPolicy;
 import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/BaseFederationPoliciesTest.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.federation.policies;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
@@ -30,16 +32,19 @@ import java.util.Map;
 import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.yarn.api.protocolrecords.ReservationSubmissionRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.FederationAMRMProxyPolicy;
+import org.apache.hadoop.yarn.server.federation.policies.amrmproxy.RejectAMRMProxyPolicy;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyInitializationException;
 import org.apache.hadoop.yarn.server.federation.policies.router.FederationRouterPolicy;
+import org.apache.hadoop.yarn.server.federation.policies.router.RejectRouterPolicy;
 import org.apache.hadoop.yarn.server.federation.store.FederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.impl.MemoryFederationStateStore;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
@@ -125,23 +130,39 @@ public abstract class BaseFederationPoliciesTest {
 
   @Test
   public void testNoSubclusters() throws YarnException {
-    assertThrows(FederationPolicyException.class, () -> {
-      // empty the activeSubclusters map
-      FederationPoliciesTestUtil.initializePolicyContext(getPolicy(),
-          getPolicyInfo(), new HashMap<>());
+    // empty the activeSubclusters map
+    FederationPoliciesTestUtil.initializePolicyContext(getPolicy(),
+        getPolicyInfo(), new HashMap<>());
 
-      ConfigurableFederationPolicy localPolicy = getPolicy();
-      if (localPolicy instanceof FederationRouterPolicy) {
+    ConfigurableFederationPolicy localPolicy = getPolicy();
+    if (localPolicy instanceof FederationRouterPolicy) {
+      try {
         ((FederationRouterPolicy) localPolicy)
-        .getHomeSubcluster(getApplicationSubmissionContext(), null);
-      } else {
+            .getHomeSubcluster(getApplicationSubmissionContext(), null);
+        fail();
+      } catch (Exception e) {
+        if (localPolicy instanceof RejectRouterPolicy) {
+          assertTrue(e instanceof FederationPolicyException);
+        } else {
+          assertTrue(e instanceof RetriableException);
+        }
+      }
+    } else {
+      try {
         String[] hosts = new String[] {"host1", "host2"};
         List<ResourceRequest> resourceRequests = FederationPoliciesTestUtil
             .createResourceRequests(hosts, 2 * 1024, 2, 1, 3, null, false);
         ((FederationAMRMProxyPolicy) localPolicy).splitResourceRequests(
             resourceRequests, new HashSet<SubClusterId>());
+        fail();
+      } catch (Exception e) {
+        if (localPolicy instanceof RejectAMRMProxyPolicy) {
+          assertTrue(e instanceof FederationPolicyException);
+        } else {
+          assertTrue(e instanceof RetriableException);
+        }
       }
-    });
+    }
   }
 
   public ConfigurableFederationPolicy getPolicy() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/TestRouterPolicyFacade.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.federation.policies;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,7 @@ public class TestRouterPolicyFacade {
   }
 
   @Test
-  public void testConfigurationUpdate() throws YarnException {
+  public void testConfigurationUpdate() throws YarnException, IOException {
 
     // in this test we see what happens when the configuration is changed
     // between calls. We achieve this by changing what is in the store.
@@ -115,7 +116,7 @@ public class TestRouterPolicyFacade {
   }
 
   @Test
-  public void testGetHomeSubcluster() throws YarnException {
+  public void testGetHomeSubcluster() throws YarnException, IOException {
 
     ApplicationSubmissionContext applicationSubmissionContext =
         mock(ApplicationSubmissionContext.class);
@@ -146,7 +147,7 @@ public class TestRouterPolicyFacade {
   }
 
   @Test
-  public void testFallbacks() throws YarnException {
+  public void testFallbacks() throws YarnException, IOException {
 
     // this tests the behavior of the system when the queue requested is
     // not configured (or null) and there is no default policy configured

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -72,7 +74,7 @@ public class TestHomeAMRMProxyPolicy extends BaseFederationPoliciesTest {
   }
 
   @Test
-  public void testSplitAllocateRequest() throws YarnException {
+  public void testSplitAllocateRequest() throws YarnException, IOException {
 
     // Verify the request only goes to the home subcluster
     String[] hosts = new String[] {"host0", "host1", "host2", "host3"};
@@ -89,7 +91,7 @@ public class TestHomeAMRMProxyPolicy extends BaseFederationPoliciesTest {
   }
 
   @Test
-  public void testHomeSubclusterNotActive() throws YarnException {
+  public void testHomeSubclusterNotActive() throws YarnException, IOException {
 
     // We setup the home subcluster to a non-existing one
     initializePolicyContext(getPolicy(), mock(WeightedPolicyInfo.class),
@@ -104,7 +106,7 @@ public class TestHomeAMRMProxyPolicy extends BaseFederationPoliciesTest {
       federationPolicy.splitResourceRequests(resourceRequests,
           new HashSet<SubClusterId>());
       fail("It should fail when the home subcluster is not active");
-    } catch(FederationPolicyException e) {
+    } catch(RetriableException e) {
       GenericTestUtils.assertExceptionContains("is not active", e);
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestHomeAMRMProxyPolicy.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.BaseFederationPoliciesTest;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/amrmproxy/TestLocalityMulticastAMRMProxyPolicy.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -683,7 +684,7 @@ public class TestLocalityMulticastAMRMProxyPolicy
   }
 
   @Test
-  public void testCancelWithLocalizedResource() throws YarnException {
+  public void testCancelWithLocalizedResource() throws YarnException, IOException {
     // Configure policy to be 100% headroom based
     getPolicyInfo().setHeadroomAlpha(1.0f);
 
@@ -814,7 +815,7 @@ public class TestLocalityMulticastAMRMProxyPolicy
       Map<SubClusterId, SubClusterInfo> activeClusters = null;
       try {
         activeClusters = getActiveSubclusters();
-      } catch (YarnException e) {
+      } catch (Exception e) {
         throw new RuntimeException(e);
       }
       // The randomly selected sub-cluster should at least be active

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/BaseRouterPoliciesTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/BaseRouterPoliciesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +60,7 @@ public abstract class BaseRouterPoliciesTest
     extends BaseFederationPoliciesTest {
 
   @Test
-  public void testNullQueueRouting() throws YarnException {
+  public void testNullQueueRouting() throws YarnException, IOException {
     FederationRouterPolicy localPolicy = (FederationRouterPolicy) getPolicy();
     ApplicationSubmissionContext applicationSubmissionContext =
         ApplicationSubmissionContext.newInstance(null, null, null, null, null,
@@ -77,7 +78,7 @@ public abstract class BaseRouterPoliciesTest
   }
 
   @Test
-  public void testBlacklistSubcluster() throws YarnException {
+  public void testBlacklistSubcluster() throws YarnException, IOException {
     FederationRouterPolicy localPolicy = (FederationRouterPolicy) getPolicy();
     ApplicationSubmissionContext applicationSubmissionContext =
         ApplicationSubmissionContext.newInstance(null, null, null, null, null,
@@ -127,7 +128,7 @@ public abstract class BaseRouterPoliciesTest
         localPolicy.getHomeSubcluster(applicationSubmissionContext,
             blacklistSubclusters);
         fail();
-      } catch (YarnException e) {
+      } catch (Exception e) {
         assertTrue(e.getMessage()
             .equals(FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE));
       }
@@ -167,7 +168,7 @@ public abstract class BaseRouterPoliciesTest
   }
 
   @Test
-  public void testFollowReservation() throws YarnException {
+  public void testFollowReservation() throws YarnException, IOException {
 
     long now = Time.now();
     ReservationSubmissionRequest resReq = getReservationSubmissionRequest();
@@ -201,7 +202,7 @@ public abstract class BaseRouterPoliciesTest
   }
 
   @Test
-  public void testUpdateReservation() throws YarnException {
+  public void testUpdateReservation() throws YarnException, IOException {
     long now = Time.now();
     ReservationSubmissionRequest resReq = getReservationSubmissionRequest();
     when(resReq.getQueue()).thenReturn("queue1");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestHashBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestHashBasedRouterPolicy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.federation.policies.router;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -54,7 +55,7 @@ public class TestHashBasedRouterPolicy extends BaseRouterPoliciesTest {
   }
 
   @Test
-  public void testHashSpreadUniformlyAmongSubclusters() throws YarnException {
+  public void testHashSpreadUniformlyAmongSubclusters() throws YarnException, IOException {
     SubClusterId chosen;
 
     Map<SubClusterId, AtomicLong> counter = new HashMap<>();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLoadBasedRouterPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -109,7 +110,7 @@ public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
   }
 
   @Test
-  public void testLoadIsRespected() throws YarnException {
+  public void testLoadIsRespected() throws YarnException, IOException {
 
     SubClusterId chosen = ((FederationRouterPolicy) getPolicy())
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
@@ -141,13 +142,13 @@ public class TestLoadBasedRouterPolicy extends BaseRouterPoliciesTest {
     FederationPoliciesTestUtil.initializePolicyContext(policy,
         getPolicyInfo(), getActiveSubclusters());
 
-    LambdaTestUtils.intercept(YarnException.class, "Zero Active Subcluster with weight 1.",
+    LambdaTestUtils.intercept(IOException.class, "Zero Active Subcluster with weight 1.",
         () ->  ((FederationRouterPolicy) policy).
         getHomeSubcluster(getApplicationSubmissionContext(), null));
   }
 
   @Test
-  public void testUpdateReservation() throws YarnException {
+  public void testUpdateReservation() throws YarnException, IOException {
     long now = Time.now();
     ReservationSubmissionRequest resReq = getReservationSubmissionRequest();
     when(resReq.getQueue()).thenReturn("queue1");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestLocalityRouterPolicy.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.yarn.server.federation.policies.router;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -99,7 +100,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * the node belongs to an active subcluster.
    */
   @Test
-  public void testNodeInActiveSubCluster() throws YarnException {
+  public void testNodeInActiveSubCluster() throws YarnException, IOException {
     List<ResourceRequest> requests = new ArrayList<ResourceRequest>();
     requests.add(ResourceRequest
         .newInstance(Priority.UNDEFINED, "node1", Resource.newInstance(10, 1),
@@ -135,7 +136,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * TestWeightedRandomRouterPolicy.
    */
   @Test
-  public void testMultipleResourceRequests() throws YarnException {
+  public void testMultipleResourceRequests() throws YarnException, IOException {
     List<ResourceRequest> requests = new ArrayList<ResourceRequest>();
     requests.add(ResourceRequest
         .newInstance(Priority.UNDEFINED, "node1", Resource.newInstance(10, 1),
@@ -161,7 +162,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * the node does not exist in the Resolver MachineList file.
    */
   @Test
-  public void testNodeNotExists() throws YarnException {
+  public void testNodeNotExists() throws YarnException, IOException {
     List<ResourceRequest> requests = new ArrayList<ResourceRequest>();
     boolean relaxLocality = true;
     requests.add(ResourceRequest
@@ -190,7 +191,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * the node is in a blacklist subclusters.
    */
   @Test
-  public void testNodeInABlacklistSubCluster() throws YarnException {
+  public void testNodeInABlacklistSubCluster() throws YarnException, IOException {
     // Blacklist SubCluster3
     String subClusterToBlacklist = "subcluster3";
     // Remember the current value of subcluster3
@@ -239,7 +240,7 @@ public class TestLocalityRouterPolicy extends TestWeightedRandomRouterPolicy {
    * the node is not in the policy weights.
    */
   @Test
-  public void testNodeNotInPolicy() throws YarnException {
+  public void testNodeNotInPolicy() throws YarnException, IOException {
     // Blacklist SubCluster3
     String subClusterToBlacklist = "subcluster3";
     // Remember the current value of subcluster3

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
-import org.apache.hadoop.yarn.server.federation.policies.exceptions.FederationPolicyException;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterId;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterIdInfo;
 import org.apache.hadoop.yarn.server.federation.store.records.SubClusterInfo;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestPriorityRouterPolicy.java
@@ -18,9 +18,11 @@ package org.apache.hadoop.yarn.server.federation.policies.router;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.federation.policies.dao.WeightedPolicyInfo;
@@ -78,7 +80,7 @@ public class TestPriorityRouterPolicy extends BaseRouterPoliciesTest {
   }
 
   @Test
-  public void testPickLowestWeight() throws YarnException {
+  public void testPickLowestWeight() throws YarnException, IOException {
     SubClusterId chosen = ((FederationRouterPolicy) getPolicy())
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
     assertEquals("sc5", chosen.getId());
@@ -104,7 +106,7 @@ public class TestPriorityRouterPolicy extends BaseRouterPoliciesTest {
     FederationPoliciesTestUtil.initializePolicyContext(getPolicy(),
         getPolicyInfo(), getActiveSubclusters());
 
-    intercept(FederationPolicyException.class,
+    intercept(RetriableException.class,
         "No Active Subcluster with weight vector greater than zero.",
         () -> ((FederationRouterPolicy) getPolicy())
             .getHomeSubcluster(getApplicationSubmissionContext(), null));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestUniformRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestUniformRandomRouterPolicy.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -55,7 +57,7 @@ public class TestUniformRandomRouterPolicy extends BaseRouterPoliciesTest {
   }
 
   @Test
-  public void testOneSubclusterIsChosen() throws YarnException {
+  public void testOneSubclusterIsChosen() throws YarnException, IOException {
     SubClusterId chosen = ((FederationRouterPolicy) getPolicy())
         .getHomeSubcluster(getApplicationSubmissionContext(), null);
     assertTrue(getActiveSubclusters().keySet().contains(chosen));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/federation/policies/router/TestWeightedRandomRouterPolicy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.federation.policies.router;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -90,7 +91,7 @@ public class TestWeightedRandomRouterPolicy extends BaseRouterPoliciesTest {
   }
 
   @Test
-  public void testClusterChosenWithRightProbability() throws YarnException {
+  public void testClusterChosenWithRightProbability() throws YarnException, IOException {
 
     ApplicationSubmissionContext context =
         mock(ApplicationSubmissionContext.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -1789,6 +1789,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
    * @param askList the ask list to split
    * @return the split asks
    * @throws YarnException if split fails
+   * @throws IOException if no active subclusters.
    */
   protected Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
       List<ResourceRequest> askList) throws YarnException, IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/amrmproxy/FederationInterceptor.java
@@ -762,12 +762,12 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
       }
     }
 
-    try {
-      // Split the heart beat request into multiple requests, one for each
-      // sub-cluster RM that is used by this application.
-      Map<SubClusterId, AllocateRequest> requests =
-          splitAllocateRequest(request);
+    // Split the heart beat request into multiple requests, one for each
+    // sub-cluster RM that is used by this application.
+    Map<SubClusterId, AllocateRequest> requests =
+        splitAllocateRequest(request);
 
+    try {
       /**
        * Send the requests to the all sub-cluster resource managers. All
        * requests are synchronously triggered but sent asynchronously. Later the
@@ -1143,7 +1143,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
    * sub-cluster RM.
    */
   private Map<SubClusterId, AllocateRequest> splitAllocateRequest(
-      AllocateRequest request) throws YarnException {
+      AllocateRequest request) throws YarnException, IOException {
     Map<SubClusterId, AllocateRequest> requestMap = new HashMap<>();
 
     // Create heart beat request for home sub-cluster resource manager
@@ -1791,7 +1791,7 @@ public class FederationInterceptor extends AbstractRequestInterceptor {
    * @throws YarnException if split fails
    */
   protected Map<SubClusterId, List<ResourceRequest>> splitResourceRequests(
-      List<ResourceRequest> askList) throws YarnException {
+      List<ResourceRequest> askList) throws YarnException, IOException {
     return policyInterpreter.splitResourceRequests(askList,
         getTimedOutSCs(true));
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/recovery/NMLeveldbStateStoreService.java
@@ -1797,6 +1797,7 @@ public class NMLeveldbStateStoreService extends NMStateStoreService {
    * 4) Within a major upgrade, say 1.2 to 2.0:
    *    throw exception and indicate user to use a separate upgrade tool to
    *    upgrade NM state or remove incompatible old state.
+   * @throws IOException if NM state version is incompatible.
    */
   protected void checkVersion() throws IOException {
     Version loadedVersion = loadVersion();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -530,6 +530,12 @@ public class FederationClientInterceptor
         return response;
       }
 
+    } catch (IOException e) {
+      routerMetrics.incrAppsFailedSubmitted();
+      RouterAuditLogger.logFailure(user.getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
+          TARGET_CLIENT_RM_SERVICE, e.getMessage(), applicationId);
+      LOG.error(e.getMessage());
+      throw e;
     } catch (Exception e) {
       routerMetrics.incrAppsFailedSubmitted();
       RouterAuditLogger.logFailure(user.getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -365,6 +365,12 @@ public class FederationClientInterceptor
         routerMetrics.succeededAppsCreated(stopTime - startTime);
         return response;
       }
+    } catch (IOException e) {
+      routerMetrics.incrAppsFailedCreated();
+      RouterAuditLogger.logFailure(user.getShortUserName(), GET_NEW_APP, UNKNOWN,
+          TARGET_CLIENT_RM_SERVICE, e.getMessage());
+      LOG.error(e.getMessage());
+      throw e;
     } catch (Exception e) {
       routerMetrics.incrAppsFailedCreated();
       RouterAuditLogger.logFailure(user.getShortUserName(), GET_NEW_APP, UNKNOWN,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -365,7 +365,7 @@ public class FederationClientInterceptor
         routerMetrics.succeededAppsCreated(stopTime - startTime);
         return response;
       }
-    } catch (IOException e) {
+    } catch (RetriableException e) {
       routerMetrics.incrAppsFailedCreated();
       RouterAuditLogger.logFailure(user.getShortUserName(), GET_NEW_APP, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, e.getMessage());
@@ -530,7 +530,7 @@ public class FederationClientInterceptor
         return response;
       }
 
-    } catch (IOException e) {
+    } catch (RetriableException e) {
       routerMetrics.incrAppsFailedSubmitted();
       RouterAuditLogger.logFailure(user.getShortUserName(), SUBMIT_NEW_APP, UNKNOWN,
           TARGET_CLIENT_RM_SERVICE, e.getMessage(), applicationId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/clientrm/FederationClientInterceptor.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.yarn.server.router.clientrm;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ipc.RetriableException;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -306,10 +307,10 @@ public class FederationClientInterceptor
   }
 
   private SubClusterId getRandomActiveSubCluster(
-      Map<SubClusterId, SubClusterInfo> activeSubClusters) throws YarnException {
+      Map<SubClusterId, SubClusterInfo> activeSubClusters) throws IOException {
     if (activeSubClusters == null || activeSubClusters.isEmpty()) {
-      RouterServerUtil.logAndThrowException(
-          FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE, null);
+      throw new RetriableException(
+          FederationPolicyUtils.NO_ACTIVE_SUBCLUSTER_AVAILABLE);
     }
     List<SubClusterId> list = new ArrayList<>(activeSubClusters.keySet());
     return list.get(rand.nextInt(list.size()));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/main/java/org/apache/hadoop/yarn/server/router/webapp/FederationInterceptorREST.java
@@ -405,8 +405,8 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
         routerMetrics.succeededAppsCreated(stopTime - startTime);
         return response;
       }
-    } catch (FederationPolicyException e) {
-      // If a FederationPolicyException is thrown, the service is unavailable.
+    } catch (IOException e) {
+      // If a IOException is thrown, the service is unavailable.
       routerMetrics.incrAppsFailedCreated();
       RouterAuditLogger.logFailure(getUser().getShortUserName(), GET_NEW_APP, UNKNOWN,
           TARGET_WEB_SERVICE, e.getLocalizedMessage());
@@ -2466,7 +2466,7 @@ public class FederationInterceptorREST extends AbstractRESTRequestInterceptor {
 
   private Response invokeCreateNewReservation(Map<SubClusterId, SubClusterInfo> subClustersActive,
       List<SubClusterId> blackList, HttpServletRequest hsr, int retryCount)
-      throws YarnException {
+      throws YarnException, IOException {
     SubClusterId subClusterId = getRandomActiveSubCluster(subClustersActive, blackList);
     LOG.info("createNewReservation try #{} on SubCluster {}.", retryCount, subClusterId);
     SubClusterInfo subClusterInfo = subClustersActive.get(subClusterId);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-router/src/test/java/org/apache/hadoop/yarn/server/router/clientrm/TestFederationClientInterceptorRetry.java
@@ -193,7 +193,7 @@ public class TestFederationClientInterceptorRetry
     setupCluster(Arrays.asList(bad2));
 
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
-    LambdaTestUtils.intercept(YarnException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    LambdaTestUtils.intercept(IOException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         () -> interceptor.getNewApplication(request));
   }
 
@@ -209,7 +209,7 @@ public class TestFederationClientInterceptorRetry
     setupCluster(Arrays.asList(bad1, bad2));
 
     GetNewApplicationRequest request = GetNewApplicationRequest.newInstance();
-    LambdaTestUtils.intercept(YarnException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    LambdaTestUtils.intercept(IOException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         () -> interceptor.getNewApplication(request));
   }
 
@@ -247,7 +247,7 @@ public class TestFederationClientInterceptorRetry
         ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     final SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
-    LambdaTestUtils.intercept(YarnException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    LambdaTestUtils.intercept(IOException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         () -> interceptor.submitApplication(request));
   }
 
@@ -277,7 +277,7 @@ public class TestFederationClientInterceptorRetry
         ApplicationId.newInstance(System.currentTimeMillis(), 1);
 
     final SubmitApplicationRequest request = mockSubmitApplicationRequest(appId);
-    LambdaTestUtils.intercept(YarnException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
+    LambdaTestUtils.intercept(IOException.class, NO_ACTIVE_SUBCLUSTER_AVAILABLE,
         () -> interceptor.submitApplication(request));
   }
 


### PR DESCRIPTION
### Description of PR
Under the YARN Federation architecture, when there's only one sub-cluster, or when multiple sub-clusters exist but a queue is configured to submit exclusively to a specific sub-cluster, the following problem occurs: If this target sub-cluster failover, its state will remain "non-active" until the new active RM completes registration and sends the first heartbeat (default 30 seconds later). During this window, any client attempting to submit applications will fail with the error: "No active SubCluster available to submit the request" or "No positive weight found on active subclusters".

In non-YARN Federation setups, clients automatically retry during RM failover. We expect this retry behavior to be preserved when transitioning to the YARN Federation architecture.

### How was this patch tested?
unit test

