### PR TITLE
YARN-11875. Fix build failure caused by color@5.0.2.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-catalog/hadoop-yarn-applications-catalog-webapp/package.json
@@ -20,6 +20,7 @@
         "apidoc": "0.17.7"
     },
     "resolutions": {
+        "color": "3.1.3",
         "triple-beam": "1.3.0"
     },
     "scripts": {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11875. Fix build failure caused by color@5.0.2.

A build failure occurs in the Yarn UI module due to an incompatible dependency version of `color@5.0.2`, which requires `Node.js ≥ 18`. The current build environment uses `Node.js 12.22.1`, resulting in the following error during dependency installation.

```
error color@5.0.2: The engine "node" is incompatible with this module. Expected version ">=18". Got "12.22.1"
error Found incompatible module. 
```

- Root Cause

The color package was pulled in as a transitive dependency from other modules (e.g., apidoc).
Version 5.0.2 introduced a strict Node.js engine requirement (≥18), which is incompatible with the current Node 12 environment

- Fix

```
Manually pinned the dependency to a Node 12–compatible version:
"resolutions": {
  "color": "^3.1.3"
}
```

This resolves the build failure without requiring a Node.js upgrade.

### How was this patch tested?

CI.



### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

