### PR TITLE
YARN-11891. Yarn logs command hangs for running applications

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/LogsCLI.java
@@ -538,6 +538,9 @@ public class LogsCLI extends Configured implements Tool {
           JSONArray array = new JSONArray();
           String entity = response.readEntity(String.class);
           JSONObject json = new JSONObject(entity);
+          if (json.has("containerLogsInfoes")) {
+            json = json.getJSONObject("containerLogsInfoes");
+          }
           if (!json.has("containerLogsInfo")) {
             return logFileInfos;
           }
@@ -1531,6 +1534,7 @@ public class LogsCLI extends Configured implements Tool {
           }
           // check if a URL is reachable
           checkUrlConnectivity(uri);
+          return;
         } catch (Exception e) {
           leftRetries--;
           if (leftRetries <= 0) {


### PR DESCRIPTION
### Description of PR

JIRA: YARN-11891. Yarn logs command hangs for running applications.

filter() method inside the ClientJerseyRetryFilter class, calls checkUrlConnectivity() in a while loop, If there is any issue with connectivity, it decrements the leftRetries till it becomes 0 and throws an Exception, but if it succeeds it keeps on spinning inside the infinite while loop, so added a return after checkUrlConnectivity().

After fixing the above issue, the yarn logs command was throwing below error.

Can not find any log file matching the pattern: [ALL] for the container: container_id within the application: app_id

The XML response of /ws/v1/node/containers/<container_id>/logs is

<img width="824" height="774" alt="Screenshot from 2025-11-05 19-27-47" src="https://github.com/user-attachments/assets/ea8a1b88-7be5-46d0-ab7c-eae8186ee4f4" />

So in getContainerLogFiles(), an additional getJSONObject("containerLogsInfoes") has been added to ensure the XML response is parsed properly


### How was this patch tested?
Validated yarn logs -applicationId <appID> for running and completed applications.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

