### PR TITLE
HADOOP-17629. TestRPC#testAuthorization fails.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPC.java
@@ -702,6 +702,8 @@ public class TestRPC extends TestRpcBase {
 
     // Expect to succeed
     myConf.set(ACL_CONFIG, "*");
+    RPC.setProtocolEngine(myConf, TestRpcService.class, ProtobufRpcEngine2.class);
+
     doRPCs(myConf, false);
 
     // Reset authorization to expect failure


### PR DESCRIPTION
### Description of PR

TestRPC#testAuthorization  fails with below IOException. It was using WritableRpcEngine to run TestProtobufRpcProto.
```
java.io.IOException: protocolClass interface org.apache.hadoop.ipc.TestRpcBase$TestRpcService is not implemented by protocolImpl which is of class class org.apache.hadoop.ipc.protobuf.TestRpcServiceProtos$TestProtobufRpcProto$2

	at org.apache.hadoop.ipc.WritableRpcEngine$Server.<init>(WritableRpcEngine.java:523)
	at org.apache.hadoop.ipc.WritableRpcEngine.getServer(WritableRpcEngine.java:379)
	at org.apache.hadoop.ipc.RPC$Builder.build(RPC.java:986)
	at org.apache.hadoop.ipc.TestRpcBase.setupTestServer(TestRpcBase.java:124)
	at org.apache.hadoop.ipc.TestRpcBase.setupTestServer(TestRpcBase.java:119)
	at org.apache.hadoop.ipc.TestRpcBase.setupTestServer(TestRpcBase.java:102)
	at org.apache.hadoop.ipc.TestRPC.doRPCs(TestRPC.java:646)
	at org.apache.hadoop.ipc.TestRPC.testAuthorization(TestRPC.java:705)
	...
```

### How was this patch tested?

This is fixing a test failure.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [NA] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [NA] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

