### PR TITLE
YARN-11839. [RM HA] - In corner case, RM stay in ACTIVE with RMStateStore in FENCED state

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -1218,7 +1218,11 @@ public class ResourceManager extends CompositeService
    * Transition to standby state in a new thread. The transition operation is
    * asynchronous to avoid deadlock caused by cyclic dependency.
    */
-  private void handleTransitionToStandByInNewThread() {
+  private synchronized void handleTransitionToStandByInNewThread() {
+    if (rmContext.getHAServiceState() == HAServiceProtocol.HAServiceState.STANDBY) {
+      LOG.info("RM already in standby state");
+      return;
+    }
     Thread standByTransitionThread =
         new Thread(activeServices.standByTransitionRunnable);
     standByTransitionThread.setName("StandByTransitionThread");


### PR DESCRIPTION

- Adds recheck of current state before invoking `transitionToStandBy()` in a new thread.
- This re-check avoids setting of `StandByTransitionRunnable#hasAlreadyRun = true` when the state is already StandBy.
- This fix, allows proper `transitionToStandby()` when RMStateStore reaches FENCED state.