### PR TITLE
HADOOP-19012. Use CRC tables to speed up galoisFieldMultiply in CrcUtil.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DataChecksum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,6 +22,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.ToIntFunction;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
@@ -118,15 +119,14 @@ public class DataChecksum implements Checksum {
    * @return the int representation of the polynomial associated with the
    *     CRC {@code type}, suitable for use with further CRC arithmetic.
    */
-  public static int getCrcPolynomialForType(Type type) {
+  static ToIntFunction<Long> getModFunction(Type type) {
     switch (type) {
     case CRC32:
-      return CrcUtil.GZIP_POLYNOMIAL;
+      return PureJavaCrc32::mod;
     case CRC32C:
-      return CrcUtil.CASTAGNOLI_POLYNOMIAL;
+      return PureJavaCrc32C::mod;
     default:
-      throw new IllegalArgumentException(
-          "No CRC polynomial could be associated with type: " + type);
+      throw new IllegalArgumentException("Unexpected type: " + type);
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PureJavaCrc32.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PureJavaCrc32.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -88,6 +88,18 @@ public class PureJavaCrc32 implements Checksum {
     
     // Publish crc out to object
     crc = localCrc;
+  }
+
+  /**
+   * Compute x mod p, where p is the CRC32 polynomial.
+   * @param x the input value
+   * @return x mod p
+   */
+  public static int mod(long x) {
+    final int y = (int)(x);
+    return (int)(x >> 32)
+           ^ ((T[((y << 24) >>> 24) + 0x300] ^ T[((y << 16) >>> 24) + 0x200])
+           ^  (T[((y <<  8) >>> 24) + 0x100] ^ T[((y /* */) >>> 24) /*   */]));
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PureJavaCrc32C.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PureJavaCrc32C.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -98,6 +98,18 @@ public class PureJavaCrc32C implements Checksum {
     
     // Publish crc out to object
     crc = localCrc;
+  }
+
+  /**
+   * Compute x mod p, where p is the CRC32C polynomial.
+   * @param x the input value
+   * @return x mod p
+   */
+  public static int mod(long x) {
+    final int y = (int)(x);
+    return (int)(x >> 32)
+        ^ ((T[((y << 24) >>> 24) + 0x300] ^ T[((y << 16) >>> 24) + 0x200])
+        ^  (T[((y <<  8) >>> 24) + 0x100] ^ T[((y /* */) >>> 24) /*   */]));
   }
 
   @Override

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestCrcUtil.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.util;
 
 import java.util.Objects;
 import java.util.Random;
-
+import java.util.function.ToIntFunction;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Timeout(10)
 public class TestCrcUtil {
 
-  private static final Random RANDOM = new Random(1234);
+  private static final Random RANDOM = new Random();
 
   @Test
   public void testComposeCrc32() {
@@ -91,7 +91,7 @@ public class TestCrcUtil {
    */
   private static void doTestComposeCrc(
       byte[] data, DataChecksum.Type type, int chunkSize, boolean useMonomial) {
-    int crcPolynomial = DataChecksum.getCrcPolynomialForType(type);
+    final ToIntFunction<Long> mod = DataChecksum.getModFunction(type);
 
     // Get full end-to-end CRC in a single shot first.
     DataChecksum checksum = DataChecksum.newDataChecksum(
@@ -104,7 +104,7 @@ public class TestCrcUtil {
     // second pass to compare to the end-to-end CRC.
     int compositeCrc = 0;
     int crcMonomial =
-        useMonomial ? CrcUtil.getMonomial(chunkSize, crcPolynomial) : 0;
+        useMonomial ? CrcUtil.getMonomial(chunkSize, mod) : 0;
     for (int offset = 0;
         offset + chunkSize <= data.length;
         offset += chunkSize) {
@@ -113,10 +113,10 @@ public class TestCrcUtil {
       int partialCrc = (int) checksum.getValue();
       if (useMonomial) {
         compositeCrc = CrcUtil.composeWithMonomial(
-            compositeCrc, partialCrc, crcMonomial, crcPolynomial);
+            compositeCrc, partialCrc, crcMonomial, mod);
       } else {
         compositeCrc = CrcUtil.compose(
-            compositeCrc, partialCrc, chunkSize, crcPolynomial);
+            compositeCrc, partialCrc, chunkSize, mod);
       }
     }
 
@@ -127,12 +127,11 @@ public class TestCrcUtil {
       checksum.update(data, data.length - partialChunkSize, partialChunkSize);
       int partialCrc = (int) checksum.getValue();
       compositeCrc = CrcUtil.compose(
-          compositeCrc, partialCrc, partialChunkSize, crcPolynomial);
+          compositeCrc, partialCrc, partialChunkSize, mod);
     }
     assertEquals(fullCrc, compositeCrc, String.format(
-        "Using CRC type '%s' with crcPolynomial '0x%08x' and chunkSize '%d'" +
-        ", expected '0x%08x', got '0x%08x'",
-        type, crcPolynomial, chunkSize, fullCrc, compositeCrc));
+        "Using CRC type '%s' and chunkSize '%d', expected '0x%08x', got '0x%08x'",
+        type, chunkSize, fullCrc, compositeCrc));
   }
 
   /**
@@ -143,16 +142,16 @@ public class TestCrcUtil {
     // Without loss of generality, we can pick any integer as our fake crcA
     // even if we don't happen to know the preimage.
     int crcA = 0xCAFEBEEF;
-    int crcPolynomial = DataChecksum.getCrcPolynomialForType(type);
+    final ToIntFunction<Long> mod = DataChecksum.getModFunction(type);
     DataChecksum checksum = DataChecksum.newDataChecksum(
         type, Integer.MAX_VALUE);
     Objects.requireNonNull(checksum, "checksum");
     int crcB = (int) checksum.getValue();
-    assertEquals(crcA, CrcUtil.compose(crcA, crcB, 0, crcPolynomial));
+    assertEquals(crcA, CrcUtil.compose(crcA, crcB, 0, mod));
 
-    int monomial = CrcUtil.getMonomial(0, crcPolynomial);
+    int monomial = CrcUtil.getMonomial(0, mod);
     assertEquals(
-        crcA, CrcUtil.composeWithMonomial(crcA, crcB, monomial, crcPolynomial));
+        crcA, CrcUtil.composeWithMonomial(crcA, crcB, monomial, mod));
   }
 
   @Test
@@ -220,5 +219,146 @@ public class TestCrcUtil {
     assertEquals(
         "[]",
         CrcUtil.toMultiCrcString(new byte[0]));
+  }
+
+  @Test
+  public void testMultiplyMod() {
+    runTestMultiplyMod(10_000_000, DataChecksum.Type.CRC32);
+    runTestMultiplyMod(10_000_000, DataChecksum.Type.CRC32C);
+  }
+
+  private static long[] runTestMultiplyMod(int n, DataChecksum.Type type) {
+    System.out.printf("Run %s with %d computations%n", type, n);
+    final int polynomial = getCrcPolynomialForType(type);
+    final ToIntFunction<Long> mod = DataChecksum.getModFunction(type);
+
+    final int[] p = new int[n];
+    final int[] q = new int[n];
+    for (int i = 0; i < n; i++) {
+      p[i] = RANDOM.nextInt();
+      q[i] = RANDOM.nextInt();
+    }
+
+    final int[] expected = new int[n];
+    final long[] times = new long[2];
+    final long t0 = System.currentTimeMillis();
+    for (int i = 0; i < n; i++) {
+      expected[i] = galoisFieldMultiply(p[i], q[i], polynomial);
+    }
+    times[0] = System.currentTimeMillis() - t0;
+    final double ops0 = n * 1000.0 / times[0];
+    System.out.printf("galoisFieldMultiply: %.3fs (%.2f ops)%n", times[0] / 1000.0, ops0);
+
+    final int[] computed = new int[n];
+    final long t1 = System.currentTimeMillis();
+    for (int i = 0; i < n; i++) {
+      computed[i] = CrcUtil.multiplyMod(p[i], q[i], mod);
+    }
+    times[1] = System.currentTimeMillis() - t1;
+    final double ops1 = n * 1000.0 / times[1];
+    System.out.printf("multiplyCrc32      : %.3fs (%.2f ops)%n", times[1] / 1000.0, ops1);
+    System.out.printf("multiplyCrc32 is %.2f%% faster%n", (ops1 - ops0) * 100.0 / ops0);
+
+    for (int i = 0; i < n; i++) {
+      if (expected[i] != computed[i]) {
+        System.out.printf("expected %08X%n", expected[i]);
+        System.out.printf("computed %08X%n", computed[i]);
+        throw new IllegalStateException();
+      }
+    }
+    return times;
+  }
+
+  /**
+   * getCrcPolynomialForType.
+   *
+   * @param type type.
+   * @return the int representation of the polynomial associated with the
+   * CRC {@code type}, suitable for use with further CRC arithmetic.
+   */
+  private static int getCrcPolynomialForType(DataChecksum.Type type) {
+    switch (type) {
+    case CRC32:
+      return CrcUtil.GZIP_POLYNOMIAL;
+    case CRC32C:
+      return CrcUtil.CASTAGNOLI_POLYNOMIAL;
+    default:
+      throw new IllegalArgumentException("Unexpected type: " + type);
+    }
+  }
+
+  /**
+   * Galois field multiplication of {@code p} and {@code q} with the
+   * generator polynomial {@code m} as the modulus.
+   *
+   * @param m The little-endian polynomial to use as the modulus when
+   *          multiplying p and q, with implicit "1" bit beyond the bottom bit.
+   */
+  private static int galoisFieldMultiply(int p, int q, int m) {
+    int summation = 0;
+
+    // Top bit is the x^0 place; each right-shift increments the degree of the
+    // current term.
+    int curTerm = CrcUtil.MULTIPLICATIVE_IDENTITY;
+
+    // Iteratively multiply p by x mod m as we go to represent the q[i] term
+    // (of degree x^i) times p.
+    int px = p;
+
+    while (curTerm != 0) {
+      if ((q & curTerm) != 0) {
+        summation ^= px;
+      }
+
+      // Bottom bit represents highest degree since we're little-endian; before
+      // we multiply by "x" for the next term, check bottom bit to know whether
+      // the resulting px will thus have a term matching the implicit "1" term
+      // of "m" and thus will need to subtract "m" after mutiplying by "x".
+      boolean hasMaxDegree = ((px & 1) != 0);
+      px >>>= 1;
+      if (hasMaxDegree) {
+        px ^= m;
+      }
+      curTerm >>>= 1;
+    }
+    return summation;
+  }
+
+  /** For running benchmarks. */
+  public static class Benchmark {
+    /**
+     * Usages: java {@link Benchmark} [m] [n] [type]
+     *      m: the number of iterations
+     *      n: the number of multiplication
+     *   type: the CRC type, either CRC32 or CRC32C.
+     */
+    public static void main(String[] args) throws Exception {
+      final int m = args.length >= 1? Integer.parseInt(args[0]) : 10;
+      final int n = args.length >= 2? Integer.parseInt(args[1]) : 100_000_000;
+      final DataChecksum.Type type = args.length >= 3? DataChecksum.Type.valueOf(args[2])
+          : DataChecksum.Type.CRC32;
+
+      final int warmUpIterations = 2;
+      System.out.printf("%nStart warming up with %d iterations ...%n", warmUpIterations);
+      for (int i = 0; i < 2; i++) {
+        runTestMultiplyMod(n, type);
+      }
+
+      System.out.printf("%nStart benchmark with %d iterations ...%n", m);
+      final long[] times = new long[2];
+      for (int i = 0; i < m; i++) {
+        System.out.printf("%d) ", i);
+        final long[] t = runTestMultiplyMod(n, type);
+        times[0] += t[0];
+        times[1] += t[1];
+      }
+
+      System.out.printf("%nResult) %d x %d computations:%n", m, n);
+      final double ops0 = n * 1000.0 / times[0];
+      System.out.printf("galoisFieldMultiply: %.3fs (%.2f ops)%n", times[0] / 1000.0, ops0);
+      final double ops1 = n * 1000.0 / times[1];
+      System.out.printf("multiplyCrc32      : %.3fs (%.2f ops)%n", times[1] / 1000.0, ops1);
+      System.out.printf("multiplyCrc32 is %.2f%% faster%n", (ops1 - ops0) * 100.0 / ops0);
+    }
   }
 }


### PR DESCRIPTION
### Description of PR

HADOOP-19012

(Resubmitting https://github.com/apache/hadoop/pull/6542 )

CrcUtil.galoisFieldMultiply(p, q, m) supports multiplying two polynomials p, q modulo any modulus polynomial m over GF(2). Since the method is used for CRC calculations, the modulus polynomial m is restricted to either the GZIP_POLYNOMIAL or the CASTAGNOLI_POLYNOMIAL. We may use CRC tables in PureJavaCrc32/PureJavaCrc32C to speed up the computation.

### How was this patch tested?

Added new tests.

### For code changes:

- [X] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

