### PR TITLE
HDFS-17849 : Fix for Namenode crashed while cleaning up Expired Delegation tokens of older realm

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -861,7 +861,8 @@ extends AbstractDelegationTokenIdentifier>
           try {
             removeTokenForOwnerStats(entry.getKey());
           } catch (Exception e) {
-            LOG.warn("Ignoring the exception in removeTokenForOwnerStats to remove expired delegation tokens from cache and proceeding to remove", e);
+            LOG.warn("Ignoring the exception in removeTokenForOwnerStats to remove expired " +
+                    "delegation tokens from cache and proceeding to remove", e);
           }
           i.remove();
         }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -858,7 +858,11 @@ extends AbstractDelegationTokenIdentifier>
         long renewDate = entry.getValue().getRenewDate();
         if (renewDate < now) {
           expiredTokens.add(entry.getKey());
-          removeTokenForOwnerStats(entry.getKey());
+          try {
+            removeTokenForOwnerStats(entry.getKey());
+          } catch (Exception e) {
+            LOG.warn("Ignoring the exception in removeTokenForOwnerStats to remove expired delegation tokens from cache and proceeding to remove", e);
+          }
           i.remove();
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/delegation/AbstractDelegationTokenSecretManager.java
@@ -860,7 +860,7 @@ extends AbstractDelegationTokenIdentifier>
           expiredTokens.add(entry.getKey());
           try {
             removeTokenForOwnerStats(entry.getKey());
-          } catch (Exception e) {
+          } catch (IllegalArgumentException e) {
             LOG.warn("Ignoring the exception in removeTokenForOwnerStats to remove expired " +
                     "delegation tokens from cache and proceeding to remove", e);
           }


### PR DESCRIPTION
### Description of PR
JIRA: [HDFS-17849](https://issues.apache.org/jira/browse/HDFS-17849). Fix for NN crash issue during token cleanup after updating the kerb auth rules to pickup new realm configuration from existing one.

### How was this patch tested?
I have tested this change on Hadoop 3.4.1 by replacing the hadoop-common JARs.
The log message appears correctly in the NameNode logs as shared below, and the NameNode starts up successfully.

```
2025-10-30 14:49:54,582 WARN  delegation.AbstractDelegationTokenSecretManager (AbstractDelegationTokenSecretManager.java:removeExpiredToken(776)) - Ignoring the exception in removeTokenForOwnerStats to remove expired delegation tokens from cache and proceeding to remove
java.lang.IllegalArgumentException: Illegal principal name spark/<hostname>@<old_realm>: org.apache.hadoop.security.authentication.util.KerberosName$NoMatchingRule: No rules applied to spark/<hostname>@<old_realm>
        at org.apache.hadoop.security.User.<init>(User.java:51)
        at org.apache.hadoop.security.User.<init>(User.java:43)
        at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1458)
        at org.apache.hadoop.security.UserGroupInformation.createRemoteUser(UserGroupInformation.java:1441)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier.getUser(AbstractDelegationTokenIdentifier.java:80)
        at org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.getUser(DelegationTokenIdentifier.java:81)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager.getTokenRealOwner(AbstractDelegationTokenSecretManager.java:923)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager.removeTokenForOwnerStats(AbstractDelegationTokenSecretManager.java:945)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager.removeExpiredToken(AbstractDelegationTokenSecretManager.java:774)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager.access$400(AbstractDelegationTokenSecretManager.java:71)
        at org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager$ExpiredTokenRemover.run(AbstractDelegationTokenSecretManager.java:850)
        at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.hadoop.security.authentication.util.KerberosName$NoMatchingRule: No rules applied to spark/<hostname>@<old_realm>
        at org.apache.hadoop.security.authentication.util.KerberosName.getShortName(KerberosName.java:429)
        at org.apache.hadoop.security.User.<init>(User.java:48)
        ... 11 more
```

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

