### PR TITLE
HADOOP-19723. Build multi-arch hadoop image

### DIFF
--- a/.github/workflows/build-hadoop-image.yaml
+++ b/.github/workflows/build-hadoop-image.yaml
@@ -48,6 +48,12 @@ jobs:
           flavor: |
             latest=false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
       - name: Login to ghcr.io
         id: login
         if: ${{ github.event_name != 'pull_request' }}
@@ -61,7 +67,7 @@ jobs:
         id: build
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf
 WORKDIR /opt/hadoop
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*
-ENV HADOOP_CONF_DIR /opt/hadoop/etc/hadoop
+ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/hadoop-runner
-ARG HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.2/hadoop-3.4.2-lean.tar.gz
-WORKDIR /opt
-RUN sudo rm -rf /opt/hadoop && curl -LSs -o hadoop.tar.gz $HADOOP_URL && tar zxf hadoop.tar.gz && rm hadoop.tar.gz && mv hadoop* hadoop && rm -rf /opt/hadoop/share/doc
+FROM ghcr.io/apache/hadoop-runner:jdk11-u2204
+ARG HADOOP_VERSION=3.4.2
+ARG HADOOP_FLAVOR=-lean
+ARG BASE_URL=https://dlcdn.apache.org/hadoop/common
+ARG TARGETPLATFORM
 WORKDIR /opt/hadoop
+RUN set -eux; \
+    echo "Building for ${TARGETPLATFORM}"; \
+    case "${TARGETPLATFORM}" in \
+        linux/amd64) HADOOP_ARCH='' ;; \
+        linux/arm64) HADOOP_ARCH='-aarch64' ;; \
+        *) echo "Unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \
+    esac; \
+    export HADOOP_URL="${BASE_URL}/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}${HADOOP_ARCH}${HADOOP_FLAVOR}.tar.gz"; \
+    curl -LSs "$HADOOP_URL" | tar -x -z --strip-components 1 && rm -rf /opt/hadoop/share/doc
 ADD log4j.properties /opt/hadoop/etc/hadoop/log4j.properties
 RUN sudo chown -R hadoop:users /opt/hadoop/etc/hadoop/*
 ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: HADOOP-19723. Build multi-arch hadoop image

- Update `Dockerfile` (on branch `docker-hadoop-3.4.2-lean`) to support building for `arm64`, too.
    - Use `ghcr.io/apache/hadoop-runner:jdk11-u2204` as base, because `apache/hadoop-runner:latest` only has `amd64` image available.
    - Use `TARGETPLATFORM` to decide which tarball to use.
    - Create args for version and flavor, replacing URL.
- Update the `build-hadoop-image` workflow to create multi-arch images.
- Add build-arg `BASE_URL` to allow using mirrors (for faster local build).
- Replace deprecated `ENV HADOOP_CONF_DIR ` syntax.

https://issues.apache.org/jira/browse/HADOOP-19723

## How was this patch tested?

Workflow [run](https://github.com/adoroszlai/hadoop/actions/runs/18377713437) in my fork created multi-arch [image](https://github.com/adoroszlai/hadoop/pkgs/container/hadoop/539671710?tag=HADOOP-19723).

```
#8 0.060 Building for linux/amd64
...
#8 0.060 + export HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.2/hadoop-3.4.2-lean.tar.gz
...

#10 0.076 Building for linux/arm64
...
#10 0.077 + export HADOOP_URL=https://dlcdn.apache.org/hadoop/common/hadoop-3.4.2/hadoop-3.4.2-aarch64-lean.tar.gz
```

Tested on both amd64 and arm64 platforms.

```
$ docker run -it --rm ghcr.io/adoroszlai/hadoop:HADOOP-19723 bash -c "uname -a; hadoop version"
Linux cdb5cdd5ace9 6.8.0-65-generic #68~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 15 18:06:34 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
Hadoop 3.4.2
Source code repository https://github.com/apache/hadoop.git -r 84e8b89ee2ebe6923691205b9e171badde7a495c
Compiled by ahmarsu on 2025-08-20T10:30Z
Compiled on platform linux-x86_64
Compiled with protoc 3.23.4
From source with checksum fa94c67d4b4be021b9e9515c9b0f7b6
This command was run using /opt/hadoop/share/hadoop/common/hadoop-common-3.4.2.jar
```

```
$ docker run -it --rm ghcr.io/adoroszlai/hadoop:HADOOP-19723 bash -c "uname -a; hadoop version"
Linux 9a1237ba8fbc 6.10.14-linuxkit #1 SMP Thu Oct 24 19:28:55 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
Hadoop 3.4.2
Source code repository https://github.com/apache/hadoop.git -r e1c0dee881820a4d834ec4a4d2c70d0d953bb933
Compiled by ahmar on 2025-08-07T15:32Z
Compiled on platform linux-aarch_64
Compiled with protoc 3.23.4
From source with checksum fa94c67d4b4be021b9e9515c9b0f7b6
This command was run using /opt/hadoop/share/hadoop/common/hadoop-common-3.4.2.jar
```