### PR TITLE
HADOOP-19364. S3A: IoStats support for AAL.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -497,7 +497,8 @@ public final class StreamStatisticNames {
   /**
    * Tracks failures in footer parsing.
    */
-  public static final String STREAM_READ_PARQUET_FOOTER_PARSING_FAILED = "stream_read_parquet_footer_parsing_failed";
+  public static final String STREAM_READ_PARQUET_FOOTER_PARSING_FAILED
+          = "stream_read_parquet_footer_parsing_failed";
 
   /**
    * A cache hit occurs when the request range can be satisfied by the data in the cache.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/statistics/StreamStatisticNames.java
@@ -489,6 +489,22 @@ public final class StreamStatisticNames {
   public static final String STREAM_FILE_CACHE_EVICTION
       = "stream_file_cache_eviction";
 
+  /**
+   * Bytes that were prefetched by the stream.
+   */
+  public static final String STREAM_READ_PREFETCHED_BYTES = "stream_read_prefetched_bytes";
+
+  /**
+   * Tracks failures in footer parsing.
+   */
+  public static final String STREAM_READ_PARQUET_FOOTER_PARSING_FAILED = "stream_read_parquet_footer_parsing_failed";
+
+  /**
+   * A cache hit occurs when the request range can be satisfied by the data in the cache.
+   */
+  public static final String STREAM_READ_CACHE_HIT = "stream_read_cache_hit";
+
+
   private StreamStatisticNames() {
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -81,6 +81,9 @@ import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_EXECUTO
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.SUFFIX_FAILURES;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_UNBUFFERED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCHED_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PARQUET_FOOTER_PARSING_FAILED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_CACHE_HIT;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 import static org.apache.hadoop.fs.s3a.Statistic.*;
 
@@ -891,7 +894,12 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
               StreamStatisticNames.STREAM_READ_VECTORED_READ_BYTES_DISCARDED,
               StreamStatisticNames.STREAM_READ_VERSION_MISMATCHES,
               StreamStatisticNames.STREAM_EVICT_BLOCKS_FROM_FILE_CACHE,
-              StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED)
+              StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST,
+              StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED,
+              StreamStatisticNames.STREAM_READ_CACHE_HIT,
+              StreamStatisticNames.STREAM_READ_PREFETCHED_BYTES,
+              StreamStatisticNames.STREAM_READ_PARQUET_FOOTER_PARSING_FAILED
+                  )
           .withGauges(STREAM_READ_GAUGE_INPUT_POLICY,
               STREAM_READ_BLOCKS_IN_FILE_CACHE.getSymbol(),
               STREAM_READ_ACTIVE_PREFETCH_OPERATIONS.getSymbol(),
@@ -1127,6 +1135,32 @@ public class S3AInstrumentation implements Closeable, MetricsSource,
     public void readVectoredBytesDiscarded(int discarded) {
       bytesDiscardedInVectoredIO.addAndGet(discarded);
     }
+
+    @Override
+    public void getRequestInitiated() {
+      increment(ACTION_HTTP_GET_REQUEST);
+    }
+
+    @Override
+    public void headRequestInitiated() {
+      increment(StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST);
+    }
+
+    @Override
+    public void bytesPrefetched(long size) {
+      increment(STREAM_READ_PREFETCHED_BYTES, size);
+    }
+
+    @Override
+    public void footerParsingFailed() {
+      increment(STREAM_READ_PARQUET_FOOTER_PARSING_FAILED);
+    }
+
+    @Override
+    public void streamReadCacheHit() {
+      increment(STREAM_READ_CACHE_HIT);
+    }
+
 
     @Override
     public void executorAcquired(Duration timeInQueue) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Statistic.java
@@ -458,9 +458,21 @@ public enum Statistic {
       StreamStatisticNames.STREAM_READ_ACTIVE_MEMORY_IN_USE,
       "Gauge of active memory in use",
       TYPE_GAUGE),
+  STREAM_READ_PREFETCH_BYTES(
+          StreamStatisticNames.STREAM_READ_PREFETCHED_BYTES,
+          "Bytes prefetched by AAL stream",
+          TYPE_COUNTER),
+  STREAM_READ_PARQUET_FOOTER_PARSING_FAILED(
+          StreamStatisticNames.STREAM_READ_PARQUET_FOOTER_PARSING_FAILED,
+          "Count of Parquet footer parsing failures encountered by AAL",
+          TYPE_COUNTER),
+  STREAM_READ_CACHE_HIT(
+          StreamStatisticNames.STREAM_READ_CACHE_HIT,
+          "Count of cache hits in AAL stream",
+          TYPE_COUNTER),
+
 
   /* Stream Write statistics */
-
   STREAM_WRITE_EXCEPTIONS(
       StreamStatisticNames.STREAM_WRITE_EXCEPTIONS,
       "Count of stream write failures reported",

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsRequestCallback.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a.impl.streams;
+
+import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
+import org.apache.hadoop.fs.s3a.statistics.S3AInputStreamStatistics;
+
+/**
+ * Implementation of AAL's RequestCallback interface that tracks analytics operations.
+ */
+public class AnalyticsRequestCallback implements RequestCallback {
+  private final S3AInputStreamStatistics statistics;
+
+    /**
+     * Create a new callback instance.
+     * @param statistics the statistics to update
+     */
+  public AnalyticsRequestCallback(S3AInputStreamStatistics statistics) {
+    this.statistics = statistics;
+  }
+
+  @Override
+    public void onGetRequest() {
+    statistics.getRequestInitiated();
+  }
+
+  @Override
+    public void onHeadRequest() {
+    statistics.headRequestInitiated();
+  }
+
+  @Override
+  public void onBlockPrefetch(long start, long end) {
+    statistics.bytesPrefetched(end - start + 1);
+  }
+
+  @Override
+  public void footerParsingFailed() {
+    statistics.footerParsingFailed();
+  }
+
+  @Override
+  public void onReadVectored(int numIncomingRanges, int numCombinedRanges) {
+    statistics.readVectoredOperationStarted(numIncomingRanges, numCombinedRanges);
+  }
+
+  @Override
+  public void onCacheHit() {
+    statistics.streamReadCacheHit();
+  }
+
+}
+

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -276,7 +276,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
     OpenStreamInformation.OpenStreamInformationBuilder openStreamInformationBuilder =
         OpenStreamInformation.builder()
             .inputPolicy(mapS3AInputPolicyToAAL(parameters.getContext()
-            .getInputPolicy())).requestCallback(requestCallback);
+            .getInputPolicy()))
+            .requestCallback(requestCallback);
 
     if (parameters.getObjectAttributes().getETag() != null) {
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStream.java
@@ -40,6 +40,7 @@ import software.amazon.s3.analyticsaccelerator.request.StreamAuditContext;
 import software.amazon.s3.analyticsaccelerator.util.InputPolicy;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
+import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +73,7 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       final S3SeekableInputStreamFactory s3SeekableInputStreamFactory) throws IOException {
     super(InputStreamType.Analytics, parameters);
     S3ObjectAttributes s3Attributes = parameters.getObjectAttributes();
+
     this.inputStream = s3SeekableInputStreamFactory.createStream(S3URI.of(s3Attributes.getBucket(),
         s3Attributes.getKey()), buildOpenStreamInformation(parameters));
     getS3AStreamStatistics().streamOpened(InputStreamType.Analytics);
@@ -80,6 +82,9 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   @Override
   public int read() throws IOException {
     throwIfClosed();
+
+    getS3AStreamStatistics().readOperationStarted(getPos(), 1);
+
     int bytesRead;
     try {
       bytesRead = inputStream.read();
@@ -87,6 +92,11 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead != -1) {
+      incrementBytesRead(1);
+    }
+
     return bytesRead;
   }
 
@@ -122,6 +132,8 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
    */
   public int readTail(byte[] buf, int off, int len) throws IOException {
     throwIfClosed();
+    getS3AStreamStatistics().readOperationStarted(getPos(), len);
+
     int bytesRead;
     try {
       bytesRead = inputStream.readTail(buf, off, len);
@@ -129,12 +141,20 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead > 0) {
+      incrementBytesRead(bytesRead);
+    }
+
     return bytesRead;
   }
 
   @Override
   public int read(byte[] buf, int off, int len) throws IOException {
     throwIfClosed();
+
+    getS3AStreamStatistics().readOperationStarted(getPos(), len);
+
     int bytesRead;
     try {
       bytesRead = inputStream.read(buf, off, len);
@@ -142,6 +162,11 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       onReadFailure(ioe);
       throw ioe;
     }
+
+    if (bytesRead > 0) {
+      incrementBytesRead(bytesRead);
+    }
+
     return bytesRead;
   }
 
@@ -177,8 +202,6 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
       range.setData(result);
     }
 
-    // AAL does not do any range coalescing, so input and combined ranges are the same.
-    this.getS3AStreamStatistics().readVectoredOperationStarted(ranges.size(), ranges.size());
     inputStream.readVectored(objectRanges, allocate, release);
   }
 
@@ -247,10 +270,13 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   }
 
   private OpenStreamInformation buildOpenStreamInformation(ObjectReadParameters parameters) {
+
+    final RequestCallback requestCallback = new AnalyticsRequestCallback(getS3AStreamStatistics());
+
     OpenStreamInformation.OpenStreamInformationBuilder openStreamInformationBuilder =
         OpenStreamInformation.builder()
             .inputPolicy(mapS3AInputPolicyToAAL(parameters.getContext()
-            .getInputPolicy()));
+            .getInputPolicy())).requestCallback(requestCallback);
 
     if (parameters.getObjectAttributes().getETag() != null) {
       openStreamInformationBuilder.objectMetadata(ObjectMetadata.builder()
@@ -298,6 +324,18 @@ public class AnalyticsStream extends ObjectInputStream implements StreamCapabili
   protected void throwIfClosed() throws IOException {
     if (closed) {
       throw new IOException(getKey() + ": " + FSExceptionMessages.STREAM_IS_CLOSED);
+    }
+  }
+
+  /**
+   * Increment the bytes read counter if there is a stats instance
+   * and the number of bytes read is more than zero.
+   * @param bytesRead number of bytes read
+   */
+  private void incrementBytesRead(long bytesRead) {
+    getS3AStreamStatistics().bytesRead(bytesRead);
+    if (getContext().getStats() != null && bytesRead > 0) {
+      getContext().getStats().incrementBytesRead(bytesRead);
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/streams/AnalyticsStreamFactory.java
@@ -48,7 +48,6 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
 
   private S3SeekableInputStreamConfiguration seekableInputStreamConfiguration;
   private LazyAutoCloseableReference<S3SeekableInputStreamFactory>  s3SeekableInputStreamFactory;
-  private boolean requireCrt;
 
   public AnalyticsStreamFactory() {
     super("AnalyticsStreamFactory");
@@ -61,7 +60,6 @@ public class AnalyticsStreamFactory extends AbstractObjectInputStreamFactory {
                 ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX);
     this.seekableInputStreamConfiguration =
                 S3SeekableInputStreamConfiguration.fromConfiguration(configuration);
-    this.requireCrt = false;
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/S3AInputStreamStatistics.java
@@ -119,6 +119,32 @@ public interface S3AInputStreamStatistics extends AutoCloseable,
    */
   void readVectoredBytesDiscarded(int discarded);
 
+  /**
+   * Number of S3 GET requests initiated by the stream.
+   */
+  void getRequestInitiated();
+
+  /**
+   * Number of S3 HEAD requests initiated by the stream.
+   */
+  void headRequestInitiated();
+
+  /**
+   * Number of bytes prefetched.
+   * @param size number of bytes prefetched.
+   */
+  void bytesPrefetched(long size);
+
+  /**
+   * Number of failures in footer parsing.
+   */
+  void footerParsingFailed();
+
+  /**
+   * If the request data is already in the data cache.
+   */
+  void streamReadCacheHit();
+
   @Override
   void close();
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/statistics/impl/EmptyS3AStatisticsContext.java
@@ -213,6 +213,31 @@ public final class EmptyS3AStatisticsContext implements S3AStatisticsContext {
     }
 
     @Override
+    public void getRequestInitiated() {
+
+    }
+
+    @Override
+    public void headRequestInitiated() {
+
+    }
+
+    @Override
+    public void bytesPrefetched(long size) {
+
+    }
+
+    @Override
+    public void footerParsingFailed() {
+
+    }
+
+    @Override
+    public void streamReadCacheHit() {
+
+    }
+
+    @Override
     public void close() {
 
     }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.fs.FileRange;
 import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.s3a.S3ATestUtils;
+import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.test.tags.IntegrationTest;
@@ -38,12 +40,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.validateVectoredReadResult;
 import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
-
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_CACHE_TIMEOUT;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_READ_BUFFER_SIZE;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_REQUEST_COALESCE_TOLERANCE;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_SMALL_OBJECT_PREFETCH_ENABLED;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
+import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSSES3;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
@@ -69,6 +71,15 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
     super(bufferType);
   }
 
+  private static final String REQUEST_COALESCE_TOLERANCE_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
+          + AAL_REQUEST_COALESCE_TOLERANCE;
+  private static final String READ_BUFFER_SIZE_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
+          + AAL_READ_BUFFER_SIZE;
+  private static final String SMALL_OBJECT_PREFETCH_ENABLED_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
+          + AAL_SMALL_OBJECT_PREFETCH_ENABLED;
+  private static final String CACHE_TIMEOUT_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
+          + AAL_CACHE_TIMEOUT;
+
   /**
    * Create a configuration.
    * @return a configuration
@@ -76,22 +87,27 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
+
+    S3ATestUtils.disableFilesystemCaching(conf);
+
+    removeBaseAndBucketOverrides(conf,
+            REQUEST_COALESCE_TOLERANCE_KEY,
+            READ_BUFFER_SIZE_KEY,
+            SMALL_OBJECT_PREFETCH_ENABLED_KEY,
+            CACHE_TIMEOUT_KEY);
+
     // Set the coalesce tolerance to 1KB, default is 1MB.
-    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-            "."  + AAL_REQUEST_COALESCE_TOLERANCE, S_16K);
+    conf.setInt(REQUEST_COALESCE_TOLERANCE_KEY, S_16K);
 
     // Set the minimum block size to 32KB. AAL uses a default block size of 128KB, which means the minimum size a S3
     // request will be is 128KB. Since the file being read is 128KB, we need to  use this here to demonstrate that
     // separate GET requests are made for ranges that are not coalesced.
-    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-            "."  + AAL_READ_BUFFER_SIZE, S_32K);
+    conf.setInt(READ_BUFFER_SIZE_KEY, S_32K);
 
     // Disable small object prefetched, otherwise anything less than 8MB is fetched in a single GET.
-    conf.set(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-            "."  + AAL_SMALL_OBJECT_PREFETCH_ENABLED, "false");
+    conf.set(SMALL_OBJECT_PREFETCH_ENABLED_KEY, "false");
 
-    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
-            "."  + AAL_CACHE_TIMEOUT, 5000);
+    conf.setInt(CACHE_TIMEOUT_KEY, 5000);
 
     enableAnalyticsAccelerator(conf);
     // If encryption is set, some AAL tests will fail.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.fs.contract.AbstractContractVectoredReadTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.s3a.S3ATestUtils;
-import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.test.tags.IntegrationTest;
@@ -71,14 +70,17 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
     super(bufferType);
   }
 
-  private static final String REQUEST_COALESCE_TOLERANCE_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
-          + AAL_REQUEST_COALESCE_TOLERANCE;
-  private static final String READ_BUFFER_SIZE_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
-          + AAL_READ_BUFFER_SIZE;
-  private static final String SMALL_OBJECT_PREFETCH_ENABLED_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
-          + AAL_SMALL_OBJECT_PREFETCH_ENABLED;
-  private static final String CACHE_TIMEOUT_KEY = ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "."
-          + AAL_CACHE_TIMEOUT;
+  private static final String REQUEST_COALESCE_TOLERANCE_KEY =
+          ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "." + AAL_REQUEST_COALESCE_TOLERANCE;
+
+  private static final String READ_BUFFER_SIZE_KEY =
+          ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "." + AAL_READ_BUFFER_SIZE;
+
+  private static final String SMALL_OBJECT_PREFETCH_ENABLED_KEY =
+          ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "." + AAL_SMALL_OBJECT_PREFETCH_ENABLED;
+
+  private static final String CACHE_TIMEOUT_KEY =
+          ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX + "." + AAL_CACHE_TIMEOUT;
 
   /**
    * Create a configuration.
@@ -150,8 +152,8 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
     List<FileRange> fileRanges = new ArrayList<>();
     fileRanges.add(FileRange.createFileRange(0, 100));
     fileRanges.add(FileRange.createFileRange(800, 200));
-    fileRanges.add(FileRange.createFileRange(4 * S_1K , 4 * S_1K));
-    fileRanges.add(FileRange.createFileRange(80 * S_1K , 4 * S_1K));
+    fileRanges.add(FileRange.createFileRange(4 * S_1K, 4 * S_1K));
+    fileRanges.add(FileRange.createFileRange(80 * S_1K, 4 * S_1K));
 
     try (FSDataInputStream in = openVectorFile()) {
       in.readVectored(fileRanges, getAllocate());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractAnalyticsStreamVectoredRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.contract.s3a;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,9 +37,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.validateVectoredReadResult;
+import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
+
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_CACHE_TIMEOUT;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_READ_BUFFER_SIZE;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_REQUEST_COALESCE_TOLERANCE;
+import static org.apache.hadoop.fs.s3a.S3ATestConstants.AAL_SMALL_OBJECT_PREFETCH_ENABLED;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipForAnyEncryptionExceptSSES3;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
+import static org.apache.hadoop.io.Sizes.S_16K;
+import static org.apache.hadoop.io.Sizes.S_1K;
+import static org.apache.hadoop.io.Sizes.S_32K;
+
 
 /**
  * S3A contract tests for vectored reads with the Analytics stream.
@@ -64,6 +76,23 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
   @Override
   protected Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
+    // Set the coalesce tolerance to 1KB, default is 1MB.
+    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
+            "."  + AAL_REQUEST_COALESCE_TOLERANCE, S_16K);
+
+    // Set the minimum block size to 32KB. AAL uses a default block size of 128KB, which means the minimum size a S3
+    // request will be is 128KB. Since the file being read is 128KB, we need to  use this here to demonstrate that
+    // separate GET requests are made for ranges that are not coalesced.
+    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
+            "."  + AAL_READ_BUFFER_SIZE, S_32K);
+
+    // Disable small object prefetched, otherwise anything less than 8MB is fetched in a single GET.
+    conf.set(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
+            "."  + AAL_SMALL_OBJECT_PREFETCH_ENABLED, "false");
+
+    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
+            "."  + AAL_CACHE_TIMEOUT, 5000);
+
     enableAnalyticsAccelerator(conf);
     // If encryption is set, some AAL tests will fail.
     // This is because AAL caches the head request response, and uses
@@ -102,21 +131,41 @@ public class ITestS3AContractAnalyticsStreamVectoredRead extends AbstractContrac
 
   @Test
   public void testReadVectoredWithAALStatsCollection() throws Exception {
+    List<FileRange> fileRanges = new ArrayList<>();
+    fileRanges.add(FileRange.createFileRange(0, 100));
+    fileRanges.add(FileRange.createFileRange(800, 200));
+    fileRanges.add(FileRange.createFileRange(4 * S_1K , 4 * S_1K));
+    fileRanges.add(FileRange.createFileRange(80 * S_1K , 4 * S_1K));
 
-    List<FileRange> fileRanges = createSampleNonOverlappingRanges();
     try (FSDataInputStream in = openVectorFile()) {
       in.readVectored(fileRanges, getAllocate());
 
       validateVectoredReadResult(fileRanges, DATASET, 0);
       IOStatistics st = in.getIOStatistics();
 
-      // Statistics such as GET requests will be added after IoStats support.
       verifyStatisticCounterValue(st,
               StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED, 1);
 
       verifyStatisticCounterValue(st,
               StreamStatisticNames.STREAM_READ_VECTORED_OPERATIONS,
               1);
+
+      // Verify ranges are coalesced, we are using a coalescing tolerance of 16KB, so [0-100, 800-200, 4KB-8KB] will
+      // get coalesced into a single range.
+      verifyStatisticCounterValue(st, StreamStatisticNames.STREAM_READ_VECTORED_INCOMING_RANGES, 4);
+      verifyStatisticCounterValue(st, StreamStatisticNames.STREAM_READ_VECTORED_COMBINED_RANGES, 2);
+
+      verifyStatisticCounterValue(st, ACTION_HTTP_GET_REQUEST, 2);
+
+      // read the same ranges again to demonstrate that the data is cached, and no new GETs are made.
+      in.readVectored(fileRanges, getAllocate());
+      verifyStatisticCounterValue(st, ACTION_HTTP_GET_REQUEST, 2);
+
+      // Because of how AAL is currently written, it is not possible to track cache hits that originate from a
+      // readVectored() accurately. For this reason, cache hits from readVectored are currently not tracked, for more
+      // details see: https://github.com/awslabs/analytics-accelerator-s3/issues/359
+      verifyStatisticCounterValue(st, StreamStatisticNames.STREAM_READ_CACHE_HIT, 0);
     }
+
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractCreate.java
@@ -35,7 +35,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestConstants.KEY_PERFORMANCE_TESTS_EN
 import static org.apache.hadoop.fs.s3a.Constants.CONNECTION_EXPECT_CONTINUE;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfNotEnabled;
 
 /**
@@ -100,13 +99,6 @@ public class ITestS3AContractCreate extends AbstractContractCreateTest {
   @Test
   public void testOverwriteNonEmptyDirectory() throws Throwable {
     try {
-       // Currently analytics accelerator does not support reading of files that have been overwritten.
-       // This is because the analytics accelerator library caches metadata, and when a file is
-       // overwritten, the old metadata continues to be used, until it is removed from the cache over
-       // time. This will be fixed in https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-       skipIfAnalyticsAcceleratorEnabled(getContract().getConf(),
-           "Analytics Accelerator currently does not support reading of over written files");
-
        super.testOverwriteNonEmptyDirectory();
        failWithCreatePerformance();
     } catch (AssertionError e) {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDistCp.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractDistCp.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestConstants.SCALE_TEST_TIMEOUT_MILLIS;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.StorageStatistics;
@@ -87,15 +86,6 @@ public class ITestS3AContractDistCp extends AbstractContractDistCpTest {
   @Test
   @Override
   public void testDistCpUpdateCheckFileSkip() throws Exception {
-    // Currently analytics accelerator does not support reading of files that have been overwritten.
-    // This is because the analytics accelerator library caches metadata and data, and when a
-    // file is overwritten, the old data continues to be used, until it is removed from the
-    // cache over time. This will be fixed in
-    // https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-    // In this test case, the remote file is created, read, then deleted, and then created again
-    // with different contents, and read again, which leads to assertions failing.
-    skipIfAnalyticsAcceleratorEnabled(getContract().getConf(),
-        "Analytics Accelerator Library does not support update to existing files");
     super.testDistCpUpdateCheckFileSkip();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMultipartUploader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/contract/s3a/ITestS3AContractMultipartUploader.java
@@ -47,7 +47,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestPropertyBool;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getTestPropertyBytes;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.impl.ChecksumSupport.getChecksumAlgorithm;
 import static org.apache.hadoop.fs.s3a.scale.AbstractSTestS3AHugeFiles.DEFAULT_HUGE_PARTITION_SIZE;
 
@@ -173,12 +172,6 @@ public class ITestS3AContractMultipartUploader extends
   @Override
   public void testConcurrentUploads() throws Throwable {
     assumeNotS3ExpressFileSystem(getFileSystem());
-    // Currently analytics accelerator does not support reading of files that have been overwritten.
-    // This is because the analytics accelerator library caches metadata and data, and when a file
-    // is overwritten, the old data continues to be used, until it is removed from the cache over
-    // time. This will be fixed in https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-    skipIfAnalyticsAcceleratorEnabled(getContract().getConf(),
-        "Analytics Accelerator currently does not support reading of over written files");
     super.testConcurrentUploads();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -43,14 +43,27 @@ import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_RE
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_PARQUET;
 import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY_WHOLE_FILE;
 import static org.apache.hadoop.fs.audit.AuditStatisticNames.AUDIT_REQUEST_EXECUTION;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
+import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.s3a.Constants.ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.enableAnalyticsAccelerator;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
 import static org.apache.hadoop.fs.s3a.test.PublicDatasetTestUtils.getExternalData;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
-import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.ANALYTICS_STREAM_FACTORY_CLOSED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_ANALYTICS_OPENED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_CACHE_HIT;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_OPERATIONS;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PARQUET_FOOTER_PARSING_FAILED;
+import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_PREFETCHED_BYTES;
+import static org.apache.hadoop.io.Sizes.S_1K;
+import static org.apache.hadoop.io.Sizes.S_1M;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_KB;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 /**
  * Tests integration of the
@@ -88,6 +101,12 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
     S3AFileSystem fs =
         (S3AFileSystem) FileSystem.get(externalTestFile.toUri(), getConfiguration());
+
+   long fileLength = fs.getFileStatus(externalTestFile).getLen();
+
+   // Head request for the file length.
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 1);
+
     byte[] buffer = new byte[500];
     IOStatistics ioStats;
 
@@ -105,9 +124,21 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
       Assertions.assertThat(objectInputStream.streamType()).isEqualTo(InputStreamType.Analytics);
       Assertions.assertThat(objectInputStream.getInputPolicy())
           .isEqualTo(S3AInputPolicy.Sequential);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_BYTES, 500);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
+
+      long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read")
+              .isEqualTo(500);
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+
+    // Since policy is WHOLE_FILE, the whole file starts getting prefetched as soon as the stream to it is opened.
+    // So prefetched bytes is fileLen - 5
+    verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, fileLength - 5);
+
     fs.close();
     verifyStatisticCounterValue(fs.getIOStatistics(), ANALYTICS_STREAM_FACTORY_CLOSED, 1);
 
@@ -115,7 +146,68 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // in which case, AAL will start prefetching till EoF on file open in 8MB chunks. The file read here
     // s3://noaa-cors-pds/raw/2023/017/ohfh/OHFH017d.23_.gz, has a size of ~21MB, resulting in 3 GETS:
     // [0-8388607, 8388608-16777215, 16777216-21511173].
-    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 4);
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 5);
+  }
+
+  @Test
+  public void testSequentialPrefetching() throws IOException {
+
+    Configuration conf = getConfiguration();
+
+    // AAL uses a caffeine cache, and expires any prefetched data for a key 1s after it was last accessed by default.
+    // While this works well when running on EC2, for local testing, it can take more than 1s to download large chunks
+    // of data. Set this value to higher for testing to prevent early cache evictions.
+    conf.setInt(ANALYTICS_ACCELERATOR_CONFIGURATION_PREFIX +
+            "."  + AAL_CACHE_TIMEOUT, 10000);
+
+    S3AFileSystem fs =
+            (S3AFileSystem) FileSystem.get(externalTestFile.toUri(), getConfiguration());
+    byte[] buffer = new byte[10 * ONE_MB];
+    IOStatistics ioStats;
+
+    long fileLength = fs.getFileStatus(externalTestFile).getLen();
+
+    // Here we read through the 21MB external test file, but do not pass in the WHOLE_FILE policy. Instead, we rely
+    // on AAL detecting a sequential pattern being read, and then prefetching bytes in a geometrical progression.
+    // AAL's sequential prefetching starts prefetching in increments 4MB, 8MB, 16MB etc. depending on how many
+    // sequential reads happen.
+    try (FSDataInputStream inputStream = fs.open(externalTestFile)) {
+      ioStats = inputStream.getIOStatistics();
+
+      inputStream.readFully(buffer, 0, ONE_MB);
+      // The first sequential read, so prefetch the next 4MB.
+      inputStream.readFully(buffer,   0, ONE_MB);
+
+      // Since ONE_MB was requested by the reader, the prefetched bytes are 3MB.
+      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 3 * ONE_MB);
+
+      // These next two reads are within the last prefetched bytes, so no further bytes are prefetched.
+      inputStream.readFully(buffer, 0, 2 *  ONE_MB);
+      inputStream.readFully(buffer, 0, ONE_MB);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 3 * ONE_MB);
+      // Two cache hits, as the previous two reads were already prefetched.
+      verifyStatisticCounterValue(ioStats, STREAM_READ_CACHE_HIT, 2);
+
+      // Another sequential read, GP will now prefetch the next 8MB of data.
+      inputStream.readFully(buffer, 0, ONE_MB);
+      // Cache hit is still 2, as the previous read required a new GET request as it was outside the previously fetched
+      // 4MB.
+      verifyStatisticCounterValue(ioStats, STREAM_READ_CACHE_HIT, 2);
+      // A total of 10MB is prefetched - 3MB and then 7MB.
+      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 10 * ONE_MB);
+      long bytesRemainingForPrefetch = fileLength - (inputStream.getPos() + 10 * ONE_MB);
+      inputStream.readFully(buffer, 0, 10 * ONE_MB);
+
+
+      // Though the next GP should prefetch 16MB, since the file is ~23MB, only the bytes till EoF are prefetched.
+      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 10 * ONE_MB + bytesRemainingForPrefetch);
+      inputStream.readFully(buffer, 0, 3 * ONE_MB);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_CACHE_HIT, 3);
+    }
+
+    // verify all AAL stats are passed to the FS.
+    verifyStatisticCounterValue(fs.getIOStatistics(), STREAM_READ_CACHE_HIT, 3);
+    verifyStatisticCounterValue(fs.getIOStatistics(), STREAM_READ_PARQUET_FOOTER_PARSING_FAILED, 0);
   }
 
   @Test
@@ -134,9 +226,36 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     Path sourcePath = new Path(file.toURI().getPath());
     getFileSystem().copyFromLocalFile(false, true, sourcePath, dest);
 
+    long fileLength = getFileSystem().getFileStatus(dest).getLen();
+
     byte[] buffer = new byte[500];
     IOStatistics ioStats;
+    int bytesRead;
 
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      ioStats = inputStream.getIOStatistics();
+      inputStream.seek(5);
+      bytesRead = inputStream.read(buffer, 0, 500);
+
+      ObjectInputStream objectInputStream = (ObjectInputStream) inputStream.getWrappedStream();
+      long streamBytesRead = objectInputStream.getS3AStreamStatistics().getBytesRead();
+      Assertions.assertThat(streamBytesRead).as("Stream statistics should track bytes read")
+              .isEqualTo(bytesRead);
+
+    }
+
+    verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_GET_REQUEST, 1);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_HEAD_REQUEST, 0);
+    // This file has a content length of 451. Since it's a parquet file, AAL will prefetch the footer bytes (last 32KB),
+    // as soon as the file is opened, but because the file is < 32KB, the whole file is prefetched.
+    verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, fileLength);
+
+    // The footer is only prefetched once, but parsing is attempted on each stream open.
+    verifyStatisticCounterValue(ioStats, STREAM_READ_PARQUET_FOOTER_PARSING_FAILED, 1);
+
+    // Open a stream to the object twice, verifying that data is cached, and streams to the same object, do not
+    // prefetch the same data twice.
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
       ioStats = inputStream.getIOStatistics();
       inputStream.seek(5);
@@ -144,6 +263,13 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_GET_REQUEST, 0);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_HEAD_REQUEST, 0);
+    // No data is prefetched, as it already exists in the cache from the previous factory.
+    verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 0);
+
+    // The footer is only prefetched once, but parsing is attempted on each stream open.
+    verifyStatisticCounterValue(ioStats, STREAM_READ_PARQUET_FOOTER_PARSING_FAILED, 1);
   }
 
   /**
@@ -167,6 +293,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     final int size = 3000;
     byte[] buffer = new byte[size];
     int readLimit = Math.min(size, (int) fileStatus.getLen());
+
     IOStatistics ioStats;
 
     final IOStatistics fsIostats = getFileSystem().getIOStatistics();
@@ -179,6 +306,12 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_GET_REQUEST, 1);
+
+    // S3A makes a HEAD request on the stream open(), and then AAL makes a GET request to get the object, total audit
+    // operations = 10.
+    long currentAuditCount = initialAuditCount + 2;
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), AUDIT_REQUEST_EXECUTION, currentAuditCount);
 
     try (FSDataInputStream inputStream = getFileSystem().openFile(dest)
         .withFileStatus(fileStatus)
@@ -186,11 +319,17 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
         .build().get()) {
       ioStats = inputStream.getIOStatistics();
       inputStream.readFully(buffer, 0, readLimit);
+
+      verifyStatisticCounterValue(ioStats, STREAM_READ_BYTES, (int) fileStatus.getLen());
+      verifyStatisticCounterValue(ioStats, STREAM_READ_OPERATIONS, 1);
     }
 
     verifyStatisticCounterValue(ioStats, STREAM_READ_ANALYTICS_OPENED, 1);
 
-    verifyStatisticCounterValue(fsIostats, AUDIT_REQUEST_EXECUTION, initialAuditCount + 2);
+    // S3A passes in the meta-data(content length) on file open,
+    // we expect AAL to make no HEAD requests
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_HEAD_REQUEST, 0);
+    verifyStatisticCounterValue(ioStats, ACTION_HTTP_GET_REQUEST, 0);
   }
 
   @Test
@@ -210,4 +349,71 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
         () -> S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration));
   }
 
+
+  @Test
+  public void testRandomSeekPatternGets() throws Throwable {
+    describe("Random seek pattern should optimize GET requests");
+
+    Path dest = path("seek-test.txt");
+    byte[] data = dataset(5 * S_1M, 256, 255);
+    writeDataset(getFileSystem(), dest, data, 5 * S_1M, 1024, true);
+
+    byte[] buffer = new byte[S_1M];
+    try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
+      IOStatistics ioStats = inputStream.getIOStatistics();
+
+      inputStream.read(buffer);
+      inputStream.seek(2 * S_1M);
+      inputStream.read(new byte[512 * S_1K]);
+      inputStream.seek(3 * S_1M);
+      inputStream.read(new byte[512 * S_1K]);
+
+      verifyStatisticCounterValue(ioStats, ACTION_HTTP_GET_REQUEST, 1);
+      verifyStatisticCounterValue(ioStats, ACTION_HTTP_HEAD_REQUEST, 0);
+    }
+
+    // We did 3 reads, and all of them were served from the cache
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), STREAM_READ_CACHE_HIT, 3);
+  }
+
+
+  @Test
+  public void testSequentialStreamsNoDuplicateGets() throws Throwable {
+    describe("Sequential streams reading same object should not duplicate GETs");
+
+    Path dest = path("sequential-test.txt");
+    int fileLen = S_1M;
+
+    byte[] data = dataset(fileLen, 256, 255);
+    writeDataset(getFileSystem(), dest, data, fileLen, 1024, true);
+
+    byte[] buffer = new byte[ONE_MB];
+    try (FSDataInputStream stream1 = getFileSystem().open(dest);
+         FSDataInputStream stream2 = getFileSystem().open(dest)) {
+
+      stream1.read(buffer, 0, 2 * ONE_KB);
+      stream2.read(buffer);
+      stream1.read(buffer, 0 , 10 * ONE_KB);
+
+      IOStatistics stats1 = stream1.getIOStatistics();
+      IOStatistics stats2 = stream2.getIOStatistics();
+
+      verifyStatisticCounterValue(stats1, ACTION_HTTP_GET_REQUEST, 1);
+      verifyStatisticCounterValue(stats2, ACTION_HTTP_HEAD_REQUEST, 0);
+
+      // Since it's a small file (ALL will prefetch the whole file for size < 8MB), the whole file is prefetched
+      // on the first read.
+      verifyStatisticCounterValue(stats1, STREAM_READ_PREFETCHED_BYTES, fileLen);
+
+      // The second stream will not prefetch any bytes, as they have already been prefetched by stream 1.
+      verifyStatisticCounterValue(stats2, STREAM_READ_PREFETCHED_BYTES, 0);
+    }
+
+    // verify value is passed up to the FS
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), STREAM_READ_PREFETCHED_BYTES, fileLen);
+
+    // We did 3 reads, all of them were served from the small object cache. In this case, the whole object was
+    // downloaded as soon as the stream to it was opened.
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), STREAM_READ_CACHE_HIT, 3);
+  }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -256,10 +256,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // This file has a content length of 451. Since it's a parquet file, AAL will prefetch the footer bytes (last 32KB),
     // as soon as the file is opened, but because the file is < 32KB, the whole file is prefetched.
     verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, fileLength);
-
-    // The footer is only prefetched once, but parsing is attempted on each stream open.
-    verifyStatisticCounterValue(ioStats, STREAM_READ_PARQUET_FOOTER_PARSING_FAILED, 1);
-
+    
     // Open a stream to the object twice, verifying that data is cached, and streams to the same object, do not
     // prefetch the same data twice.
     try (FSDataInputStream inputStream = getFileSystem().open(dest)) {
@@ -273,9 +270,6 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     verifyStatisticCounterValue(ioStats, ACTION_HTTP_HEAD_REQUEST, 0);
     // No data is prefetched, as it already exists in the cache from the previous factory.
     verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 0);
-
-    // The footer is only prefetched once, but parsing is attempted on each stream open.
-    verifyStatisticCounterValue(ioStats, STREAM_READ_PARQUET_FOOTER_PARSING_FAILED, 1);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -102,10 +102,13 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     S3AFileSystem fs =
         (S3AFileSystem) FileSystem.get(externalTestFile.toUri(), getConfiguration());
 
+    final long initialAuditCount = fs.getIOStatistics().counters()
+            .getOrDefault(AUDIT_REQUEST_EXECUTION, 0L);
+
    long fileLength = fs.getFileStatus(externalTestFile).getLen();
 
    // Head request for the file length.
-    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 1);
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, initialAuditCount + 1);
 
     byte[] buffer = new byte[500];
     IOStatistics ioStats;
@@ -146,7 +149,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // in which case, AAL will start prefetching till EoF on file open in 8MB chunks. The file read here
     // s3://noaa-cors-pds/raw/2023/017/ohfh/OHFH017d.23_.gz, has a size of ~21MB, resulting in 3 GETS:
     // [0-8388607, 8388608-16777215, 16777216-21511173].
-    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, 5);
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, initialAuditCount + 1 + 4);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAnalyticsAcceleratorStreamReading.java
@@ -108,7 +108,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
    long fileLength = fs.getFileStatus(externalTestFile).getLen();
 
    // Head request for the file length.
-    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, initialAuditCount + 1);
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION,
+            initialAuditCount + 1);
 
     byte[] buffer = new byte[500];
     IOStatistics ioStats;
@@ -149,7 +150,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // in which case, AAL will start prefetching till EoF on file open in 8MB chunks. The file read here
     // s3://noaa-cors-pds/raw/2023/017/ohfh/OHFH017d.23_.gz, has a size of ~21MB, resulting in 3 GETS:
     // [0-8388607, 8388608-16777215, 16777216-21511173].
-    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION, initialAuditCount + 1 + 4);
+    verifyStatisticCounterValue(fs.getIOStatistics(), AUDIT_REQUEST_EXECUTION,
+            initialAuditCount + 1 + 4);
   }
 
   @Test
@@ -203,7 +205,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
 
       // Though the next GP should prefetch 16MB, since the file is ~23MB, only the bytes till EoF are prefetched.
-      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES, 10 * ONE_MB + bytesRemainingForPrefetch);
+      verifyStatisticCounterValue(ioStats, STREAM_READ_PREFETCHED_BYTES,
+              10 * ONE_MB + bytesRemainingForPrefetch);
       inputStream.readFully(buffer, 0, 3 * ONE_MB);
       verifyStatisticCounterValue(ioStats, STREAM_READ_CACHE_HIT, 3);
     }
@@ -314,7 +317,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     // S3A makes a HEAD request on the stream open(), and then AAL makes a GET request to get the object, total audit
     // operations = 10.
     long currentAuditCount = initialAuditCount + 2;
-    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), AUDIT_REQUEST_EXECUTION, currentAuditCount);
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(),
+            AUDIT_REQUEST_EXECUTION, currentAuditCount);
 
     try (FSDataInputStream inputStream = getFileSystem().openFile(dest)
         .withFileStatus(fileStatus)
@@ -396,7 +400,7 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
 
       stream1.read(buffer, 0, 2 * ONE_KB);
       stream2.read(buffer);
-      stream1.read(buffer, 0 , 10 * ONE_KB);
+      stream1.read(buffer, 0, 10 * ONE_KB);
 
       IOStatistics stats1 = stream1.getIOStatistics();
       IOStatistics stats2 = stream2.getIOStatistics();
@@ -413,7 +417,8 @@ public class ITestS3AAnalyticsAcceleratorStreamReading extends AbstractS3ATestBa
     }
 
     // verify value is passed up to the FS
-    verifyStatisticCounterValue(getFileSystem().getIOStatistics(), STREAM_READ_PREFETCHED_BYTES, fileLen);
+    verifyStatisticCounterValue(getFileSystem().getIOStatistics(),
+            STREAM_READ_PREFETCHED_BYTES, fileLen);
 
     // We did 3 reads, all of them were served from the small object cache. In this case, the whole object was
     // downloaded as soon as the stream to it was opened.

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFSMainOperations.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFSMainOperations.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Disabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.createTestPath;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.isCreatePerformanceEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -76,23 +75,11 @@ public class ITestS3AFSMainOperations extends FSMainOperationsBaseTest {
 
   @Override
   public void testWriteReadAndDeleteOneAndAHalfBlocks() throws Exception {
-    // Currently analytics accelerator does not support reading of files that have been overwritten.
-    // This is because the analytics accelerator library caches metadata, and when a file is
-    // overwritten, the old metadata continues to be used, until it is removed from the cache over
-    // time. This will be fixed in https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-    skipIfAnalyticsAcceleratorEnabled(this.contract.getConf(),
-        "Analytics Accelerator currently does not support reading of over written files");
     super.testWriteReadAndDeleteOneAndAHalfBlocks();
   }
 
   @Override
   public void testWriteReadAndDeleteTwoBlocks() throws Exception {
-    // Currently analytics accelerator does not support reading of files that have been overwritten.
-    // This is because the analytics accelerator library caches metadata, and when a file is
-    // overwritten, the old metadata continues to be used, until it is removed from the cache over
-    // time. This will be fixed in https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-    skipIfAnalyticsAcceleratorEnabled(this.contract.getConf(),
-        "Analytics Accelerator currently does not support reading of over written files");
     super.testWriteReadAndDeleteTwoBlocks();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemContract.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFileSystemContract.java
@@ -37,7 +37,6 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.isCreatePerformanceEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.setPerformanceFlags;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -168,12 +167,6 @@ public class ITestS3AFileSystemContract extends FileSystemContractBaseTest {
 
   @Override
   public void testOverWriteAndRead() throws Exception {
-    // Currently analytics accelerator does not support reading of files that have been overwritten.
-    // This is because the analytics accelerator library caches metadata, and when a file is
-    // overwritten, the old metadata continues to be used, until it is removed from the cache over
-    // time. This will be fixed in https://github.com/awslabs/analytics-accelerator-s3/issues/218.
-    skipIfAnalyticsAcceleratorEnabled(fs.getConf(),
-        "Analytics Accelerator currently does not support reading of over written files");
     super.testOverWriteAndRead();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AIOStatisticsContext.java
@@ -45,7 +45,6 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.assertCapabilities
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disablePrefetching;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.assertThatStatisticCounter;
 import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatisticCounterValue;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.STREAM_READ_BYTES;
@@ -81,10 +80,7 @@ public class ITestS3AIOStatisticsContext extends AbstractS3ATestBase {
   public void setup() throws Exception {
     super.setup();
     executor = HadoopExecutors.newFixedThreadPool(SMALL_THREADS);
-    // Analytics accelerator currently does not support IOStatisticsContext, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support IOStatisticsContext");
+
 
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AMetrics.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsSourceToString;
 
 /**
@@ -52,10 +51,6 @@ public class ITestS3AMetrics extends AbstractS3ATestBase {
 
   @Test
   public void testStreamStatistics() throws IOException {
-     // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
 
     S3AFileSystem fs = getFileSystem();
     Path file = path("testStreamStatistics");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -286,6 +286,7 @@ public interface S3ATestConstants {
   boolean DEFAULT_ROOT_TESTS_ENABLED = true;
 
   /**
+<<<<<<< HEAD
    * Flag to set when testing third party stores: {@value}.
    * <p>
    * Set to true when a completed MPU commit consumes the ID so it is no
@@ -302,4 +303,24 @@ public interface S3ATestConstants {
    * Default value of {@link #MULTIPART_COMMIT_CONSUMES_UPLOAD_ID}: {@value}.
    */
   boolean DEFAULT_MULTIPART_COMMIT_CONSUMES_UPLOAD_ID = false;
+
+  /**
+   * Ranges within this distance of each other will be coalesced.
+   */
+  String AAL_REQUEST_COALESCE_TOLERANCE = "physicalio.request.coalesce.tolerance";
+
+  /**
+   * The minimum size of a block in AAL.
+   */
+  String AAL_READ_BUFFER_SIZE = "physicalio.readbuffersize";
+
+  /**
+   * Objects smaller than this will be downloaded completely.
+   */
+  String AAL_SMALL_OBJECT_PREFETCH_ENABLED = "physicalio.small.objects.prefetching.enabled";
+
+  /**
+   * Objects in AAL's cache will expire after this duration.
+   */
+  String AAL_CACHE_TIMEOUT = "physicalio.cache.timeout";
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestConstants.java
@@ -286,7 +286,6 @@ public interface S3ATestConstants {
   boolean DEFAULT_ROOT_TESTS_ENABLED = true;
 
   /**
-<<<<<<< HEAD
    * Flag to set when testing third party stores: {@value}.
    * <p>
    * Set to true when a completed MPU commit consumes the ID so it is no

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/ITestCommitOperationCost.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.s3a.performance.AbstractS3ACostTest;
 import org.apache.hadoop.fs.statistics.IOStatisticsLogging;
 
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.assumeMultipartUploads;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.Statistic.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.s3a.Statistic.COMMITTER_MAGIC_FILES_CREATED;
 import static org.apache.hadoop.fs.s3a.Statistic.COMMITTER_MAGIC_MARKER_PUT;
@@ -175,11 +174,7 @@ public class ITestCommitOperationCost extends AbstractS3ACostTest {
   @Test
   public void testCostOfCreatingMagicFile() throws Throwable {
     describe("Files created under magic paths skip existence checks and marker deletes");
-
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
+    
     S3AFileSystem fs = getFileSystem();
     Path destFile = methodSubPath("file.txt");
     fs.delete(destFile.getParent(), true);
@@ -257,10 +252,6 @@ public class ITestCommitOperationCost extends AbstractS3ACostTest {
   public void testCostOfSavingLoadingPendingFile() throws Throwable {
     describe("Verify costs of saving .pending file under a magic path");
 
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
     S3AFileSystem fs = getFileSystem();
     Path partDir = methodSubPath("file.pending");
     Path destFile = new Path(partDir, "file.pending");

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/fileContext/ITestS3AFileContextStatistics.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.test.tags.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -48,10 +47,6 @@ public class ITestS3AFileContextStatistics extends FCStatisticsBaseTest {
   @BeforeEach
   public void setUp() throws Exception {
     conf = new Configuration();
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(conf,
-        "Analytics Accelerator currently does not support stream statistics");
     fc = S3ATestUtils.createTestFileContext(conf);
     testRootPath = fileContextTestHelper.getTestRootPath(fc, "test");
     fc.mkdir(testRootPath,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
@@ -58,7 +58,6 @@ import static org.apache.hadoop.fs.s3a.S3ATestUtils.assertStreamIsNotChecksummed
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.disableFilesystemCaching;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getS3AInputStream;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.removeBaseAndBucketOverrides;
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.streamType;
 import static org.apache.hadoop.fs.s3a.Statistic.STREAM_READ_BYTES_READ_CLOSE;
 import static org.apache.hadoop.fs.s3a.Statistic.STREAM_READ_OPENED;
@@ -71,6 +70,7 @@ import static org.apache.hadoop.fs.statistics.IOStatisticAssertions.verifyStatis
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.demandStringifyIOStatistics;
 import static org.apache.hadoop.fs.statistics.IOStatisticsLogging.ioStatisticsToPrettyString;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_FILE_OPENED;
+import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.test.LambdaTestUtils.interceptFuture;
 
@@ -95,6 +95,16 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
    */
   private boolean prefetching;
 
+  /**
+   * Is the analytics stream enabled?
+   */
+  private boolean analyticsStream;
+
+  /**
+   * Is the classic input stream enabled?
+   */
+  private boolean classicInputStream;
+
   @Override
   public Configuration createConfiguration() {
     Configuration conf = super.createConfiguration();
@@ -113,17 +123,14 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
   @Override
   public void setup() throws Exception {
     super.setup();
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
     S3AFileSystem fs = getFileSystem();
     testFile = methodPath();
-
     writeTextFile(fs, testFile, TEXT, true);
     testFileStatus = fs.getFileStatus(testFile);
     fileLength = (int)testFileStatus.getLen();
     prefetching = prefetching();
+    analyticsStream = isAnalyticsStream();
+    classicInputStream = isClassicInputStream();
   }
 
   /**
@@ -177,6 +184,10 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
 
     // if prefetching is enabled, skip this test
     assumeNoPrefetching();
+    // If AAL is enabled, skip this test. AAL uses S3A's default S3 client, and if checksumming is disabled on the
+    // client, then AAL will also not enforce it.
+    assumeNotAnalytics();
+
     S3AFileSystem fs = getFileSystem();
 
     // open the file
@@ -193,13 +204,19 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
 
       // open the stream.
       in.read();
+
       // now examine the innermost stream and make sure it doesn't have a checksum
-      assertStreamIsNotChecksummed(getS3AInputStream(in));
+        assertStreamIsNotChecksummed(getS3AInputStream(in));
     }
   }
 
   @Test
   public void testOpenFileShorterLength() throws Throwable {
+
+    // For AAL, since it makes the HEAD to get the file length if the eTag is not supplied,
+    // it is not able to use the file length supplied in the open() call, and the test fails.
+    assumeNotAnalytics();
+
     // do a second read with the length declared as short.
     // we now expect the bytes read to be shorter.
     S3AFileSystem fs = getFileSystem();
@@ -244,7 +261,6 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
     final int extra = 10;
     long longLen = fileLength + extra;
 
-
     // assert behaviors of seeking/reading past the file length.
     // there is no attempt at recovery.
     verifyMetrics(() -> {
@@ -261,10 +277,12 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       }
     },
         always(),
-        // two GET calls were made, one for readFully,
-        // the second on the read() past the EOF
+         // two GET calls were made, one for readFully,
+         // the second on the read() past the EOF
         // the operation has got as far as S3
-        probe(!prefetching(), STREAM_READ_OPENED, 1 + 1));
+        probe(classicInputStream, STREAM_READ_OPENED, 1 + 1),
+        // For AAL, the seek past content length fails, before the GET is made.
+        probe(analyticsStream, STREAM_READ_OPENED, 1));
 
     // now on a new stream, try a full read from after the EOF
     verifyMetrics(() -> {
@@ -275,10 +293,6 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
         return in.toString();
       }
     },
-        // two GET calls were made, one for readFully,
-        // the second on the read() past the EOF
-        // the operation has got as far as S3
-
         with(STREAM_READ_OPENED, 1));
   }
 
@@ -348,7 +362,9 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       }
     },
         always(),
-        probe(!prefetching, Statistic.ACTION_HTTP_GET_REQUEST, extra));
+        probe(classicInputStream, Statistic.ACTION_HTTP_GET_REQUEST, extra),
+        // AAL won't make the GET call if trying to read beyond EOF
+        probe(analyticsStream, Statistic.ACTION_HTTP_GET_REQUEST, 0));
   }
 
   /**
@@ -439,18 +455,27 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
         byte[] buf = new byte[longLen];
         ByteBuffer bb = ByteBuffer.wrap(buf);
         final FileRange range = FileRange.createFileRange(0, longLen);
-        in.readVectored(Arrays.asList(range), (i) -> bb);
-        interceptFuture(EOFException.class,
-            "",
-            ContractTestUtils.VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS,
-            TimeUnit.SECONDS,
-            range.getData());
-        assertS3StreamClosed(in);
-        return "vector read past EOF with " + in;
+
+        // For AAL, if there is no eTag, the provided length will not be passed in, and a HEAD request will be made.
+        // AAL requires the etag to detect changes in the object and then do cache eviction if required.
+        if (isAnalyticsStream()) {
+          intercept(EOFException.class, () -> in.readVectored(Arrays.asList(range), (i) -> bb));
+          verifyStatisticCounterValue(in.getIOStatistics(), ACTION_HTTP_HEAD_REQUEST, 1);
+          return "vector read past EOF with " + in;
+        } else {
+          in.readVectored(Arrays.asList(range), (i) -> bb);
+          interceptFuture(EOFException.class,
+                  "",
+                  ContractTestUtils.VECTORED_READ_OPERATION_TEST_TIMEOUT_SECONDS,
+                  TimeUnit.SECONDS,
+                  range.getData());
+          assertS3StreamClosed(in);
+          return "vector read past EOF with " + in;
+        }
       }
     },
         always(),
-        probe(!prefetching, Statistic.ACTION_HTTP_GET_REQUEST, 1));
+        probe(classicInputStream, Statistic.ACTION_HTTP_GET_REQUEST, 1));
   }
 
   /**
@@ -462,11 +487,33 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
   }
 
   /**
+   * Is the current stream type Analytics?
+   * @return true if Analytics stream is enabled.
+   */
+  private boolean isAnalyticsStream() {
+    return InputStreamType.Analytics == streamType(getFileSystem());
+  }
+
+  /**
+   * Is the current input stream type S3AInputStream?
+   * @return true if the S3AInputStream is being used.
+   */
+  private boolean isClassicInputStream() {
+    return InputStreamType.Classic == streamType(getFileSystem());
+  }
+
+  /**
    * Skip the test if prefetching is enabled.
    */
   private void assumeNoPrefetching(){
     if (prefetching) {
       skip("Prefetching is enabled");
+    }
+  }
+
+  private void assumeNotAnalytics() {
+    if (analyticsStream) {
+      skip("Analytics stream is enabled");
     }
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/performance/ITestS3AOpenCost.java
@@ -206,7 +206,7 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       in.read();
 
       // now examine the innermost stream and make sure it doesn't have a checksum
-        assertStreamIsNotChecksummed(getS3AInputStream(in));
+      assertStreamIsNotChecksummed(getS3AInputStream(in));
     }
   }
 
@@ -277,8 +277,8 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
       }
     },
         always(),
-         // two GET calls were made, one for readFully,
-         // the second on the read() past the EOF
+        // two GET calls were made, one for readFully,
+        // the second on the read() past the EOF
         // the operation has got as far as S3
         probe(classicInputStream, STREAM_READ_OPENED, 1 + 1),
         // For AAL, the seek past content length fails, before the GET is made.
@@ -459,7 +459,8 @@ public class ITestS3AOpenCost extends AbstractS3ACostTest {
         // For AAL, if there is no eTag, the provided length will not be passed in, and a HEAD request will be made.
         // AAL requires the etag to detect changes in the object and then do cache eviction if required.
         if (isAnalyticsStream()) {
-          intercept(EOFException.class, () -> in.readVectored(Arrays.asList(range), (i) -> bb));
+          intercept(EOFException.class, () ->
+                  in.readVectored(Arrays.asList(range), (i) -> bb));
           verifyStatisticCounterValue(in.getIOStatistics(), ACTION_HTTP_HEAD_REQUEST, 1);
           return "vector read past EOF with " + in;
         } else {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AContractStreamIOStatistics.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.fs.contract.s3a.S3AContract;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 import org.apache.hadoop.test.tags.IntegrationTest;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 import static org.apache.hadoop.fs.statistics.StreamStatisticNames.*;
 
 /**
@@ -86,10 +85,6 @@ public class ITestS3AContractStreamIOStatistics extends
   @Test
   @Override
   public void testInputStreamStatisticRead() throws Throwable {
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getContract().getConf(),
-        "Analytics Accelerator currently does not support stream statistics");
     super.testInputStreamStatisticRead();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/statistics/ITestS3AFileSystemStatistic.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.StreamStatisticNames;
 
-import static org.apache.hadoop.fs.s3a.S3ATestUtils.skipIfAnalyticsAcceleratorEnabled;
 
 public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
 
@@ -44,10 +43,6 @@ public class ITestS3AFileSystemStatistic extends AbstractS3ATestBase {
    */
   @Test
   public void testBytesReadWithStream() throws IOException {
-    // Analytics accelerator currently does not support IOStatistics, this will be added as
-    // part of https://issues.apache.org/jira/browse/HADOOP-19364
-    skipIfAnalyticsAcceleratorEnabled(getConfiguration(),
-        "Analytics Accelerator currently does not support stream statistics");
     S3AFileSystem fs = getFileSystem();
     Path filePath = path(getMethodName());
     byte[] oneKbBuf = new byte[ONE_KB];


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

Based off of https://github.com/apache/hadoop/pull/7763

Adds stats for

* bytes prefetched
* footer parsing failures
* readVectored 

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

