### PR TITLE
MAPREDUCE-7521. Fix TestUberAM failures after JUnit 5 migration

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
@@ -153,7 +153,7 @@ public class TestMRJobs {
   @BeforeAll
   public static void setup() throws IOException {
     try {
-      dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2)
+      dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(5)
         .format(true).racks(null).build();
       remoteFs = dfsCluster.getFileSystem();
     } catch (IOException io) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
@@ -45,7 +45,6 @@ public class TestUberAM extends TestMRJobs {
 
   @BeforeAll
   public static void setup() throws IOException {
-    TestMRJobs.setup();
     if (mrCluster != null) {
     	mrCluster.getConfig().setBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, true);
     	mrCluster.getConfig().setInt(MRJobConfig.JOB_UBERTASK_MAXREDUCES, 3);


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: MAPREDUCE-7521. Fix TestUberAM failures after JUnit 5 migration 

#### Background

After migrating the project to `JUnit 5`, the `TestUberAM` unit test started failing intermittently. The error message observed during test execution is as follows:

```
Remote File /apps_staging_dir/jenkins/.staging/job_1759472296837_0013/job.jar could only be written to 0 of the 1 minReplication nodes. 
There are 2 datanode(s) running and 2 node(s) are excluded in this operation. 
```

This error originates from

```
org.apache.hadoop.hdfs.server.blockmanagement.BlockManager.chooseTarget4NewBlock 
```

indicating that the MiniDFSCluster used in the test failed to find available data nodes for block writes during execution.

#### Change Summary

- Removed redundant invocation of the parent class’s BeforeAll method in subclasses to prevent double initialization.
- Increased MiniDFSCluster data node count from 2 to 5 to improve fault tolerance.
- Verified that all affected tests pass successfully.

#### Impact Scope

- Affects only AM tests based on MiniDFSCluster.
- No impact on business logic or production code.

### How was this patch tested?

Local testing was successful.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.mapreduce.v2.TestUberAM
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 638.7 s -- in org.apache.hadoop.mapreduce.v2.TestUberAM
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0
```

CI

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

