### PR TITLE
HADOOP-19716. Create lean docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.2/hadoop-3.4.2.tar.gz
+ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.2/hadoop-3.4.2-lean.tar.gz
 WORKDIR /opt
 RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
 WORKDIR /opt/hadoop


### PR DESCRIPTION
### Description of PR

HADOOP-19716. Create lean docker image.

Create a new docker image based on `hadoop-3.4.2-lean.tar.gz`, which omits AWS `bundle-2.29.52.jar`.

This PR should not be merged.  I will push it from CLI as a new branch to publish the image with Docker tag `3.4.2-lean`, rather than overwrite the existing image `3.4.2`.

### How was this patch tested?

[Workflow run](https://github.com/adoroszlai/hadoop/actions/runs/18277349554/job/52032416240) in my fork created the [image](https://github.com/adoroszlai/hadoop/pkgs/container/hadoop/535792302?tag=3.4.2-lean).