### PR TITLE
HADOOP-19722. Pin robotframework version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update -q \
     && apt clean
 
 # Robot Framework for testing
-RUN pip install robotframework \
+RUN pip install robotframework==6.1.1 \
     && rm -fr ~/.cache/pip
 
 #dumb init for proper init handling


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hadoop-runner` installs `robotframework` without version definition.  Re-building the image for unrelated changes may unexpectedly upgrade `robotframework`, too.

This PR proposes to pin `robotframework` to version 6.1.1.

https://issues.apache.org/jira/browse/HADOOP-19722

## How was this patch tested?

```
$ docker build -t hadoop-runner:dev .
...

$ docker run -it --rm hadoop-runner:dev robot --version
Robot Framework 6.1.1 (Python 3.10.12 on linux)
```
