### PR TITLE
HADOOP-19717. Resolve build error caused by missing Checker Framework  (NonNull not recognized).

### DIFF
--- a/hadoop-cloud-storage-project/hadoop-tos/src/main/java/org/apache/hadoop/fs/tosfs/util/Iterables.java
+++ b/hadoop-cloud-storage-project/hadoop-tos/src/main/java/org/apache/hadoop/fs/tosfs/util/Iterables.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.tosfs.util;
 
 import org.apache.hadoop.util.Preconditions;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.apache.hadoop.thirdparty.org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java
@@ -99,6 +99,7 @@ import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.Listenable
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.thirdparty.org.checkerframework.checker.nullness.qual.NonNull;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.CryptoProtocolVersion;
 import org.apache.hadoop.fs.BatchedRemoteIterator.BatchedEntries;
@@ -213,7 +214,6 @@ import org.apache.hadoop.tools.proto.GetUserMappingsProtocolProtos;
 import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolPB;
 import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolServerSideTranslatorPB;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: HADOOP-19717. Resolve build error caused by missing Checker Framework  (NonNull not recognized).

#8011 raised an issue: the build failed on the trunk branch with the following error

```
[ERROR] /home/jenkins/jenkins-agent/workspace/hadoop-multibranch_PR-8011/ubuntu-focal/src/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java:[216,50] package org.checkerframework.checker.nullness.qual does not exist
[ERROR] /home/jenkins/jenkins-agent/workspace/hadoop-multibranch_PR-8011/ubuntu-focal/src/hadoop-hdfs-project/hadoop-hdfs-rbf/src/main/java/org/apache/hadoop/hdfs/server/federation/router/RouterRpcServer.java:[2509,30] cannot find symbol
[ERROR]   symbol:   class NonNull
[ERROR]   location: class org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.AsyncThreadFactory
```

This is related to the Guava version upgrade in the trunk.

- com.google.guava:guava:jar:27.0-jre

```
 |  +- com.google.guava:guava:jar:27.0-jre:compile
 |  |  +- com.google.guava:failureaccess:jar:1.0:compile
 |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
 |  |  +- org.checkerframework:checker-qual:jar:2.5.2:compile
 |  |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
 |  |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
```

- com.google.guava:guava:jar:33.4.8-jre:compile

```
 |  +- com.google.guava:guava:jar:33.4.8-jre:compile
 |  |  +- com.google.guava:failureaccess:jar:1.0.3:compile
 |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
 |  |  +- org.jspecify:jspecify:jar:1.0.0:compile
 |  |  \- com.google.j2objc:j2objc-annotations:jar:3.0.0:compile
```

The dependency `org.checkerframework:checker-qual:jar` cannot be imported.
We can use `org.apache.hadoop.thirdparty.org.checkerframework.checker.nullness.qual.NonNull` as a replacement for `org.checkerframework.checker.nullness.qual.NonNull`.


### How was this patch tested?

CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

