### PR TITLE
Fix grammar issue in exception message

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/MultipleOutputs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/MultipleOutputs.java
@@ -203,7 +203,7 @@ public class MultipleOutputs {
         continue;
       }
       throw new IllegalArgumentException(
-        "Name cannot be have a '" + ch + "' char");
+        "Name cannot contain a '" + ch + "' char");
     }
   }
 


### PR DESCRIPTION
### Description of PR
Fix grammar issue in exception message in MultipleOutputs.

"Cannot be have" is incorrect, prefer using "Cannot contain" here due to the sentence meaning.

### How was this patch tested?
N/A

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
