### PR TITLE
YARN-11876. Fix AsyncDispatcher crash in TestAppManager

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.AsyncDispatcher;
-import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.exceptions.InvalidResourceRequestException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -184,7 +183,8 @@ public class TestAppManager extends AppManagerTestBase{
     for (RMApp app : apps) {
       map.put(app.getApplicationId(), app);
     }
-    Dispatcher rmDispatcher = new AsyncDispatcher();
+    AsyncDispatcher rmDispatcher = new AsyncDispatcher();
+    rmDispatcher.disableExitOnDispatchException();
     ContainerAllocationExpirer containerAllocationExpirer = new ContainerAllocationExpirer(
             rmDispatcher);
     AMLivelinessMonitor amLivelinessMonitor = new AMLivelinessMonitor(
@@ -200,7 +200,7 @@ public class TestAppManager extends AppManagerTestBase{
         return map;
       }
     };
-    ((RMContextImpl)context).setStateStore(mock(RMStateStore.class));
+    ((RMContextImpl) context).setStateStore(mock(RMStateStore.class));
     metricsPublisher = mock(SystemMetricsPublisher.class);
     context.setSystemMetricsPublisher(metricsPublisher);
     context.setRMApplicationHistoryWriter(writer);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11876. Fix AsyncDispatcher crash in TestAppManager.

After upgrading to `JUnit 5`, the `ResourceManager` module encounters a crash when running unit tests. Specifically, the failure occurs in the test case `TestAppManager#testRMAppSubmitWithQueueChanged`.
During application submission, the test changes the queue assignment, which triggers a `SchedulerEvent` that the AsyncDispatcher cannot handle.

As a result, the dispatcher thread throws an exception and terminates, causing the test JVM to exit abnormally with a `SurefireBooterForkException`.

- Error Details

```
2025-10-08 07:56:46,833 ERROR [AsyncDispatcher event handler] event.AsyncDispatcher (MarkerIgnoringBase.java:error(159)) - Error in dispatcher thread
java.lang.Exception: No handler registered for class org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEventType
    at org.apache.hadoop.yarn.event.AsyncDispatcher.dispatch(AsyncDispatcher.java:277)
    at org.apache.hadoop.yarn.event.AsyncDispatcher$1.run(AsyncDispatcher.java:162)
    at java.lang.Thread.run(Thread.java:750) 
```

This leads to Maven Surefire reporting a forked VM crash:

```
org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Process Exit Code: 255
Crashed tests: org.apache.hadoop.yarn.server.resourcemanager.TestAppManager
```

### How was this patch tested?

CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

