### PR TITLE
HDFS-17710. Don't add journal edits to cache until after persisted to storage

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalFaultInjector.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/qjournal/server/JournalFaultInjector.java
@@ -38,4 +38,5 @@ public class JournalFaultInjector {
 
   public void beforePersistPaxosData() throws IOException {}
   public void afterPersistPaxosData() throws IOException {}
+  public void writeEdits() throws IOException {}
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournal.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/server/TestJournal.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdfs.qjournal.server;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -516,6 +517,29 @@ public class TestJournal {
     journal.journal(makeRI(7), 16, 16, 5, QJMTestUtil.createTxnData(16, 5));
 
     assertJournaledEditsTxnCountAndContents(16, 10, 20, newLayoutVersion);
+  }
+
+  @Test
+  public void testOnlyReadPersistedEditsFromCache() throws Exception {
+    JournalFaultInjector faultInjector = Mockito.mock(JournalFaultInjector.class);
+    JournalFaultInjector.instance = faultInjector;
+
+    journal.newEpoch(FAKE_NSINFO, 1);
+    journal.startLogSegment(makeRI(1), 1,
+        NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION);
+    journal.journal(makeRI(2), 1, 1, 5, QJMTestUtil.createTxnData(1, 5));
+    assertJournaledEditsTxnCountAndContents(1, 10, 5,
+        NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION);
+
+    Mockito.doThrow(new IOException("Injected")).when(faultInjector)
+        .writeEdits();
+    assertThrows(IOException.class, () ->
+        journal.journal(makeRI(3), 1, 6, 5, QJMTestUtil.createTxnData(6, 5)));
+    Mockito.reset(faultInjector);
+
+    // We should not see the edits that failed to persist to storage
+    assertJournaledEditsTxnCountAndContents(1, 10, 5,
+        NameNodeLayoutVersion.CURRENT_LAYOUT_VERSION);
   }
 
   private void assertJournaledEditsTxnCountAndContents(int startTxn,


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
Update the process of JournalNodes journaling new edits to persist edits to disk before adding them to the edit cache. This prevents standby and observer nodes from accidentally reading transactions from the edit cache when tailing logs that have not actually been durably persisted, making the standby or observer have in invalid state thinking the latest committed transaction is higher than it should be.

### How was this patch tested?
New UT using a new fault injector method to simulate a disk write failure.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

