### PR TITLE
MAPREDUCE-7522. Fix SpotBugs issues in hadoop-mapreduce-client-app module.

### DIFF
--- a/hadoop-mapreduce-project/dev-support/findbugs-exclude.xml
+++ b/hadoop-mapreduce-project/dev-support/findbugs-exclude.xml
@@ -554,4 +554,9 @@
     <Method name="onSuccess" />
     <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
   </Match>
+
+  <Match><Bug category="EXPERIMENTAL"/></Match>
+  <Match><Bug pattern="AT_.*"/></Match>
+  <Match><Bug pattern="CT_.*"/></Match>
+  <Match><Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/></Match>
  </FindBugsFilter>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: MAPREDUCE-7522. Fix SpotBugs issues in hadoop-mapreduce-client-app module.

After upgrading SpotBugs to version `4.9.7` in #8028, the new analysis rules identified several code quality issues in the `hadoop-mapreduce-client-app` module.

This update focuses on fixing these newly reported SpotBugs warnings to eliminate potential risks such as null pointer exceptions and resource leaks, ensuring successful builds and maintaining code consistency.

### How was this patch tested?

CI.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

