### PR TITLE
HDFS-17844. Fix the incorrect collision detection logic that causes nondeterministic behavior of testViewFsMultipleExportPoint()

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/DFSClientCache.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/DFSClientCache.java
@@ -170,15 +170,19 @@ class DFSClientCache {
       // if a unique nnid, add it to the map
       if (value == null) {
         LOG.info("Added export: {} FileSystem URI: {} with namenodeId: {}",
-            exportPath, exportPath, namenodeId);
+            exportPath, exportURI, namenodeId);
         namenodeUriMap.put(namenodeId, exportURI);
-      } else {
-        // if the nnid already exists, it better be the for the same namenode
+      } else if (!value.equals(exportURI)) {
+        // Only throw exception if different URIs have the same namenode ID
         String msg = String.format("FS:%s, Namenode ID collision for path:%s "
                 + "nnid:%s uri being added:%s existing uri:%s", fs.getScheme(),
             exportPath, namenodeId, exportURI, value);
         LOG.error(msg);
         throw new FileSystemException(msg);
+      } else {
+        // Same URI with same namenode ID - this is expected and safe to ignore
+        LOG.debug("Export path {} resolves to same URI {} as existing entry, skipping",
+            exportPath, exportURI);
       }
     }
   }

--- a/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/Nfs3Utils.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-nfs/src/main/java/org/apache/hadoop/hdfs/nfs/nfs3/Nfs3Utils.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.file.FileSystemException;
+import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -242,7 +243,7 @@ public class Nfs3Utils {
   public static int getNamenodeId(Configuration conf, URI namenodeURI) {
     InetSocketAddress address =
         DFSUtilClient.getNNAddressCheckLogical(conf, namenodeURI);
-    return address.hashCode();
+    return Objects.hash(namenodeURI.toString(), address.toString());
   }
 
   public static URI getResolvedURI(FileSystem fs, String exportPath)


### PR DESCRIPTION
## Problem
There could be a race condition in generating namenode ID. What is problematic is that different URIs resolve to the same namenode ID, which leads to data integrity issues and security problems. The logic of the underlying function used to detect such problem is incorrect as it throws an error whenever the namenode exists even if the URI is the same. As a result, `testViewFsMultipleExportPoint()` has a nondeterministic behavior when the test execution order and timing change.

Command line used to identify the nondeterminism of `testViewFsMultipleExportPoint()`:

```
mvn -pl hadoop-hdfs-project/hadoop-hdfs-nfs \
    -Dcheckstyle.skip=true -Drat.skip=true \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.hadoop.hdfs.nfs.nfs3.TestExportsTable#testViewFsMultipleExportPoint \
    -DnondexRuns=20 |& tee nondex-$(date +%s).log
```
Error example:
```
[ERROR]   TestExportsTable.testViewFsMultipleExportPoint:111 » FileSystem FS:viewfs, Namenode ID collision for path:/hdfs2 nnid:2130740544 uri being added:hdfs://localhost:34111/ existing uri:hdfs://localhost:34111/
```

## Patch
The proposed fix has changed the collision detection logic in `prepareAddressMap()` so that it will throw errors only when different URIs resolves to the same namenode ID. 

In addition, the namenode ID generation logic in `getNamenodeId()` is modified where a robust hash function combines URI and address strings, so it now reduces the chance of hash collision.


