### PR TITLE
HADOOP-19720. Publish multi-arch hadoop-runner image to GitHub

### DIFF
--- a/.github/workflows/build-hadoop-runner-image.yaml
+++ b/.github/workflows/build-hadoop-runner-image.yaml
@@ -62,7 +62,6 @@ jobs:
 
       - name: Build and push image to GitHub Container Registry
         id: build
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-hadoop-runner-image.yaml
+++ b/.github/workflows/build-hadoop-runner-image.yaml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build-hadoop-runner-image
+
+# This workflow builds the Docker image if it does not exists already.
+# For non-PR runs, it also publishes the image to the registry, tagging it based on the branch name:
+#    docker-hadoop-runner-X-Y => apache/hadoop-runner:X-Y
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - 'docker-hadoop-runner-**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate image ID
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/hadoop-runner
+          tags: |
+            type=match,pattern=docker-hadoop-runner-(.*),value={{branch}},group=1
+          flavor: |
+            latest=false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
+      - name: Login to GitHub Container Registry
+        id: login
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GitHub Container Registry
+        id: build
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

HADOOP-19720. Publish multi-arch hadoop-runner image to GitHub.

Similar to #7143.  Add workflow to publish `apache/hadoop-runner` (`jdk11-u2204` in this case) to GitHub Container Registry.  The image is built for both `amd64` and `arm64`.

https://issues.apache.org/jira/browse/HADOOP-19720

## How was this patch tested?

[Workflow run](https://github.com/adoroszlai/hadoop/actions/runs/18353000644) in my fork for push to branch `docker-hadoop-runner-HADOOP-19720-jdk11-u2204` built [image](https://github.com/adoroszlai/hadoop/pkgs/container/hadoop-runner/538747134?tag=HADOOP-19720-jdk11-u2204) `ghcr.io/adoroszlai/hadoop-runner:HADOOP-19720-jdk11-u2204`.

```bash
$ docker run -it --rm ghcr.io/adoroszlai/hadoop-runner:HADOOP-19720-jdk11-u2204 bash -c 'uname -a; cat /etc/lsb-release; java -version'
Linux 8099f50d7322 6.8.0-65-generic #68~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 15 18:06:34 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.5 LTS"
openjdk version "11.0.28" 2025-07-15
OpenJDK Runtime Environment Temurin-11.0.28+6 (build 11.0.28+6)
OpenJDK 64-Bit Server VM Temurin-11.0.28+6 (build 11.0.28+6, mixed mode, sharing)
```