### PR TITLE
HADOOP-19707: Add quiet-surefire profile for tests

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -2773,6 +2773,23 @@
         <maven.compiler.release>${javac.version}</maven.compiler.release>
       </properties>
     </profile>
+    <profile>
+      <id>quiet-surefire</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <enableOutErrElements>false</enableOutErrElements>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <repositories>


### PR DESCRIPTION
### Description of PR

Adds the `quiet-surefire` profile to set enableOutErrElements=false for maven-surefire-plugin. This restores the behavior prior to Surefire 3.3 that stdout/stderr are not included in the TEST-<package>.<class>.xml file for passing tests. The newer default behavior results in much larger TEST-*.xml files that can be a problem for CI tools processing them.

### How was this patch tested?

Ran `mvn clean test -Dtest=TestHttpServer` and `mvn clean test -Dtest=TestHttpServer -Pquiet-surefire` and compared size and contents of hadoop-common-project/hadoop-common/target/surefire-reports/TEST-org.apache.hadoop.http.TestHttpServer.xml.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

