### PR TITLE
HDFS-17846. Enhance the stability of the unit test TestDirectoryScanner.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDirectoryScanner.java
@@ -831,7 +831,7 @@ public class TestDirectoryScanner {
 
     // We need lots of blocks so the report compiler threads have enough to
     // keep them busy while we watch them.
-    int blocks = 20000;
+    int blocks = 40000;
     int maxRetries = 3;
 
     cluster = new MiniDFSCluster.Builder(conf).build();


### PR DESCRIPTION
### Description of PR

JIRA: HDFS-17846. Enhance the stability of the unit test TestDirectoryScanner.

We need lots of blocks so the report compiler threads have enough to keep them busy while we watch them.
The number of blocks: 20000->40000.

