### PR TITLE
HDFS-17847 OIV exits with code 0 (success) even when the output file is incomplete

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
@@ -265,6 +265,10 @@ public class OfflineImageViewerPB {
         printUsage();
         return -1;
       }
+      if ((out != null) && out.checkError()) {
+        System.err.println("CRITICAL FAILURE: PrintStream reported a write error (e.g., Disk Full).");
+        return -1;
+      }
       return 0;
     } catch (EOFException e) {
       System.err.println("Input file ended unexpectedly. Exiting");

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/offlineImageViewer/OfflineImageViewerPB.java
@@ -266,7 +266,8 @@ public class OfflineImageViewerPB {
         return -1;
       }
       if ((out != null) && out.checkError()) {
-        System.err.println("CRITICAL FAILURE: PrintStream reported a write error (e.g., Disk Full).");
+        System.err.println("CRITICAL FAILURE: PrintStream reported a write error " +
+                "(e.g., Disk Full).");
         return -1;
       }
       return 0;


### PR DESCRIPTION
### Description of PR

HDFS-17847

When running hdfs oiv (OfflineImageViewer) to convert an fsimage into CSV, the command exits with code 0 (success) even when the output file is truncated due to local filesystem quota being exhausted. This prevents users or automation scripts from detecting that the operation has failed.

### How was this patch tested?
From CommandLine CLI

### For code changes:
Fine

